### PR TITLE
[Fire Mage] Guide Crash Fix + Flame Accelerant

### DIFF
--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { Sharrq, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 4, 8), <>Added the <SpellLink spell={TALENTS.FLAME_ACCELERANT_TALENT} /> buff to the timeline.</>, Sharrq),
   change(date(2024, 4, 8), <>Fixed a crash in <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> Active Time if a <SpellLink spell={TALENTS.SUN_KINGS_BLESSING_TALENT} /> <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> buff was refreshed by a <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> cast.</>, Sharrq),
   change(date(2024, 4, 8), <>Fixed a bug that was checking for the <SpellLink spell={TALENTS.FLAME_ACCELERANT_TALENT} /> buff at the end of the fight instead of on <SpellLink spell={SPELLS.FIREBALL} /> casts.</>, Sharrq),
   change(date(2024, 4, 7), <>Added the new Guide View for Fire Mage.</>, Sharrq),

--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,8 @@ import { Sharrq, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 4, 8), <>Fixed a crash in <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> Active Time if a <SpellLink spell={TALENTS.SUN_KINGS_BLESSING_TALENT} /> <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> buff was refreshed by a <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> cast.</>, Sharrq),
+  change(date(2024, 4, 8), <>Fixed a bug that was checking for the <SpellLink spell={TALENTS.FLAME_ACCELERANT_TALENT} /> buff at the end of the fight instead of on <SpellLink spell={SPELLS.FIREBALL} /> casts.</>, Sharrq),
   change(date(2024, 4, 7), <>Added the new Guide View for Fire Mage.</>, Sharrq),
   change(date(2024, 3, 10), <>Added a check to filter out <SpellLink spell={TALENTS.FIRE_BLAST_TALENT} /> without <SpellLink spell={SPELLS.HEATING_UP} /> if it is within a second of <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> starting.</>, Sharrq),
   change(date(2024, 1, 20), <>Fixed an issue with <SpellLink spell={TALENTS.METEOR_TALENT} /> that was counting <SpellLink spell={TALENTS.FIREFALL_TALENT} /> Meteors as mistakes for not landing in <SpellLink spell={TALENTS.COMBUSTION_TALENT} />.</>, Sharrq),

--- a/src/analysis/retail/mage/fire/core/Buffs.tsx
+++ b/src/analysis/retail/mage/fire/core/Buffs.tsx
@@ -70,6 +70,11 @@ class Buffs extends CoreAuras {
         timelineHighlight: true,
       },
       {
+        spellId: SPELLS.FLAME_ACCELERANT_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS.FLAME_ACCELERANT_TALENT),
+        timelineHighlight: true,
+      },
+      {
         spellId: Object.keys(BLOODLUST_BUFFS).map((item) => Number(item)),
         timelineHighlight: true,
       },

--- a/src/analysis/retail/mage/fire/core/Combustion.tsx
+++ b/src/analysis/retail/mage/fire/core/Combustion.tsx
@@ -126,7 +126,7 @@ class CombustionCasts extends Analyzer {
 
     //If the player had a Flame Accelerant proc, disregard it.
     if (this.hasFlameAccelerant) {
-      fireballCasts = fireballCasts.filter(f => this.selectedCombatant.hasBuff(SPELLS.FLAME_ACCELERANT_BUFF.id));
+      fireballCasts = fireballCasts.filter(f => this.selectedCombatant.hasBuff(SPELLS.FLAME_ACCELERANT_BUFF.id, f.cast?.timestamp, -10));
     }
 
     const tooltip = `This Fireball was cast during Combustion. Since Combustion has a short duration, you are better off using your instant abilities to get as many instant/free Pyroblasts as possible. If you run out of instant abilities, cast Scorch instead unless you have >100% Haste (Double Lust) or you have a Flame Accelerant proc`;

--- a/src/analysis/retail/mage/fire/guide/HeatingUp.tsx
+++ b/src/analysis/retail/mage/fire/guide/HeatingUp.tsx
@@ -74,7 +74,7 @@ class HeatingUpGuide extends Analyzer {
             </li>
             <li>
               Unless you are guaranteed to crit ({combustion}, {firestarter}, {searingTouch}), or
-              are capped on charges, do'nt use your guaranteed crit abilities without {heatingUp}.
+              are capped on charges, don't use your guaranteed crit abilities without {heatingUp}.
             </li>
           </ul>
         </div>

--- a/src/analysis/retail/mage/fire/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/fire/normalizers/CastLinkNormalizer.ts
@@ -49,7 +49,7 @@ const EVENT_LINKS: EventLink[] = [
     anyTarget: true,
     maximumLinks: 1,
     forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: 7_000, //Needed for an edge case where SKB Combust was active and was refreshed by a Combust cast
   },
   {
     reverseLinkRelation: BUFF_APPLY,


### PR DESCRIPTION
- Fixed a typo in the Heating Up Guide section
- Fixed a bug in the Fireball during Combustion checks that was checking for the Flame Accelerant buff at the end of the fight instead of at the Fireball cast
- Added Flame Accelerant to the timeline buffs
- Fixed a crash in Combustion Active Time if the player had an SKB Combust and refreshed the buff by casting Combustion