### PR TITLE
partially rollback Fury waste changes

### DIFF
--- a/src/analysis/retail/demonhunter/shared/guide/FuryCapWaste.tsx
+++ b/src/analysis/retail/demonhunter/shared/guide/FuryCapWaste.tsx
@@ -1,8 +1,14 @@
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { ResourceLink } from 'interface';
+import { useFight } from 'interface/report/context/FightContext';
+import { useInfo } from 'interface/guide';
+import TALENTS from 'common/TALENTS/demonhunter';
+import SPELLS from 'common/SPELLS/demonhunter';
+import SpellLink from 'interface/SpellLink';
 
 import PerformancePercentage from './PerformancePercentage';
+import { isMythicPlus } from 'common/isMythicPlus';
 
 interface Props {
   percentAtCap: number;
@@ -20,6 +26,13 @@ const FuryCapWaste = ({
   okTimeAtFuryCap,
   wasted,
 }: Props) => {
+  const { fight } = useFight();
+  const info = useInfo();
+
+  if (!info) {
+    return null;
+  }
+
   return (
     <p>
       The chart below shows your <ResourceLink id={RESOURCE_TYPES.FURY.id} /> over the course of the
@@ -33,6 +46,15 @@ const FuryCapWaste = ({
         flatAmount={wasted}
       />{' '}
       of your <ResourceLink id={RESOURCE_TYPES.FURY.id} />.
+      {isMythicPlus(fight) && info.combatant.hasTalent(TALENTS.SPIRIT_BOMB_TALENT) ? (
+        <>
+          {' '}
+          <ResourceLink id={RESOURCE_TYPES.FURY.id} /> waste when taking{' '}
+          <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT} /> in Mythic+ content is not an issue, as
+          Vengeance's goal in AoE is to spend as many <SpellLink spell={SPELLS.SOUL_FRAGMENT} />s as
+          possible.
+        </>
+      ) : null}
     </p>
   );
 };

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -11,7 +11,8 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 // prettier-ignore
 export default [
-  change(date(2023, 4, 8), <>Improve <ResourceLink id={RESOURCE_TYPES.FURY.id} /> waste advice in M+ content.</>, ToppleTheNun),
+  change(date(2024, 4, 9), <>Partially rollback changes to support M+ in Guide for <ResourceLink id={RESOURCE_TYPES.FURY.id} /> waste.</>, ToppleTheNun),
+  change(date(2024, 4, 8), <>Improve <ResourceLink id={RESOURCE_TYPES.FURY.id} /> waste advice in M+ content.</>, ToppleTheNun),
   change(date(2023, 12, 14), <>Detect if no targets were hit by <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} />.</>, ToppleTheNun),
   change(date(2023, 12, 10), <>Add CDR calculations for <ItemSetLink id={DEMON_HUNTER_DF3_ID}>Screaming Torchfiend&apos;s Brutality.</ItemSetLink>.</>, ToppleTheNun),
   change(date(2023, 11, 19), <>Revise <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT} /> guidance in single target and fix bug with <SpellLink spell={SPELLS.SOUL_FRAGMENT_STACK} /> consumption.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/Guide.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/Guide.tsx
@@ -22,7 +22,6 @@ import {
 import { PerformanceStrong } from 'analysis/retail/priest/shadow/modules/guide/ExtraComponents';
 import { formatPercentage } from 'common/format';
 import ActiveTimeGraph from 'parser/ui/ActiveTimeGraph';
-import { isMythicPlus } from 'common/isMythicPlus';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -49,15 +48,6 @@ function CoreSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
           avoid capping <ResourceLink id={RESOURCE_TYPES.FURY.id} /> - lost{' '}
           <ResourceLink id={RESOURCE_TYPES.FURY.id} /> generation is lost DPS.
         </p>
-        {isMythicPlus(info.fight) &&
-        info.combatant.hasTalent(TALENTS_DEMON_HUNTER.SPIRIT_BOMB_TALENT) ? (
-          <p>
-            <ResourceLink id={RESOURCE_TYPES.FURY.id} /> waste when taking{' '}
-            <SpellLink spell={TALENTS_DEMON_HUNTER.SPIRIT_BOMB_TALENT} /> in Mythic+ content is not
-            an issue, as Vengeance's goal in AoE is to spend as many{' '}
-            <SpellLink spell={SPELLS.SOUL_FRAGMENT} />s as possible.
-          </p>
-        ) : null}
         <FuryCapWaste
           percentAtCap={percentAtFuryCap}
           percentAtCapPerformance={percentAtFuryCapPerformance}
@@ -99,8 +89,8 @@ function CoreSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
         </p>
         <ActiveTimeGraph
           activeTimeSegments={modules.alwaysBeCasting.activeTimeSegments}
-          fightStart={info.fight.start_time}
-          fightEnd={info.fight.end_time}
+          fightStart={info.fightStart}
+          fightEnd={info.fightEnd}
         />
       </SubSection>
     </Section>

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -826,10 +826,6 @@ class CombatLogParser {
       defaultRange: this.getModule(Abilities).defaultRange,
       playerId: this.selectedCombatant.id,
       pets: this.playerPets.filter((pet) => pet.fights.some((fight) => fight.id === this.fight.id)),
-      fight: {
-        ...this.fight,
-        duration: this.fight.end_time - this.fight.start_time,
-      },
       fightStart: this.fight.start_time,
       fightEnd: this.fight.end_time,
       fightDuration: this.fight.end_time - this.fight.start_time,

--- a/src/parser/core/metric.ts
+++ b/src/parser/core/metric.ts
@@ -14,22 +14,9 @@ export interface Info {
   // TODO: this piece of plucking props from the Abilities module is not ideal
   abilities: Ability[];
   defaultRange: number;
-  fight: WCLFightWithDuration;
-  /**
-   * @deprecated use {@link fight} instead
-   */
   fightStart: number;
-  /**
-   * @deprecated use {@link fight} instead
-   */
   fightEnd: number;
-  /**
-   * @deprecated use {@link fight} instead
-   */
   fightDuration: number;
-  /**
-   * @deprecated use {@link fight} instead
-   */
   fightId: number;
   reportCode: string;
   combatant: Combatant;


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fight data was accessible using `useFight()` instead of the Guide context.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/JnB4Mxfb7FLQR6XK/2-Mythic++Dawn+of+the+Infinite:+Galakrond's+Fall+-+Wipe+1+(29:59)/1-Dholy/standard`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/5d527ce3-e097-4d65-9e75-cfc10e2aa012)
