### PR TITLE
Add BDK Rotation section

### DIFF
--- a/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
@@ -3,8 +3,9 @@ import talents from 'common/TALENTS/deathknight';
 import { Tialyss, Chizu, emallson, ToppleTheNun, Yajinni, Arlie } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
-
+// prettier-ignore
 export default [
+  change(date(2024, 6, 1), <>Add rotational analysis to the guide.</>, emallson),
   change(date(2024, 5, 22), <>Extend <SpellLink spell={talents.DEATH_STRIKE_TALENT} /> section of the guide.</>, emallson),
   change(date(2024, 3, 26), 'Remove support for Shadowlands tier set.', ToppleTheNun),
   change(date(2024, 3, 18), <>Updated spec to 10.2.5 and added new guide items</>, Arlie),

--- a/src/analysis/retail/deathknight/blood/CONFIG.tsx
+++ b/src/analysis/retail/deathknight/blood/CONFIG.tsx
@@ -65,6 +65,7 @@ const config: Config = {
     ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: import.meta.url,
+  guideDefault: true,
 };
 
 export default config;

--- a/src/analysis/retail/deathknight/blood/CombatLogParser.ts
+++ b/src/analysis/retail/deathknight/blood/CombatLogParser.ts
@@ -47,6 +47,7 @@ import WillOfTheNecropolis from './modules/talents/WillOfTheNecropolis';
 import RuneTracker from './modules/core/RuneTracker';
 import ResourceOrderNormalizer from './modules/core/ResourceOrderNormalizer';
 import BoneShieldOrderNormalizer from './modules/core/BoneShieldOrderNormalizer';
+import AplCheck from './modules/features/AplCheck';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -105,6 +106,7 @@ class CombatLogParser extends CoreCombatLogParser {
     // guide stuff
     deathStrike: DeathStrike,
     bloodShield: BloodShield,
+    aplCheck: AplCheck,
 
     // normalizers
     deathStrikeNormalizer: DeathStrikeLinkNormalizer,

--- a/src/analysis/retail/deathknight/blood/modules/features/AplCheck.tsx
+++ b/src/analysis/retail/deathknight/blood/modules/features/AplCheck.tsx
@@ -10,6 +10,7 @@ import aplCheck, { Condition, build, tenseAlt } from 'parser/shared/metrics/apl'
 import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import * as cnd from 'parser/shared/metrics/apl/conditions';
 import { DEATH_STRIKE_HEAL } from '../spells/DeathStrike/normalizer';
+import { useInfo } from 'interface/guide';
 
 const boneShieldLow = (maxStacks: number) =>
   cnd.or(
@@ -126,6 +127,22 @@ export const apl = build([
       <>you {tenseAlt(tense, 'need', 'needed')} to defensively</>
     )),
   },
+  {
+    spell: talents.DEATH_STRIKE_TALENT,
+    condition: cnd.optionalRule(
+      cnd.buffMissing(SPELLS.COAGULOPATHY_BUFF, {
+        duration: 8000,
+        pandemicCap: 1,
+        timeRemaining: 2000,
+      }),
+    ),
+    description: (
+      <>
+        Cast <SpellLink spell={talents.DEATH_STRIKE_TALENT} /> to prevent{' '}
+        <SpellLink spell={SPELLS.COAGULOPATHY_BUFF} /> from dropping (optional).
+      </>
+    ),
+  },
   runeRules.drw.marrowrend,
   deathAndDecay,
   runeRules.drw.soulReaper,
@@ -166,109 +183,117 @@ export default suggestion((events, info) => {
   return undefined;
 });
 
-export const AplSummary = () => (
-  <>
-    <p>
-      <strong>
-        During <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT} />
-      </strong>
-      <ol>
-        <li>
-          Use <SpellLink spell={talents.MARROWREND_TALENT} /> to refresh{' '}
-          <SpellLink spell={SPELLS.BONE_SHIELD} /> at the end of{' '}
-          <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT}>DRW</SpellLink> (
-          <TooltipElement
-            content={
-              <>
-                <p>
-                  With the cooldown reduction from{' '}
-                  <SpellLink spell={talents.INSATIABLE_BLADE_TALENT} />, the math works out that
-                  ending <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT}>DRW</SpellLink> with
-                  10 stacks of <SpellLink spell={SPELLS.BONE_SHIELD} /> allows you to cast only a
-                  single <SpellLink spell={talents.MARROWREND_TALENT} /> between uses of{' '}
-                  <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT}>DRW</SpellLink>.
-                </p>
-                <p>
-                  <SpellLink spell={talents.MARROWREND_TALENT} /> is less efficient at converting{' '}
-                  <ResourceLink id={RESOURCE_TYPES.RUNES.id} /> to{' '}
-                  <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id}>RP</ResourceLink> than other
-                  spells, so this leads to more{' '}
-                  <SpellLink spell={talents.DEATH_STRIKE_TALENT}>Death Strikes</SpellLink>.
-                </p>
-              </>
-            }
-            hoverable
-          >
-            Why?
-          </TooltipElement>
-          )
-        </li>
-        <li>
-          Put down <SpellLink spell={SPELLS.DEATH_AND_DECAY} /> if it has expired or you can't stand
-          in your prevoius one
-        </li>
-        <li>
-          Cast <SpellLink spell={talents.SOUL_REAPER_TALENT} /> if the explosion will happen below
-          35% HP
-        </li>
-        <li>
-          Use <SpellLink spell={talents.MARROWREND_TALENT} /> to apply{' '}
-          <SpellLink spell={SPELLS.BONE_SHIELD} /> if it is missing
-        </li>
-        <li>
-          Try not to let any of your resources cap:
-          <ul>
+export const AplSummary = () => {
+  const info = useInfo();
+  const hasSoulReaper = info?.combatant.hasTalent(talents.SOUL_REAPER_TALENT) ?? false;
+  return (
+    <>
+      <p>
+        <strong>
+          During <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT} />
+        </strong>
+        <ol>
+          <li>
+            Use <SpellLink spell={talents.MARROWREND_TALENT} /> to refresh{' '}
+            <SpellLink spell={SPELLS.BONE_SHIELD} /> at the end of{' '}
+            <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT}>DRW</SpellLink> (
+            <TooltipElement
+              content={
+                <>
+                  <p>
+                    With the cooldown reduction from{' '}
+                    <SpellLink spell={talents.INSATIABLE_BLADE_TALENT} />, the math works out that
+                    ending <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT}>DRW</SpellLink>{' '}
+                    with 10 stacks of <SpellLink spell={SPELLS.BONE_SHIELD} /> allows you to cast
+                    only a single <SpellLink spell={talents.MARROWREND_TALENT} /> between uses of{' '}
+                    <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT}>DRW</SpellLink>.
+                  </p>
+                  <p>
+                    <SpellLink spell={talents.MARROWREND_TALENT} /> is less efficient at converting{' '}
+                    <ResourceLink id={RESOURCE_TYPES.RUNES.id} /> to{' '}
+                    <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id}>RP</ResourceLink> than other
+                    spells, so this leads to more{' '}
+                    <SpellLink spell={talents.DEATH_STRIKE_TALENT}>Death Strikes</SpellLink>.
+                  </p>
+                </>
+              }
+              hoverable
+            >
+              Why?
+            </TooltipElement>
+            )
+          </li>
+          <li>
+            Put down <SpellLink spell={SPELLS.DEATH_AND_DECAY} /> if it has expired or you can't
+            stand in your prevoius one
+          </li>
+          {hasSoulReaper && (
             <li>
-              <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} />, spent on{' '}
-              <SpellLink spell={talents.DEATH_STRIKE_TALENT} />
+              Cast <SpellLink spell={talents.SOUL_REAPER_TALENT} /> if the explosion will happen
+              below 35% HP
             </li>
-            <li>
-              <ResourceLink id={RESOURCE_TYPES.RUNES.id} />, spent on{' '}
-              <SpellLink spell={talents.HEART_STRIKE_TALENT} />
-            </li>
-            <li>
-              <SpellLink spell={talents.BLOOD_BOIL_TALENT} /> charges
-            </li>
-          </ul>
-        </li>
-      </ol>
-    </p>
-    <p>
-      <strong>
-        Outside of <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT} />
-      </strong>
+          )}
+          <li>
+            Use <SpellLink spell={talents.MARROWREND_TALENT} /> to apply{' '}
+            <SpellLink spell={SPELLS.BONE_SHIELD} /> if it is missing
+          </li>
+          <li>
+            Try not to let any of your resources cap:
+            <ul>
+              <li>
+                <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} />, spent on{' '}
+                <SpellLink spell={talents.DEATH_STRIKE_TALENT} />
+              </li>
+              <li>
+                <ResourceLink id={RESOURCE_TYPES.RUNES.id} />, spent on{' '}
+                <SpellLink spell={talents.HEART_STRIKE_TALENT} />
+              </li>
+              <li>
+                <SpellLink spell={talents.BLOOD_BOIL_TALENT} /> charges
+              </li>
+            </ul>
+          </li>
+        </ol>
+      </p>
+      <p>
+        <strong>
+          Outside of <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT} />
+        </strong>
 
-      <ol>
-        <li>
-          Put down <SpellLink spell={SPELLS.DEATH_AND_DECAY} /> if it has expired or you can't stand
-          in your prevoius one
-        </li>
-        <li>
-          Cast <SpellLink spell={talents.SOUL_REAPER_TALENT} /> if the explosion will happen below
-          35% HP
-        </li>
-        <li>
-          Use <SpellLink spell={talents.MARROWREND_TALENT} /> to maintain{' '}
-          <SpellLink spell={SPELLS.BONE_SHIELD} /> at 5+ stacks to enable{' '}
-          <SpellLink spell={talents.OSSUARY_TALENT} />
-        </li>
-        <li>
-          Try not to let any of your resources cap:
-          <ul>
+        <ol>
+          <li>
+            Put down <SpellLink spell={SPELLS.DEATH_AND_DECAY} /> if it has expired or you can't
+            stand in your prevoius one
+          </li>
+          {hasSoulReaper && (
             <li>
-              <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} />, spent on{' '}
-              <SpellLink spell={talents.DEATH_STRIKE_TALENT} />
+              Cast <SpellLink spell={talents.SOUL_REAPER_TALENT} /> if the explosion will happen
+              below 35% HP
             </li>
-            <li>
-              <ResourceLink id={RESOURCE_TYPES.RUNES.id} />, spent on{' '}
-              <SpellLink spell={talents.HEART_STRIKE_TALENT} />
-            </li>
-            <li>
-              <SpellLink spell={talents.BLOOD_BOIL_TALENT} /> charges
-            </li>
-          </ul>
-        </li>
-      </ol>
-    </p>
-  </>
-);
+          )}
+          <li>
+            Use <SpellLink spell={talents.MARROWREND_TALENT} /> to maintain{' '}
+            <SpellLink spell={SPELLS.BONE_SHIELD} /> at 5+ stacks to enable{' '}
+            <SpellLink spell={talents.OSSUARY_TALENT} />
+          </li>
+          <li>
+            Try not to let any of your resources cap:
+            <ul>
+              <li>
+                <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} />, spent on{' '}
+                <SpellLink spell={talents.DEATH_STRIKE_TALENT} />
+              </li>
+              <li>
+                <ResourceLink id={RESOURCE_TYPES.RUNES.id} />, spent on{' '}
+                <SpellLink spell={talents.HEART_STRIKE_TALENT} />
+              </li>
+              <li>
+                <SpellLink spell={talents.BLOOD_BOIL_TALENT} /> charges
+              </li>
+            </ul>
+          </li>
+        </ol>
+      </p>
+    </>
+  );
+};

--- a/src/analysis/retail/deathknight/blood/modules/features/AplCheck.tsx
+++ b/src/analysis/retail/deathknight/blood/modules/features/AplCheck.tsx
@@ -1,0 +1,274 @@
+import SPELLS from 'common/SPELLS';
+import talents from 'common/TALENTS/deathknight';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import ResourceLink from 'interface/ResourceLink';
+import SpellLink from 'interface/SpellLink';
+import { TooltipElement } from 'interface/Tooltip';
+import { suggestion } from 'parser/core/Analyzer';
+import { EventType, GetRelatedEvent } from 'parser/core/Events';
+import aplCheck, { Condition, build, tenseAlt } from 'parser/shared/metrics/apl';
+import annotateTimeline from 'parser/shared/metrics/apl/annotate';
+import * as cnd from 'parser/shared/metrics/apl/conditions';
+import { DEATH_STRIKE_HEAL } from '../spells/DeathStrike/normalizer';
+
+const boneShieldLow = (maxStacks: number) =>
+  cnd.or(
+    cnd.buffMissing(SPELLS.BONE_SHIELD, {
+      timeRemaining: 4500,
+      duration: 30000,
+      pandemicCap: 1,
+    }),
+    cnd.buffStacks(SPELLS.BONE_SHIELD, { atMost: maxStacks }),
+  );
+
+const ossuaryCnd = cnd.describe(
+  cnd.and(boneShieldLow(4), cnd.buffMissing(SPELLS.DANCING_RUNE_WEAPON_TALENT_BUFF)),
+  (tense) => (
+    <>
+      <SpellLink spell={talents.OSSUARY_TALENT} /> {tenseAlt(tense, 'is', 'was')} inactive
+    </>
+  ),
+);
+
+export const runeRules = {
+  marrowrend: {
+    spell: talents.MARROWREND_TALENT,
+    condition: ossuaryCnd,
+  },
+  soulReaper: {
+    spell: talents.SOUL_REAPER_TALENT,
+    condition: cnd.inExecute(0.35), // this should really get a custom condition for the case where you cast soul reaper and then it explodes below 35%, but that can only happen 1 time per target
+  },
+  deathsCaress: {
+    spell: talents.DEATHS_CARESS_TALENT,
+    condition: cnd.optionalRule(ossuaryCnd), // allow optionally using DC for BS refresh. i'm not here to litigate optimality. some high end people use DC for it a ton
+  },
+  drw: {
+    soulReaper: {
+      spell: talents.SOUL_REAPER_TALENT,
+      condition: cnd.and(
+        cnd.buffPresent(SPELLS.DANCING_RUNE_WEAPON_TALENT_BUFF),
+        cnd.inExecute(0.35),
+      ),
+    },
+    marrowrend: {
+      // the guide includes this. it isn't strictly optimal under certain settings but we allow it
+      spell: talents.MARROWREND_TALENT,
+      condition: cnd.describe(
+        cnd.optionalRule(
+          cnd.and(
+            cnd.buffPresent(SPELLS.DANCING_RUNE_WEAPON_TALENT_BUFF),
+            // cheating with DRW duration because EVERYONE uses the same core talents
+            cnd.buffRemaining(SPELLS.DANCING_RUNE_WEAPON_TALENT_BUFF, 16000, { atMost: 4500 }),
+            // this condition prevents spamming it from passing muster
+            cnd.buffRemaining(SPELLS.BONE_SHIELD, 30000, { atMost: 27000 }),
+          ),
+        ),
+        (tense) => (
+          <>
+            <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT} /> {tenseAlt(tense, 'is', 'was')}{' '}
+            about to end to refresh <SpellLink spell={SPELLS.BONE_SHIELD} /> to max stacks
+          </>
+        ),
+      ),
+    },
+
+    marrowrendMissing: {
+      spell: talents.MARROWREND_TALENT,
+      condition: cnd.describe(
+        cnd.and(cnd.buffPresent(SPELLS.DANCING_RUNE_WEAPON_TALENT_BUFF), boneShieldLow(1)),
+        () => (
+          <>
+            <SpellLink spell={SPELLS.BONE_SHIELD} /> is at 0 or 1 stacks during{' '}
+            <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT} />
+          </>
+        ),
+      ),
+    },
+  },
+};
+
+const deathAndDecay = {
+  spell: SPELLS.DEATH_AND_DECAY,
+  condition: cnd.optionalRule(
+    cnd.buffMissing(SPELLS.DEATH_AND_DECAY_BUFF, {
+      pandemicCap: 1,
+      duration: 10,
+      timeRemaining: 3,
+    }),
+  ),
+};
+
+const defensiveUseCondition: Condition<null> = {
+  key: 'ds-defensive-use',
+  init: () => null,
+  update: () => null,
+  validate: (_state, event) => {
+    if (event.ability.guid !== talents.DEATH_STRIKE_TALENT.id) {
+      return false;
+    }
+
+    const heal = GetRelatedEvent(event, DEATH_STRIKE_HEAL);
+
+    if (heal?.type === EventType.Heal) {
+      return heal.amount / heal.maxHitPoints >= 0.25;
+    } else {
+      return false;
+    }
+  },
+  describe: () => <></>,
+};
+
+export const apl = build([
+  {
+    spell: talents.DEATH_STRIKE_TALENT,
+    condition: cnd.describe(defensiveUseCondition, (tense) => (
+      <>you {tenseAlt(tense, 'need', 'needed')} to defensively</>
+    )),
+  },
+  runeRules.drw.marrowrend,
+  deathAndDecay,
+  runeRules.drw.soulReaper,
+  runeRules.drw.marrowrendMissing,
+  runeRules.deathsCaress,
+  runeRules.marrowrend,
+  runeRules.soulReaper,
+  {
+    spell: talents.DEATH_STRIKE_TALENT,
+    // Runic Power is scaled up by 10x
+    condition: cnd.describe(
+      cnd.hasResource(RESOURCE_TYPES.RUNIC_POWER, { atLeast: 1000 }, 0),
+      (tense) => (
+        <>
+          you {tenseAlt(tense, 'have', 'had')} 100+{' '}
+          <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} /> to prevent capping
+        </>
+      ),
+    ),
+  },
+  {
+    spell: talents.HEART_STRIKE_TALENT,
+    condition: cnd.describe(cnd.hasResource(RESOURCE_TYPES.RUNES, { atLeast: 4 }, 6), (tense) => (
+      <>
+        you {tenseAlt(tense, 'have', 'had')} fewer than 3{' '}
+        <ResourceLink id={RESOURCE_TYPES.RUNES.id} /> on cooldown
+      </>
+    )),
+  },
+  [talents.DEATH_STRIKE_TALENT, talents.HEART_STRIKE_TALENT, talents.BLOOD_BOIL_TALENT],
+]);
+
+export const check = aplCheck(apl);
+
+export default suggestion((events, info) => {
+  const { violations } = check(events, info);
+  annotateTimeline(violations);
+  return undefined;
+});
+
+export const AplSummary = () => (
+  <>
+    <p>
+      <strong>
+        During <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT} />
+      </strong>
+      <ol>
+        <li>
+          Use <SpellLink spell={talents.MARROWREND_TALENT} /> to refresh{' '}
+          <SpellLink spell={SPELLS.BONE_SHIELD} /> at the end of{' '}
+          <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT}>DRW</SpellLink> (
+          <TooltipElement
+            content={
+              <>
+                <p>
+                  With the cooldown reduction from{' '}
+                  <SpellLink spell={talents.INSATIABLE_BLADE_TALENT} />, the math works out that
+                  ending <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT}>DRW</SpellLink> with
+                  10 stacks of <SpellLink spell={SPELLS.BONE_SHIELD} /> allows you to cast only a
+                  single <SpellLink spell={talents.MARROWREND_TALENT} /> between uses of{' '}
+                  <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT}>DRW</SpellLink>.
+                </p>
+                <p>
+                  <SpellLink spell={talents.MARROWREND_TALENT} /> is less efficient at converting{' '}
+                  <ResourceLink id={RESOURCE_TYPES.RUNES.id} /> to{' '}
+                  <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id}>RP</ResourceLink> than other
+                  spells, so this leads to more{' '}
+                  <SpellLink spell={talents.DEATH_STRIKE_TALENT}>Death Strikes</SpellLink>.
+                </p>
+              </>
+            }
+            hoverable
+          >
+            Why?
+          </TooltipElement>
+          )
+        </li>
+        <li>
+          Put down <SpellLink spell={SPELLS.DEATH_AND_DECAY} /> if it has expired or you can't stand
+          in your prevoius one
+        </li>
+        <li>
+          Cast <SpellLink spell={talents.SOUL_REAPER_TALENT} /> if the explosion will happen below
+          35% HP
+        </li>
+        <li>
+          Use <SpellLink spell={talents.MARROWREND_TALENT} /> to apply{' '}
+          <SpellLink spell={SPELLS.BONE_SHIELD} /> if it is missing
+        </li>
+        <li>
+          Try not to let any of your resources cap:
+          <ul>
+            <li>
+              <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} />, spent on{' '}
+              <SpellLink spell={talents.DEATH_STRIKE_TALENT} />
+            </li>
+            <li>
+              <ResourceLink id={RESOURCE_TYPES.RUNES.id} />, spent on{' '}
+              <SpellLink spell={talents.HEART_STRIKE_TALENT} />
+            </li>
+            <li>
+              <SpellLink spell={talents.BLOOD_BOIL_TALENT} /> charges
+            </li>
+          </ul>
+        </li>
+      </ol>
+    </p>
+    <p>
+      <strong>
+        Outside of <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT} />
+      </strong>
+
+      <ol>
+        <li>
+          Put down <SpellLink spell={SPELLS.DEATH_AND_DECAY} /> if it has expired or you can't stand
+          in your prevoius one
+        </li>
+        <li>
+          Cast <SpellLink spell={talents.SOUL_REAPER_TALENT} /> if the explosion will happen below
+          35% HP
+        </li>
+        <li>
+          Use <SpellLink spell={talents.MARROWREND_TALENT} /> to maintain{' '}
+          <SpellLink spell={SPELLS.BONE_SHIELD} /> at 5+ stacks to enable{' '}
+          <SpellLink spell={talents.OSSUARY_TALENT} />
+        </li>
+        <li>
+          Try not to let any of your resources cap:
+          <ul>
+            <li>
+              <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} />, spent on{' '}
+              <SpellLink spell={talents.DEATH_STRIKE_TALENT} />
+            </li>
+            <li>
+              <ResourceLink id={RESOURCE_TYPES.RUNES.id} />, spent on{' '}
+              <SpellLink spell={talents.HEART_STRIKE_TALENT} />
+            </li>
+            <li>
+              <SpellLink spell={talents.BLOOD_BOIL_TALENT} /> charges
+            </li>
+          </ul>
+        </li>
+      </ol>
+    </p>
+  </>
+);

--- a/src/analysis/retail/deathknight/blood/modules/features/Ossuary.tsx
+++ b/src/analysis/retail/deathknight/blood/modules/features/Ossuary.tsx
@@ -1,3 +1,4 @@
+import { i18n } from '@lingui/core';
 import { defineMessage, Trans } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
@@ -42,10 +43,12 @@ class Ossuary extends Analyzer {
 
       event.meta = event.meta || {};
       event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = defineMessage({
-        id: 'deathknight.blood.ossuary.ineffectiveCast',
-        message: `This Death Strike cast was without Ossuary.`,
-      });
+      event.meta.inefficientCastReason = i18n._(
+        defineMessage({
+          id: 'deathknight.blood.ossuary.ineffectiveCast',
+          message: `This Death Strike cast was without Ossuary.`,
+        }),
+      );
     }
   }
 

--- a/src/analysis/retail/deathknight/blood/modules/features/Ossuary.tsx
+++ b/src/analysis/retail/deathknight/blood/modules/features/Ossuary.tsx
@@ -1,4 +1,3 @@
-import { i18n } from '@lingui/core';
 import { defineMessage, Trans } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
@@ -43,12 +42,10 @@ class Ossuary extends Analyzer {
 
       event.meta = event.meta || {};
       event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = i18n._(
-        defineMessage({
-          id: 'deathknight.blood.ossuary.ineffectiveCast',
-          message: `This Death Strike cast was without Ossuary.`,
-        }),
-      );
+      event.meta.inefficientCastReason = defineMessage({
+        id: 'deathknight.blood.ossuary.ineffectiveCast',
+        message: `This Death Strike cast was without Ossuary.`,
+      });
     }
   }
 

--- a/src/analysis/retail/deathknight/blood/modules/guide/index.tsx
+++ b/src/analysis/retail/deathknight/blood/modules/guide/index.tsx
@@ -7,7 +7,7 @@ import CooldownGraphSubsection, {
 } from 'interface/guide/components/CooldownGraphSubSection';
 import DRAGONFLIGHT_OTHERS_SPELLS from 'common/SPELLS/dragonflight/others';
 import DRAGONFLIGHT_OTHERS_ITEMS from 'common/ITEMS/dragonflight/others';
-import { GuideProps, Section, SubSection } from 'interface/guide';
+import { GuideProps, Section, SubSection, useInfo } from 'interface/guide';
 import DeathStrikeSection from '../spells/DeathStrike/DeathStrikeSection';
 import { AplSectionData } from 'interface/guide/components/Apl';
 import * as apl from '../features/AplCheck';
@@ -41,9 +41,31 @@ export default function BloodGuide(props: GuideProps<typeof CombatLogParser>): J
     },
   ];
 
-  const hasTalent = props.info.combatant.hasTalent.bind(props.info.combatant);
+  return (
+    <>
+      <Section title="Death Strike">
+        <DeathStrikeSection />
+        {props.modules.deathStrikeTiming.guideSubsection}
+      </Section>
+      <Section title="Rotation">
+        <AplDescription />
+        <SubSection>
+          <AplSectionData checker={apl.check} apl={apl.apl} summary={apl.AplSummary} />
+        </SubSection>
+      </Section>
+      <Section title="Cooldowns">
+        <CooldownGraphSubsection cooldowns={cooldowns} />
+      </Section>
+      <PreparationSection />
+    </>
+  );
+}
 
-  const rotationWarnings = (
+function AplDescription() {
+  const info = useInfo();
+  const hasTalent = info?.combatant.hasTalent.bind(info?.combatant);
+
+  const rotationWarnings = hasTalent ? (
     <>
       {hasTalent(TALENTS_DEATH_KNIGHT.INSATIABLE_BLADE_TALENT) &&
       hasTalent(TALENTS_DEATH_KNIGHT.TOMBSTONE_TALENT) ? null : (
@@ -62,73 +84,60 @@ export default function BloodGuide(props: GuideProps<typeof CombatLogParser>): J
           Using <SpellLink spell={TALENTS_DEATH_KNIGHT.SANGUINE_GROUND_TALENT} />,{' '}
           <SpellLink spell={TALENTS_DEATH_KNIGHT.DEATHS_ECHO_TALENT} /> and{' '}
           <SpellLink spell={TALENTS_DEATH_KNIGHT.SHATTERING_BONE_TALENT} /> is recommended because
-          it provides a very large increase to your overally damage, improving threat generation
+          it provides a very large increase to your overall damage, improving threat generation
           (especially in AoE settings like Mythic+).
         </AlertWarning>
       )}
     </>
-  );
+  ) : null;
 
   return (
     <>
-      <Section title="Death Strike">
-        <DeathStrikeSection />
-        {props.modules.deathStrikeTiming.guideSubsection}
-      </Section>
-      <Section title="Rotation">
-        {rotationWarnings}
-        <Explanation>
-          <p>
-            The Blood DK rotation is built around three overlapping loops:
-            <ol>
-              <li>
-                Spending as many of your <ResourceLink id={RESOURCE_TYPES.RUNES.id} /> /{' '}
-                <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} /> /{' '}
-                <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} /> charges as possible
-                without wasting any, and
-              </li>
-              <li>
-                Using <SpellLink spell={TALENTS_DEATH_KNIGHT.INSATIABLE_BLADE_TALENT} /> +{' '}
-                <SpellLink spell={TALENTS_DEATH_KNIGHT.TOMBSTONE_TALENT} /> to use{' '}
-                <SpellLink spell={TALENTS_DEATH_KNIGHT.DANCING_RUNE_WEAPON_TALENT} /> as often as
-                possible, and
-              </li>
-              <li>
-                Getting as much use out of <SpellLink spell={SPELLS.DEATH_AND_DECAY} />
-                -related talents like{' '}
-                <SpellLink spell={TALENTS_DEATH_KNIGHT.SANGUINE_GROUND_TALENT} /> and{' '}
-                <SpellLink spell={TALENTS_DEATH_KNIGHT.SHATTERING_BONE_TALENT} /> as possible
-              </li>
-            </ol>
-          </p>
-          <p>
-            This is not as complicated as it might sound. Mostly, it means:{' '}
-            <strong>
-              try to always stand in <SpellLink spell={SPELLS.DEATH_AND_DECAY}>D&amp;D</SpellLink>
-            </strong>{' '}
-            and <strong>use as many abilities as possible</strong>. Most of the nuance comes from
-            trying to balance spending <ResourceLink id={RESOURCE_TYPES.RUNES.id} />,{' '}
-            <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} /> and{' '}
-            <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} />.
-          </p>
-          <p>
-            If you're having a hard time, remember that{' '}
-            <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} /> is almost pure damage,
-            while <ResourceLink id={RESOURCE_TYPES.RUNES.id} /> and{' '}
-            <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} /> power your defensive abilities. It
-            is okay to use <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} /> on pull for
-            threat and then forget about it while learning the spec, and then add it in as you get
-            better.
-          </p>
-        </Explanation>
-        <SubSection>
-          <AplSectionData checker={apl.check} apl={apl.apl} summary={apl.AplSummary} />
-        </SubSection>
-      </Section>
-      <Section title="Cooldowns">
-        <CooldownGraphSubsection cooldowns={cooldowns} />
-      </Section>
-      <PreparationSection />
+      {rotationWarnings}
+      <Explanation>
+        <p>
+          The Blood DK rotation is built around three overlapping loops:
+          <ol>
+            <li>
+              Spending as many of your <ResourceLink id={RESOURCE_TYPES.RUNES.id} /> /{' '}
+              <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} /> /{' '}
+              <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} /> charges as possible
+              without wasting any, and
+            </li>
+            <li>
+              Using <SpellLink spell={TALENTS_DEATH_KNIGHT.INSATIABLE_BLADE_TALENT} /> +{' '}
+              <SpellLink spell={TALENTS_DEATH_KNIGHT.TOMBSTONE_TALENT} /> to use{' '}
+              <SpellLink spell={TALENTS_DEATH_KNIGHT.DANCING_RUNE_WEAPON_TALENT} /> as often as
+              possible, and
+            </li>
+            <li>
+              Getting as much use out of <SpellLink spell={SPELLS.DEATH_AND_DECAY} />
+              -related talents like{' '}
+              <SpellLink spell={TALENTS_DEATH_KNIGHT.SANGUINE_GROUND_TALENT} /> and{' '}
+              <SpellLink spell={TALENTS_DEATH_KNIGHT.SHATTERING_BONE_TALENT} /> as possible
+            </li>
+          </ol>
+        </p>
+        <p>
+          This is not as complicated as it might sound. Mostly, it means:{' '}
+          <strong>
+            try to always stand in <SpellLink spell={SPELLS.DEATH_AND_DECAY}>D&amp;D</SpellLink>
+          </strong>{' '}
+          and <strong>use as many abilities as possible</strong>. Most of the nuance comes from
+          trying to balance spending <ResourceLink id={RESOURCE_TYPES.RUNES.id} />,{' '}
+          <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} /> and{' '}
+          <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} />.
+        </p>
+        <p>
+          If you're having a hard time, remember that{' '}
+          <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} /> is almost pure damage, while{' '}
+          <ResourceLink id={RESOURCE_TYPES.RUNES.id} /> and{' '}
+          <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} /> power your defensive abilities. It is
+          okay to use <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} /> on pull for
+          threat and then forget about it while learning the spec, and then add it in as you get
+          better.
+        </p>
+      </Explanation>
     </>
   );
 }

--- a/src/analysis/retail/deathknight/blood/modules/guide/index.tsx
+++ b/src/analysis/retail/deathknight/blood/modules/guide/index.tsx
@@ -7,14 +7,25 @@ import CooldownGraphSubsection, {
 } from 'interface/guide/components/CooldownGraphSubSection';
 import DRAGONFLIGHT_OTHERS_SPELLS from 'common/SPELLS/dragonflight/others';
 import DRAGONFLIGHT_OTHERS_ITEMS from 'common/ITEMS/dragonflight/others';
-import { GuideProps, Section } from 'interface/guide';
+import { GuideProps, Section, SubSection } from 'interface/guide';
 import DeathStrikeSection from '../spells/DeathStrike/DeathStrikeSection';
+import { AplSectionData } from 'interface/guide/components/Apl';
+import * as apl from '../features/AplCheck';
+import Explanation from 'interface/guide/components/Explanation';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import SpellLink from 'interface/SpellLink';
+import ResourceLink from 'interface/ResourceLink';
+import AlertWarning from 'interface/AlertWarning';
 
 export default function BloodGuide(props: GuideProps<typeof CombatLogParser>): JSX.Element {
   const cooldowns: Cooldown[] = [
     {
       spell: TALENTS_DEATH_KNIGHT.DANCING_RUNE_WEAPON_TALENT,
       isActive: (c) => c.hasTalent(TALENTS_DEATH_KNIGHT.DANCING_RUNE_WEAPON_TALENT),
+    },
+    {
+      spell: TALENTS_DEATH_KNIGHT.TOMBSTONE_TALENT,
+      isActive: (c) => c.hasTalent(TALENTS_DEATH_KNIGHT.TOMBSTONE_TALENT),
     },
     {
       spell: SPELLS.EMPOWER_RUNE_WEAPON,
@@ -30,11 +41,89 @@ export default function BloodGuide(props: GuideProps<typeof CombatLogParser>): J
     },
   ];
 
+  const hasTalent = props.info.combatant.hasTalent.bind(props.info.combatant);
+
+  const rotationWarnings = (
+    <>
+      {hasTalent(TALENTS_DEATH_KNIGHT.INSATIABLE_BLADE_TALENT) &&
+      hasTalent(TALENTS_DEATH_KNIGHT.TOMBSTONE_TALENT) ? null : (
+        <AlertWarning>
+          Using <SpellLink spell={TALENTS_DEATH_KNIGHT.INSATIABLE_BLADE_TALENT} /> and{' '}
+          <SpellLink spell={TALENTS_DEATH_KNIGHT.TOMBSTONE_TALENT} /> is strongly recommended
+          because it dramatically increases the amount of time that you spend with{' '}
+          <SpellLink spell={TALENTS_DEATH_KNIGHT.DANCING_RUNE_WEAPON_TALENT} /> active, improving
+          both defensiveness and damage done.
+        </AlertWarning>
+      )}
+      {hasTalent(TALENTS_DEATH_KNIGHT.DEATHS_ECHO_TALENT) &&
+      hasTalent(TALENTS_DEATH_KNIGHT.SANGUINE_GROUND_TALENT) &&
+      hasTalent(TALENTS_DEATH_KNIGHT.SHATTERING_BONE_TALENT) ? null : (
+        <AlertWarning>
+          Using <SpellLink spell={TALENTS_DEATH_KNIGHT.SANGUINE_GROUND_TALENT} />,{' '}
+          <SpellLink spell={TALENTS_DEATH_KNIGHT.DEATHS_ECHO_TALENT} /> and{' '}
+          <SpellLink spell={TALENTS_DEATH_KNIGHT.SHATTERING_BONE_TALENT} /> is recommended because
+          it provides a very large increase to your overally damage, improving threat generation
+          (especially in AoE settings like Mythic+).
+        </AlertWarning>
+      )}
+    </>
+  );
+
   return (
     <>
       <Section title="Death Strike">
         <DeathStrikeSection />
         {props.modules.deathStrikeTiming.guideSubsection}
+      </Section>
+      <Section title="Rotation">
+        {rotationWarnings}
+        <Explanation>
+          <p>
+            The Blood DK rotation is built around three overlapping loops:
+            <ol>
+              <li>
+                Spending as many of your <ResourceLink id={RESOURCE_TYPES.RUNES.id} /> /{' '}
+                <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} /> /{' '}
+                <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} /> charges as possible
+                without wasting any, and
+              </li>
+              <li>
+                Using <SpellLink spell={TALENTS_DEATH_KNIGHT.INSATIABLE_BLADE_TALENT} /> +{' '}
+                <SpellLink spell={TALENTS_DEATH_KNIGHT.TOMBSTONE_TALENT} /> to use{' '}
+                <SpellLink spell={TALENTS_DEATH_KNIGHT.DANCING_RUNE_WEAPON_TALENT} /> as often as
+                possible, and
+              </li>
+              <li>
+                Getting as much use out of <SpellLink spell={SPELLS.DEATH_AND_DECAY} />
+                -related talents like{' '}
+                <SpellLink spell={TALENTS_DEATH_KNIGHT.SANGUINE_GROUND_TALENT} /> and{' '}
+                <SpellLink spell={TALENTS_DEATH_KNIGHT.SHATTERING_BONE_TALENT} /> as possible
+              </li>
+            </ol>
+          </p>
+          <p>
+            This is not as complicated as it might sound. Mostly, it means:{' '}
+            <strong>
+              try to always stand in <SpellLink spell={SPELLS.DEATH_AND_DECAY}>D&amp;D</SpellLink>
+            </strong>{' '}
+            and <strong>use as many abilities as possible</strong>. Most of the nuance comes from
+            trying to balance spending <ResourceLink id={RESOURCE_TYPES.RUNES.id} />,{' '}
+            <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} /> and{' '}
+            <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} />.
+          </p>
+          <p>
+            If you're having a hard time, remember that{' '}
+            <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} /> is almost pure damage,
+            while <ResourceLink id={RESOURCE_TYPES.RUNES.id} /> and{' '}
+            <ResourceLink id={RESOURCE_TYPES.RUNIC_POWER.id} /> power your defensive abilities. It
+            is okay to use <SpellLink spell={TALENTS_DEATH_KNIGHT.BLOOD_BOIL_TALENT} /> on pull for
+            threat and then forget about it while learning the spec, and then add it in as you get
+            better.
+          </p>
+        </Explanation>
+        <SubSection>
+          <AplSectionData checker={apl.check} apl={apl.apl} summary={apl.AplSummary} />
+        </SubSection>
       </Section>
       <Section title="Cooldowns">
         <CooldownGraphSubsection cooldowns={cooldowns} />

--- a/src/common/SPELLS/deathknight.ts
+++ b/src/common/SPELLS/deathknight.ts
@@ -94,6 +94,11 @@ const spells = {
     name: 'Relish in Blood',
     icon: 'ability_deathknight_roilingblood',
   },
+  COAGULOPATHY_BUFF: {
+    id: 391477,
+    name: 'Coagulopathy',
+    icon: 'ability_skeer_bloodletting',
+  },
 
   // Other
   HEARTBREAKER_ENERGIZE: {

--- a/src/interface/guide/components/Apl/violations/claims.tsx
+++ b/src/interface/guide/components/Apl/violations/claims.tsx
@@ -113,7 +113,7 @@ export const ActualCastDescription = ({
   <>
     At <EventTimestamp event={event} /> into the fight, you cast{' '}
     <SpellLink spell={event.ability.guid} />
-    {!omitTarget && event.targetID && (
+    {!omitTarget && (event.targetID ?? 0) > 0 && (
       <>
         {' '}
         on <TargetName event={event} />


### PR DESCRIPTION
### Description

This adds a rotation section to the Blood DK guide and promotes it to default.

### Testing

Can pull up any blood DK log. 

Sample: `/report/V7KjhDHGytXZ6aq9/71-Mythic+Smolderon+-+Kill+(5:11)/Grerzet/standard`

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/831f2d24-2102-41aa-b8bb-64f8b1a9ad6e)