### PR TITLE
[Mage] Error corrections: Alter Time - Ice Cold

### DIFF
--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { Earosselot, Sharrq, Sref, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 4, 4), <>Fixed <SpellLink spell={TALENTS.ALTER_TIME_TALENT} /> GCD, added <SpellLink spell={TALENTS.ICE_COLD_TALENT} /> to spellbook </>, Earosselot),
   change(date(2024, 3, 14), <>Fixed <SpellLink spell={SPELLS.WINTERS_CHILL} /> module, to account correctly when flurry is casted at 4 <SpellLink spell={SPELLS.ICICLES_BUFF} /> </>, Earosselot),
   change(date(2024, 2, 22), <>Html fixes and <SpellLink spell={TALENTS.SHIFTING_POWER_TALENT} /> cd reduction correction </>, Earosselot),
   change(date(2024, 2, 2), <>Added <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} />, <SpellLink spell={TALENTS.BRAIN_FREEZE_TALENT} /> and <SpellLink spell={TALENTS.FINGERS_OF_FROST_TALENT} /> to Guide view</>, Earosselot),

--- a/src/analysis/retail/mage/shared/Abilities.tsx
+++ b/src/analysis/retail/mage/shared/Abilities.tsx
@@ -139,11 +139,20 @@ class Abilities extends CoreAbilities {
         spell: TALENTS.ICE_BLOCK_TALENT.id,
         buffSpellId: TALENTS.ICE_BLOCK_TALENT.id,
         category: SPELL_CATEGORY.DEFENSIVE,
-        enabled: combatant.hasTalent(TALENTS.ICE_BLOCK_TALENT),
+        enabled:
+          combatant.hasTalent(TALENTS.ICE_BLOCK_TALENT) &&
+          !combatant.hasTalent(TALENTS.ICE_COLD_TALENT),
         cooldown: 240 - combatant.getTalentRank(TALENTS.WINTERS_PROTECTION_TALENT) * 30,
         gcd: {
           base: 1500,
         },
+      },
+      {
+        spell: SPELLS.ICE_COLD.id,
+        category: SPELL_CATEGORY.DEFENSIVE,
+        enabled: combatant.hasTalent(TALENTS.ICE_COLD_TALENT),
+        cooldown: 240 - combatant.getTalentRank(TALENTS.WINTERS_PROTECTION_TALENT) * 30,
+        gcd: null,
       },
       {
         spell: TALENTS.MIRROR_IMAGE_TALENT.id,
@@ -254,9 +263,14 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.UTILITY,
         enabled: combatant.hasTalent(TALENTS.ALTER_TIME_TALENT),
         cooldown: 60 - combatant.getTalentRank(TALENTS.ALTER_TIME_TALENT) * 10,
-        gcd: {
-          base: 1500,
-        },
+        gcd: null,
+      },
+      {
+        spell: SPELLS.ALTER_TIME_RETURN.id,
+        category: SPELL_CATEGORY.UTILITY,
+        enabled: combatant.hasTalent(TALENTS.ALTER_TIME_TALENT),
+        cooldown: 0,
+        gcd: null,
       },
       {
         spell: SPELLS.INVISIBILITY.id,

--- a/src/analysis/retail/mage/shared/SPELLS.ts
+++ b/src/analysis/retail/mage/shared/SPELLS.ts
@@ -179,6 +179,11 @@ const spells = {
     name: 'Temporal Warp',
     icon: 'ability_bossmagistrix_timewarp2',
   },
+  ICE_COLD: {
+    id: 414658,
+    name: 'Ice Cold',
+    icon: 'spell_fire_bluefire',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;


### PR DESCRIPTION
- added Ice Cold to spellbook
- corrected (off) GCD for Alter Time

### Testing

- Test report URL: `/reports/jhRJ74ZPMgxVmAW9/#fight=10&source=31`
- Screenshot(s):

Timeline showing AT off-GCD and Ice Cold now on CDs
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/32552126/aecce3e3-1300-431e-907f-5ef601c43557)


Errors gone:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/32552126/d277e7ca-d471-443b-af5e-2648e683c21d)

