### PR TITLE
use addInefficientCastReason everywhere possible

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -37,6 +37,7 @@ module.exports = {
     'wowanalyzer/spell-icon-spell-object': 'error',
     'wowanalyzer/boring-spell-value-text-spell-object': 'error',
     'wowanalyzer/lingui-t-macro-outside-jsx': 'error',
+    'wowanalyzer/event-meta-inefficient-cast': 'error',
 
     // region Syntax
 

--- a/packages/eslint-plugin-wowanalyzer/index.js
+++ b/packages/eslint-plugin-wowanalyzer/index.js
@@ -4,4 +4,5 @@ exports.rules = {
   'spell-icon-spell-object': require('./rules/spell-icon-spell-object'),
   'boring-spell-value-text-spell-object': require('./rules/boring-spell-value-text-spell-object'),
   'lingui-t-macro-outside-jsx': require('./rules/lingui-t-macro-outside-jsx'),
+  'event-meta-inefficient-cast': require('./rules/event-meta-inefficient-cast'),
 };

--- a/packages/eslint-plugin-wowanalyzer/rules/event-meta-inefficient-cast.js
+++ b/packages/eslint-plugin-wowanalyzer/rules/event-meta-inefficient-cast.js
@@ -1,0 +1,41 @@
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    messages: {
+      settingEventMetaDirectly:
+        'Use addInefficientCastReason or addEnhancedCastReason instead of setting event meta directly',
+    },
+  },
+  create(context) {
+    return {
+      'AssignmentExpression > MemberExpression'(node) {
+        const { object, property } = node;
+        if (property.type !== 'Identifier') {
+          return;
+        }
+
+        if (property.name === 'meta') {
+          context.report({
+            node: node.parent.parent,
+            messageId: 'settingEventMetaDirectly',
+          });
+        } else if (
+          property.name === 'isInefficientCast' ||
+          property.name === 'inefficientCastReason'
+        ) {
+          if (
+            object.type === 'MemberExpression' &&
+            object.property.type === 'Identifier' &&
+            object.property.name === 'meta'
+          ) {
+            context.report({
+              node: node.parent.parent,
+              messageId: 'settingEventMetaDirectly',
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-wowanalyzer/rules/event-meta-inefficient-cast.js
+++ b/packages/eslint-plugin-wowanalyzer/rules/event-meta-inefficient-cast.js
@@ -4,7 +4,7 @@ module.exports = {
     type: 'problem',
     messages: {
       settingEventMetaDirectly:
-        'Use addInefficientCastReason or addEnhancedCastReason instead of setting event meta directly',
+        'Use addInefficientCastReason, addEnhancedCastReason, or replace instead of setting event meta directly',
     },
   },
   create(context) {

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,7 +35,8 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2022, 6, 3), 'Update Classic Flasks for Cataclysm', jazminite),
+  change(date(2024, 6, 3), 'Update event meta usage.', ToppleTheNun),
+  change(date(2024, 6, 3), 'Update Classic Flasks for Cataclysm', jazminite),
   change(date(2024, 5, 31), 'Update Classic Enchants for Cataclysm', jazminite),
   change(date(2024, 5, 31), "Add Cataclysm patch 4.4.0.", Putro),
   change(date(2024, 5, 28), 'Add Cataclysm boss images and raid zones', emallson),

--- a/src/analysis/classic/druid/balance/modules/features/FillerUsage.tsx
+++ b/src/analysis/classic/druid/balance/modules/features/FillerUsage.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const MINOR_THRESHOLD = 0;
 const AVERAGE_THRESHOLD = 0.05;
@@ -34,9 +35,10 @@ class FillerUsage extends Analyzer {
     for (const [eclipse, spell] of ECLIPSE_FILLER) {
       if (this.selectedCombatant.hasBuff(eclipse.id) && event.ability.guid !== spell.id) {
         this.badFillerCasts += 1;
-        event.meta = event.meta || {};
-        event.meta.isInefficientCast = true;
-        event.meta.inefficientCastReason = `Wrong usage of ${event.ability.name} during ${eclipse.name}. Use ${spell.name} instead`;
+        addInefficientCastReason(
+          event,
+          `Wrong usage of ${event.ability.name} during ${eclipse.name}. Use ${spell.name} instead`,
+        );
         return;
       }
     }

--- a/src/analysis/retail/deathknight/blood/components/ResourceWasteProblemRenderer.tsx
+++ b/src/analysis/retail/deathknight/blood/components/ResourceWasteProblemRenderer.tsx
@@ -13,6 +13,7 @@ import EmbeddedTimelineContainer, {
 } from 'interface/report/Results/Timeline/EmbeddedTimeline';
 import { AnyEvent, CastEvent, EventMeta, EventType } from 'parser/core/Events';
 import { useMemo } from 'react';
+import { replace } from 'parser/core/EventMetaLib';
 
 interface WastedMeta extends EventMeta {
   _wastedRp: number;
@@ -45,9 +46,7 @@ export function ResourceWasteProblemRenderer({
               return <>This cast wasted {this._wastedRp} RP.</>;
             },
           };
-          // TODO: Come up with a better way of handling this so that it doesn't break any existing meta
-          // eslint-disable-next-line wowanalyzer/event-meta-inefficient-cast
-          lastCast.meta = meta;
+          replace(lastCast, meta);
         } else {
           const meta = lastCast.meta as WastedMeta;
           meta._wastedRp += event.waste;

--- a/src/analysis/retail/deathknight/blood/components/ResourceWasteProblemRenderer.tsx
+++ b/src/analysis/retail/deathknight/blood/components/ResourceWasteProblemRenderer.tsx
@@ -11,12 +11,12 @@ import Casts, { isApplicableEvent } from 'interface/report/Results/Timeline/Cast
 import EmbeddedTimelineContainer, {
   SpellTimeline,
 } from 'interface/report/Results/Timeline/EmbeddedTimeline';
-import { AnyEvent, CastEvent, EventType } from 'parser/core/Events';
+import { AnyEvent, CastEvent, EventMeta, EventType } from 'parser/core/Events';
 import { useMemo } from 'react';
 
-type WastedMeta = Required<CastEvent>['meta'] & {
+interface WastedMeta extends EventMeta {
   _wastedRp: number;
-};
+}
 
 export function ResourceWasteProblemRenderer({
   problem,
@@ -45,6 +45,8 @@ export function ResourceWasteProblemRenderer({
               return <>This cast wasted {this._wastedRp} RP.</>;
             },
           };
+          // TODO: Come up with a better way of handling this so that it doesn't break any existing meta
+          // eslint-disable-next-line wowanalyzer/event-meta-inefficient-cast
           lastCast.meta = meta;
         } else {
           const meta = lastCast.meta as WastedMeta;

--- a/src/analysis/retail/deathknight/blood/modules/features/MarrowrendUsage.tsx
+++ b/src/analysis/retail/deathknight/blood/modules/features/MarrowrendUsage.tsx
@@ -17,6 +17,7 @@ import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const REFRESH_AT_STACKS = 7;
 
@@ -117,9 +118,7 @@ class MarrowrendUsage extends Analyzer {
       }
 
       if (badCast) {
-        event.meta = event.meta || {};
-        event.meta.isInefficientCast = true;
-        event.meta.inefficientCastReason = badCast;
+        addInefficientCastReason(event, badCast);
       }
     }
 

--- a/src/analysis/retail/deathknight/blood/modules/features/Ossuary.tsx
+++ b/src/analysis/retail/deathknight/blood/modules/features/Ossuary.tsx
@@ -9,8 +9,14 @@ import { NumberThreshold, ThresholdStyle, When } from 'parser/core/ParseResults'
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const OSSUARY_RUNICPOWER_REDUCTION = 5;
+
+const ineffectiveCastMessage = defineMessage({
+  id: 'deathknight.blood.ossuary.ineffectiveCast',
+  message: `This Death Strike cast was without Ossuary.`,
+});
 
 class Ossuary extends Analyzer {
   dsWithOS = 0;
@@ -40,12 +46,7 @@ class Ossuary extends Analyzer {
     } else {
       this.dsWithoutOS += 1;
 
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = defineMessage({
-        id: 'deathknight.blood.ossuary.ineffectiveCast',
-        message: `This Death Strike cast was without Ossuary.`,
-      });
+      addInefficientCastReason(event, ineffectiveCastMessage);
     }
   }
 

--- a/src/analysis/retail/demonhunter/havoc/modules/spells/BladeDance.tsx
+++ b/src/analysis/retail/demonhunter/havoc/modules/spells/BladeDance.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, DamageEvent, FightEndEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 //Example data for bad cast https://wowanalyzer.com/report/g4Pja6pLHnmQtbvk/32-Normal+Sun+King's+Salvation+-+Kill+(10:14)/Zyg/standard
 //For Blade dance and Death Sweep
@@ -103,9 +104,7 @@ class BladeDance extends Analyzer {
     if (this.hitCount < 5 && this.hitCount > 1) {
       //Check last strike
       this.badCast += 1;
-      this.lastCastEvent.meta = this.lastCastEvent.meta || {};
-      this.lastCastEvent.meta.isInefficientCast = true;
-      this.lastCastEvent.meta.inefficientCastReason = 'Bad cast on single target';
+      addInefficientCastReason(this.lastCastEvent, `Bad cast on single target`);
     }
   }
 }

--- a/src/analysis/retail/demonhunter/vengeance/modules/spells/ShearFracture.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/spells/ShearFracture.tsx
@@ -11,6 +11,7 @@ import {
   getGeneratingCast,
   getWastedSoulFragment,
 } from '../../normalizers/ShearFractureNormalizer';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /*WCL: https://www.warcraftlogs.com/reports/Y7BWyCx3mHVZzPrk#fight=last&type=summary&view=events&pins=2%24Off%24%23244F4B%24casts%7Cauras%24-1%240.0.0.Any%240.0.0.Any%24true%240.0.0.Any%24true%24258920%7C204255%7C203981%7C263642
 Default spell is Shear (generates 1 soul). Fracture (generates 2 souls) talent replaces it.
@@ -64,9 +65,7 @@ export default class ShearFracture extends Analyzer {
 
     this.lastCast = generatingCast;
     this.badCasts += 1;
-    this.lastCast.meta = this.lastCast.meta || {};
-    this.lastCast.meta.isInefficientCast = true;
-    this.lastCast.meta.inefficientCastReason = 'Fracture cast that overcapped souls';
+    addInefficientCastReason(this.lastCast, 'Fracture cast that overcapped souls');
   }
 
   suggestions(when: When) {

--- a/src/analysis/retail/druid/balance/modules/features/FillerUsage.tsx
+++ b/src/analysis/retail/druid/balance/modules/features/FillerUsage.tsx
@@ -6,6 +6,7 @@ import { hardcastTargetsHit } from '../../normalizers/CastLinkNormalizer';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { currentEclipse } from 'analysis/retail/druid/balance/constants';
 import GradiatedPerformanceBar from 'interface/guide/components/GradiatedPerformanceBar';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const MIN_STARFIRE_TARGETS_LUNAR = 3;
 const MIN_STARFIRE_TARGETS_CA = 4;
@@ -39,22 +40,25 @@ export default class FillerUsage extends Analyzer {
     const eclipse = currentEclipse(this.selectedCombatant);
 
     if (eclipse === 'solar') {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = `Use Wrath instead of Starfire in Solar Eclipse, regardless of target count`;
+      addInefficientCastReason(
+        event,
+        `Use Wrath instead of Starfire in Solar Eclipse, regardless of target count`,
+      );
       this.solarStarfires += 1;
     } else if (eclipse === 'lunar') {
       if (targetsHit < MIN_STARFIRE_TARGETS_LUNAR) {
-        event.meta = event.meta || {};
-        event.meta.isInefficientCast = true;
-        event.meta.inefficientCastReason = `You hit too few targets: ${targetsHit} - use Wrath instead`;
+        addInefficientCastReason(
+          event,
+          `You hit too few targets: ${targetsHit} - use Wrath instead`,
+        );
         this.lowTargetStarfires += 1;
       }
     } else if (eclipse === 'both') {
       if (targetsHit < MIN_STARFIRE_TARGETS_CA) {
-        event.meta = event.meta || {};
-        event.meta.isInefficientCast = true;
-        event.meta.inefficientCastReason = `You hit too few targets: ${targetsHit} - use Wrath instead`;
+        addInefficientCastReason(
+          event,
+          `You hit too few targets: ${targetsHit} - use Wrath instead`,
+        );
         this.lowTargetStarfires += 1;
       }
     }

--- a/src/analysis/retail/druid/balance/modules/features/SpenderUsage.tsx
+++ b/src/analysis/retail/druid/balance/modules/features/SpenderUsage.tsx
@@ -6,6 +6,7 @@ import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import GradiatedPerformanceBar from 'interface/guide/components/GradiatedPerformanceBar';
 import { encodeEventTargetString } from 'parser/shared/modules/Enemies';
 import { currentEclipse } from 'analysis/retail/druid/balance/constants';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const MIN_STARFALL_TARGETS = 3;
 
@@ -42,9 +43,7 @@ export default class SpenderUsage extends Analyzer {
   onStarsurge(event: CastEvent) {
     if (currentEclipse(this.selectedCombatant) === 'none') {
       this.noEclipseStarsurges += 1;
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = `You should only cast Starsurge during Eclipse!`;
+      addInefficientCastReason(event, `You should only cast Starsurge during Eclipse!`);
     }
     this.totalStarsurges += 1;
   }
@@ -52,9 +51,7 @@ export default class SpenderUsage extends Analyzer {
   onStarfall(event: CastEvent) {
     if (currentEclipse(this.selectedCombatant) === 'none') {
       this.noEclipseStarfalls += 1;
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = `You should only cast Starfall during Eclipse!`;
+      addInefficientCastReason(event, `You should only cast Starfall during Eclipse!`);
     }
     this.totalStarfalls += 1;
 
@@ -77,9 +74,7 @@ export default class SpenderUsage extends Analyzer {
   _tallyLastStarfall() {
     if (this.recentlyHitStarfallTargets.size < MIN_STARFALL_TARGETS && this.lastStarfallCast) {
       this.lowTargetStarfalls += 1;
-      this.lastStarfallCast.meta = this.lastStarfallCast.meta || {};
-      this.lastStarfallCast.meta.isInefficientCast = true;
-      this.lastStarfallCast.meta.inefficientCastReason = `This Starfall hit too few targets!`;
+      addInefficientCastReason(this.lastStarfallCast, `This Starfall hit too few targets!`);
 
       this.recentlyHitStarfallTargets.clear();
       this.lastStarfallCast = undefined;

--- a/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
@@ -23,6 +23,7 @@ import { explanationAndDataSubsection } from 'interface/guide/components/Explana
 import { BadColor, OkColor } from 'interface/guide';
 import { getHits } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
 import HIT_TYPES from 'game/HIT_TYPES';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const MIN_ACCEPTABLE_TIME_LEFT_ON_RIP_MS = 5000;
 
@@ -72,11 +73,12 @@ class FerociousBite extends Analyzer {
     const usedMax = extraEnergyUsed >= maxExtraEnergy;
 
     if (!duringBerserkAndSotf && usedMax) {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = `Used with low energy, causing only ${extraEnergyUsed}
+      addInefficientCastReason(
+        event,
+        `Used with low energy, causing only ${extraEnergyUsed}
         extra energy to be turned in to bonus damage. You should always cast Ferocious Bite with
-        the full extra energy available in order to maximize damage`;
+        the full extra energy available in order to maximize damage`,
+      );
     }
 
     // fill out cast entry

--- a/src/analysis/retail/druid/feral/modules/spells/HitCountAoE.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/HitCountAoE.tsx
@@ -16,6 +16,7 @@ import ThrashUptimeAndSnapshot from 'analysis/retail/druid/feral/modules/spells/
 import { PANDEMIC_FRACTION } from 'analysis/retail/druid/feral/constants';
 import Spell from 'common/SPELLS/Spell';
 import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /**
  * Tracks the number of targets hit by Feral's AoE abilities.
@@ -139,9 +140,7 @@ class HitCountAoE extends Analyzer {
     tracker.hits += hits;
     if (hits === 0) {
       tracker.zeroHitCasts += 1;
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = 'This cast hit nothing!';
+      addInefficientCastReason(event, 'This cast hit nothing!');
     } else if (hits === 1) {
       tracker.oneHitCasts += 1;
     } else {

--- a/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
@@ -31,6 +31,7 @@ import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/Perfo
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { BadColor, OkColor } from 'interface/guide';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 class RipUptimeAndSnapshots extends Snapshots {
   static dependencies = {
@@ -186,13 +187,13 @@ class RipUptimeAndSnapshots extends Snapshots {
     if (prevPower >= power && clipped > 0) {
       const cast = getHardcast(application);
       if (cast) {
-        cast.meta = {
-          isInefficientCast: true,
-          inefficientCastReason: `This cast clipped ${(clipped / 1000).toFixed(
+        addInefficientCastReason(
+          cast,
+          `This cast clipped ${(clipped / 1000).toFixed(
             1,
           )} seconds of Rip time without upgrading the snapshot.
           Try to wait until the last 30% of Rip's duration before refreshing`,
-        };
+        );
       }
     }
   }

--- a/src/analysis/retail/hunter/beastmastery/modules/talents/CobraShot.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/talents/CobraShot.tsx
@@ -13,6 +13,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 import { COBRA_SHOT_CDR_MS, COBRA_SHOT_FOCUS_THRESHOLD_TO_WAIT } from '../../constants';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /**
  * A quick shot causing Physical damage.
@@ -90,8 +91,7 @@ class CobraShot extends Analyzer {
     if (!this.spellUsable.isOnCooldown(TALENTS.KILL_COMMAND_SHARED_TALENT.id)) {
       this.wastedCasts += 1;
       this.wastedKCReductionMs += this.cobraShotCDR;
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = 'Cobra Shot cast while Kill Command is not on cooldown.';
+      addInefficientCastReason(event, 'Cobra Shot cast while Kill Command is not on cooldown.');
       return;
     }
     const globalCooldown = this.globalCooldown.getGlobalCooldownDuration(
@@ -115,13 +115,14 @@ class CobraShot extends Analyzer {
         return;
       }
       if (resource.amount < COBRA_SHOT_FOCUS_THRESHOLD_TO_WAIT) {
-        event.meta.isInefficientCast = true;
-        event.meta.inefficientCastReason =
+        addInefficientCastReason(
+          event,
           "Cobra Shot cast while Kill Command's cooldown was under " +
-          (globalCooldown + this.cobraShotCDR / 1000).toFixed(1) +
-          's remaining and you were not close to capping focus as you only had ' +
-          resource.amount +
-          ' focus.';
+            (globalCooldown + this.cobraShotCDR / 1000).toFixed(1) +
+            's remaining and you were not close to capping focus as you only had ' +
+            resource.amount +
+            ' focus.',
+        );
       }
     } else {
       this.effectiveKCReductionMs += this.spellUsable.reduceCooldown(

--- a/src/analysis/retail/hunter/beastmastery/modules/talents/CobraShot.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/talents/CobraShot.tsx
@@ -81,12 +81,6 @@ class CobraShot extends Analyzer {
   }
 
   onCobraShotCast(event: CastEvent) {
-    if (event.meta === undefined) {
-      event.meta = {
-        isInefficientCast: false,
-        inefficientCastReason: '',
-      };
-    }
     this.casts += 1;
     if (!this.spellUsable.isOnCooldown(TALENTS.KILL_COMMAND_SHARED_TALENT.id)) {
       this.wastedCasts += 1;

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/AimedShot.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/AimedShot.tsx
@@ -12,6 +12,7 @@ import Events, {
 } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /**
  * A powerful aimed shot that deals [(248.4% of Attack power) * ((max(0, min(Level - 10, 10)) * 8 + 130) / 210)] Physical damage.
@@ -129,8 +130,7 @@ class AimedShot extends Analyzer {
     const hasTrueshotBuff = this.selectedCombatant.hasBuff(SPELLS.TRUESHOT.id);
 
     if (hasPreciseShotsBuff && !hasTrueshotBuff) {
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = 'Aimed Shot while having Precise Shots stacks left.';
+      addInefficientCastReason(event, 'Aimed Shot while having Precise Shots stacks left.');
     }
   }
 }

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/AimedShot.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/AimedShot.tsx
@@ -120,12 +120,6 @@ class AimedShot extends Analyzer {
       this.casts += 1;
     }
 
-    if (event.meta === undefined) {
-      event.meta = {
-        isEnhancedCast: false,
-        isInefficientCast: false,
-      };
-    }
     const hasPreciseShotsBuff = this.selectedCombatant.hasBuff(SPELLS.PRECISE_SHOTS.id);
     const hasTrueshotBuff = this.selectedCombatant.hasBuff(SPELLS.TRUESHOT.id);
 

--- a/src/analysis/retail/hunter/survival/modules/talents/MongooseBite.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/MongooseBite.tsx
@@ -25,6 +25,7 @@ import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { addEnhancedCastReason } from 'parser/core/EventMetaLib';
 
 /**
  * Mongoose Fury increases Mongoose Bite damage by 15% for 14 sec, stacking up to 5 times. Successive attacks do not increase duration.
@@ -165,18 +166,11 @@ class MongooseBite extends Analyzer {
       }
       this.windowCheckedForFocus = true;
     }
-    if (event.meta === undefined) {
-      event.meta = {
-        isEnhancedCast: false,
-        enhancedCastReason: '',
-      };
-    }
     if (
       this.lastMongooseBiteStack === 5 &&
       this.selectedCombatant.hasBuff(SPELLS.MONGOOSE_FURY.id)
     ) {
-      event.meta.isEnhancedCast = true;
-      event.meta.enhancedCastReason = 'Mongoose Bite at 5 stacks of Mongoose Fury';
+      addEnhancedCastReason(event, 'Mongoose Bite at 5 stacks of Mongoose Fury');
     }
   }
 

--- a/src/analysis/retail/hunter/survival/modules/talents/RaptorStrike.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/RaptorStrike.tsx
@@ -27,12 +27,6 @@ class RaptorStrike extends Analyzer {
   }
 
   onCast(event: CastEvent) {
-    if (event.meta === undefined) {
-      event.meta = {
-        isInefficientCast: false,
-        inefficientCastReason: '',
-      };
-    }
     if (this.selectedCombatant.hasBuff(SPELLS.VIPERS_VENOM_BUFF.id)) {
       addInefficientCastReason(event, "Viper's Venom buff still active.");
     }

--- a/src/analysis/retail/hunter/survival/modules/talents/RaptorStrike.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/RaptorStrike.tsx
@@ -2,6 +2,7 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/hunter';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /**
  * A vicious slash dealing (70% of Attack power) Physical damage.
@@ -33,8 +34,7 @@ class RaptorStrike extends Analyzer {
       };
     }
     if (this.selectedCombatant.hasBuff(SPELLS.VIPERS_VENOM_BUFF.id)) {
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = "Viper's Venom buff still active.";
+      addInefficientCastReason(event, "Viper's Venom buff still active.");
     }
   }
 }

--- a/src/analysis/retail/mage/fire/talents/SearingTouch.tsx
+++ b/src/analysis/retail/mage/fire/talents/SearingTouch.tsx
@@ -11,6 +11,7 @@ import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const DAMAGE_MODIFIER = 1.5;
 
@@ -77,13 +78,14 @@ class SearingTouch extends Analyzer {
     } else if (spellId === SPELLS.FIREBALL.id && this.healthPercent < SEARING_TOUCH_THRESHOLD) {
       this.fireballExecuteCasts += 1;
       if (this.lastCastEvent) {
-        this.lastCastEvent.meta = this.lastCastEvent.meta || {};
-        this.lastCastEvent.meta.isInefficientCast = true;
-        this.lastCastEvent.meta.inefficientCastReason = `This Fireball was cast while the target was under ${formatPercentage(
-          SEARING_TOUCH_THRESHOLD,
-        )}% health. While talented into Searing Touch, ensure that you are casting Scorch instead of Fireball while the target is under 30% health since Scorch does ${formatPercentage(
-          DAMAGE_MODIFIER,
-        )}% additional damage.`;
+        addInefficientCastReason(
+          this.lastCastEvent,
+          `This Fireball was cast while the target was under ${formatPercentage(
+            SEARING_TOUCH_THRESHOLD,
+          )}% health. While talented into Searing Touch, ensure that you are casting Scorch instead of Fireball while the target is under 30% health since Scorch does ${formatPercentage(
+            DAMAGE_MODIFIER,
+          )}% additional damage.`,
+        );
         debug && this.log('Cast Fireball under 30% Health');
       }
     }

--- a/src/analysis/retail/monk/brewmaster/modules/spells/PurifyingBrew.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/PurifyingBrew.tsx
@@ -23,6 +23,7 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 import BrewCDR from '../core/BrewCDR';
 import SharedBrews from '../core/SharedBrews';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const PURIFY_DELAY_THRESHOLD = 1000; // with the removal of ISB, i'm cutting the delay threshold.
 
@@ -40,15 +41,13 @@ function markupPurify(event: CastEvent, delay: number, hasHeavyStagger: boolean)
   if (msgs.length === 0) {
     return;
   }
-  const meta = event.meta || {};
-  meta.isInefficientCast = true;
-  meta.inefficientCastReason = (
+  addInefficientCastReason(
+    event,
     <>
       This Purifying Brew cast was inefficient because:
       <ul>{msgs}</ul>
-    </>
+    </>,
   );
-  event.meta = meta;
 }
 
 class PurifyingBrew extends Analyzer {

--- a/src/analysis/retail/monk/brewmaster/modules/talents/ScaldingBrew.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/ScaldingBrew.tsx
@@ -11,6 +11,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const DAMAGE_AMP_PER_RANK = 0.0075;
 const BASE_DAMAGE_AMP = 0.075;
@@ -70,15 +71,13 @@ export default class ScaldingBrew extends Analyzer {
       this.missedHits += 1;
 
       if (this.lastCast) {
-        this.lastCast.meta = {
-          isInefficientCast: true,
-          inefficientCastReason: (
-            <>
-              This cast did not benefit from <SpellLink spell={talents.SCALDING_BREW_TALENT} /> or
-              freshly apply the <SpellLink spell={talents.KEG_SMASH_TALENT} /> debuff.
-            </>
-          ),
-        };
+        addInefficientCastReason(
+          this.lastCast,
+          <>
+            This cast did not benefit from <SpellLink spell={talents.SCALDING_BREW_TALENT} /> or
+            freshly apply the <SpellLink spell={talents.KEG_SMASH_TALENT} /> debuff.
+          </>,
+        );
       }
     }
   }

--- a/src/analysis/retail/monk/windwalker/modules/core/SpellUsable.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/core/SpellUsable.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { AbilityEvent, CastEvent, EventType } from 'parser/core/Events';
 import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
+import { addEnhancedCastReason } from 'parser/core/EventMetaLib';
 
 // Override spell usable to handle CD resets on RSK from Teachings of the Monastery
 // There is no direct event to observe, so if we detect RSK being used earlier than its CD dictates,
@@ -49,13 +50,12 @@ class SpellUsable extends CoreSpellUsable {
         this.endCooldown(spellId, this.lastPotentialTriggerForRskReset.timestamp + 1);
 
         // flag the reset event in the timeline
-        this.lastPotentialTriggerForRskReset.meta = this.lastPotentialTriggerForRskReset.meta || {};
-        this.lastPotentialTriggerForRskReset.meta.isEnhancedCast = true;
-        this.lastPotentialTriggerForRskReset.meta.enhancedCastReason = (
+        addEnhancedCastReason(
+          this.lastPotentialTriggerForRskReset,
           <>
             This cast reset the cooldown of <SpellLink spell={TALENTS.RISING_SUN_KICK_TALENT} /> due
             to <SpellLink spell={TALENTS.TEACHINGS_OF_THE_MONASTERY_TALENT} />
-          </>
+          </>,
         );
       }
       this.lastPotentialTriggerForRskReset = null;

--- a/src/analysis/retail/monk/windwalker/modules/spells/BlackoutKick.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/BlackoutKick.tsx
@@ -11,6 +11,7 @@ import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import { TALENTS_MONK } from 'common/TALENTS';
 
 import { BLACKOUT_KICK_COOLDOWN_REDUCTION_MS } from '../../constants';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 function oxfordCommaJoin(list: JSX.Element[], joiner = 'and'): JSX.Element {
   switch (list.length) {
@@ -94,16 +95,15 @@ class BlackoutKick extends Analyzer {
      */
     const modRate = this.selectedCombatant.hasBuff(TALENTS_MONK.SERENITY_TALENT.id) ? 2 : 1;
     if (availableImportantCast.length > 0) {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
       const linkList = availableImportantCast.map((spellId) => (
         <SpellLink key={spellId} spell={spellId} />
       ));
-      event.meta.inefficientCastReason = (
+      addInefficientCastReason(
+        event,
         <>
           You cast this <SpellLink spell={SPELLS.BLACKOUT_KICK} /> while {oxfordCommaJoin(linkList)}{' '}
           was available.
-        </>
+        </>,
       );
     }
 

--- a/src/analysis/retail/monk/windwalker/modules/talents/DanceOfChiJi.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/DanceOfChiJi.tsx
@@ -8,6 +8,7 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import { TALENTS_MONK } from 'common/TALENTS';
+import { addEnhancedCastReason } from 'parser/core/EventMetaLib';
 
 const DAMAGE_MODIFIER = 1;
 const STORM_EARTH_AND_FIRE_CAST_BUFFER = 200;
@@ -45,21 +46,11 @@ class DANCE_OF_CHI_JI extends Analyzer {
       )
     ) {
       this.buffedCast = true;
-      event.meta = event.meta || {};
-      event.meta.isEnhancedCast = true;
-      const reason = (
+      addEnhancedCastReason(
+        event,
         <>
           This cast was empowered by <SpellLink spell={SPELLS.DANCE_OF_CHI_JI_BUFF} />
-        </>
-      );
-      event.meta.enhancedCastReason = event.meta.enhancedCastReason ? (
-        <>
-          {event.meta.enhancedCastReason}
-          <br />
-          {reason}
-        </>
-      ) : (
-        reason
+        </>,
       );
     } else {
       // GCD is shorter than the duration SCK deals damage, and new SCK casts override any ongoing SCK cast, so this prevents a directly following from being marked as benefitting

--- a/src/analysis/retail/paladin/holy/modules/spells/FillerFlashOfLight.tsx
+++ b/src/analysis/retail/paladin/holy/modules/spells/FillerFlashOfLight.tsx
@@ -9,6 +9,7 @@ import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 
 import AbilityTracker from '../core/PaladinAbilityTracker';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /** @type {number} (ms) When Holy Shock has less than this as cooldown remaining you should wait and still not cast that filler FoL. */
 const HOLY_SHOCK_COOLDOWN_WAIT_TIME = 200;
@@ -75,13 +76,12 @@ class FillerFlashOfLight extends Analyzer {
    */
   onCast(event: CastEvent) {
     if (this._isCurrentCastInefficient) {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = (
+      addInefficientCastReason(
+        event,
         <Trans id="paladin.holy.modules.fillerFlashOfLight.inefficientCastReason">
           Holy Shock was off cooldown when you started casting this unbuffed Flash of Light. You
           should cast Holy Shock instead.
-        </Trans>
+        </Trans>,
       );
     }
   }

--- a/src/analysis/retail/paladin/holy/modules/spells/FillerLightOfTheMartyrs.tsx
+++ b/src/analysis/retail/paladin/holy/modules/spells/FillerLightOfTheMartyrs.tsx
@@ -7,6 +7,7 @@ import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
 import { When, ThresholdStyle } from 'parser/core/ParseResults';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /** @type {number} (ms) When Holy Shock has less than this as cooldown remaining you should wait and still not cast that filler FoL. */
 const HOLY_SHOCK_COOLDOWN_WAIT_TIME = 200;
@@ -43,9 +44,8 @@ class FillerLightOfTheMartyrs extends Analyzer {
       }
     }
     this.inefficientCasts.push(event);
-    event.meta = event.meta || {};
-    event.meta.isInefficientCast = true;
-    event.meta.inefficientCastReason = i18n._(
+    addInefficientCastReason(
+      event,
       defineMessage({
         id: 'paladin.holy.modules.fillerLightOfTheMatyrs.holyShockWasAvailable',
         message: `Holy Shock was available and should have been cast instead as it is a much more efficient spell.`,

--- a/src/analysis/retail/paladin/holy/modules/spells/FillerLightOfTheMartyrs.tsx
+++ b/src/analysis/retail/paladin/holy/modules/spells/FillerLightOfTheMartyrs.tsx
@@ -1,11 +1,9 @@
 import { defineMessage, t, Trans } from '@lingui/macro';
-import { i18n } from '@lingui/core';
 import TALENTS from 'common/TALENTS/paladin';
-import { SpellLink } from 'interface';
-import { TooltipElement } from 'interface';
-import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
+import { SpellLink, TooltipElement } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
-import { When, ThresholdStyle } from 'parser/core/ParseResults';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 

--- a/src/analysis/retail/paladin/holy/modules/spells/InefficientLightOfTheMartyrs.tsx
+++ b/src/analysis/retail/paladin/holy/modules/spells/InefficientLightOfTheMartyrs.tsx
@@ -3,6 +3,7 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/paladin';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
 import Events, { CastEvent, DamageEvent, HealEvent } from 'parser/core/Events';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 class InefficientLightOfTheMartyrs extends Analyzer {
   // have to track over multiple events when player has Maraad's talent
@@ -61,12 +62,13 @@ class InefficientLightOfTheMartyrs extends Analyzer {
 
     const effectiveHealing = healingDone - this.damageTakenSinceLast;
     if (effectiveHealing <= 0) {
-      cast.meta = cast.meta || {};
-      cast.meta.isInefficientCast = true;
-      cast.meta.inefficientCastReason = defineMessage({
-        id: 'paladin.holy.timeline.badLotM',
-        message: `This cast dealt more damage to you than it healed the target. If there is nothing to heal, you should deal damage instead.`,
-      });
+      addInefficientCastReason(
+        cast,
+        defineMessage({
+          id: 'paladin.holy.timeline.badLotM',
+          message: `This cast dealt more damage to you than it healed the target. If there is nothing to heal, you should deal damage instead.`,
+        }),
+      );
     }
   }
 }

--- a/src/analysis/retail/paladin/holy/modules/talents/CrusadersMight.tsx
+++ b/src/analysis/retail/paladin/holy/modules/talents/CrusadersMight.tsx
@@ -10,6 +10,7 @@ import GlobalCooldown from 'parser/shared/modules/GlobalCooldown';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import StatisticBox, { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const COOLDOWN_REDUCTION_MS_PER_POINT = 1500;
 
@@ -64,13 +65,13 @@ class CrusadersMight extends Analyzer {
       this.holyShocksCastsLost += timeWasted / holyShockCooldown;
 
       // mark the event on the timeline
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = (
-        <Trans id="paladin.holy.modules.talents.crusadersMight.inefficientCast">
-          Holy Shock was off cooldown when you cast Crusader Strike. You should cast Holy Shock
-          before Crusader Strike for maximum healing or damage.
-        </Trans>
+      addInefficientCastReason(
+        event,
+        defineMessage({
+          id: 'paladin.holy.modules.talents.crusadersMight.inefficientCast',
+          message:
+            'Holy Shock was off cooldown when you cast Crusader Strike. You should cast Holy Shock before Crusader Strike for maximum healing or damage.',
+        }),
       );
     }
   }

--- a/src/analysis/retail/paladin/holy/modules/talents/ImbuedInfusion.tsx
+++ b/src/analysis/retail/paladin/holy/modules/talents/ImbuedInfusion.tsx
@@ -13,6 +13,7 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import TalentSpellText from 'parser/ui/TalentSpellText';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 // its one point right now but I already had this so w/e
 const COOLDOWN_REDUCTION_MS_PER_POINT = 2000;
@@ -74,13 +75,12 @@ class ImbuedInfusion extends Analyzer {
       this.holyShocksCastsLost += timeWasted / holyShockCooldown;
 
       // mark the event on the timeline
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = (
+      addInefficientCastReason(
+        event,
         <Trans id="paladin.holy.modules.talents.imbuedInfusion.inefficientCast">
           Holy Shock was off cooldown when you consumed Infusion of Light. You should cast Holy
           Shock before Crusader Strike for maximum healing or damage.
-        </Trans>
+        </Trans>,
       );
     }
   }

--- a/src/analysis/retail/paladin/retribution/modules/core/CrusaderStrike.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/core/CrusaderStrike.tsx
@@ -1,6 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 class CrusaderStrike extends Analyzer {
   wasteHP = false;
@@ -25,10 +26,10 @@ class CrusaderStrike extends Analyzer {
 
   onCrusaderStrikeCast(event: CastEvent) {
     if (this.wasteHP) {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason =
-        'Crusader Strike was cast while at max Holy Power. Make sure to use a Holy Power spender first to avoid overcapping.';
+      addInefficientCastReason(
+        event,
+        'Crusader Strike was cast while at max Holy Power. Make sure to use a Holy Power spender first to avoid overcapping.',
+      );
       this.wasteHP = false;
     }
   }

--- a/src/analysis/retail/paladin/retribution/modules/talents/BladeofJustice.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/talents/BladeofJustice.tsx
@@ -1,6 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 class BladeofJustice extends Analyzer {
   wastedHP = 0;
@@ -25,13 +26,14 @@ class BladeofJustice extends Analyzer {
 
   onBladeOfJusticeCast(event: CastEvent) {
     if (this.wastedHP > 0) {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = `Blade of Justice was cast while at ${
-        this.wastedHP === 1 ? '4 Holy Power' : 'max Holy Power'
-      }. Make sure to either use a ${
-        this.wastedHP === 1 ? '1 Holy Power Generator or' : ''
-      } Holy Power spender first to avoid overcapping.`;
+      addInefficientCastReason(
+        event,
+        `Blade of Justice was cast while at ${
+          this.wastedHP === 1 ? '4 Holy Power' : 'max Holy Power'
+        }. Make sure to either use a ${
+          this.wastedHP === 1 ? '1 Holy Power Generator or' : ''
+        } Holy Power spender first to avoid overcapping.`,
+      );
       this.wastedHP = 0;
     }
   }

--- a/src/analysis/retail/paladin/retribution/modules/talents/Crusade.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/talents/Crusade.tsx
@@ -9,6 +9,7 @@ import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import GlobalCooldown from 'parser/shared/modules/GlobalCooldown';
 import TALENTS from 'common/TALENTS/paladin';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const CAST_BUFFER = 500;
 
@@ -47,10 +48,10 @@ class Crusade extends Analyzer {
     this.crusadeCastTimestamp = event.timestamp;
     this.gcdBuffer = this.globalCooldown.getGlobalCooldownDuration(TALENTS.CRUSADE_TALENT.id);
     if (this.holyPowerTracker.current < 3) {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason =
-        'Make sure to have at least 3 Holy Power before using Crusade. Ideally you should have 5 Holy Power before using Crusade after your first use.';
+      addInefficientCastReason(
+        event,
+        'Make sure to have at least 3 Holy Power before using Crusade. Ideally you should have 5 Holy Power before using Crusade after your first use.',
+      );
     }
   }
 

--- a/src/analysis/retail/paladin/retribution/modules/talents/HammerofWrath.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/talents/HammerofWrath.tsx
@@ -1,6 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 // TODO: Needs updating with ExecuteHelper
 
@@ -27,10 +28,10 @@ class HammerofWrath extends Analyzer {
 
   onHammerofWrathCast(event: CastEvent) {
     if (this.wasteHP) {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason =
-        'Hammer of Wrath was cast while at max Holy Power. Make sure to use a Holy Power spender first to avoid overcapping.';
+      addInefficientCastReason(
+        event,
+        'Hammer of Wrath was cast while at max Holy Power. Make sure to use a Holy Power spender first to avoid overcapping.',
+      );
       this.wasteHP = false;
     }
   }

--- a/src/analysis/retail/paladin/retribution/modules/talents/WakeofAshes.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/talents/WakeofAshes.tsx
@@ -13,6 +13,7 @@ import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import StatisticBox, { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 class WakeofAshes extends Analyzer {
   static dependencies = {
@@ -61,10 +62,10 @@ class WakeofAshes extends Analyzer {
     }
     this.wakeCast = true;
     if (this.wasteHP) {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason =
-        '1 Holy Power or more wasted. You should be at 2 Holy Power or less before using Wake.';
+      addInefficientCastReason(
+        event,
+        '1 Holy Power or more wasted. You should be at 2 Holy Power or less before using Wake.',
+      );
       this.wasteHP = false;
     }
   }

--- a/src/analysis/retail/rogue/shared/FilteredDamageTracker.ts
+++ b/src/analysis/retail/rogue/shared/FilteredDamageTracker.ts
@@ -2,6 +2,7 @@ import Spell from 'common/SPELLS/Spell';
 import { AnyEvent, CastEvent, DamageEvent, HealEvent } from 'parser/core/Events';
 import DamageTracker from 'parser/shared/modules/AbilityTracker';
 import { ReactNode } from 'react';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 type FilteredDamageObserver = (event: CastEvent) => void;
 
@@ -42,9 +43,7 @@ class FilteredDamageTracker extends DamageTracker {
     this.subscribeToCastEvent((event) => {
       const spell = spells.find((s) => event.ability.guid === s.id);
       if (spell) {
-        event.meta = event.meta || {};
-        event.meta.isInefficientCast = true;
-        event.meta.inefficientCastReason = messageFunction(spell);
+        addInefficientCastReason(event, messageFunction(spell));
       }
     });
   }

--- a/src/analysis/retail/rogue/shared/StealthAbilityFollowingSepsis.tsx
+++ b/src/analysis/retail/rogue/shared/StealthAbilityFollowingSepsis.tsx
@@ -11,6 +11,7 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import * as React from 'react';
 import { abilityToSpell } from 'common/abilityToSpell';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const STEALTH_ABILITIES: Spell[] = [
   SPELLS.PICK_POCKET,
@@ -71,9 +72,10 @@ class StealthAbilityFollowingSepsis extends Analyzer {
     if (event.ability.guid !== this.properStealthAbility.id) {
       debug && console.log(`Recorded bad cast with id ${event.ability.guid}`);
       this.badCasts.push(event);
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = `You used the incorrect Stealth ability. You should've used ${this.properStealthAbility.name}.`;
+      addInefficientCastReason(
+        event,
+        `You used the incorrect Stealth ability. You should've used ${this.properStealthAbility.name}.`,
+      );
     } else {
       debug && console.log(`Recorded good cast with id ${event.ability.guid}`);
     }

--- a/src/analysis/retail/shaman/elemental/modules/features/SubOptimalChainLightning.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/features/SubOptimalChainLightning.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 // https://stormearthandlava.com/guide/general/priority_list.html
 const TARGETS_FOR_GOOD_CAST = 3;
@@ -49,9 +50,10 @@ class SubOptimalChainLightning extends Analyzer {
       return;
     }
     this.badCasts += 1;
-    this.lastCast.meta = this.lastCast.meta || {};
-    this.lastCast.meta.isInefficientCast = true;
-    this.lastCast.meta.inefficientCastReason = `Chain Lightning hit less than ${TARGETS_FOR_GOOD_CAST} targets.`;
+    addInefficientCastReason(
+      this.lastCast,
+      `Chain Lightning hit less than ${TARGETS_FOR_GOOD_CAST} targets.`,
+    );
   }
 
   onCast(event: CastEvent) {

--- a/src/analysis/retail/shaman/elemental/modules/talents/MasterOfTheElements.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/talents/MasterOfTheElements.tsx
@@ -9,6 +9,7 @@ import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import TalentSpellText from 'parser/ui/TalentSpellText';
+import { addEnhancedCastReason } from 'parser/core/EventMetaLib';
 
 const MASTER_OF_THE_ELEMENTS = {
   INCREASE: 0.2,
@@ -90,8 +91,7 @@ class MasterOfTheElements extends Analyzer {
     }
     this.moteConsumptionTimestamp = event.timestamp;
     this.moteActivationTimestamp = null;
-    event.meta = event.meta || {};
-    event.meta.isEnhancedCast = true;
+    addEnhancedCastReason(event);
     this.moteBuffedAbilities[event.ability.guid] += 1;
   }
 

--- a/src/analysis/retail/shaman/elemental/modules/talents/Stormkeeper.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/talents/Stormkeeper.tsx
@@ -27,6 +27,7 @@ import { formatDuration } from 'common/format';
 import { PerformanceMark } from 'interface/guide';
 import SpellMaelstromCost from '../core/SpellMaelstromCost';
 import MaelstromTracker from '../resources/MaelstromTracker';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const SK_DAMAGE_AFFECTED_ABILITIES = [
   SPELLS.LIGHTNING_BOLT_OVERLOAD,
@@ -237,10 +238,10 @@ class Stormkeeper extends MajorCooldown<SKCast> {
         // Some rotations cast SK before pull. In this case, the rotation is slightly different.
         !(isPrepull && spenderNotAlreadyCast)
       ) {
-        event.meta = {
-          isInefficientCast: true,
-          inefficientCastReason: <>{this.stSpender.name} cast without Master of the Elements</>,
-        };
+        addInefficientCastReason(
+          event,
+          <>{this.stSpender.name} cast without Master of the Elements</>,
+        );
         this.activeWindow.timeline.performance = getLowestPerf([
           MISSING_MOTE_PERFORMANCE,
           this.activeWindow.timeline.performance,
@@ -262,10 +263,7 @@ class Stormkeeper extends MajorCooldown<SKCast> {
         // Some rotations cast SK before pull. In this case, the rotation is slightly different.
         !(isPrepull && sopSpellNotAlreadyCast)
       ) {
-        event.meta = {
-          isInefficientCast: true,
-          inefficientCastReason: <>{event.ability.name} cast without Surge of Power</>,
-        };
+        addInefficientCastReason(event, <>{event.ability.name} cast without Surge of Power</>);
         this.activeWindow.timeline.performance = getLowestPerf([
           SOP_BUFF_MISSING_PERFORMANCE,
           this.activeWindow.timeline.performance,

--- a/src/analysis/retail/shaman/elemental/modules/talents/SurgeOfPower.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/talents/SurgeOfPower.tsx
@@ -11,6 +11,7 @@ import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import { GUIDE_EXPLANATION_PERCENT_WIDTH, ON_CAST_BUFF_REMOVAL_GRACE_MS } from '../../constants';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
+import { addEnhancedCastReason } from 'parser/core/EventMetaLib';
 
 const SURGE_OF_POWER = {
   AFFECTED_CASTS: [
@@ -95,8 +96,7 @@ class SurgeOfPower extends Analyzer {
       return;
     }
 
-    event.meta = event.meta || {};
-    event.meta.isEnhancedCast = true;
+    addEnhancedCastReason(event);
     this.sopBuffedAbilities[event.ability.guid] += 1;
     this.sopActive = false;
 

--- a/src/analysis/retail/shaman/enhancement/modules/talents/ChainLightning.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/ChainLightning.tsx
@@ -6,6 +6,7 @@ import { CHAIN_LIGHTNING_LINK } from 'analysis/retail/shaman/enhancement/modules
 import SPELLS from 'common/SPELLS';
 import { TIERS } from 'game/TIERS';
 import { SpellLink } from 'interface';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const CRASH_LIGHTNING_REDUCTION = 1000;
 
@@ -52,23 +53,21 @@ class ChainLightning extends Analyzer {
     if (hits < 2) {
       if (this.has4pcT30) {
         if (!this.selectedCombatant.getBuff(SPELLS.CRACKLING_THUNDER_TIER_BUFF.id)) {
-          event.meta = event.meta || {};
-          event.meta.isInefficientCast = true;
-          event.meta.inefficientCastReason = (
+          addInefficientCastReason(
+            event,
             <>
               <SpellLink spell={TALENTS_SHAMAN.CHAIN_LIGHTNING_TALENT} /> only hit one target and
               was cast without <SpellLink spell={SPELLS.CRACKLING_THUNDER_TIER_BUFF} />
-            </>
+            </>,
           );
         }
       }
     } else {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = (
+      addInefficientCastReason(
+        event,
         <>
           <SpellLink spell={TALENTS_SHAMAN.CHAIN_LIGHTNING_TALENT} /> only hit one target
-        </>
+        </>,
       );
     }
   }

--- a/src/analysis/retail/shaman/enhancement/modules/talents/Sundering.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/Sundering.tsx
@@ -10,6 +10,7 @@ import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /**
  * This can be quite a large gap since the cooldown of Sundering is `only` 40 seconds.
@@ -87,9 +88,7 @@ class Sundering extends Analyzer {
    */
   markBadCasts() {
     this.missedCasts.forEach((cast) => {
-      cast.meta = cast.meta || {};
-      cast.meta.isInefficientCast = true;
-      cast.meta.inefficientCastReason = <>Sundering did not hit any targets.</>;
+      addInefficientCastReason(cast, <>Sundering did not hit any targets.</>);
     });
   }
 

--- a/src/analysis/retail/shaman/enhancement/modules/talents/ThorimsInvocation.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/ThorimsInvocation.tsx
@@ -14,6 +14,7 @@ import { formatNumber } from 'common/format';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import GlobalCooldown from 'parser/shared/modules/GlobalCooldown';
 import { DamageIcon, UptimeIcon } from 'interface/icons';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /** Lightning Bolt and Chain Lightning damage increased by 20%.
  *
@@ -107,22 +108,20 @@ class ThorimsInvocation extends Analyzer {
           this.spellUsable.cooldownRemaining(SPELLS.WINDSTRIKE_CAST.id) +
             this.gcd.getGlobalCooldownDuration(event.ability.guid)
       ) {
-        event.meta = event.meta || {};
-        event.meta.isInefficientCast = true;
-        event.meta.inefficientCastReason = (
+        addInefficientCastReason(
+          event,
           <>
             You should have re-primed <SpellLink spell={TALENTS.THORIMS_INVOCATION_TALENT} /> by
             casting <SpellLink spell={SPELLS.LIGHTNING_BOLT} />
-          </>
+          </>,
         );
       } else if (!cracklingThunder && hits < 2) {
-        event.meta = event.meta || {};
-        event.meta.isInefficientCast = true;
-        event.meta.inefficientCastReason = (
+        addInefficientCastReason(
+          event,
           <>
             <SpellLink spell={TALENTS.THORIMS_INVOCATION_TALENT} /> was not primed with{' '}
             <SpellLink spell={SPELLS.LIGHTNING_BOLT} />
-          </>
+          </>,
         );
       }
     }

--- a/src/analysis/retail/shaman/restoration/modules/spells/HealingWave.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/spells/HealingWave.tsx
@@ -7,6 +7,7 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { BeginCastEvent, CastEvent } from 'parser/core/Events';
 import { When } from 'parser/core/ParseResults';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 import RestorationAbilityTracker from '../core/RestorationAbilityTracker';
 
@@ -70,14 +71,13 @@ class HealingWave extends Analyzer {
    */
   onHealingWaveCast(event: CastEvent) {
     if (this._isCurrentCastInefficient) {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = (
+      addInefficientCastReason(
+        event,
         <Trans id="shaman.restoration.healingWave.inefficientCast.reason">
           Riptide was off cooldown when you started casting this unbuffed Healing Wave. Casting
           Riptide into Healing Wave to generate and use a Tidal Wave stack, or using a Flash Flood
           buff (if talented) is a lot more efficient compared to casting a full-length Healing Wave.
-        </Trans>
+        </Trans>,
       );
     }
   }

--- a/src/analysis/retail/shaman/restoration/modules/talents/Wellspring.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/Wellspring.tsx
@@ -19,6 +19,7 @@ import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 class Wellspring extends Analyzer {
   static dependencies = {
@@ -108,12 +109,11 @@ class Wellspring extends Analyzer {
     if (!this.castEvent) {
       return;
     }
-    this.castEvent.meta = this.castEvent.meta || {};
-    this.castEvent.meta.isInefficientCast = true;
-    this.castEvent.meta.inefficientCastReason = (
+    addInefficientCastReason(
+      this.castEvent,
       <Trans id="shaman.restoration.wellspring.inefficientCast.reason">
         This Wellspring cast hit less than 6 targets.
-      </Trans>
+      </Trans>,
     );
   }
 

--- a/src/analysis/retail/warrior/arms/modules/core/Bladestorm.tsx
+++ b/src/analysis/retail/warrior/arms/modules/core/Bladestorm.tsx
@@ -10,6 +10,7 @@ import { ThresholdStyle, When } from 'parser/core/ParseResults';
 
 import SpellUsable from '../features/SpellUsable';
 import ExecuteRangeTracker from './Execute/ExecuteRange';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 interface CurrentCast {
   event: CastEvent | null;
@@ -113,10 +114,10 @@ class Bladestorm extends Analyzer {
       this.currentCast.event.classResources.find((e) => e.type === RESOURCE_TYPES.RAGE.id);
     if (rage && rage.amount > RAGE_STARVED_AMOUNT) {
       this.badCasts += 1;
-      this.currentCast.event.meta = this.currentCast.event.meta || {};
-      this.currentCast.event.meta.isInefficientCast = true;
-      this.currentCast.event.meta.inefficientCastReason =
-        'Bladestorm was used while you still had rage to use on higher priority abilities during a single target situation';
+      addInefficientCastReason(
+        this.currentCast.event,
+        'Bladestorm was used while you still had rage to use on higher priority abilities during a single target situation',
+      );
     }
   }
 
@@ -168,9 +169,7 @@ class Bladestorm extends Analyzer {
 
     if (badCast) {
       this.badCasts += 1;
-      this.currentCast.event.meta = this.currentCast.event.meta || {};
-      this.currentCast.event.meta.isInefficientCast = true;
-      this.currentCast.event.meta.inefficientCastReason = this.currentCast.text;
+      addInefficientCastReason(this.currentCast.event, this.currentCast.text);
     }
   }
 

--- a/src/analysis/retail/warrior/arms/modules/core/Overpower.tsx
+++ b/src/analysis/retail/warrior/arms/modules/core/Overpower.tsx
@@ -11,6 +11,7 @@ import { When, ThresholdStyle } from 'parser/core/ParseResults';
 
 import SpellUsable from '../features/SpellUsable';
 import ExecuteRange from './Execute/ExecuteRange';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /**
  * Logs used to test:
@@ -71,10 +72,10 @@ class OverpowerAnalyzer extends Analyzer {
     if (!this.executeRange.isTargetInExecuteRange(event.targetID || 0, event.targetInstance || 0)) {
       this.wastedProc += 1;
 
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason =
-        'This Overpower was used while already at 2 stacks and Mortal Strike was available';
+      addInefficientCastReason(
+        event,
+        'This Overpower was used while already at 2 stacks and Mortal Strike was available',
+      );
     }
   }
 

--- a/src/analysis/retail/warrior/arms/modules/core/Slam.tsx
+++ b/src/analysis/retail/warrior/arms/modules/core/Slam.tsx
@@ -9,6 +9,7 @@ import { ThresholdStyle, When } from 'parser/core/ParseResults';
 
 import SpellUsable from '../features/SpellUsable';
 import ExecuteRange from './Execute/ExecuteRange';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 class Slam extends Analyzer {
   static dependencies = {
@@ -47,10 +48,7 @@ class Slam extends Analyzer {
       this.spellUsable.isAvailable(SPELLS.MORTAL_STRIKE.id) &&
       !this.executeRange.isTargetInExecuteRange(event.targetID || 0, event.targetInstance || 0)
     ) {
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason =
-        'This Slam was used on a target while Mortal Strike was off cooldown.';
+      addInefficientCastReason(event, 'This Slam was used on a target while Mortal Strike was off cooldown.');
       this.badCast += 1;
     } else if (
       this.executeRange.isTargetInExecuteRange(event.targetID || 0, event.targetInstance || 0)

--- a/src/analysis/retail/warrior/arms/modules/core/Slam.tsx
+++ b/src/analysis/retail/warrior/arms/modules/core/Slam.tsx
@@ -9,7 +9,7 @@ import { ThresholdStyle, When } from 'parser/core/ParseResults';
 
 import SpellUsable from '../features/SpellUsable';
 import ExecuteRange from './Execute/ExecuteRange';
-import { addInefficientCastReason } from 'parser/core/EventMetaLib';
+import { addEnhancedCastReason, addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 class Slam extends Analyzer {
   static dependencies = {
@@ -48,14 +48,15 @@ class Slam extends Analyzer {
       this.spellUsable.isAvailable(SPELLS.MORTAL_STRIKE.id) &&
       !this.executeRange.isTargetInExecuteRange(event.targetID || 0, event.targetInstance || 0)
     ) {
-      addInefficientCastReason(event, 'This Slam was used on a target while Mortal Strike was off cooldown.');
+      addInefficientCastReason(
+        event,
+        'This Slam was used on a target while Mortal Strike was off cooldown.',
+      );
       this.badCast += 1;
     } else if (
       this.executeRange.isTargetInExecuteRange(event.targetID || 0, event.targetInstance || 0)
     ) {
-      event.meta = event.meta || {};
-      event.meta.isEnhancedCast = true;
-      event.meta.enhancedCastReason = 'This Slam consumed a Crushing Assasult buff.';
+      addEnhancedCastReason(event, 'This Slam consumed a Crushing Assasult buff.');
     }
   }
 

--- a/src/analysis/retail/warrior/arms/modules/core/SweepingStrikes.tsx
+++ b/src/analysis/retail/warrior/arms/modules/core/SweepingStrikes.tsx
@@ -9,6 +9,7 @@ import Abilities from 'parser/core/modules/Abilities';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 
 import SpellUsable from '../features/SpellUsable';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /**
  * Example report: /report/YXFby87mzNrLtwj1/12-Normal+King+Rastakhan+-+Wipe+1+(3:32)/30-Korebian/timeline
@@ -57,9 +58,10 @@ class SweepingStrikes extends Analyzer {
       const cdElapsed = spellCd * 1000 - this.spellUsable.cooldownRemaining(spell.id);
       if (cdElapsed < 1000) {
         this.badCasts += 1;
-        event.meta = event.meta || {};
-        event.meta.isInefficientCast = true;
-        event.meta.inefficientCastReason = `This Sweeping Strikes was used on a target during ${spell.name}.`;
+        addInefficientCastReason(
+          event,
+          `This Sweeping Strikes was used on a target during ${spell.name}.`,
+        );
       }
     }
   }

--- a/src/analysis/retail/warrior/fury/modules/spells/Whirlwind.tsx
+++ b/src/analysis/retail/warrior/fury/modules/spells/Whirlwind.tsx
@@ -9,6 +9,7 @@ import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 
 import RageTracker from '../core/RageTracker';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 class Whirlwind extends Analyzer {
   static dependencies = {
@@ -144,8 +145,7 @@ class Whirlwind extends Analyzer {
     }
 
     if (badCast) {
-      this.lastEvent.meta = event.meta || {};
-      this.lastEvent.meta.isInefficientCast = true;
+      addInefficientCastReason(this.lastEvent);
       this.badWWCast += 1;
     }
   }

--- a/src/analysis/retail/warrior/protection/modules/spells/BoomingVoice.tsx
+++ b/src/analysis/retail/warrior/protection/modules/spells/BoomingVoice.tsx
@@ -12,6 +12,7 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TALENTS from 'common/TALENTS/warrior';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const BOOMING_VOICE_DAMAGE_INCREASE = 0.2;
 const BOOMING_VOICE_RAGE_GENERATION = 30;
@@ -49,9 +50,7 @@ class BoomingVoice extends Analyzer {
       return;
     }
 
-    event.meta = event.meta || {};
-    event.meta.isInefficientCast = true;
-    event.meta.inefficientCastReason = `This cast wasted ${this.nextCastWasted} Rage.`;
+    addInefficientCastReason(event, `This cast wasted ${this.nextCastWasted} Rage.`);
     this.nextCastWasted = 0;
   }
 

--- a/src/analysis/retail/warrior/protection/modules/spells/ShieldBlock.tsx
+++ b/src/analysis/retail/warrior/protection/modules/spells/ShieldBlock.tsx
@@ -8,6 +8,7 @@ import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import BoringValueText from 'parser/ui/BoringValueText';
 import Statistic from 'parser/ui/Statistic';
 import TALENTS from 'common/TALENTS/warrior';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const debug = false;
 
@@ -144,9 +145,10 @@ class ShieldBlock extends Analyzer {
     } else {
       this.badCast += 1;
       const event = this.shieldBlocksOffensive[this.shieldBlocksOffensive.length - 1].event;
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = `This Shield Block didn't block enough damage nor did you cast enough Shield Slams.`;
+      addInefficientCastReason(
+        event,
+        `This Shield Block didn't block enough damage nor did you cast enough Shield Slams.`,
+      );
       this.shieldBlocksOffensive[this.shieldBlocksOffensive.length - 1].event = event;
     }
 

--- a/src/interface/report/Results/Timeline/Casts.tsx
+++ b/src/interface/report/Results/Timeline/Casts.tsx
@@ -17,6 +17,7 @@ import {
 import { Fragment, CSSProperties, HTMLAttributes, ReactNode } from 'react';
 
 import './Casts.scss';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 const ICON_WIDTH = 22;
 
@@ -67,14 +68,13 @@ export const highlightInefficientCast = (
 ) => {
   if (Array.isArray(event)) {
     event.forEach((e) => {
+      addInefficientCastReason(e, tooltip);
       e.meta = e.meta || {};
       e.meta.isInefficientCast = true;
       e.meta.inefficientCastReason = tooltip;
     });
   } else {
-    event.meta = event.meta || {};
-    event.meta.isInefficientCast = true;
-    event.meta.inefficientCastReason = tooltip;
+    addInefficientCastReason(event, tooltip);
   }
 };
 

--- a/src/interface/report/Results/Timeline/Casts.tsx
+++ b/src/interface/report/Results/Timeline/Casts.tsx
@@ -69,9 +69,6 @@ export const highlightInefficientCast = (
   if (Array.isArray(event)) {
     event.forEach((e) => {
       addInefficientCastReason(e, tooltip);
-      e.meta = e.meta || {};
-      e.meta.isInefficientCast = true;
-      e.meta.inefficientCastReason = tooltip;
     });
   } else {
     addInefficientCastReason(event, tooltip);

--- a/src/parser/core/EventMetaLib.tsx
+++ b/src/parser/core/EventMetaLib.tsx
@@ -1,39 +1,60 @@
-import { CastEvent } from './Events';
+/* This eslint-disable is here because this is the blessed way to modify event.meta */
+/* eslint-disable wowanalyzer/event-meta-inefficient-cast */
+import { MessageDescriptor } from '@lingui/core';
+import { useLingui } from '@lingui/react';
+import { ReactNode } from 'react';
+import { isMessageDescriptor } from 'localization/isMessageDescriptor';
 
-export const addInefficientCastReason = (event: CastEvent, reason?: React.ReactNode) => {
-  const meta = (event.meta = event.meta || {});
-  meta.isInefficientCast = true;
-  if (!reason) {
-    return;
-  }
-  meta.inefficientCastReason = (
+import type { BeginChannelEvent, CastEvent } from './Events';
+
+function MetaCastReason({
+  originalReason,
+  reason,
+}: {
+  originalReason: ReactNode;
+  reason: ReactNode | MessageDescriptor;
+}) {
+  const { i18n } = useLingui();
+
+  return (
     <>
-      {meta.inefficientCastReason ? (
+      {originalReason ? (
         <>
-          {meta.inefficientCastReason}
+          {originalReason}
           <br />
         </>
       ) : null}
-      {reason}
+      {isMessageDescriptor(reason) ? i18n._(reason) : reason}
     </>
+  );
+}
+
+export const addInefficientCastReason = (
+  event: BeginChannelEvent | CastEvent,
+  reason?: ReactNode | MessageDescriptor,
+) => {
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
+  event.meta ??= {};
+  event.meta.isInefficientCast = true;
+  if (!reason) {
+    return;
+  }
+  event.meta.inefficientCastReason = (
+    <MetaCastReason originalReason={event.meta.inefficientCastReason} reason={reason} />
   );
 };
 
-export const addEnhancedCastReason = (event: CastEvent, reason?: React.ReactNode) => {
-  const meta = (event.meta = event.meta || {});
-  meta.isEnhancedCast = true;
+export const addEnhancedCastReason = (
+  event: BeginChannelEvent | CastEvent,
+  reason?: ReactNode | MessageDescriptor,
+) => {
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
+  event.meta ??= {};
+  event.meta.isEnhancedCast = true;
   if (!reason) {
     return;
   }
-  meta.enhancedCastReason = (
-    <>
-      {meta.enhancedCastReason ? (
-        <>
-          {meta.enhancedCastReason}
-          <br />
-        </>
-      ) : null}
-      {reason}
-    </>
+  event.meta.enhancedCastReason = (
+    <MetaCastReason originalReason={event.meta.enhancedCastReason} reason={reason} />
   );
 };

--- a/src/parser/core/EventMetaLib.tsx
+++ b/src/parser/core/EventMetaLib.tsx
@@ -5,7 +5,7 @@ import { useLingui } from '@lingui/react';
 import { ReactNode } from 'react';
 import { isMessageDescriptor } from 'localization/isMessageDescriptor';
 
-import type { BeginChannelEvent, CastEvent } from './Events';
+import type { BeginChannelEvent, CastEvent, EventMeta } from './Events';
 
 function MetaCastReason({
   originalReason,
@@ -29,10 +29,10 @@ function MetaCastReason({
   );
 }
 
-export const addInefficientCastReason = (
+export function addInefficientCastReason(
   event: BeginChannelEvent | CastEvent,
   reason?: ReactNode | MessageDescriptor,
-) => {
+) {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
   event.meta ??= {};
   event.meta.isInefficientCast = true;
@@ -42,12 +42,12 @@ export const addInefficientCastReason = (
   event.meta.inefficientCastReason = (
     <MetaCastReason originalReason={event.meta.inefficientCastReason} reason={reason} />
   );
-};
+}
 
-export const addEnhancedCastReason = (
+export function addEnhancedCastReason(
   event: BeginChannelEvent | CastEvent,
   reason?: ReactNode | MessageDescriptor,
-) => {
+) {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
   event.meta ??= {};
   event.meta.isEnhancedCast = true;
@@ -57,4 +57,8 @@ export const addEnhancedCastReason = (
   event.meta.enhancedCastReason = (
     <MetaCastReason originalReason={event.meta.enhancedCastReason} reason={reason} />
   );
-};
+}
+
+export function replace(event: BeginChannelEvent | CastEvent, meta: EventMeta) {
+  event.meta = meta;
+}

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -250,6 +250,16 @@ export enum ResourceActor {
   Target = 2,
 }
 
+/**
+ * Event meta information filled in by various modules.
+ */
+export interface EventMeta {
+  isInefficientCast?: boolean;
+  inefficientCastReason?: React.ReactNode;
+  isEnhancedCast?: boolean;
+  enhancedCastReason?: React.ReactNode;
+}
+
 export type AbilityEvent<T extends string> = Event<T> & { ability: Ability };
 export type SourcedEvent<T extends string> = Event<T> & {
   sourceID: number;
@@ -418,12 +428,7 @@ export interface BeginChannelEvent extends Event<EventType.BeginChannel> {
   targetIsFriendly: boolean;
   classResources?: Array<ClassResources & { cost: number }>;
   // Added by any module, used in the timeline
-  meta?: {
-    isInefficientCast?: boolean;
-    inefficientCastReason?: React.ReactNode;
-    isEnhancedCast?: boolean;
-    enhancedCastReason?: React.ReactNode;
-  };
+  meta?: EventMeta;
   trigger?: AnyEvent;
   globalCooldown?: GlobalCooldownEvent;
 }
@@ -471,12 +476,7 @@ export interface BaseCastEvent<T extends string> extends Event<T> {
   // Added by the GlobalCooldown module
   globalCooldown?: GlobalCooldownEvent;
   // Added by any module, used in the timeline
-  meta?: {
-    isInefficientCast?: boolean;
-    inefficientCastReason?: React.ReactNode;
-    isEnhancedCast?: boolean;
-    enhancedCastReason?: React.ReactNode;
-  };
+  meta?: EventMeta;
 }
 
 export type CastEvent = BaseCastEvent<EventType.Cast>;

--- a/src/parser/core/HitCountAoE.tsx
+++ b/src/parser/core/HitCountAoE.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from 'react';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { SpellIcon, TooltipElement } from 'interface';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 export default abstract class HitCountAoE extends Analyzer {
   allTrackers: SpellAoeTracker[] = [];
@@ -64,9 +65,7 @@ export default abstract class HitCountAoE extends Analyzer {
     tracker.hits += hits;
     if (hits === 0) {
       tracker.zeroHitCasts += 1;
-      event.meta = event.meta || {};
-      event.meta.isInefficientCast = true;
-      event.meta.inefficientCastReason = 'This cast hit nothing!';
+      addInefficientCastReason(event, 'This cast hit nothing!');
     } else if (hits === 1) {
       tracker.oneHitCasts += 1;
     } else {

--- a/src/parser/shared/metrics/apl/annotate.tsx
+++ b/src/parser/shared/metrics/apl/annotate.tsx
@@ -1,6 +1,7 @@
 import { SpellLink } from 'interface';
 
 import type { Tense, CheckResult, InternalRule, Violation } from './index';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 export function ConditionDescription({
   tense,
@@ -55,9 +56,9 @@ function InefficientCastAnnotation({ violation }: { violation: Violation }) {
  */
 export default function annotateTimeline(violations: CheckResult['violations']) {
   for (const violation of violations) {
-    violation.actualCast.meta = {
-      isInefficientCast: true,
-      inefficientCastReason: <InefficientCastAnnotation violation={violation} />,
-    };
+    addInefficientCastReason(
+      violation.actualCast,
+      <InefficientCastAnnotation violation={violation} />,
+    );
   }
 }

--- a/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.tsx
+++ b/src/parser/shared/modules/earlydotrefreshes/EarlyDotRefreshes.tsx
@@ -10,6 +10,7 @@ import Events, {
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import Enemies from 'parser/shared/modules/Enemies';
 import { encodeTargetString } from 'parser/shared/modules/Enemies';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 const BUFFER_MS = 100;
 export const PANDEMIC_WINDOW = 0.3;
 
@@ -77,9 +78,7 @@ class EarlyDotRefreshes extends Analyzer {
 
     this.casts[this.lastCast.ability.guid].badCasts += 1;
     this.casts[this.lastCast.ability.guid].wastedDuration += this.lastCastMinWaste;
-    event.meta = event.meta || {};
-    event.meta.isInefficientCast = true;
-    event.meta.inefficientCastReason = text;
+    addInefficientCastReason(event, text);
   }
 
   onRefreshDebuff(event: RefreshDebuffEvent) {


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Use `addInefficientCastReason` everywhere instead of `event.meta.isInefficientCast` so that logic can be centralized.

Adds an ESLint rule for enforcing this.
