### PR TITLE
fix overflow on cooldown bars with phase selected

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -34,6 +34,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 3, 14), 'Fix overflow on cooldown bars while using the phase selector.', ToppleTheNun),
   change(date(2024, 3, 14), 'Bump opacity on phase selector to 75% from 40%.', ToppleTheNun),
   change(date(2024, 3, 13), 'Bump opacity on muted text to 75% from 47%.', ToppleTheNun),
   change(date(2024, 3, 2), 'Correct an issue with the Power Word: Radiance icon.', emallson),

--- a/src/parser/ui/CooldownBar.scss
+++ b/src/parser/ui/CooldownBar.scss
@@ -13,6 +13,7 @@
   width: 100%;
   height: 24px;
   background: $muted;
+  overflow: clip;
 
   .cooldown-unavailable {
     background: transparentize($primaryColor, 0.3);


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fix overflow on cooldown bars when using the phase selector.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/JnB4Mxfb7FLQR6XK/2-Mythic++Dawn+of+the+Infinite:+Galakrond's+Fall+-+Wipe+1+(29:59)/Dholy/standard/overview`
- Screenshot(s):
**Before**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/b64bf0c1-b6f1-469e-bc94-01f697031017)
**After**
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/c8937e28-3ca6-4f7f-96ff-54fe900a6c9c)
