### PR TITLE
[Frost Mage] Adding statistics for Chain Reaction Talent

### DIFF
--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { Earosselot, Sharrq, Sref, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 4, 4), <>Added <SpellLink spell={TALENTS.CHAIN_REACTION_TALENT} /> statistics </>, Earosselot),
   change(date(2024, 3, 14), <>Fixed <SpellLink spell={SPELLS.WINTERS_CHILL} /> module, to account correctly when flurry is casted at 4 <SpellLink spell={SPELLS.ICICLES_BUFF} /> </>, Earosselot),
   change(date(2024, 2, 22), <>Html fixes and <SpellLink spell={TALENTS.SHIFTING_POWER_TALENT} /> cd reduction correction </>, Earosselot),
   change(date(2024, 2, 2), <>Added <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} />, <SpellLink spell={TALENTS.BRAIN_FREEZE_TALENT} /> and <SpellLink spell={TALENTS.FINGERS_OF_FROST_TALENT} /> to Guide view</>, Earosselot),

--- a/src/analysis/retail/mage/frost/CombatLogParser.ts
+++ b/src/analysis/retail/mage/frost/CombatLogParser.ts
@@ -46,6 +46,7 @@ import ThermalVoid from './talents/ThermalVoid';
 import CometStormLinkNormalizer from './normalizers/CometStormLinkNormalizer';
 import CastLinkNormalizer from './normalizers/CastLinkNormalizer';
 import ShiftingPowerFrost from 'analysis/retail/mage/frost/talents/ShiftingPowerFrost';
+import ChainReaction from 'analysis/retail/mage/frost/talents/ChainReaction';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -85,6 +86,7 @@ class CombatLogParser extends CoreCombatLogParser {
     frozenOrb: FrozenOrb,
     coldSnap: ColdSnap,
     shiftingPowerFrost: ShiftingPowerFrost,
+    chainReaction: ChainReaction,
 
     //Talents - Shared
     elementalBarrier: ElementalBarrier,

--- a/src/analysis/retail/mage/frost/SPELLS.ts
+++ b/src/analysis/retail/mage/frost/SPELLS.ts
@@ -122,6 +122,11 @@ const spells = {
     name: 'Cold Snap',
     icon: 'spell_frost_wizardmark',
   },
+  CHAIN_REACTION_BUFF: {
+    id: 278310,
+    name: 'Chain Reaction',
+    icon: 'spell_frost_frostblast',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/analysis/retail/mage/frost/core/IceLance.tsx
+++ b/src/analysis/retail/mage/frost/core/IceLance.tsx
@@ -18,7 +18,14 @@ class IceLance extends Analyzer {
   };
   protected enemies!: Enemies;
 
-  icelance: { cast: CastEvent; shattered: boolean; hadFingers: boolean; cleaved: boolean }[] = [];
+  icelance: {
+    cast: CastEvent;
+    shattered: boolean;
+    hadFingers: boolean;
+    cleaved: boolean;
+    damage: DamageEvent | undefined;
+    cleaveDamage: DamageEvent | undefined;
+  }[] = [];
 
   constructor(options: Options) {
     super(options);
@@ -41,6 +48,8 @@ class IceLance extends Analyzer {
         event.timestamp - 10,
       ),
       cleaved: cleave ? true : false,
+      damage: damage,
+      cleaveDamage: cleave,
     });
   }
 

--- a/src/analysis/retail/mage/frost/talents/ChainReaction.tsx
+++ b/src/analysis/retail/mage/frost/talents/ChainReaction.tsx
@@ -1,0 +1,52 @@
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import TALENTS from 'common/TALENTS/mage';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import IceLance from 'analysis/retail/mage/frost/core/IceLance';
+import SPELLS from 'common/SPELLS';
+
+const STACK_DMG_INCREASE = 0.02;
+
+export default class ChainReaction extends Analyzer {
+  static dependencies = {
+    iceLance: IceLance,
+  };
+
+  protected iceLance!: IceLance;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.CHAIN_REACTION_TALENT);
+  }
+
+  statistic() {
+    let chainReactionTotalDamage = 0;
+
+    this.iceLance.icelance.forEach((icelance) => {
+      if (typeof icelance.damage !== 'undefined') {
+        const chainReactionStacks = this.selectedCombatant.getBuffStacks(
+          SPELLS.CHAIN_REACTION_BUFF.id,
+          icelance.damage.timestamp,
+        );
+        const chainReactionDamage =
+          icelance.damage.amount * chainReactionStacks * STACK_DMG_INCREASE;
+        const chainReactionCleaveDamage = icelance.cleaveDamage
+          ? icelance.cleaveDamage.amount * chainReactionStacks * STACK_DMG_INCREASE
+          : 0;
+        chainReactionTotalDamage += chainReactionDamage;
+        chainReactionTotalDamage += chainReactionCleaveDamage;
+      }
+    });
+
+    return (
+      <Statistic size="flexible" category={STATISTIC_CATEGORY.TALENTS}>
+        <BoringSpellValueText spell={TALENTS.CHAIN_REACTION_TALENT}>
+          <>
+            <p>{this.owner.formatItemDamageDone(chainReactionTotalDamage)}</p>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}


### PR DESCRIPTION
### Description

Added analysis to calculate the dps due to Chain Reaction Talent. I asked on mages discord for when is the right time to calculate the buff contribution and they said: most frost spells calculate on hit, including ice lance. So buffs are calculated when damage is dealt (so CR would affect ice lances).

### Testing

- Test report URL: /reports/BtwMqQ9mJcjYTvKz/#fight=4&source=18
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/32552126/afbd12a5-13a8-418f-9948-52a68b617c26)
