### PR TITLE
fix FoF clipping detection

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import spells from 'common/SPELLS/monk';
 import talents, { TALENTS_MONK } from 'common/TALENTS/monk';
-import { Durpn, Hursti, nullDozzer, Tenooki, ToppleTheNun } from 'CONTRIBUTORS';
+import { Durpn, emallson, Hursti, nullDozzer, Tenooki, ToppleTheNun } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 5, 4), <>Fix <SpellLink spell={spells.FISTS_OF_FURY_CAST} /> clipping detection.</>, emallson),
   change(date(2023, 12, 6), <>Add T31 Tier set, and add <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT}/> to now be tracked for mastery.</>, Durpn),
   change(date(2023, 11, 1), <>Add Guide, and set it to default for Windwalker</>, Durpn),
   change(date(2023, 10, 27), <>Add graphs for <SpellLink spell={spells.FISTS_OF_FURY_CAST}/> to show charts of tick distribution</>, Durpn),

--- a/src/analysis/retail/monk/windwalker/normalizers/FistsOfFuryNormalizer.tsx
+++ b/src/analysis/retail/monk/windwalker/normalizers/FistsOfFuryNormalizer.tsx
@@ -3,6 +3,7 @@ import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer'
 import EventOrderNormalizer, { EventOrder } from 'parser/core/EventOrderNormalizer';
 import { EventType } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
+import Channeling from 'parser/shared/normalizers/Channeling';
 
 const MAX_DELAY = 500;
 
@@ -28,6 +29,11 @@ const EVENT_ORDERS: EventOrder[] = [
 ];
 
 export class FistsOfFuryNormalizer extends EventOrderNormalizer {
+  static dependencies = {
+    ...EventOrderNormalizer.dependencies,
+    // we explicitly depend on the channeling normalizer here to make sure the endchannel event exists
+    channeling: Channeling,
+  };
   constructor(options: Options) {
     super(options, EVENT_ORDERS);
   }
@@ -37,7 +43,7 @@ const castLink: EventLink = {
   linkRelation: 'fof-cast',
   linkingEventId: SPELLS.FISTS_OF_FURY_CAST.id,
   linkingEventType: EventType.EndChannel,
-  referencedEventType: EventType.Cast,
+  referencedEventType: [EventType.Cast, EventType.BeginCast],
   referencedEventId: null,
   forwardBufferMs: 100,
   anySource: false,
@@ -46,6 +52,11 @@ const castLink: EventLink = {
 };
 
 export class FistsOfFuryLinkNormalizer extends EventLinkNormalizer {
+  static dependencies = {
+    ...EventLinkNormalizer.dependencies,
+    // we explicitly depend on the channeling normalizer here to make sure the endchannel event exists
+    channeling: Channeling,
+  };
   constructor(options: Options) {
     super(options, [castLink]);
   }


### PR DESCRIPTION
the issue is that the Channeling normalizer had started running *after* the event link / event order normalizers.

normalizer order is arbitrary without explicit priorities or dependencies. in this case, I used dependencies to force the Channeling normalizer to run first.

i also fixed an issue where clipping with Chi Burst was not detected because the `BeginCast` event type was not linked

### Testing

tested on `report/XFrZNAtdpaRWwVCY/19-Heroic+Rashok,+the+Elder+-+Kill+(3:00)/Durpn/standard/overview`
