### PR TITLE
Druid - added detection of Season 4 set for Feral and Resto modules

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS/druid';
 
 export default [
+  change(date(2024, 5, 11), <>Added detection of Season 4 set.</>, Sref),
   change(date(2024, 1, 19), <>Marked up to date for 10.2.5</>, Sref),
   change(date(2023, 11, 7), <>Added statistic for <SpellLink spell={TALENTS_DRUID.SABER_JAWS_TALENT}/>, fixed some numbers, and marked as supported for 10.2.</>, Sref),
   change(date(2023, 10, 12), <>Added Guide items for the Amirdrassil tier set</>, Sref),

--- a/src/analysis/retail/druid/feral/constants.ts
+++ b/src/analysis/retail/druid/feral/constants.ts
@@ -6,6 +6,7 @@ import { CastEvent, DamageEvent } from 'parser/core/Events';
 import getResourceSpent from 'parser/core/getResourceSpent';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { getHardcast } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
+import { TIERS } from 'game/TIERS';
 
 /** Feral combo point cap */
 export const MAX_CPS = 5;
@@ -234,4 +235,14 @@ export function getTigersFuryDuration(c: Combatant) {
     TIGERS_FURY_BASE_DURATION +
     (c.hasTalent(TALENTS_DRUID.PREDATOR_TALENT) ? PREDATOR_DURATION_BOOST : 0)
   );
+}
+
+/** If player has the Feral Frenzy 2set (same bonus Season 3 and 4) */
+export function has2pcDF3or4(c: Combatant) {
+  return c.has2PieceByTier(TIERS.DF3) || c.has2PieceByTier(TIERS.DF4);
+}
+
+/** If player has the Feral Frenzy 4set (same bonus Season 3 and 4) */
+export function has4pcDF3or4(c: Combatant) {
+  return c.has4PieceByTier(TIERS.DF3) || c.has4PieceByTier(TIERS.DF4);
 }

--- a/src/analysis/retail/druid/feral/modules/Abilities.ts
+++ b/src/analysis/retail/druid/feral/modules/Abilities.ts
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
-import { TIERS } from 'game/TIERS';
+import { has4pcDF3or4 } from 'analysis/retail/druid/feral/constants';
 
 class Abilities extends CoreAbilities {
   spellbook(): SpellbookAbility[] {
@@ -193,7 +193,7 @@ class Abilities extends CoreAbilities {
         spell: TALENTS_DRUID.FERAL_FRENZY_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         enabled: combatant.hasTalent(TALENTS_DRUID.FERAL_FRENZY_TALENT),
-        cooldown: combatant.has4PieceByTier(TIERS.DF3) ? 30 : 45,
+        cooldown: has4pcDF3or4(combatant) ? 30 : 45,
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.9,

--- a/src/analysis/retail/druid/feral/modules/spells/ConvokeSpiritsFeral.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/ConvokeSpiritsFeral.tsx
@@ -14,8 +14,8 @@ import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { ApplyBuffEvent } from 'parser/core/Events';
 import ComboPointTracker from 'analysis/retail/druid/feral/modules/core/combopoints/ComboPointTracker';
 import { PassFailCheckmark, PerformanceMark } from 'interface/guide';
-import { TIERS } from 'game/TIERS';
 import ItemSetLink from 'interface/ItemSetLink';
+import { has2pcDF3or4 } from 'analysis/retail/druid/feral/constants';
 import { DRUID_DF3_ID } from 'common/ITEMS/dragonflight';
 
 class ConvokeSpiritsFeral extends ConvokeSpirits {
@@ -77,7 +77,7 @@ class ConvokeSpiritsFeral extends ConvokeSpirits {
 
   /** Guide fragment showing a breakdown of each Convoke cast */
   get guideCastBreakdown() {
-    const hasT31 = this.selectedCombatant.has2PieceByTier(TIERS.DF3);
+    const hasT31 = has2pcDF3or4(this.selectedCombatant);
     const explanation = (
       <>
         <p>

--- a/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
@@ -11,10 +11,10 @@ import CooldownExpandable, {
   CooldownExpandableItem,
 } from 'interface/guide/components/CooldownExpandable';
 import { PassFailCheckmark, PerformanceMark } from 'interface/guide';
-import { TIERS } from 'game/TIERS';
 import { DRUID_DF3_ID } from 'common/ITEMS/dragonflight';
 import ItemSetLink from 'interface/ItemSetLink';
 import EnergyTracker from 'analysis/retail/druid/feral/modules/core/energy/EnergyTracker';
+import { has2pcDF3or4 } from 'analysis/retail/druid/feral/constants';
 
 /**
  * **Feral Frenzy**
@@ -45,7 +45,7 @@ export default class FeralFrenzy extends Analyzer {
 
     this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.FERAL_FRENZY_TALENT);
     this.hasSwarm = this.selectedCombatant.hasTalent(TALENTS_DRUID.ADAPTIVE_SWARM_TALENT);
-    this.hasT31 = this.selectedCombatant.has2PieceByTier(TIERS.DF3);
+    this.hasT31 = has2pcDF3or4(this.selectedCombatant);
 
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS_DRUID.FERAL_FRENZY_TALENT),

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_DRUID } from 'common/TALENTS';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2024, 5, 11), <>Added detection of Season 4 set.</>, Sref),
   change(date(2024, 1, 17), <>Fixed some issues causing "average mastery stacks" statistic to undercount.</>, Sref),
   change(date(2024, 1, 19), <>Marked up to date for 10.2.5</>, Sref),
   change(date(2024, 1, 2), <>Fixed a bug where the 2nd stack of Clearcasting wasn't being properly counted.</>, Sref),

--- a/src/analysis/retail/druid/restoration/modules/dragonflight/Tier31.tsx
+++ b/src/analysis/retail/druid/restoration/modules/dragonflight/Tier31.tsx
@@ -21,13 +21,17 @@ export default class Tier31 extends Analyzer.withDependencies(deps) {
   constructor(options: Options) {
     super(options);
 
+    this.active =
+      this.selectedCombatant.has2PieceByTier(TIERS.DF3) ||
+      this.selectedCombatant.has2PieceByTier(TIERS.DF4);
     // the calculations here only work if player doesn't take Nourish
     // Nourish should never be picked in current state (choice w/ GG), so we'll just disable when Nourish picked
     // instead of wasting the time trying to handle the case
-    this.active =
-      this.selectedCombatant.has2PieceByTier(TIERS.DF3) &&
-      !this.selectedCombatant.hasTalent(TALENTS_DRUID.NOURISH_TALENT);
-    this.has4pc = this.selectedCombatant.has4PieceByTier(TIERS.DF3);
+    this.active = this.active && !this.selectedCombatant.hasTalent(TALENTS_DRUID.NOURISH_TALENT);
+
+    this.has4pc =
+      this.selectedCombatant.has4PieceByTier(TIERS.DF3) ||
+      this.selectedCombatant.has4PieceByTier(TIERS.DF4);
   }
 
   get total2pcHealing() {


### PR DESCRIPTION
### Description

Feral and Resto Druid's Season 3 and 4 sets are the same. Add detection to the S3 modules so they will stay active when player has S4 set.

### Testing

- Test report URL for Resto: `/report/aGpQm7ZbDJYn3R41/95-Heroic+Fyrakk+the+Blazing+-+Kill+(7:41)/Shåped/standard/statistics`
- Test report URL for Feral: `/report/mz9J4KFTkXv23gp8/26-Heroic+Nymue,+Weaver+of+the+Cycle+-+Kill+(4:40)/Azlann/standard/overview`
