### PR TITLE
update paths used by Sentry for error reporting

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -103,8 +103,8 @@ const config: PlaywrightTestConfig = {
   webServer: process.env.CI
     ? {
         command: 'npx vite preview --outDir dist --port 3000',
-        port: 3000,
         timeout: 60000,
+        url: 'http://localhost:3000/',
       }
     : undefined,
 };

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 4, 10), 'Update paths used by Sentry.', ToppleTheNun),
   change(date(2024, 4, 10), 'Update dependencies.', ToppleTheNun),
   change(date(2024, 4, 9), 'Swap to Vite instead of create-react-app and use the WCL V2 API.', [ToppleTheNun, emallson]),
   change(date(2024, 4, 8), 'Fix handling of character parse lookup for Classic', emallson),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,20 +26,18 @@ if (import.meta.env.VITE_SENTRY_DSN) {
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
     integrations: [
-      new Sentry.BrowserTracing({
-        routingInstrumentation: Sentry.reactRouterV6Instrumentation(
-          useEffect,
-          useLocation,
-          useNavigationType,
-          createRoutesFromChildren,
-          matchRoutes,
-        ),
+      Sentry.reactRouterV6BrowserTracingIntegration({
+        useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
       }),
     ],
 
     release: import.meta.env.VITE_VERSION,
     environment: import.meta.env.VITE_ENVIRONMENT_NAME,
-    allowUrls: ['wowanalyzer.com/static/js/'],
+    allowUrls: ['wowanalyzer.com/assets/'],
 
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Fix paths used by Sentry as our JS files now live at URLs like https://wowanalyzer.com/assets/index-6D59v4AH.js.
