### PR TITLE
Druid Balance: fixed an issue where CA/Incarn casts weren't being detected while Oribital Strike is talented

### DIFF
--- a/src/analysis/retail/druid/balance/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/balance/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Hartra344, Sref, ToppleTheNun, ap2355, attluh, Jundarer } from 'CONTRIB
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 4, 10), <>Fixed an issue where <SpellLink spell={TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT} /> and <SpellLink spell={TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT} /> weren't tracked properly when <SpellLink spell={TALENTS_DRUID.ORBITAL_STRIKE_TALENT} /> is talented.</>, Sref),
   change(date(2024, 1, 19), <>Marked up to date for 10.2.5</>, Sref),
   change(date(2023, 11, 13), <>Added Active Time breakdown to Incarnation casts. Added <SpellLink spell={TALENTS_DRUID.WILD_MUSHROOM_TALENT} /> usage section. Tweaked spell efficiency thresholds.</>, Sref),
   change(date(2023, 11, 12), <>Added Active Time Graph to Guide.</>, Sref),

--- a/src/analysis/retail/druid/balance/Guide.tsx
+++ b/src/analysis/retail/druid/balance/Guide.tsx
@@ -17,6 +17,7 @@ import {
 } from 'analysis/retail/druid/balance/modules/core/astralpower/AstralPowerTracker';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
 import ActiveTimeGraph from 'parser/ui/ActiveTimeGraph';
+import { cdSpell } from 'analysis/retail/druid/balance/constants';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -140,17 +141,9 @@ function CooldownGraphSubsection({ modules, events, info }: GuideProps<typeof Co
       you waited to use them again. Grey segments show when the spell was available, yellow segments
       show when the spell was cooling down. Red segments highlight times when you could have fit a
       whole extra use of the cooldown.
-      {info.combatant.hasTalent(TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT) &&
-        !info.combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT) && (
-          <CastEfficiencyBar
-            spellId={SPELLS.CELESTIAL_ALIGNMENT.id}
-            gapHighlightMode={GapHighlight.FullCooldown}
-            useThresholds
-          />
-        )}
-      {info.combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT) && (
+      {info.combatant.hasTalent(TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT) && (
         <CastEfficiencyBar
-          spellId={SPELLS.INCARNATION_CHOSEN_OF_ELUNE.id}
+          spellId={cdSpell(info.combatant).id}
           gapHighlightMode={GapHighlight.FullCooldown}
           useThresholds
         />

--- a/src/analysis/retail/druid/balance/constants.ts
+++ b/src/analysis/retail/druid/balance/constants.ts
@@ -21,9 +21,15 @@ export const WHITELIST_ABILITIES = [
 
 /** Returns the Balance Druid's primary cooldown spell, which changes based on talent */
 export function cdSpell(c: Combatant): Spell {
-  return c.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT)
-    ? SPELLS.INCARNATION_CHOSEN_OF_ELUNE
-    : SPELLS.CELESTIAL_ALIGNMENT;
+  const hasIncarn = c.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT);
+  const hasOs = c.hasTalent(TALENTS_DRUID.ORBITAL_STRIKE_TALENT);
+  return hasIncarn
+    ? hasOs
+      ? SPELLS.INCARNATION_ORBITAL_STRIKE
+      : SPELLS.INCARNATION_CHOSEN_OF_ELUNE
+    : hasOs
+      ? SPELLS.CELESTIAL_ALIGNMENT_ORBITAL_STRIKE
+      : SPELLS.CELESTIAL_ALIGNMENT;
 }
 
 export const CA_DURATION = 20_000;

--- a/src/analysis/retail/druid/balance/modules/Abilities.tsx
+++ b/src/analysis/retail/druid/balance/modules/Abilities.tsx
@@ -83,9 +83,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.8,
         },
-        gcd: {
-          base: combatant.hasTalent(TALENTS_DRUID.ORBITAL_STRIKE_TALENT) ? 1500 : 0,
-        },
+        gcd: combatant.hasTalent(TALENTS_DRUID.ORBITAL_STRIKE_TALENT) ? { base: 1500 } : null,
         timelineSortIndex: 9,
       },
       {
@@ -100,9 +98,7 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.8,
         },
-        gcd: {
-          base: combatant.hasTalent(TALENTS_DRUID.ORBITAL_STRIKE_TALENT) ? 1500 : 0,
-        },
+        gcd: combatant.hasTalent(TALENTS_DRUID.ORBITAL_STRIKE_TALENT) ? { base: 1500 } : null,
         timelineSortIndex: 9,
       },
       {

--- a/src/analysis/retail/druid/balance/modules/Abilities.tsx
+++ b/src/analysis/retail/druid/balance/modules/Abilities.tsx
@@ -3,6 +3,7 @@ import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 import { TALENTS_DRUID } from 'common/TALENTS';
+import { cdSpell } from 'analysis/retail/druid/balance/constants';
 
 class Abilities extends CoreAbilities {
   spellbook() {
@@ -73,7 +74,7 @@ class Abilities extends CoreAbilities {
 
       // Cooldowns
       {
-        spell: SPELLS.INCARNATION_CHOSEN_OF_ELUNE.id,
+        spell: cdSpell(combatant).id,
         buffSpellId: SPELLS.INCARNATION_CHOSEN_OF_ELUNE.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: combatant.hasTalent(TALENTS_DRUID.ORBITAL_STRIKE_TALENT) ? 120 : 180,
@@ -82,10 +83,13 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.8,
         },
+        gcd: {
+          base: combatant.hasTalent(TALENTS_DRUID.ORBITAL_STRIKE_TALENT) ? 1500 : 0,
+        },
         timelineSortIndex: 9,
       },
       {
-        spell: SPELLS.CELESTIAL_ALIGNMENT.id,
+        spell: cdSpell(combatant).id,
         buffSpellId: SPELLS.CELESTIAL_ALIGNMENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: combatant.hasTalent(TALENTS_DRUID.ORBITAL_STRIKE_TALENT) ? 120 : 180,
@@ -95,6 +99,9 @@ class Abilities extends CoreAbilities {
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.8,
+        },
+        gcd: {
+          base: combatant.hasTalent(TALENTS_DRUID.ORBITAL_STRIKE_TALENT) ? 1500 : 0,
         },
         timelineSortIndex: 9,
       },

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -785,6 +785,18 @@ const spells = {
     name: 'Celestial Alignment',
     icon: 'spell_nature_natureguardian',
   },
+  CELESTIAL_ALIGNMENT_ORBITAL_STRIKE: {
+    // CA has different cast ID when Orbital Strike is talented
+    id: 383410,
+    name: 'Celestial Alignment',
+    icon: 'spell_nature_natureguardian',
+  },
+  INCARNATION_ORBITAL_STRIKE: {
+    // Incarn has different cast ID when Orbital Strike is talented
+    id: 390414, // TODO double check this
+    name: 'Incarnation: Chosen of Elune',
+    icon: 'spell_druid_incarnation',
+  },
   NATURES_GRACE: {
     id: 393959,
     name: "Nature's Grace",


### PR DESCRIPTION
### Description

When Orbital Strike is talented, CA/Incarn casts have a different ID and are on the GCD. This PR handles these cases.

### Testing

- Test report URL: `report/9bPGBg4YANL1DkZf/5-Mythic+Gnarlroot+-+Kill+(2:48)/Gamz/standard/about`
