### PR TITLE
fix TS2612 findings

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -34,6 +34,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 3, 8), 'Prepare for TypeScript target update.', ToppleTheNun),
   change(date(2024, 3, 2), 'Correct an issue with the Power Word: Radiance icon.', emallson),
   change(date(2024, 3, 2), 'Correct incorrect tertiary stat scaling above 25% raw and 19% character sheet rating', Putro),
   change(date(2024, 2, 26), <>Added checklist support for <ItemLink id={ITEMS.IRIDAL_THE_EARTHS_MASTER.id}/>, <ItemLink id={ITEMS.DREAMBINDER_LOOM_OF_THE_GREAT_CYCLE.id}/>, <ItemLink id={ITEMS.BELORRELOS_THE_SUNCALLER.id}/>, <ItemLink id={ITEMS.NYMUES_UNRAVELING_SPINDLE.id}/></>, Zyer),

--- a/src/analysis/classic/mage/arcane/modules/core/GlobalCooldown.ts
+++ b/src/analysis/classic/mage/arcane/modules/core/GlobalCooldown.ts
@@ -1,16 +1,12 @@
 import SPELLS from 'common/SPELLS/classic/mage';
 import CoreGlobalCooldown from 'parser/shared/modules/GlobalCooldown';
-import Haste from 'analysis/classic/mage/shared/Haste';
 
 const GCD_REDUCTION = 500;
 
 class GlobalCooldown extends CoreGlobalCooldown {
   static dependencies = {
     ...CoreGlobalCooldown.dependencies,
-    haste: Haste,
   };
-
-  protected haste!: Haste;
 
   getGlobalCooldownDuration(spellId: number) {
     const gcd = super.getGlobalCooldownDuration(spellId);

--- a/src/analysis/classic/shaman/shared/totems/AirTotems.tsx
+++ b/src/analysis/classic/shaman/shared/totems/AirTotems.tsx
@@ -1,16 +1,12 @@
 import { Options } from 'parser/core/Analyzer';
 
 import { TotemElements } from './totemConstants';
-import TotemTracker from '../TotemTracker';
 import BaseTotem from './BaseTotem';
 
 export default class AirTotems extends BaseTotem {
   static dependencies = {
     ...BaseTotem.dependencies,
-    totemTracker: TotemTracker,
   };
-
-  protected totemTracker!: TotemTracker;
 
   constructor(options: Options) {
     super(options, TotemElements.Air);

--- a/src/analysis/classic/shaman/shared/totems/EarthTotems.tsx
+++ b/src/analysis/classic/shaman/shared/totems/EarthTotems.tsx
@@ -1,16 +1,12 @@
 import { Options } from 'parser/core/Analyzer';
 
 import { TotemElements } from './totemConstants';
-import TotemTracker from '../TotemTracker';
 import BaseTotem from './BaseTotem';
 
 export default class EarthTotems extends BaseTotem {
   static dependencies = {
     ...BaseTotem.dependencies,
-    totemTracker: TotemTracker,
   };
-
-  protected totemTracker!: TotemTracker;
 
   constructor(options: Options) {
     super(options, TotemElements.Earth);

--- a/src/analysis/classic/shaman/shared/totems/FireTotems.tsx
+++ b/src/analysis/classic/shaman/shared/totems/FireTotems.tsx
@@ -1,16 +1,12 @@
 import { Options } from 'parser/core/Analyzer';
 
 import { TotemElements } from './totemConstants';
-import TotemTracker from '../TotemTracker';
 import BaseTotem from './BaseTotem';
 
 export default class FireTotems extends BaseTotem {
   static dependencies = {
     ...BaseTotem.dependencies,
-    totemTracker: TotemTracker,
   };
-
-  protected totemTracker!: TotemTracker;
 
   constructor(options: Options) {
     super(options, TotemElements.Fire);

--- a/src/analysis/classic/shaman/shared/totems/WaterTotems.tsx
+++ b/src/analysis/classic/shaman/shared/totems/WaterTotems.tsx
@@ -1,16 +1,12 @@
 import { Options } from 'parser/core/Analyzer';
 
 import { TotemElements } from './totemConstants';
-import TotemTracker from '../TotemTracker';
 import BaseTotem from './BaseTotem';
 
 export default class WaterTotems extends BaseTotem {
   static dependencies = {
     ...BaseTotem.dependencies,
-    totemTracker: TotemTracker,
   };
-
-  protected totemTracker!: TotemTracker;
 
   constructor(options: Options) {
     super(options, TotemElements.Water);

--- a/src/analysis/retail/druid/restoration/modules/features/RestoDruidHealingEfficiencyDetails.tsx
+++ b/src/analysis/retail/druid/restoration/modules/features/RestoDruidHealingEfficiencyDetails.tsx
@@ -3,19 +3,11 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import HealingEfficiencyBreakdown from 'parser/core/healingEfficiency/HealingEfficiencyBreakdown';
 import HealingEfficiencyDetails from 'parser/core/healingEfficiency/HealingEfficiencyDetails';
-import HealingEfficiencyTracker from 'parser/core/healingEfficiency/HealingEfficiencyTracker';
 import Panel from 'parser/ui/Panel';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 /** Display module for healing efficiency data */
 class RestoDruidHealingEfficiencyDetails extends HealingEfficiencyDetails {
-  static dependencies = {
-    ...HealingEfficiencyDetails.dependencies,
-    healingEfficiencyTracker: HealingEfficiencyTracker,
-  };
-
-  protected healingEfficiencyTracker!: HealingEfficiencyTracker;
-
   statistic() {
     return (
       <Panel

--- a/src/analysis/retail/druid/restoration/modules/features/RestoDruidHealingEfficiencyTracker.ts
+++ b/src/analysis/retail/druid/restoration/modules/features/RestoDruidHealingEfficiencyTracker.ts
@@ -2,11 +2,6 @@ import SPELLS from 'common/SPELLS';
 import HealingEfficiencyTracker, {
   SpellInfoDetails,
 } from 'parser/core/healingEfficiency/HealingEfficiencyTracker';
-import ManaTracker from 'parser/core/healingEfficiency/ManaTracker';
-import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-import CastEfficiency from 'parser/shared/modules/CastEfficiency';
-import DamageDone from 'parser/shared/modules/throughput/DamageDone';
-import HealingDone from 'parser/shared/modules/throughput/HealingDone';
 
 import HotAttributor from '../../modules/core/hottracking/HotAttributor';
 import Abilities from '../Abilities';
@@ -18,11 +13,6 @@ import { TALENTS_DRUID } from 'common/TALENTS';
 class RestoDruidHealingEfficiencyTracker extends HealingEfficiencyTracker {
   static dependencies = {
     ...HealingEfficiencyTracker.dependencies,
-    manaTracker: ManaTracker,
-    abilityTracker: AbilityTracker,
-    healingDone: HealingDone,
-    damageDone: DamageDone,
-    castEfficiency: CastEfficiency,
 
     // Custom dependencies
     abilities: Abilities,
@@ -31,7 +21,6 @@ class RestoDruidHealingEfficiencyTracker extends HealingEfficiencyTracker {
     hotAttributor: HotAttributor,
   };
 
-  protected healingDone!: HealingDone;
   protected swiftmend!: Swiftmend;
   protected hotAttributor!: HotAttributor;
 

--- a/src/analysis/retail/druid/shared/spells/AdaptiveSwarmDamageDealer.tsx
+++ b/src/analysis/retail/druid/shared/spells/AdaptiveSwarmDamageDealer.tsx
@@ -1,7 +1,6 @@
 import { formatNumber, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { ThresholdStyle } from 'parser/core/ParseResults';
-import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentDamageDone from 'parser/ui/ItemPercentDamageDone';
 import Statistic from 'parser/ui/Statistic';
@@ -14,13 +13,6 @@ import AdaptiveSwarm from './AdaptiveSwarm';
  * A damage dealing focused extension display module for Adaptive Swarm - for Feral and Balance
  */
 class AdaptiveSwarmDamageDealer extends AdaptiveSwarm {
-  static dependencies = {
-    ...AdaptiveSwarm.dependencies,
-    enemies: Enemies,
-  };
-
-  enemies!: Enemies;
-
   get damageUptimeHistory() {
     return this.enemies.getDebuffHistory(SPELLS.ADAPTIVE_SWARM_DAMAGE.id);
   }

--- a/src/analysis/retail/evoker/preservation/modules/core/PreservationHealingEfficiencyDetails.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/core/PreservationHealingEfficiencyDetails.tsx
@@ -2,17 +2,9 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import HealingEfficiencyBreakdown from 'parser/core/healingEfficiency/HealingEfficiencyBreakdown';
 import HealingEfficiencyDetails from 'parser/core/healingEfficiency/HealingEfficiencyDetails';
-import HealingEfficiencyTracker from 'parser/core/healingEfficiency/HealingEfficiencyTracker';
 import Panel from 'parser/ui/Panel';
 
 class PreservationHealingEfficiencyDetails extends HealingEfficiencyDetails {
-  static dependencies = {
-    ...HealingEfficiencyDetails.dependencies,
-    healingEfficiencyTracker: HealingEfficiencyTracker,
-  };
-
-  protected healingEfficiencyTracker!: HealingEfficiencyTracker;
-
   statistic() {
     return (
       <Panel

--- a/src/analysis/retail/hunter/beastmastery/modules/core/GlobalCooldown.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/core/GlobalCooldown.tsx
@@ -1,15 +1,8 @@
 import TALENTS from 'common/TALENTS/hunter';
 import { CastEvent } from 'parser/core/Events';
 import CoreGlobalCooldown from 'parser/shared/modules/GlobalCooldown';
-import Haste from 'parser/shared/modules/Haste';
+
 class GlobalCooldown extends CoreGlobalCooldown {
-  static dependencies = {
-    ...CoreGlobalCooldown.dependencies,
-    haste: Haste,
-  };
-
-  protected haste!: Haste;
-
   /**
    * Barrage GCDs are triggered when fabricating channel events
    */

--- a/src/analysis/retail/hunter/marksmanship/modules/core/GlobalCooldown.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/core/GlobalCooldown.tsx
@@ -3,16 +3,8 @@ import { TALENTS_HUNTER } from 'common/TALENTS';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { BeginCastEvent, CastEvent } from 'parser/core/Events';
 import CoreGlobalCooldown from 'parser/shared/modules/GlobalCooldown';
-import Haste from 'parser/shared/modules/Haste';
 
 class GlobalCooldown extends CoreGlobalCooldown {
-  static dependencies = {
-    ...CoreGlobalCooldown.dependencies,
-    haste: Haste,
-  };
-
-  protected haste!: Haste;
-
   aimedShotTimestamp: number | null = null;
 
   /**

--- a/src/analysis/retail/hunter/survival/modules/core/GlobalCooldown.tsx
+++ b/src/analysis/retail/hunter/survival/modules/core/GlobalCooldown.tsx
@@ -1,15 +1,8 @@
 import TALENTS from 'common/TALENTS/hunter';
 import { CastEvent } from 'parser/core/Events';
 import CoreGlobalCooldown from 'parser/shared/modules/GlobalCooldown';
-import Haste from 'parser/shared/modules/Haste';
+
 class GlobalCooldown extends CoreGlobalCooldown {
-  static dependencies = {
-    ...CoreGlobalCooldown.dependencies,
-    haste: Haste,
-  };
-
-  protected haste!: Haste;
-
   /**
    * Barrage GCDs are triggered when fabricating channel events
    */

--- a/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyDetails.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyDetails.tsx
@@ -3,17 +3,9 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import HealingEfficiencyBreakdown from 'parser/core/healingEfficiency/HealingEfficiencyBreakdown';
 import HealingEfficiencyDetails from 'parser/core/healingEfficiency/HealingEfficiencyDetails';
-import HealingEfficiencyTracker from 'parser/core/healingEfficiency/HealingEfficiencyTracker';
 import Panel from 'parser/ui/Panel';
 
 class MistweaverHealingEfficiencyDetails extends HealingEfficiencyDetails {
-  static dependencies = {
-    ...HealingEfficiencyDetails.dependencies,
-    healingEfficiencyTracker: HealingEfficiencyTracker,
-  };
-
-  protected healingEfficiencyTracker!: HealingEfficiencyTracker;
-
   statistic() {
     return (
       <Panel

--- a/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
@@ -3,12 +3,6 @@ import { TALENTS_MONK } from 'common/TALENTS';
 import HealingEfficiencyTracker, {
   SpellInfoDetails,
 } from 'parser/core/healingEfficiency/HealingEfficiencyTracker';
-import ManaTracker from 'parser/core/healingEfficiency/ManaTracker';
-import Abilities from 'parser/core/modules/Abilities';
-import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-import CastEfficiency from 'parser/shared/modules/CastEfficiency';
-import DamageDone from 'parser/shared/modules/throughput/DamageDone';
-import HealingDone from 'parser/shared/modules/throughput/HealingDone';
 
 import FaelineStompHealing from '../spells/FaelineStompHealing';
 import EnvelopingMists from '../spells/EnvelopingMists';
@@ -28,14 +22,8 @@ import ShaohaosLessons from '../spells/ShaohaosLessons';
 class MistweaverHealingEfficiencyTracker extends HealingEfficiencyTracker {
   static dependencies = {
     ...HealingEfficiencyTracker.dependencies,
-    manaTracker: ManaTracker,
-    abilityTracker: AbilityTracker,
-    healingDone: HealingDone,
-    damageDone: DamageDone,
-    castEfficiency: CastEfficiency,
 
     // Custom dependencies
-    abilities: Abilities,
     essenceFont: EssenceFont,
     envelopingMists: EnvelopingMists,
     soothingMist: SoothingMist,
@@ -52,12 +40,6 @@ class MistweaverHealingEfficiencyTracker extends HealingEfficiencyTracker {
     shaohaosLessons: ShaohaosLessons,
   };
 
-  protected manaTracker!: ManaTracker;
-  protected abilityTracker!: AbilityTracker;
-  protected healingDone!: HealingDone;
-  protected damageDone!: DamageDone;
-  protected castEfficiency!: CastEfficiency;
-  protected abilities!: Abilities;
   protected essenceFont!: EssenceFont;
   protected envelopingMists!: EnvelopingMists;
   protected soothingMist!: SoothingMist;

--- a/src/analysis/retail/priest/discipline/modules/features/CooldownThroughputTracker.ts
+++ b/src/analysis/retail/priest/discipline/modules/features/CooldownThroughputTracker.ts
@@ -5,7 +5,6 @@ import CoreCooldownThroughputTracker, {
   TrackedCooldown,
 } from 'parser/shared/modules/CooldownThroughputTracker';
 import { TALENTS_PRIEST } from 'common/TALENTS';
-import EventHistory from 'parser/shared/modules/EventHistory';
 
 import isAtonement from '../core/isAtonement';
 import Atonement from '../spells/Atonement';
@@ -17,7 +16,6 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   static dependencies = {
     ...CoreCooldownThroughputTracker.dependencies,
     atonementModule: Atonement,
-    eventHistory: EventHistory,
   };
   static cooldownSpells = [
     ...CoreCooldownThroughputTracker.cooldownSpells,
@@ -33,7 +31,6 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
   ];
   lastEvangelism: TrackedCooldown | null = null;
   protected atonementModule!: Atonement;
-  protected eventHistory!: EventHistory;
 
   onCast(event: CastEvent) {
     const spellId = event.ability.guid;

--- a/src/analysis/retail/priest/holy/modules/features/StatWeights.tsx
+++ b/src/analysis/retail/priest/holy/modules/features/StatWeights.tsx
@@ -3,8 +3,6 @@ import TALENTS from 'common/TALENTS/priest';
 import Combatants from 'parser/shared/modules/Combatants';
 import BaseHealerStatValues from 'parser/shared/modules/features/BaseHealerStatValues';
 import STAT from 'parser/shared/modules/features/STAT';
-import CritEffectBonus from 'parser/shared/modules/helpers/CritEffectBonus';
-import StatTracker from 'parser/shared/modules/StatTracker';
 
 import Mastery from '../core/EchoOfLightMastery';
 import PRIEST_HEAL_INFO from './StatValuesSpellInfo';
@@ -13,13 +11,10 @@ class StatWeights extends BaseHealerStatValues {
   static dependencies = {
     ...BaseHealerStatValues.dependencies,
     combatants: Combatants,
-    critEffectBonus: CritEffectBonus,
-    statTracker: StatTracker,
     mastery: Mastery,
   };
   spellInfo = PRIEST_HEAL_INFO;
   qeLive = false;
-  protected statTracker!: StatTracker;
 
   _hasteHpm(event: any, healVal: any) {
     if (event.ability.guid === TALENTS.RENEW_TALENT.id && !event.tick) {

--- a/src/analysis/retail/rogue/outlaw/modules/core/OutlawEnergyCapTracker.tsx
+++ b/src/analysis/retail/rogue/outlaw/modules/core/OutlawEnergyCapTracker.tsx
@@ -1,4 +1,4 @@
-import { EnergyCapTracker, EnergyTracker } from 'analysis/retail/rogue/shared';
+import { EnergyCapTracker } from 'analysis/retail/rogue/shared';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/rogue';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
@@ -10,12 +10,6 @@ const ADRENALINE_RUSH_REGEN_MULTIPLIER = 1.6;
 class OutlawEnergyCapTracker extends EnergyCapTracker {
   static buffsChangeMax = [TALENTS.ADRENALINE_RUSH_TALENT.id];
   static buffsChangeRegen = [TALENTS.ADRENALINE_RUSH_TALENT, SPELLS.BURIED_TREASURE];
-
-  static dependencies = {
-    ...EnergyCapTracker.dependencies,
-  };
-
-  protected energyTracker!: EnergyTracker;
 
   constructor(options: Options) {
     super(options);

--- a/src/analysis/retail/shaman/restoration/modules/core/HealingEfficiencyDetails.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/core/HealingEfficiencyDetails.tsx
@@ -4,17 +4,9 @@ import TALENTS from 'common/TALENTS/shaman';
 import { SpellLink } from 'interface';
 import HealingEfficiencyBreakdown from 'parser/core/healingEfficiency/HealingEfficiencyBreakdown';
 import CoreHealingEfficiencyDetails from 'parser/core/healingEfficiency/HealingEfficiencyDetails';
-import HealingEfficiencyTracker from 'parser/core/healingEfficiency/HealingEfficiencyTracker';
 import Panel from 'parser/ui/Panel';
 
 class HealingEfficiencyDetails extends CoreHealingEfficiencyDetails {
-  static dependencies = {
-    ...CoreHealingEfficiencyDetails.dependencies,
-    healingEfficiencyTracker: HealingEfficiencyTracker,
-  };
-
-  protected healingEfficiencyTracker!: HealingEfficiencyTracker;
-
   statistic() {
     return (
       <Panel

--- a/src/analysis/retail/shaman/restoration/modules/core/HealingEfficiencyTracker.ts
+++ b/src/analysis/retail/shaman/restoration/modules/core/HealingEfficiencyTracker.ts
@@ -4,10 +4,6 @@ import TALENTS from 'common/TALENTS/shaman';
 import CoreHealingEfficiencyTracker, {
   SpellInfoDetails,
 } from 'parser/core/healingEfficiency/HealingEfficiencyTracker';
-import ManaTracker from 'parser/core/healingEfficiency/ManaTracker';
-import Abilities from 'parser/core/modules/Abilities';
-import CastEfficiency from 'parser/shared/modules/CastEfficiency';
-import DamageDone from 'parser/shared/modules/throughput/DamageDone';
 
 import CooldownThroughputTracker from '../features/CooldownThroughputTracker';
 import PrimordialWave from '../talents/PrimordialWave';
@@ -19,12 +15,8 @@ import RestorationAbilityTracker from './RestorationAbilityTracker';
 class HealingEfficiencyTracker extends CoreHealingEfficiencyTracker {
   static dependencies = {
     ...CoreHealingEfficiencyTracker.dependencies,
-    manaTracker: ManaTracker,
     abilityTracker: RestorationAbilityTracker,
     healingDone: HealingDone,
-    damageDone: DamageDone,
-    castEfficiency: CastEfficiency,
-    abilities: Abilities,
     resurgence: Resurgence,
     cooldownThroughputTracker: CooldownThroughputTracker,
     unleashLife: UnleashLife,
@@ -32,12 +24,8 @@ class HealingEfficiencyTracker extends CoreHealingEfficiencyTracker {
     primordialWave: PrimordialWave,
   };
 
-  protected manaTracker!: ManaTracker;
-  protected abilityTracker!: RestorationAbilityTracker;
-  protected healingDone!: HealingDone;
-  protected damageDone!: DamageDone;
-  protected castEfficiency!: CastEfficiency;
-  protected abilities!: Abilities;
+  protected declare abilityTracker: RestorationAbilityTracker;
+  protected declare healingDone: HealingDone;
   protected resurgence!: Resurgence;
   protected cooldownThroughputTracker!: CooldownThroughputTracker;
   protected unleashLife!: UnleashLife;

--- a/src/analysis/retail/shaman/shared/core/FlameShock.tsx
+++ b/src/analysis/retail/shaman/shared/core/FlameShock.tsx
@@ -9,7 +9,6 @@ import Events from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import EarlyDotRefreshesAnalyzer from 'parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes';
 import badRefreshSuggestion from 'parser/shared/modules/earlydotrefreshes/EarlyDotRefreshesSuggestionByCount';
-import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
@@ -18,13 +17,6 @@ import { TALENTS_SHAMAN } from 'common/TALENTS';
 export const FLAMESHOCK_BASE_DURATION = 18000;
 
 class FlameShock extends EarlyDotRefreshesAnalyzer {
-  static dependencies = {
-    ...EarlyDotRefreshesAnalyzer.dependencies,
-    enemies: Enemies,
-  };
-
-  protected enemies!: Enemies;
-
   static dots = [
     {
       name: 'Flame Shock',

--- a/src/analysis/retail/warrior/arms/modules/features/SpellUsable.tsx
+++ b/src/analysis/retail/warrior/arms/modules/features/SpellUsable.tsx
@@ -1,18 +1,10 @@
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warrior';
-import { EventType } from 'parser/core/Events';
-import Abilities from 'parser/core/modules/Abilities';
+import { AnyEvent, EventType } from 'parser/core/Events';
 import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
 
 class SpellUsable extends CoreSpellUsable {
-  static dependencies = {
-    ...CoreSpellUsable.dependencies,
-    abilities: Abilities,
-  };
-
-  protected abilities!: Abilities;
-
-  onEvent(event: any) {
+  onEvent(event: AnyEvent) {
     super.onEvent(event);
     // Tactician passive: You have a 1.40% chance per Rage spent on damaging abilities to reset the remaining cooldown on Overpower.
     // normally charges dont count down simultaneously. these do

--- a/src/parser/classic/modules/items/FoodChecker.tsx
+++ b/src/parser/classic/modules/items/FoodChecker.tsx
@@ -221,7 +221,6 @@ const DebugText = () => {
 };
 
 class FoodChecker extends BaseFoodChecker {
-  foodBuffId?: number;
   recommendedHigherTierFoods?: number[];
 
   constructor(options: Options) {


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fix TS2612 findings caused by bumping the `target` field in the tsconfig.json to `ES2022` or later.

More or less, when `target` is `ES2022` or later, this setting defaults to true: https://www.typescriptlang.org/tsconfig#useDefineForClassFields

This is the behavior it causes: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier

The fix is to not redeclare the fields that are defined in the parent OR to use the `declare` modifier if the type you're using actually matters.
