### PR TITLE
ignore failed to fetch errors in sentry

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,6 +45,8 @@ if (import.meta.env.VITE_SENTRY_DSN) {
 
     // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
     tracePropagationTargets: ['localhost', /^https:\/\/wowanalyzer\.com\/i/],
+
+    ignoreErrors: [/TypeError: Failed to fetch/, /Failed to fetch/],
   });
 }
 


### PR DESCRIPTION
this *will* still capture errors about failing to load dynamically imported modules, which have a different message


