### PR TITLE
Improve cache busting via Refresh button

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 5, 3), 'Improve behavior of "Refresh" button', emallson),
   change(date(2024, 5, 3), 'Second pass at cleaning up dead code using knip', Putro),
   change(date(2024, 5, 2), 'Fix issue with boss detection', emallson),
   change(date(2024, 4, 26), 'Actually fix friendly/enemy determination', emallson),

--- a/src/common/fetchWclApi.ts
+++ b/src/common/fetchWclApi.ts
@@ -89,12 +89,12 @@ export async function toJson(response: string | Response) {
   }
 }
 
-async function rawFetchWcl(endpoint: string, queryParams: QueryParams) {
+async function rawFetchWcl(endpoint: string, queryParams: QueryParams, noCache: boolean = false) {
   if (import.meta.env.MODE === 'test') {
     throw new Error('Unable to query WCL during test');
   }
   const url = makeWclApiUrl(endpoint, queryParams);
-  const response = await fetch(url);
+  const response = await fetch(url, { cache: noCache ? 'reload' : 'default' });
 
   if (Object.values(HTTP_CODES.CLOUDFLARE).includes(response.status)) {
     throw new ApiDownError(
@@ -133,6 +133,7 @@ export default function fetchWcl<T extends WCLResponseJSON>(
   endpoint: string,
   queryParams: QueryParams,
   options?: WclOptions,
+  noCache: boolean = false,
 ): Promise<T> {
   options = !options ? defaultOptions : { ...defaultOptions, ...options };
 
@@ -143,7 +144,7 @@ export default function fetchWcl<T extends WCLResponseJSON>(
       reject(new Error('Request timed out, probably due to an issue on our side. Try again.'));
     }, options!.timeout);
 
-    rawFetchWcl(endpoint, queryParams)
+    rawFetchWcl(endpoint, queryParams, noCache)
       .then((results) => {
         clearTimeout(timeoutTimer);
         if (timedOut) {
@@ -162,10 +163,14 @@ export default function fetchWcl<T extends WCLResponseJSON>(
 }
 
 function rawFetchFights(code: string, refresh = false, translate = true) {
-  return fetchWcl<WCLFightsResponse>(`report/fights/${code}`, {
-    _: refresh ? Number(new Date()) : undefined,
-    translate: translate ? true : undefined, // so long as we don't have the entire site localized, it's better to have 1 consistent language
-  });
+  return fetchWcl<WCLFightsResponse>(
+    `report/fights/${code}`,
+    {
+      translate: translate ? true : undefined, // so long as we don't have the entire site localized, it's better to have 1 consistent language
+    },
+    undefined,
+    refresh,
+  );
 }
 export async function fetchFights(code: string, refresh = false) {
   // This deals with a bunch of bugs in the fights API so implementers don't have to

--- a/src/game/ZONES.ts
+++ b/src/game/ZONES.ts
@@ -21,6 +21,7 @@ export interface Zone {
   frozen?: boolean;
   encounters: Encounter[];
   usePtrTooltips?: boolean;
+  partition?: number;
 }
 
 const ZONES: Zone[] = [
@@ -28,6 +29,7 @@ const ZONES: Zone[] = [
     id: 31,
     name: 'Vault of the Incarnates',
     frozen: false,
+    partition: 4,
     encounters: [
       vaultOfTheIncarnates.bosses.Eranog,
       vaultOfTheIncarnates.bosses.Terros,
@@ -58,6 +60,7 @@ const ZONES: Zone[] = [
     id: 33,
     name: 'Aberrus, the Shadowed Crucible',
     frozen: false,
+    partition: 6,
     encounters: [
       aberrus.bosses.Kazzara,
       aberrus.bosses.AmalgamationChamber,
@@ -91,6 +94,7 @@ const ZONES: Zone[] = [
     id: 35,
     name: "Amirdrassil, the Dream's Hope",
     frozen: false,
+    partition: 3,
     encounters: [
       amirdrassil.bosses.Gnarlroot,
       amirdrassil.bosses.Igira,

--- a/src/interface/CharacterParses.tsx
+++ b/src/interface/CharacterParses.tsx
@@ -313,18 +313,12 @@ class CharacterParses extends Component<CharacterParsesProps, CharacterParsesSta
 
     const data = await response.json();
 
-    if (!data.thumbnail) {
-      this.setState({
-        isLoading: false,
-        error: ERRORS.UNEXPECTED,
-        errorMessage: 'Corrupt Battle.net API response received.',
-      });
-      return;
-    }
-    const avatarUrl = data.thumbnail.startsWith('https')
-      ? data.thumbnail
-      : `https://render-${this.props.region}.worldofwarcraft.com/character/${data.thumbnail}`;
-    const imageUrl = avatarUrl.replace('avatar.jpg', 'main.jpg');
+    const avatarUrl = data.thumbnail
+      ? data.thumbnail.startsWith('https')
+        ? data.thumbnail
+        : `https://render-${this.props.region}.worldofwarcraft.com/character/${data.thumbnail}`
+      : undefined;
+    const imageUrl = avatarUrl?.replace('avatar.jpg', 'main.jpg');
     const role = data.role;
     const metric = role === 'HEALING' ? 'hps' : 'dps';
     this.setState(
@@ -389,10 +383,10 @@ class CharacterParses extends Component<CharacterParsesProps, CharacterParsesSta
         metric: this.state.metric,
         zone: this.state.activeZoneID,
         timeframe: 'historical',
-        _: refresh ? Number(new Date()) : undefined,
-        // Always refresh since requiring a manual refresh is unclear and unfriendly to users and they cache hits are low anyway
-        // _: +new Date(), // disabled due to Uldir raid release hitting cap all the time
+        partition: this.zones.find((z) => z.id === this.state.activeZoneID)?.partition ?? -1,
       },
+      undefined,
+      refresh,
     )
       .then((rawParses) => {
         if (rawParses.length === 0) {


### PR DESCRIPTION
Part of the v2 server migration greatly improved the use of caching and cache-control headers on the server. This had the side-effect of revealing some issues with our cache-busting method. Specifically: if you bust the cache by setting a query param, the new response is stored under a new URL. But when you refresh the page *the old response under the old URL is read.*

This PR changes the cache-busting method to use the `cache-control` header via the [`cache` parameter of `fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch#options). When set to `reload`, the behavior is:

> The browser fetches the resource from the remote server without first looking in the cache, but then will update the cache with the downloaded resource.

per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache).

While I was working on this, I realized that we can't retrieve Awakened parses on the character parses page due to how the partitions are set up on WCL. I worked around it since we don't really support old seasons' logs anyway.

This requires [this PR](https://github.com/WoWAnalyzer/server/pull/61) on the backend.