### PR TITLE
switch enemy "type" usage to "subType"

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 5, 2), 'Fix issue with boss detection', emallson),
   change(date(2024, 4, 24), 'Bump for season 4 start.', ToppleTheNun),
   change(date(2024, 4, 22), 'Clean up dead code using knip', Putro),
   change(date(2024, 4, 20), 'Fix friendly/enemy determination', emallson),

--- a/src/analysis/classic/warlock/affliction/modules/spells/DrainSoul.tsx
+++ b/src/analysis/classic/warlock/affliction/modules/spells/DrainSoul.tsx
@@ -68,7 +68,7 @@ class DrainSoul extends Analyzer {
   onFinished() {
     const allEnemies = this.enemies.getEntities();
     this.totalNumOfAdds = Object.values(allEnemies)
-      .filter((enemy) => enemy.type === 'NPC')
+      .filter((enemy) => enemy.subType === 'NPC')
       .reduce((count, enemy) => count + enemy._baseInfo.fights[0].instances, 0);
   }
 

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -108,7 +108,7 @@ class BuffTargetHelper extends Analyzer {
   filterBossDamage: boolean = false;
   nameFilter: string = '';
   bossFilter: string = this.owner.report.enemies
-    .filter((enemy) => enemy.type === 'Boss')
+    .filter((enemy) => enemy.subType === 'Boss')
     .map((enemy) => `${enemy.guid}`)
     .join(',');
   abilityBlacklist: string = [...ABILITY_BLACKLIST].join(', ');

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/CarefulAim.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/CarefulAim.tsx
@@ -68,7 +68,7 @@ class CarefulAim extends ExecuteHelper {
     this.active = this.selectedCombatant.hasTalent(TALENTS_HUNTER.CAREFUL_AIM_TALENT);
     this.owner.report.enemies.forEach((enemy) => {
       enemy.fights.forEach((fight) => {
-        if (fight.id === this.owner.fight.id && enemy.type === 'Boss') {
+        if (fight.id === this.owner.fight.id && enemy.subType === 'Boss') {
           this.bossIDs.push(enemy.id);
         }
       });

--- a/src/analysis/retail/warlock/affliction/modules/spells/DrainSoul.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/DrainSoul.tsx
@@ -77,7 +77,7 @@ class DrainSoul extends Analyzer {
       if (!enemy) {
         return;
       }
-      if (enemy.type.toLowerCase() === 'boss' && !this._lastEnergizeWasted) {
+      if (enemy.subType.toLowerCase() === 'boss' && !this._lastEnergizeWasted) {
         // it's a boss kill and we didn't waste the shard, subtract it
         this._subtractBossShards += 1;
       }
@@ -87,7 +87,7 @@ class DrainSoul extends Analyzer {
   onFinished() {
     const allEnemies = this.enemies.getEntities();
     this.totalNumOfAdds = Object.values(allEnemies)
-      .filter((enemy) => enemy.type === 'NPC')
+      .filter((enemy) => enemy.subType === 'NPC')
       .reduce((count, enemy) => count + enemy._baseInfo.fights[0].instances, 0);
     this._shardsGained =
       this.soulShardTracker.getGeneratedBySpell(SPELLS.DRAIN_SOUL_KILL_SHARD_GEN.id) -

--- a/src/analysis/retail/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.ts
+++ b/src/analysis/retail/warlock/demonology/modules/pets/normalizers/PrepullPetNormalizer.ts
@@ -104,6 +104,7 @@ class PrepullPetNormalizer extends EventsNormalizer {
               petOwner: this.owner.playerId,
               fights: [],
               type: 'faketype',
+              subType: 'faketype',
               icon: spell.icon,
             },
             timestamp: this.owner.fight.start_time,

--- a/src/interface/EventsTab.tsx
+++ b/src/interface/EventsTab.tsx
@@ -182,7 +182,7 @@ const EntityCell = ({ entity }: { entity: PlayerInfo | PetInfo | EnemyInfo | nul
   if (!entity) {
     return null;
   }
-  return <span className={entity.type}>{entity.name}</span>;
+  return <span className={entity.subType || entity.type}>{entity.name}</span>;
 };
 
 const AbilityCell = ({ ability }: { ability: Ability | null }) => {

--- a/src/parser/core/Enemy.ts
+++ b/src/parser/core/Enemy.ts
@@ -17,8 +17,14 @@ class Enemy extends Entity {
     return this._baseInfo.name;
   }
 
+  /** Generally "NPC" */
   get type() {
     return this._baseInfo.type;
+  }
+
+  /** Generally "Boss" or "NPC" */
+  get subType() {
+    return this._baseInfo.subType;
   }
 
   get guid() {

--- a/src/parser/core/Unit.ts
+++ b/src/parser/core/Unit.ts
@@ -3,6 +3,7 @@ interface Unit {
   id: number;
   guid: number;
   type: string;
+  subType: string;
   icon: string;
 }
 

--- a/src/parser/core/tests/constants.ts
+++ b/src/parser/core/tests/constants.ts
@@ -64,6 +64,7 @@ export const DEFAULT_PLAYER_INFO: PlayerInfo = {
   id: 1,
   name: '',
   type: '',
+  subType: '',
 };
 
 export const DEFAULT_FIGHT: Fight = {


### PR DESCRIPTION
tl;dr - in v1 the "type" field is actualy "subType". I mapped subType to type for Players but not enemies/pets. that mostly doesn't matter because they always match---*except* for bosses.

this fixes several cases where boss/add-related code broke because it was looking at the wrong field