### PR TITLE
fix Fury warnings in M+ content

### DIFF
--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -6,9 +6,12 @@ import SPELLS from 'common/SPELLS/demonhunter';
 import TALENTS from 'common/TALENTS/demonhunter';
 import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 import { DEMON_HUNTER_DF3_ID } from 'common/ITEMS/dragonflight';
+import ResourceLink from 'interface/ResourceLink';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 // prettier-ignore
 export default [
+  change(date(2023, 4, 8), <>Improve <ResourceLink id={RESOURCE_TYPES.FURY.id} /> waste advice in M+ content.</>, ToppleTheNun),
   change(date(2023, 12, 14), <>Detect if no targets were hit by <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} />.</>, ToppleTheNun),
   change(date(2023, 12, 10), <>Add CDR calculations for <ItemSetLink id={DEMON_HUNTER_DF3_ID}>Screaming Torchfiend&apos;s Brutality.</ItemSetLink>.</>, ToppleTheNun),
   change(date(2023, 11, 19), <>Revise <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT} /> guidance in single target and fix bug with <SpellLink spell={SPELLS.SOUL_FRAGMENT_STACK} /> consumption.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/Guide.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/Guide.tsx
@@ -22,6 +22,7 @@ import {
 import { PerformanceStrong } from 'analysis/retail/priest/shadow/modules/guide/ExtraComponents';
 import { formatPercentage } from 'common/format';
 import ActiveTimeGraph from 'parser/ui/ActiveTimeGraph';
+import { isMythicPlus } from 'common/isMythicPlus';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -48,6 +49,15 @@ function CoreSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
           avoid capping <ResourceLink id={RESOURCE_TYPES.FURY.id} /> - lost{' '}
           <ResourceLink id={RESOURCE_TYPES.FURY.id} /> generation is lost DPS.
         </p>
+        {isMythicPlus(info.fight) &&
+        info.combatant.hasTalent(TALENTS_DEMON_HUNTER.SPIRIT_BOMB_TALENT) ? (
+          <p>
+            <ResourceLink id={RESOURCE_TYPES.FURY.id} /> waste when taking{' '}
+            <SpellLink spell={TALENTS_DEMON_HUNTER.SPIRIT_BOMB_TALENT} /> in Mythic+ content is not
+            an issue, as Vengeance's goal in AoE is to spend as many{' '}
+            <SpellLink spell={SPELLS.SOUL_FRAGMENT} />s as possible.
+          </p>
+        ) : null}
         <FuryCapWaste
           percentAtCap={percentAtFuryCap}
           percentAtCapPerformance={percentAtFuryCapPerformance}
@@ -89,8 +99,8 @@ function CoreSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
         </p>
         <ActiveTimeGraph
           activeTimeSegments={modules.alwaysBeCasting.activeTimeSegments}
-          fightStart={info.fightStart}
-          fightEnd={info.fightEnd}
+          fightStart={info.fight.start_time}
+          fightEnd={info.fight.end_time}
         />
       </SubSection>
     </Section>

--- a/src/analysis/retail/demonhunter/vengeance/modules/resourcetracker/FuryTracker.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/resourcetracker/FuryTracker.tsx
@@ -2,6 +2,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { Options } from 'parser/core/Analyzer';
 import ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { isMythicPlus } from 'common/isMythicPlus';
 
 export const PERFECT_TIME_AT_FURY_CAP = 0;
 export const GOOD_TIME_AT_FURY_CAP = 0.05;
@@ -14,6 +15,10 @@ class FuryTracker extends ResourceTracker {
   }
 
   get percentAtCapPerformance(): QualitativePerformance {
+    if (isMythicPlus(this.owner.fight)) {
+      return QualitativePerformance.Ok;
+    }
+
     const percentAtCap = this.percentAtCap;
     if (percentAtCap === PERFECT_TIME_AT_FURY_CAP) {
       return QualitativePerformance.Perfect;

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -826,6 +826,10 @@ class CombatLogParser {
       defaultRange: this.getModule(Abilities).defaultRange,
       playerId: this.selectedCombatant.id,
       pets: this.playerPets.filter((pet) => pet.fights.some((fight) => fight.id === this.fight.id)),
+      fight: {
+        ...this.fight,
+        duration: this.fight.end_time - this.fight.start_time,
+      },
       fightStart: this.fight.start_time,
       fightEnd: this.fight.end_time,
       fightDuration: this.fight.end_time - this.fight.start_time,

--- a/src/parser/core/metric.ts
+++ b/src/parser/core/metric.ts
@@ -2,6 +2,11 @@ import Combatant from './Combatant';
 import { AnyEvent } from './Events';
 import Ability from './modules/Ability';
 import { PetInfo } from './Pet';
+import { WCLFight } from 'parser/core/Fight';
+
+export interface WCLFightWithDuration extends WCLFight {
+  duration: number;
+}
 
 export interface Info {
   playerId: number;
@@ -9,9 +14,22 @@ export interface Info {
   // TODO: this piece of plucking props from the Abilities module is not ideal
   abilities: Ability[];
   defaultRange: number;
+  fight: WCLFightWithDuration;
+  /**
+   * @deprecated use {@link fight} instead
+   */
   fightStart: number;
+  /**
+   * @deprecated use {@link fight} instead
+   */
   fightEnd: number;
+  /**
+   * @deprecated use {@link fight} instead
+   */
   fightDuration: number;
+  /**
+   * @deprecated use {@link fight} instead
+   */
   fightId: number;
   reportCode: string;
   combatant: Combatant;


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fix Fury warnings in M+ content for Vengeance and add access to fight details for guides.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/JnB4Mxfb7FLQR6XK/2-Mythic++Dawn+of+the+Infinite:+Galakrond's+Fall+-+Wipe+1+(29:59)/Dholy/standard`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/9fd56b3b-58f5-4165-80e6-01781c6526d4)
