### PR TITLE
Fix chain light damage calculation

### DIFF
--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Taum, Vetyst, Vohrr, xunni, Seriousnes, ToppleTheNun, Putro } from 'CON
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 4, 10), <><SpellLink spell={TALENTS.CHAIN_LIGHTNING_TALENT} /> damage calculations didn't include chains</>, Seriousnes),
   change(date(2024, 3, 26), 'Remove support for Shadowlands tier set.', ToppleTheNun),
   change(date(2024, 1, 17), <>Mark as updated for 10.2.5, updating relevant statistics now that <SpellLink spell={TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT} /> does elemental damage.</>, Seriousnes),
   change(date(2024, 1, 7), <><SpellLink spell={SPELLS.LIGHTNING_BOLT} /> with <SpellLink spell={TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT} /> should require 8 <SpellLink spell={SPELLS.MAELSTROM_WEAPON} /> rather than 5</>, Seriousnes),

--- a/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/resourcetracker/MaelstromWeaponSpenders.tsx
@@ -18,7 +18,11 @@ import { formatNumber, formatThousands } from 'common/format';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
 import SPELLS, { maybeGetSpell } from 'common/SPELLS';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-import { LIGHTNING_BOLT_LINK, MAELSTROM_SPENDER_LINK } from '../normalizers/EventLinkNormalizer';
+import {
+  CHAIN_LIGHTNING_LINK,
+  LIGHTNING_BOLT_LINK,
+  MAELSTROM_SPENDER_LINK,
+} from '../normalizers/EventLinkNormalizer';
 import { PRIMORDIAL_WAVE_LINK } from 'analysis/retail/shaman/shared/constants';
 
 class MaelstromWeaponSpenders extends Analyzer {
@@ -54,6 +58,18 @@ class MaelstromWeaponSpenders extends Analyzer {
   onCast(event: CastEvent) {
     this.recordNextSpenderAmount = HasRelatedEvent(event, MAELSTROM_SPENDER_LINK);
 
+    if (event.ability.guid === TALENTS_SHAMAN.CHAIN_LIGHTNING_TALENT.id) {
+      const damageEvents = GetRelatedEvents<DamageEvent>(
+        event,
+        CHAIN_LIGHTNING_LINK,
+        (e) => e.type === EventType.Damage,
+      );
+      this.spenderValues[event.ability.guid] =
+        (this.spenderValues[event.ability.guid] ?? 0) +
+        damageEvents.reduce((total: number, de: DamageEvent) => (total += de.amount), 0);
+      this.recordNextSpenderAmount = false;
+      return;
+    }
     if (event.ability.guid === SPELLS.LIGHTNING_BOLT.id) {
       // lightning bolts linked to a primoridal wave should be included as part of primoridal wave's damage
       const primordialWave = GetRelatedEvent<CastEvent>(
@@ -85,6 +101,7 @@ class MaelstromWeaponSpenders extends Analyzer {
             this.maelstromWeaponTracker.lastSpenderInfo?.amount ?? 0;
         }
       }
+      return;
     }
   }
 
@@ -162,6 +179,14 @@ class MaelstromWeaponSpenders extends Analyzer {
             })}
           </tbody>
         </table>
+        <div className="panel-footer">
+          <p>
+            <small>
+              Note: Damage/Healing values include increases from Augmentation Evokers. Click the{' '}
+              <i>Augmented Damage</i>/<i>Augmented Healing</i> tabs in WCL if the values don't align
+            </small>
+          </p>
+        </div>
       </Panel>,
     ];
   }


### PR DESCRIPTION
### Description

Chain Lightning damage statistics didn't include chains

### Testing

Check "average cast" column in WCL (with Augmented Damage enabled)

- Test report URL: `/report/XRQvMhHFTnWV2xtG/18-Mythic+Fyrakk+the+Blazing+-+Wipe+17+(6:59)/Cyonic/standard/statistics`
- Screenshot(s):
