### PR TITLE
fix for the fix for source/targetIsFriendly

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 4, 26), 'Actually fix friendly/enemy determination', emallson),
   change(date(2024, 4, 24), 'Bump for season 4 start.', ToppleTheNun),
   change(date(2024, 4, 22), 'Clean up dead code using knip', Putro),
   change(date(2024, 4, 20), 'Fix friendly/enemy determination', emallson),

--- a/src/parser/core/CombatLogParser.test.jsx
+++ b/src/parser/core/CombatLogParser.test.jsx
@@ -16,6 +16,7 @@ const fakeConfig = {};
 const fakeReport = {
   friendlies: [],
   friendlyPets: [],
+  enemies: [],
 };
 const fakePlayer = {
   id: 1,

--- a/src/parser/core/FriendlyCompatNormalizer.ts
+++ b/src/parser/core/FriendlyCompatNormalizer.ts
@@ -25,7 +25,8 @@ export default class FriendlyCompatNormalizer extends EventsNormalizer {
       }
       if (
         event.type === EventType.Absorbed &&
-        (event.attackerID ?? 0) > 0 &&
+        event.attackerID &&
+        event.attackerID > 0 &&
         event.attackerIsFriendly === undefined
       ) {
         event.attackerIsFriendly = !this.enemies.isEnemy(event.attackerID, event.attackerInstance);

--- a/src/parser/core/FriendlyCompatNormalizer.ts
+++ b/src/parser/core/FriendlyCompatNormalizer.ts
@@ -1,6 +1,6 @@
 import { HasSource, HasTarget, AnyEvent, EventType } from './Events';
 import EventsNormalizer from './EventsNormalizer';
-import Enemies, { encodeTargetString } from 'parser/shared/modules/Enemies';
+import Enemies from 'parser/shared/modules/Enemies';
 
 export default class FriendlyCompatNormalizer extends EventsNormalizer {
   priority = -1000;
@@ -13,28 +13,24 @@ export default class FriendlyCompatNormalizer extends EventsNormalizer {
 
   normalize(events: AnyEvent[]): AnyEvent[] {
     for (const event of events) {
-      if (HasSource(event) && event.sourceIsFriendly === undefined) {
-        event.sourceIsFriendly = this.isFriendly(event.sourceID, event.sourceInstance);
+      if (HasSource(event) && event.sourceID > 0 && event.sourceIsFriendly === undefined) {
+        event.sourceIsFriendly = !this.enemies.isEnemy(event.sourceID, event.sourceInstance);
       }
       if (
         HasTarget(event) &&
+        event.targetID > 0 &&
         (event as unknown as Record<string, unknown>).targetIsFriendly === undefined
       ) {
-        event.targetIsFriendly = this.isFriendly(event.targetID, event.targetInstance);
+        event.targetIsFriendly = !this.enemies.isEnemy(event.targetID, event.targetInstance);
       }
       if (
         event.type === EventType.Absorbed &&
-        event.attackerID &&
+        (event.attackerID ?? 0) > 0 &&
         event.attackerIsFriendly === undefined
       ) {
-        event.attackerIsFriendly = this.isFriendly(event.attackerID, event.attackerInstance);
+        event.attackerIsFriendly = !this.enemies.isEnemy(event.attackerID, event.attackerInstance);
       }
     }
     return events;
-  }
-
-  private isFriendly(actorId: number, instance?: number): boolean {
-    const key = encodeTargetString(actorId, instance);
-    return this.enemies.enemies[key] !== undefined;
   }
 }

--- a/src/parser/shared/modules/Enemies.ts
+++ b/src/parser/shared/modules/Enemies.ts
@@ -3,6 +3,7 @@ import { TrackedBuffEvent } from 'parser/core/Entity';
 import { AnyEvent, HasSource, HasTarget, SourcedEvent, TargettedEvent } from 'parser/core/Events';
 
 import Entities from './Entities';
+import { Options } from 'parser/core/Analyzer';
 
 const debug = false;
 
@@ -50,9 +51,42 @@ export function decodeTargetString(string: string) {
 
 class Enemies extends Entities<Enemy> {
   enemies: { [enemyId: string]: Enemy } = {};
+  /**
+   * The set of all known enemy ids. Used to speed up negative lookups.
+   */
+  enemyIds: Set<number>;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.enemyIds = new Set(this.owner.report.enemies.map((enemy) => enemy.id));
+  }
 
   getEntities() {
     return this.enemies;
+  }
+
+  isEnemy(id: number, instanceId?: number): boolean {
+    return this.getById(id, instanceId) !== null;
+  }
+
+  getById(id: number, instanceId?: number): Enemy | null {
+    if (!this.enemyIds.has(id)) {
+      return null;
+    }
+    const enemyId = encodeTargetString(id, instanceId ?? 0);
+
+    let enemy = this.enemies[enemyId];
+
+    if (!enemy) {
+      const baseInfo = this.owner.report.enemies.find((enemy: { id: number }) => enemy.id === id);
+      if (!baseInfo) {
+        debug && console.warn('Enemy not noteworthy enough:', id, instanceId);
+        return null;
+      }
+      this.enemies[enemyId] = enemy = new Enemy(this.owner, baseInfo, instanceId);
+    }
+    return enemy;
   }
 
   /**
@@ -64,27 +98,7 @@ class Enemies extends Entities<Enemy> {
     if (!HasTarget(event)) {
       return null;
     }
-    if (event.targetIsFriendly) {
-      return null;
-    }
-    const targetId = event.targetID;
-    const targetInstance = event.targetInstance || 0;
-
-    const enemyId = encodeTargetString(targetId, targetInstance);
-
-    let enemy = this.enemies[enemyId];
-
-    if (!enemy) {
-      const baseInfo = this.owner.report.enemies.find(
-        (enemy: { id: number }) => enemy.id === targetId,
-      );
-      if (!baseInfo) {
-        debug && console.warn('Enemy not noteworthy enough:', targetId, targetInstance, event);
-        return null;
-      }
-      this.enemies[enemyId] = enemy = new Enemy(this.owner, baseInfo, targetInstance);
-    }
-    return enemy;
+    return this.getById(event.targetID, event.targetInstance);
   }
 
   /**
@@ -96,28 +110,8 @@ class Enemies extends Entities<Enemy> {
     if (!HasSource(event)) {
       return null;
     }
-    if (event.sourceIsFriendly) {
-      return null;
-    }
 
-    const sourceId = event.sourceID;
-    const sourceInstance = event.sourceInstance ?? 0;
-
-    const enemyId = encodeTargetString(sourceId, sourceInstance);
-
-    let enemy = this.enemies[enemyId];
-
-    if (!enemy) {
-      const baseInfo = this.owner.report.enemies.find(
-        (enemy: { id: number }) => enemy.id === sourceId,
-      );
-      if (!baseInfo) {
-        debug && console.warn('Enemy not noteworthy enough:', sourceId, sourceInstance, event);
-        return null;
-      }
-      this.enemies[enemyId] = enemy = new Enemy(this.owner, baseInfo, sourceInstance);
-    }
-    return enemy;
+    return this.getById(event.sourceID, event.sourceInstance);
   }
 
   /**


### PR DESCRIPTION
after initially confirming that my fix for this worked, I broke it (oops).

while debugging this, I also discovered a subtle bug in the normalizer that would improperly set some enemies as friendly because they would not be in the `enemies` object yet since `getEntity` had not been called. I rewrote bits of `FriendlyCompatNormalizer` to (a) make sure that this does not happen, and (b) make sure that we're not doing a huge amount of `find` calls for lookups of ids that are not enemies.

this fixes the issue that @trevorm4 reported in discord