### PR TITLE
[Frost Mage] Cryopathy talent

### DIFF
--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { Earosselot, Sharrq, Sref, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 4, 5), <>Added <SpellLink spell={TALENTS.CRYOPATHY_TALENT} /> statistics</>, Earosselot),
   change(date(2024, 4, 4), <>Fixed <SpellLink spell={TALENTS.ALTER_TIME_TALENT} /> GCD, added <SpellLink spell={TALENTS.ICE_COLD_TALENT} /> to spellbook </>, Earosselot),
   change(date(2024, 4, 4), <>Added <SpellLink spell={TALENTS.CHAIN_REACTION_TALENT} /> statistics </>, Earosselot),
   change(date(2024, 4, 2), <>Update <SpellLink spell={TALENTS.THERMAL_VOID_TALENT} /> statistic from 10.0.0 to 10.1.5 (current)</>, Earosselot),

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Sharrq } from 'CONTRIBUTORS';
+import { Earosselot, Sharrq } from 'CONTRIBUTORS';
 import Expansion from 'game/Expansion';
 import SPECS from 'game/SPECS';
 import Config from 'parser/Config';
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Sharrq],
+  contributors: [Sharrq, Earosselot],
   expansion: Expansion.Dragonflight,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '10.2.6',
@@ -32,7 +32,7 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/BtwMqQ9mJcjYTvKz/4-Mythic+Gnarlroot+-+Kill+(2:53)/18-Choihyeon/standard',
+  exampleReport: '/report/RJ1MXnb2zymgQ8pF/49/20',
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.FROST_MAGE,

--- a/src/analysis/retail/mage/frost/CombatLogParser.ts
+++ b/src/analysis/retail/mage/frost/CombatLogParser.ts
@@ -41,12 +41,13 @@ import GlacialSpike from './talents/GlacialSpike';
 import LonelyWinter from './talents/LonelyWinter';
 import SplittingIce from './talents/SplittingIce';
 import ThermalVoid from './talents/ThermalVoid';
+import ChainReaction from 'analysis/retail/mage/frost/talents/ChainReaction';
+import Cryopathy from 'analysis/retail/mage/frost/talents/Cryopathy';
 
 //Normalizers
 import CometStormLinkNormalizer from './normalizers/CometStormLinkNormalizer';
 import CastLinkNormalizer from './normalizers/CastLinkNormalizer';
 import ShiftingPowerFrost from 'analysis/retail/mage/frost/talents/ShiftingPowerFrost';
-import ChainReaction from 'analysis/retail/mage/frost/talents/ChainReaction';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -87,6 +88,7 @@ class CombatLogParser extends CoreCombatLogParser {
     coldSnap: ColdSnap,
     shiftingPowerFrost: ShiftingPowerFrost,
     chainReaction: ChainReaction,
+    cryopathy: Cryopathy,
 
     //Talents - Shared
     elementalBarrier: ElementalBarrier,

--- a/src/analysis/retail/mage/frost/SPELLS.ts
+++ b/src/analysis/retail/mage/frost/SPELLS.ts
@@ -127,6 +127,11 @@ const spells = {
     name: 'Chain Reaction',
     icon: 'spell_frost_frostblast',
   },
+  CRYOPATHY_BUFF: {
+    id: 417492,
+    name: 'Cryopathy',
+    icon: 'ability_hunter_pointofnoescape',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/analysis/retail/mage/frost/talents/Cryopathy.tsx
+++ b/src/analysis/retail/mage/frost/talents/Cryopathy.tsx
@@ -7,6 +7,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import { formatNumber } from 'common/format';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
 
 const STACK_DMG_INCREASE = 0.05;
 

--- a/src/analysis/retail/mage/frost/talents/Cryopathy.tsx
+++ b/src/analysis/retail/mage/frost/talents/Cryopathy.tsx
@@ -48,7 +48,7 @@ export default class Cryopathy extends Analyzer {
             <p>
               {formatNumber(cryopathyTotalDamage)} <small>Damage contribution</small>
             </p>
-            <p>{this.owner.formatItemDamageDone(cryopathyTotalDamage)}</p>
+            <ItemDamageDone amount={cryopathyTotalDamage} />
           </>
         </BoringSpellValueText>
       </Statistic>

--- a/src/analysis/retail/mage/frost/talents/Cryopathy.tsx
+++ b/src/analysis/retail/mage/frost/talents/Cryopathy.tsx
@@ -32,7 +32,10 @@ export default class Cryopathy extends Analyzer {
           ray.timestamp,
         );
         const cryopathyAmount =
-          ray.damage.reduce((totalAmount, damage) => (totalAmount += damage.amount), 0) *
+          ray.damage.reduce(
+            (totalAmount, damage) => totalAmount + damage.amount + (damage.absorbed || 0),
+            0,
+          ) *
           STACK_DMG_INCREASE *
           cryopathyStacks;
         cryopathyTotalDamage += cryopathyAmount;

--- a/src/analysis/retail/mage/frost/talents/Cryopathy.tsx
+++ b/src/analysis/retail/mage/frost/talents/Cryopathy.tsx
@@ -1,0 +1,54 @@
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import TALENTS from 'common/TALENTS/mage';
+import RayOfFrost from 'analysis/retail/mage/frost/talents/RayOfFrost';
+import React from 'react';
+import SPELLS from 'common/SPELLS';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import { formatNumber } from 'common/format';
+
+const STACK_DMG_INCREASE = 0.05;
+
+export default class Cryopathy extends Analyzer {
+  static dependencies = {
+    rayOfFrost: RayOfFrost,
+  };
+
+  protected rayOfFrost!: RayOfFrost;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.CRYOPATHY_TALENT);
+  }
+
+  statistic(): React.ReactNode {
+    let cryopathyTotalDamage = 0;
+
+    this.rayOfFrost.rayOfFrost.forEach((ray) => {
+      if (typeof ray.damage !== 'undefined') {
+        const cryopathyStacks = this.selectedCombatant.getBuffStacks(
+          SPELLS.CRYOPATHY_BUFF.id,
+          ray.timestamp,
+        );
+        const cryopathyAmount =
+          ray.damage.reduce((totalAmount, damage) => (totalAmount += damage.amount), 0) *
+          STACK_DMG_INCREASE *
+          cryopathyStacks;
+        cryopathyTotalDamage += cryopathyAmount;
+      }
+    });
+    return (
+      <Statistic size="flexible" category={STATISTIC_CATEGORY.TALENTS}>
+        <BoringSpellValueText spell={TALENTS.CRYOPATHY_TALENT}>
+          <>
+            <p>
+              {formatNumber(cryopathyTotalDamage)} <small>Damage contribution</small>
+            </p>
+            <p>{this.owner.formatItemDamageDone(cryopathyTotalDamage)}</p>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/mage/frost/talents/RayOfFrost.tsx
+++ b/src/analysis/retail/mage/frost/talents/RayOfFrost.tsx
@@ -24,7 +24,8 @@ class RayOfFrost extends Analyzer {
   };
   protected enemies!: Enemies;
 
-  rayOfFrost: { hits: number; shatteredHits: number }[] = [];
+  rayOfFrost: { timestamp: number; hits: number; shatteredHits: number; damage: DamageEvent[] }[] =
+    [];
   castEntries: BoxRowEntry[] = [];
 
   constructor(options: Options) {
@@ -50,6 +51,7 @@ class RayOfFrost extends Analyzer {
       timestamp: event.timestamp,
       hits: damage.length,
       shatteredHits: shattered,
+      damage: damage,
     };
     this.rayOfFrost.push(rayOfFrostDetails);
 

--- a/src/common/TALENTS/mage.ts
+++ b/src/common/TALENTS/mage.ts
@@ -1238,7 +1238,7 @@ const talents = {
   SPLITTING_ICE_TALENT: {
     id: 56377,
     name: 'Splitting Ice',
-    icon: 'spell_frost_ice_shards',
+    icon: 'spell_frost_ice-shards',
     maxRanks: 1,
     entryIds: [80224],
     definitionIds: [{ id: 85227, specId: 64 }],


### PR DESCRIPTION
### Description

Added Cryopathy talent statistics.
Minor fixes:
- Splitting ice icon
- Updated example report

### Testing

- Test report URL: `/report/RJ1MXnb2zymgQ8pF/49-Mythic+Fyrakk+the+Blazing+-+Kill+(9:17)/Gladrien/standard/statistics`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/32552126/242da904-235f-4741-80e7-d1cbe864d445)

