### PR TITLE
bump muted text opacity

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -34,6 +34,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 3, 13), 'Bump opacity on muted text to 75% from 47%.', ToppleTheNun),
   change(date(2024, 3, 2), 'Correct an issue with the Power Word: Radiance icon.', emallson),
   change(date(2024, 3, 2), 'Correct incorrect tertiary stat scaling above 25% raw and 19% character sheet rating', Putro),
   change(date(2024, 2, 26), <>Added checklist support for <ItemLink id={ITEMS.IRIDAL_THE_EARTHS_MASTER.id}/>, <ItemLink id={ITEMS.DREAMBINDER_LOOM_OF_THE_GREAT_CYCLE.id}/>, <ItemLink id={ITEMS.BELORRELOS_THE_SUNCALLER.id}/>, <ItemLink id={ITEMS.NYMUES_UNRAVELING_SPINDLE.id}/></>, Zyer),

--- a/src/interface/Theme.scss
+++ b/src/interface/Theme.scss
@@ -1,7 +1,7 @@
 @import '~sass-text-stroke/_text-stroke';
 
 $primaryColor: #fab700; // #f86725?
-$muted: hsla(44, 6%, 78%, 0.47);
+$muted: hsla(44, 6%, 78%, 0.75);
 $red: #ac1f39;
 $panelColor: hsla(44, 3%, 11%, 1);
 $backgroundColor: hsl(44, 7%, 8%);

--- a/src/interface/guide/components/MajorDefensives/AllCooldownUsagesList.tsx
+++ b/src/interface/guide/components/MajorDefensives/AllCooldownUsagesList.tsx
@@ -315,8 +315,8 @@ const CooldownUsage = ({
           <div>
             <strong>Cast Breakdown</strong>{' '}
             <small>
-              - These boxes each cast, colored by how much damage was mitigated. Missed casts are
-              also shown in{' '}
+              - These boxes represent each cast, colored by how much damage was mitigated. Missed
+              casts are also shown in{' '}
               <TooltipElement content="Used for casts that may have been skipped in order to cover major damage events.">
                 <Highlight color={OkColor} textColor="black">
                   yellow


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Improve visibility of muted text by bumping the opacity from 47% to 75%.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/...`
- Screenshot(s):
**Before**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/323632a1-56d2-464b-b7c4-9108258fa3d3)
**After**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/17e4dfaa-f540-47a0-9223-72012d6c5086)
