### PR TITLE
update k-values for DF S4

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 5, 22), 'Update k-values for Dragonflight S4.', ToppleTheNun),
   change(date(2024, 5, 31), "Add Cataclysm patch 4.4.0.", Putro),
   change(date(2024, 5, 28), 'Add Cataclysm boss images and raid zones', emallson),
   change(date(2024, 5, 22), 'Update GitHub Actions versions.', ToppleTheNun),

--- a/src/parser/retail/armorMitigation.ts
+++ b/src/parser/retail/armorMitigation.ts
@@ -16,11 +16,11 @@ enum ArmorCoefficientKey {
 // These were pulled from Peak of Serenity theorycrafting channel and need to be updated every tier.
 const armorCoefficients = {
   [ArmorCoefficientKey.BASE]: 11766.0,
-  [ArmorCoefficientKey.MYTHIC_PLUS]: 18672.64,
-  [ArmorCoefficientKey.RAID_LFR]: 19155.05,
-  [ArmorCoefficientKey.RAID_NORMAL]: 20872.88,
-  [ArmorCoefficientKey.RAID_HEROIC]: 22814.27,
-  [ArmorCoefficientKey.RAID_MYTHIC]: 25014.52,
+  [ArmorCoefficientKey.MYTHIC_PLUS]: 27485.37559607322,
+  [ArmorCoefficientKey.RAID_LFR]: 24308.55582045084,
+  [ArmorCoefficientKey.RAID_NORMAL]: 27485.37559607322,
+  [ArmorCoefficientKey.RAID_HEROIC]: 30285.68260855284,
+  [ArmorCoefficientKey.RAID_MYTHIC]: 33438.97208977458,
 };
 
 /**


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Update k-values from:
```
Level 70 Season 3 M0/M+: 18,672.64201458984 (ExpectedStatModID: 249; ArmorConstMod: 1.5870000124)
Amirdrassil, the Dream's Hope LFR: 19,155.04824685068 (ExpectedStatModID: 228; ArmorConstMod: 1.62800002098)
Amirdrassil, the Dream's Hope Normal: 20,872.88457229824 (ExpectedStatModID: 229; ArmorConstMod: 1.77400004864)
Amirdrassil, the Dream's Hope Heroic: 22,814.27412342534 (ExpectedStatModID: 230; ArmorConstMod: 1.93900001049)
Amirdrassil, the Dream's Hope Mythic: 25,014.51514720032 (ExpectedStatModID: 231; ArmorConstMod: 2.12599992752)
Level 70 Season 4 M0/M+: 27,485.37559607322 (ExpectedStatModID: 252; ArmorConstMod: 2.33599996567)
Awakened LFR: 24,308.55582045084 (ExpectedStatModID: 253; ArmorConstMod: 2.06599998474)
Awakened Normal: 27,485.37559607322 (ExpectedStatModID: 252; ArmorConstMod: 2.33599996567)
Awakened Heroic: 30,285.68260855284 (ExpectedStatModID: 251; ArmorConstMod: 2.57399988174)
Awakened Mythic: 33,438.97208977458 (ExpectedStatModID: 254; ArmorConstMod: 2.84200000763)
```
