### PR TITLE
fix mana level chart

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 4, 12), 'Fix mana level chart', emallson),
   change(date(2024, 4, 10), 'Update paths used by Sentry.', ToppleTheNun),
   change(date(2024, 4, 10), 'Update dependencies.', ToppleTheNun),
   change(date(2024, 4, 9), 'Swap to Vite instead of create-react-app and use the WCL V2 API.', [ToppleTheNun, emallson]),

--- a/src/analysis/retail/monk/brewmaster/modules/problems/PurifyingBrew/index.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/problems/PurifyingBrew/index.tsx
@@ -32,7 +32,7 @@ import CastReasonBreakdownTableContents from 'interface/guide/components/CastRea
 
 export { default } from './analyzer';
 
-export function useThreatTable({
+function useThreatTable({
   reportCode,
   fightStart,
   fightEnd,

--- a/src/interface/report/ConfigContext.tsx
+++ b/src/interface/report/ConfigContext.tsx
@@ -1,46 +1,25 @@
-import Config from 'parser/Config';
-import { createContext, useContext, ReactNode } from 'react';
+import type Config from 'parser/Config';
 import { usePlayer } from 'interface/report/context/PlayerContext';
 import { useReport } from 'interface/report/context/ReportContext';
 import getConfig from 'parser/getConfig';
 import { wclGameVersionToExpansion } from 'game/VERSIONS';
 
-const ConfigContext = createContext<Config | undefined>(undefined);
-
-export default ConfigContext;
-
-export const useConfig = () => {
-  const ctx = useContext(ConfigContext);
-  if (ctx === undefined) {
-    throw new Error('Unable to get Config for selected report/player combination');
-  }
-  return ctx;
+export const useMaybeConfig = (): Config | undefined => {
+  const { report } = useReport();
+  const { player, combatant } = usePlayer();
+  return getConfig(
+    wclGameVersionToExpansion(report.gameVersion),
+    combatant.specID,
+    player,
+    combatant,
+  );
 };
 
-interface ConfigProviderProps {
-  children: ReactNode;
-  config: Config | undefined;
-}
-export const ConfigProvider = ({ children, config }: ConfigProviderProps) => (
-  <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>
-);
+export const useConfig = (): Config => {
+  const config = useMaybeConfig();
+  if (!config) {
+    throw new Error('Unable to get Config for selected report/player combination');
+  }
 
-interface ReportPlayerConfigProviderProps {
-  children: ReactNode;
-}
-export const ReportPlayerConfigProvider = ({ children }: ReportPlayerConfigProviderProps) => {
-  const { combatant, player } = usePlayer();
-  const { report } = useReport();
-  return (
-    <ConfigProvider
-      config={getConfig(
-        wclGameVersionToExpansion(report.gameVersion),
-        combatant.specID,
-        player,
-        combatant,
-      )}
-    >
-      {children}
-    </ConfigProvider>
-  );
+  return config;
 };

--- a/src/interface/report/ConfigContext.tsx
+++ b/src/interface/report/ConfigContext.tsx
@@ -15,7 +15,7 @@ export const useMaybeConfig = (): Config | undefined => {
     /* do nothing */
   }
   let player = undefined;
-    let combatant = undefined;
+  let combatant = undefined;
 
   try {
     const playerData = usePlayer();

--- a/src/interface/report/ConfigContext.tsx
+++ b/src/interface/report/ConfigContext.tsx
@@ -5,8 +5,29 @@ import getConfig from 'parser/getConfig';
 import { wclGameVersionToExpansion } from 'game/VERSIONS';
 
 export const useMaybeConfig = (): Config | undefined => {
-  const { report } = useReport();
-  const { player, combatant } = usePlayer();
+  // this mess of try/catch papers over some historical choices to throw for these contexts instead of allowing them to return undefined.
+  // that refactor is...big enough that i'm not doing it today
+  let report = undefined;
+  try {
+    const data = useReport();
+    report = data.report;
+  } catch {
+    /* do nothing */
+  }
+  let player = undefined;
+    let combatant = undefined;
+
+  try {
+    const playerData = usePlayer();
+    player = playerData.player;
+    combatant = playerData.combatant;
+  } catch {
+    /* do nothing */
+  }
+
+  if (!report || !player || !combatant) {
+    return undefined;
+  }
   return getConfig(
     wclGameVersionToExpansion(report.gameVersion),
     combatant.specID,

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -4,7 +4,7 @@ import NavigationBar from 'interface/NavigationBar';
 import { useCallback, useState } from 'react';
 
 import BOSS_PHASES_STATE from './BOSS_PHASES_STATE';
-import { ReportPlayerConfigProvider, useConfig } from './ConfigContext';
+import { useConfig } from './ConfigContext';
 import EVENT_PARSING_STATE from './EVENT_PARSING_STATE';
 import { ReportExpansionContextProvider } from './ExpansionContext';
 import FightSelection from './FightSelection';
@@ -214,11 +214,9 @@ const ReportLayout = () => (
           <PatchChecker>
             <FightSelection>
               <PlayerLoader>
-                <ReportPlayerConfigProvider>
-                  <SupportChecker>
-                    <ResultsLoader />
-                  </SupportChecker>
-                </ReportPlayerConfigProvider>
+                <SupportChecker>
+                  <ResultsLoader />
+                </SupportChecker>
               </PlayerLoader>
             </FightSelection>
           </PatchChecker>

--- a/src/interface/useGoogleAnalytics.ts
+++ b/src/interface/useGoogleAnalytics.ts
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react';
-import ConfigContext from './report/ConfigContext';
+import { useMaybeConfig } from './report/ConfigContext';
 import FightCtx from './report/context/FightContext';
 
 interface PageViewProperties {
@@ -27,7 +27,7 @@ declare global {
  * to add extra tags to the page view event.
  */
 export function usePageView(componentName: string, key?: unknown) {
-  const config = useContext(ConfigContext);
+  const config = useMaybeConfig();
   const fight = useContext(FightCtx);
   useEffect(() => {
     const props = {

--- a/src/parser/Config.ts
+++ b/src/parser/Config.ts
@@ -6,7 +6,7 @@ import { AlertKind } from 'interface/Alert';
 import CombatLogParser from 'parser/core/CombatLogParser';
 import { ReactNode } from 'react';
 
-import { Stats } from './shared/modules/StatTracker';
+import type { Stats } from './shared/modules/StatTracker';
 
 export type Build = {
   url: string;

--- a/src/parser/shared/modules/resources/mana/ManaLevelChartComponent.tsx
+++ b/src/parser/shared/modules/resources/mana/ManaLevelChartComponent.tsx
@@ -43,11 +43,11 @@ class ManaLevelChartComponent extends PureComponent<Props, State> {
 
   load() {
     const { reportCode, start, end } = this.props;
-    fetchWcl(`report/tables/resources/${reportCode}`, {
+    fetchWcl(`report/graph/resources/${reportCode}`, {
       start,
       end,
       sourceclass: 'Boss',
-      hostility: 1,
+      hostility: 'Enemies',
       abilityid: 1000,
     }).then((json) => {
       this.setState({


### PR DESCRIPTION
> so the v1 api has a special case for the resources "table" endpoint that causes it to return graph data. the v2 api doesn't do that, so it was returning an (empty) table, which broke the chart