### PR TITLE
fix EventsTab omitting some events

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -34,6 +34,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 4, 5), 'Fix events tab omitting some events.', ToppleTheNun),
   change(date(2024, 3, 30), 'Update Nymue spellids and make Channeling normalizer normalize fabricated Prepull events.', Vollmer),
   change(date(2024, 3, 27), 'Rewrite events tab in TypeScript.', ToppleTheNun),
   change(date(2024, 3, 26), 'Add patch 10.2.6.', ToppleTheNun),

--- a/src/interface/EventsTab.tsx
+++ b/src/interface/EventsTab.tsx
@@ -163,11 +163,17 @@ const findEntity = (parser: CombatLogParser, id: number) => {
   return null;
 };
 
-const getEventTypeName = (name: keyof typeof FILTERABLE_TYPES, isRawNames: boolean) => {
+const getEventTypeName = (name: string, isRawNames: boolean) => {
+  if (!isFilterableEventType(name)) {
+    return name;
+  }
   return isRawNames ? name : FILTERABLE_TYPES[name].name;
 };
 
-const getEventTypeExplanation = (name: keyof typeof FILTERABLE_TYPES) => {
+const getEventTypeExplanation = (name: string) => {
+  if (!isFilterableEventType(name)) {
+    return undefined;
+  }
   const eventType = FILTERABLE_TYPES[name];
   return 'explanation' in eventType ? eventType.explanation : undefined;
 };
@@ -284,7 +290,7 @@ export default function EventsTabFn({ parser }: EventsTabFnProps) {
   const searchTerms = (search.match(regex) || []).map((m) => m.replace(regex, '$1$2'));
 
   const events = parser.eventHistory.filter((event) => {
-    if (!isFilterableEventType(event.type) || types[event.type] === false) {
+    if (isFilterableEventType(event.type) && !types[event.type]) {
       return false;
     }
     if (!showFabricated && event.__fabricated === true) {


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fix EventsTab omitting events that were not available as toggle options.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/BNxf9VWHzjtyrDYQ/12-Mythic+Igira+the+Cruel+-+Kill+(4:10)/Vollmer/standard/events`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/ebea74fe-711b-4a0d-9a5d-3d021b439c53)
