### PR TITLE
[Frost Mage] Thermal void update

### DIFF
--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { Earosselot, Sharrq, Sref, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 4, 2), <>Update <SpellLink spell={TALENTS.THERMAL_VOID_TALENT} /> statistic from 10.0.0 to 10.1.5 (current)</>, Earosselot),
   change(date(2024, 3, 14), <>Fixed <SpellLink spell={SPELLS.WINTERS_CHILL} /> module, to account correctly when flurry is casted at 4 <SpellLink spell={SPELLS.ICICLES_BUFF} /> </>, Earosselot),
   change(date(2024, 2, 22), <>Html fixes and <SpellLink spell={TALENTS.SHIFTING_POWER_TALENT} /> cd reduction correction </>, Earosselot),
   change(date(2024, 2, 2), <>Added <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} />, <SpellLink spell={TALENTS.BRAIN_FREEZE_TALENT} /> and <SpellLink spell={TALENTS.FINGERS_OF_FROST_TALENT} /> to Guide view</>, Earosselot),

--- a/src/analysis/retail/mage/frost/talents/ThermalVoid.tsx
+++ b/src/analysis/retail/mage/frost/talents/ThermalVoid.tsx
@@ -7,7 +7,7 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 
-const BASE_DURATION = 30_000;
+const BASE_DURATION = 25_000;
 
 /*
  * Icy Veins' duration is increased by 5 sec.

--- a/src/analysis/retail/mage/frost/talents/ThermalVoid.tsx
+++ b/src/analysis/retail/mage/frost/talents/ThermalVoid.tsx
@@ -7,11 +7,12 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 
-const BASE_DURATION = 20_000;
+const BASE_DURATION = 30_000;
 
 /*
- * Icy Veins' duration is increased by 10 sec.
- * Your Ice Lances against frozen targets extend your Icy Veins by an additional 1 sec.
+ * Icy Veins' duration is increased by 5 sec.
+ * Your Ice Lances against frozen targets extend your Icy Veins by an additional 0.5 sec.
+ * Your Glacial Spike against frozen targets extend your Icy Veins by an additional 1 sec.
  */
 class ThermalVoid extends Analyzer {
   constructor(options: Options) {
@@ -48,7 +49,7 @@ class ThermalVoid extends Analyzer {
       <Statistic
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
-        tooltip="Extension times include the base 10 second increase from the talent."
+        tooltip="Extension times include the base 5 second increase from the talent."
         dropdown={
           <>
             <table className="table table-condensed">


### PR DESCRIPTION
### Description

Update for Thermal void statistics. They were outdated.
Current Icy Veins base duration -> 25 secs.
Current Thermal void increase -> 5 secs.

### Testing

- Test report URL:  report/jhRJ74ZPMgxVmAW9/10-Mythic+Igira+the+Cruel+-+Kill+(4:03)/Manather/standard/statistics
- Screenshot(s):

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/32552126/384d8882-0b5f-4a83-b810-1840928fac8e)

