### PR TITLE
Support DF S3 and S4 tier sets for enhancement

### DIFF
--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -6,7 +6,7 @@ import { Earosselot, Sharrq, Sref, ToppleTheNun } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
-  change(date(2024, 20, 4), <>Improved <SpellLink spell={SPELLS.WINTERS_CHILL} /> analysis on guide. Setting guide as default view. </>, Earosselot),
+  change(date(2024, 4, 20), <>Improved <SpellLink spell={SPELLS.WINTERS_CHILL} /> analysis on guide. Setting guide as default view. </>, Earosselot),
   change(date(2024, 4, 5), <>Added <SpellLink spell={TALENTS.CRYOPATHY_TALENT} /> statistics</>, Earosselot),
   change(date(2024, 4, 4), <>Minor error correction <SpellLink spell={TALENTS.GREATER_INVISIBILITY_TALENT} /> cast  </>, Earosselot),
   change(date(2024, 4, 4), <>Fixed <SpellLink spell={TALENTS.ALTER_TIME_TALENT} /> GCD, added <SpellLink spell={TALENTS.ICE_COLD_TALENT} /> to spellbook </>, Earosselot),

--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -5,6 +5,8 @@ import { Taum, Vetyst, Vohrr, xunni, Seriousnes, ToppleTheNun, Putro } from 'CON
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 4, 24), <>Updating mana cost for <SpellLink spell={TALENTS.EARTH_SHIELD_TALENT} />.</>, Seriousnes),
+  change(date(2024, 4, 24), <>Updated to 10.2.6 compatibility </>, Seriousnes),
   change(date(2024, 4, 10), <><SpellLink spell={TALENTS.CHAIN_LIGHTNING_TALENT} /> damage calculations didn't include chains</>, Seriousnes),
   change(date(2024, 3, 26), 'Remove support for Shadowlands tier set.', ToppleTheNun),
   change(date(2024, 1, 17), <>Mark as updated for 10.2.5, updating relevant statistics now that <SpellLink spell={TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT} /> does elemental damage.</>, Seriousnes),

--- a/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
@@ -112,7 +112,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Tier
     tier30: Tiers.T30,
-    tier31: Tiers.T31,
+    tier31: Tiers.Season3And4Tier,
 
     // Items
     callToDominance: CallToDominance,

--- a/src/analysis/retail/shaman/enhancement/modules/apl/AplCheck.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/apl/AplCheck.tsx
@@ -17,9 +17,9 @@ import SPELLS from 'common/SPELLS';
 import { AtLeastFiveMSW, MaxStacksMSW } from './Conditions';
 import { TIERS } from 'game/TIERS';
 import {
-  getTier31ElementalistApl,
-  getTier31StormApl,
-} from 'analysis/retail/shaman/enhancement/modules/apl/Tier31';
+  getSeason3or4ElementalistApl,
+  getSeason3or4StormApl,
+} from 'analysis/retail/shaman/enhancement/modules/apl/DragonflightS3AndS4';
 
 /**
  * Based on https://www.icy-veins.com/wow/enhancement-shaman-pve-dps-guide
@@ -28,11 +28,11 @@ import {
 export const apl = (info: PlayerInfo): Apl => {
   const combatant = info.combatant;
 
-  if (combatant.has4PieceByTier(TIERS.DF3)) {
+  if (combatant.has4PieceByTier(TIERS.DF3) || combatant.has4PieceByTier(TIERS.DF4)) {
     return build(
       combatant.hasTalent(TALENTS.HOT_HAND_TALENT)
-        ? getTier31ElementalistApl()
-        : getTier31StormApl(),
+        ? getSeason3or4ElementalistApl()
+        : getSeason3or4StormApl(),
     );
   }
   const rules: Rule[] = [];

--- a/src/analysis/retail/shaman/enhancement/modules/apl/DragonflightS3AndS4.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/apl/DragonflightS3AndS4.tsx
@@ -11,7 +11,7 @@ import {
 import { minimumMaelstromWeaponStacks } from 'analysis/retail/shaman/enhancement/modules/apl/Conditions';
 import SpellLink from 'interface/SpellLink';
 
-export function getTier31ElementalistApl(): Rule[] {
+export function getSeason3or4ElementalistApl(): Rule[] {
   return [
     {
       spell: SPELLS.FLAME_SHOCK,
@@ -64,7 +64,7 @@ export function getTier31ElementalistApl(): Rule[] {
   ];
 }
 
-export function getTier31StormApl(): Rule[] {
+export function getSeason3or4StormApl(): Rule[] {
   return [
     {
       spell: SPELLS.WINDSTRIKE_CAST,

--- a/src/analysis/retail/shaman/enhancement/modules/dragonflight/Season3And4Tier.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/dragonflight/Season3And4Tier.tsx
@@ -8,14 +8,14 @@ import { TALENTS_SHAMAN } from 'common/TALENTS';
 import Events, { CastEvent } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import ItemSetLink from 'interface/ItemSetLink';
-import { SHAMAN_DF3_ID } from 'common/ITEMS/dragonflight';
+import { SHAMAN_DF3_ID, SHAMAN_DF4_ID } from 'common/ITEMS/dragonflight';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import { UptimeIcon } from 'interface/icons';
 import { formatNumber, formatPercentage } from 'common/format';
 
 const PRIMORDIAL_WAVE_COOLDOWN_PER_SUMMON = 7000;
 
-class Tier31 extends Analyzer {
+class Season3And4Tier extends Analyzer {
   static dependencies = {
     abilities: Abilities,
     spellUsable: SpellUsable,
@@ -31,7 +31,8 @@ class Tier31 extends Analyzer {
     super(options);
 
     this.active =
-      this.selectedCombatant.has4PieceByTier(TIERS.DF3) &&
+      (this.selectedCombatant.has4PieceByTier(TIERS.DF3) ||
+        this.selectedCombatant.has4PieceByTier(TIERS.DF4)) &&
       this.selectedCombatant.hasTalent(TALENTS_SHAMAN.PRIMORDIAL_WAVE_SPEC_TALENT);
     if (!this.active) {
       return;
@@ -78,6 +79,10 @@ class Tier31 extends Analyzer {
   }
 
   statistic() {
+    const tierSetId = this.selectedCombatant.has4PieceByTier(TIERS.DF4)
+      ? SHAMAN_DF4_ID
+      : SHAMAN_DF3_ID;
+
     return (
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL(0)}
@@ -95,7 +100,7 @@ class Tier31 extends Analyzer {
       >
         <div className="pad boring-text">
           <label>
-            <ItemSetLink id={SHAMAN_DF3_ID}>
+            <ItemSetLink id={tierSetId}>
               <>
                 Vision of the Greatwolf Outcast
                 <br />
@@ -117,4 +122,4 @@ class Tier31 extends Analyzer {
   }
 }
 
-export default Tier31;
+export default Season3And4Tier;

--- a/src/analysis/retail/shaman/enhancement/modules/dragonflight/TierSets.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/dragonflight/TierSets.tsx
@@ -1,2 +1,2 @@
 export { default as T30 } from './Tier30';
-export { default as T31 } from './Tier31';
+export { default as Season3And4Tier } from './Season3And4Tier';

--- a/src/common/TALENTS/shaman.ts
+++ b/src/common/TALENTS/shaman.ts
@@ -349,7 +349,7 @@ const talents = {
     maxRanks: 1,
     entryIds: [102004],
     definitionIds: [{ id: 106968, specId: 262 }],
-    manaCost: 5000,
+    manaCost: 12500,
   },
   EARTH_SHOCK_TALENT: {
     id: 8042,


### PR DESCRIPTION
### Description

* Adding support for S4 tier set
* Earth Shield mana cost was wrong
* Frost Mage changelog was using wrong format

### Testing

- Test report URL: `/report/mjypMY7QtC6TLP1w/17-Mythic+Fyrakk+the+Blazing+-+Kill+(9:26)/2-Seriousnes/standard`
