### PR TITLE
add damage mitigated statistic for Enduring Dreadplate

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 5, 6), <>Add simple damage mitigated statistic for <ItemLink id={ITEMS.ENDURING_DREADPLATE.id} />.</>, ToppleTheNun),
   change(date(2024, 5, 3), 'Improve behavior of "Refresh" button', emallson),
   change(date(2024, 5, 3), 'Second pass at cleaning up dead code using knip', Putro),
   change(date(2024, 5, 2), 'Fix issue with boss detection', emallson),

--- a/src/common/ITEMS/dragonflight/trinkets.ts
+++ b/src/common/ITEMS/dragonflight/trinkets.ts
@@ -41,6 +41,11 @@ const trinkets = {
     name: "Belor'relos, the Suncaller",
     icon: 'inv_wand_1h_firelandsraid_d_01',
   },
+  ENDURING_DREADPLATE: {
+    id: 202616,
+    name: 'Enduring Dreadplate',
+    icon: 'inv_10_blacksmithing_craftedbar_bloodyalloy',
+  },
 } satisfies Record<string, Item>;
 
 export default trinkets;

--- a/src/common/SPELLS/dragonflight/trinkets.ts
+++ b/src/common/SPELLS/dragonflight/trinkets.ts
@@ -106,6 +106,11 @@ const spells = {
     name: 'Solar Maelstrom',
     icon: 'inv_10_jewelcrafting_gem3primal_titan_cut_bronze',
   },
+  HELLSTEEL_PLATING: {
+    id: 400986,
+    name: 'Hellsteel Plating',
+    icon: 'inv_10_blacksmithing_craftedoptional_reinforcedmetalplating_color01',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/game/HIT_TYPES.ts
+++ b/src/game/HIT_TYPES.ts
@@ -1,6 +1,4 @@
-const HIT_TYPES: {
-  [key: string]: number;
-} = {
+const HIT_TYPES: Record<string, number> = {
   MISS: 0,
   NORMAL: 1,
   CRIT: 2,

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -111,6 +111,9 @@ import Dreambinder from 'parser/retail/modules/items/dragonflight/Dreambinder';
 import Iridal from 'parser/retail/modules/items/dragonflight/Iridal';
 import BelorrelosTheSuncaller from 'parser/retail/modules/items/dragonflight/BelorrelosTheSuncaller';
 import NymuesUnravelingSpindle from 'parser/retail/modules/items/dragonflight/NymuesUnravelingSpindle';
+import EnduringDreadplate, {
+  EnduringDreadplateEventLinkNormalizer,
+} from 'parser/retail/modules/items/dragonflight/EnduringDreadplate';
 import FriendlyCompatNormalizer from './FriendlyCompatNormalizer';
 
 // This prints to console anything that the DI has to do
@@ -225,6 +228,8 @@ class CombatLogParser {
     iridal: Iridal,
     belorrelosTheSuncaller: BelorrelosTheSuncaller,
     nymuesUnravelingSpindle: NymuesUnravelingSpindle,
+    enduringDreadplateNormalizer: EnduringDreadplateEventLinkNormalizer,
+    enduringDreadplate: EnduringDreadplate,
 
     // Enchants
     burningDevotion: BurningDevotion,

--- a/src/parser/retail/modules/items/dragonflight/EnduringDreadplate.tsx
+++ b/src/parser/retail/modules/items/dragonflight/EnduringDreadplate.tsx
@@ -1,0 +1,170 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import ITEMS from 'common/ITEMS/dragonflight/trinkets';
+import SPELLS from 'common/SPELLS/dragonflight/trinkets';
+import { isPresent } from 'common/typeGuards';
+import Events, {
+  ApplyBuffEvent,
+  DamageEvent,
+  EventType,
+  GetRelatedEvents,
+  Item as EventsItem,
+  Item,
+  RemoveBuffStackEvent,
+} from 'parser/core/Events';
+import { calculateEffectScaling } from 'parser/core/stats';
+import HIT_TYPES from 'game/HIT_TYPES';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { formatNumber } from 'common/format';
+import BoringValue from 'parser/ui/BoringValueText';
+import ItemLink from 'interface/ItemLink';
+import ItemsItem from 'common/ITEMS/Item';
+
+const ENDURING_DREADPLATE_BUFF_STACK_REMOVAL_BUFFER = 15000;
+const ENDURING_DREADPLATE_BUFF_STACK_REMOVAL = 'EnduringDreadplateBuffStackRemoval';
+
+const ENDURING_DREADPLATE_EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: ENDURING_DREADPLATE_BUFF_STACK_REMOVAL,
+    referencedEventId: SPELLS.HELLSTEEL_PLATING.id,
+    referencedEventType: EventType.RemoveBuffStack,
+    linkingEventId: SPELLS.HELLSTEEL_PLATING.id,
+    linkingEventType: EventType.ApplyBuff,
+    forwardBufferMs: ENDURING_DREADPLATE_BUFF_STACK_REMOVAL_BUFFER,
+    backwardBufferMs: 0,
+    maximumLinks: 1,
+  },
+];
+
+export class EnduringDreadplateEventLinkNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, ENDURING_DREADPLATE_EVENT_LINKS);
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.ENDURING_DREADPLATE.id);
+  }
+}
+
+function getFirstBuffStackDrop(event: ApplyBuffEvent): RemoveBuffStackEvent | undefined {
+  return GetRelatedEvents<RemoveBuffStackEvent>(
+    event,
+    ENDURING_DREADPLATE_BUFF_STACK_REMOVAL,
+    (e): e is RemoveBuffStackEvent => e.type === EventType.RemoveBuffStack,
+  ).pop();
+}
+
+interface EnduringDreadplateUse {
+  timestamp: number;
+  damageReduced: number;
+  firstStackRemovalTimestamp: number | undefined;
+}
+
+export default class EnduringDreadplate extends Analyzer {
+  private drPerPlate: number = 0;
+  private trinket: Item | undefined;
+  private uses: EnduringDreadplateUse[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.trinket = this.selectedCombatant.getTrinket(ITEMS.ENDURING_DREADPLATE.id);
+    if (!isPresent(this.trinket)) {
+      this.active = false;
+      return;
+    }
+    const itemLevel = this.trinket?.itemLevel ?? 415;
+    this.drPerPlate = Math.ceil(calculateEffectScaling(415, 4860, itemLevel) as number);
+    console.info(`[EnduringDreadplate] DR per plate = ${this.drPerPlate}`);
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.HELLSTEEL_PLATING),
+      this.onHellsteelPlatingApply,
+    );
+
+    this.addEventListener(Events.damage.to(SELECTED_PLAYER), this.onDamageTaken);
+  }
+
+  statistic() {
+    const isEventsItem = (item: EventsItem | ItemsItem): item is EventsItem => 'quality' in item;
+    const item = this.trinket ?? ITEMS.ENDURING_DREADPLATE;
+    const itemLinkProps = {
+      id: item.id,
+      ...(isEventsItem(item) && {
+        quality: item.quality,
+        details: item,
+      }),
+    };
+
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(9)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.ITEMS}
+        dropdown={
+          <>
+            <table className="table table-condensed">
+              <thead>
+                <tr>
+                  <th>Use</th>
+                  <th>Timestamp</th>
+                  <th>Damage Mitigated</th>
+                </tr>
+              </thead>
+              <tbody>
+                {this.uses.map((use, index) => (
+                  <tr key={index}>
+                    <th scope="row">{index + 1}</th>
+                    <td>{this.owner.formatTimestamp(use.timestamp)}</td>
+                    <td>{formatNumber(use.damageReduced)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        }
+      >
+        <BoringValue
+          label={
+            <>
+              <ItemLink {...itemLinkProps} /> Damage Mitigated
+            </>
+          }
+        >
+          <img alt="Damage Mitigated" src="/img/shield.png" className="icon" />{' '}
+          {formatNumber(this.uses.reduce((acc, use) => acc + use.damageReduced, 0))}
+        </BoringValue>
+      </Statistic>
+    );
+  }
+
+  private onHellsteelPlatingApply(event: ApplyBuffEvent) {
+    this.uses.push({
+      timestamp: event.timestamp,
+      damageReduced: 0,
+      firstStackRemovalTimestamp: getFirstBuffStackDrop(event)?.timestamp,
+    });
+  }
+
+  private onDamageTaken(event: DamageEvent) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.HELLSTEEL_PLATING.id)) {
+      return;
+    }
+    if (event.hitType !== HIT_TYPES.NORMAL && event.hitType !== HIT_TYPES.CRIT) {
+      return;
+    }
+
+    const currentUseFirstBuffStackRemovalTimestamp =
+      this.uses[this.uses.length - 1].firstStackRemovalTimestamp;
+    let buffStacks = this.selectedCombatant.getBuffStacks(SPELLS.HELLSTEEL_PLATING.id);
+
+    // The applybuff is logged as 1 stack but is actually 5; we check if we have a stack break and if not, we treat the buff
+    // as having 5 stacks. If we do have a break, but it's after our current damage event, we also treat as 5 stacks.
+    if (
+      !currentUseFirstBuffStackRemovalTimestamp ||
+      currentUseFirstBuffStackRemovalTimestamp > event.timestamp
+    ) {
+      buffStacks = 5;
+    }
+
+    this.uses[this.uses.length - 1].damageReduced += this.drPerPlate * buffStacks;
+  }
+}


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add simple damage mitigated statistic for Enduring Dreadplate.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/XQ2TpLwDZhGRqngV/7-Mythic++Ruby+Life+Pools+-+Kill+(25:18)/1-Nomoretroll/standard`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/1672786/07a31dca-99e5-4aaf-9a52-b8f8869ad3e6)
