### PR TITLE
bump phase selector opacity

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -34,6 +34,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 3, 14), 'Bump opacity on phase selector to 75% from 40%.', ToppleTheNun),
   change(date(2024, 3, 13), 'Bump opacity on muted text to 75% from 47%.', ToppleTheNun),
   change(date(2024, 3, 2), 'Correct an issue with the Power Word: Radiance icon.', emallson),
   change(date(2024, 3, 2), 'Correct incorrect tertiary stat scaling above 25% raw and 19% character sheet rating', Putro),

--- a/src/interface/report/Results/Header.scss
+++ b/src/interface/report/Results/Header.scss
@@ -57,7 +57,7 @@
     padding: 15px;
     display: flex;
     border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-    opacity: 0.4;
+    opacity: 0.75;
     transition: opacity 400ms ease-in-out;
 
     &:hover {


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Bump phase selector opacity as multiple users have just completely missed that it existed.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/MtJBd1A4DvK2wymP/1-Mythic++Throne+of+the+Tides+-+Wipe+1+(25:11)/1-Dholy/standard`
- Screenshot(s):
**Before**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/ac409089-13d4-424a-bac3-b2a1d8246de4)
**After**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/9926ba40-882f-497b-8215-34fb2d23f4d5)
