### PR TITLE
[Evoker] Leaping Flames include absorbed healing

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS/evoker';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 export default [
+    change(date(2024, 5, 3), <>Fix <SpellLink spell={SPELLS.LEAPING_FLAMES_BUFF} /> module not counting absorbed healing.</>, Vollmer),
     change(date(2024, 4, 17), 'Update modules for 10.2.6.', Vollmer),
     change(date(2024, 4, 11), <>Rework <SpellLink spell={SPELLS.LEAPING_FLAMES_BUFF} /> module to increase accuracy.</>, Vollmer),
     change(date(2024, 4, 6), 'Normalize Empower behavior to make analysis more consistent.', Vollmer),

--- a/src/analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer.ts
@@ -162,7 +162,7 @@ const EVENT_LINKS: EventLink[] = [
     additionalCondition(linkingEvent, referencedEvent) {
       if (
         !hasNoGenerationLink(referencedEvent as AnyBuffEvent) ||
-        (linkingEvent as HealEvent).amount <= 0
+        (linkingEvent as HealEvent).amount + ((linkingEvent as HealEvent).absorbed ?? 0) <= 0
       ) {
         // Only effective heals can generated EB
         return false;

--- a/src/analysis/retail/evoker/shared/modules/talents/LeapingFlames.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/LeapingFlames.tsx
@@ -118,9 +118,12 @@ class LeapingFlames extends Analyzer {
           acc.damageHits += 1;
           this.leapingFlamesDamage += event.amount + (event.absorbed ?? 0);
         } else {
-          this.leapingFlamesHealing += event.amount;
+          const absHealAmount = event.amount + (event.absorbed ?? 0);
+
+          this.leapingFlamesHealing += absHealAmount;
           this.leapingFlamesOverHealing += event.overheal ?? 0;
-          if (event.amount > 0) {
+
+          if (absHealAmount > 0) {
             acc.healHits += 1;
           }
         }


### PR DESCRIPTION
### Description

Living Flame absorbed healing was ignored, it's now included.

### Testing

- Test report URL: `/report/hjXdqR9GKMCwpkYQ/76-Mythic+Rashok,+the+Elder+-+Kill+(5:51)/Vollmer/standard/statistics`
- Screenshot(s):
Before:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/cef1597f-4837-4066-8603-25da72770bff)
After:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/3404958/d97e206d-50b4-4fca-b10d-0980417ac929)

