### PR TITLE
[Classic] Cata Food Buffs

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2022, 6, 5), 'Update Classic Food Buffs for Cataclysm', jazminite),
   change(date(2022, 6, 3), 'Update Classic Flasks for Cataclysm', jazminite),
   change(date(2024, 5, 31), 'Update Classic Enchants for Cataclysm', jazminite),
   change(date(2024, 5, 31), "Add Cataclysm patch 4.4.0.", Putro),

--- a/src/common/ITEMS/classic/cooking.ts
+++ b/src/common/ITEMS/classic/cooking.ts
@@ -1,64 +1,91 @@
 import Item from 'common/ITEMS/Item';
 
 const items = {
-  FISH_FEAST: { id: 43015, name: 'Fish Feast', icon: 'inv_misc_fish_52' },
-  DRAGONFIN_FILET: { id: 43000, name: 'Dragonfin Filet', icon: 'inv_misc_food_75' },
-  FIRECRACKER_SALMON: { id: 34767, name: 'Firecracker Salmon', icon: 'inv_misc_food_141_fish' },
-  TENDER_SHOVELTUSK_STEAK: {
-    id: 34755,
-    name: 'Tender Shoveltusk Steak',
+  // id = item id
+  BAKED_ROCKFISH: {
+    id: 62661,
+    name: 'Baked Rockfish',
+    icon: 'inv_misc_food_155_fish_78',
+  },
+  BASILISK_LIVERDOG: {
+    id: 62665,
+    name: 'Basilisk Liverdog',
+    icon: 'inv_misc_food_17',
+  },
+  BEER_BASTED_CROCOLISK: {
+    id: 62670,
+    name: 'Beer-Basted Crocolisk',
+    icon: 'inv_misc_food_meat_cooked_08',
+  },
+  BLACKBELLY_SUSHI: {
+    id: 62668,
+    name: 'Blackbelly Sushi',
+    icon: 'inv_misc_food_161_fish_89',
+  },
+  BROILED_DRAGON_FEAST: {
+    id: 62289,
+    name: 'Broiled Dragon Feast',
+    icon: 'inv_misc_food_99',
+  },
+  CRISPY_BAKON_SNACK: {
+    id: 62678,
+    name: 'Crispy "Bakon" Snack',
+    icon: 'inv_misc_food_71',
+  },
+  CROCOLISK_AU_GRATIN: {
+    id: 62664,
+    name: 'Crocolisk Au Gratin',
+    icon: 'inv_misc_food_meat_cooked_10',
+  },
+  DELICIOUS_SAGEFISH_TAIL: {
+    id: 62666,
+    name: 'Delicious Sagefish Tail',
+    icon: 'inv_misc_food_158_fish_81',
+  },
+  ENRICHED_FISH_BISCUIT: {
+    id: 62679,
+    name: 'Enriched Fish Biscuit',
+    icon: 'inv_misc_food_meat_raw_10',
+  },
+  FORTUNE_COOKIE: {
+    id: 62649,
+    name: 'Fortune Cookie',
+    icon: 'inv_misc_fortunecookie',
+  },
+  GOBLIN_BARBECUE: {
+    id: 60858,
+    name: 'Goblin Barbecue',
+    icon: 'inv_gizmo_fuelcell',
+  },
+  GRILLED_DRAGON: {
+    id: 62662,
+    name: 'Grilled Dragon',
     icon: 'inv_misc_food_122_steak',
   },
-  BLACKENED_DRAGONFIN: { id: 42999, name: 'Blackened Dragonfin', icon: 'inv_misc_food_142_fish' },
-  SPICED_MAMMOTH_TREATS: {
-    id: 43005,
-    name: 'Spiced Mammoth Treats',
-    icon: 'inv_misc_food_123_roast',
+  LAVASCALE_MINESTRONE: {
+    id: 62663,
+    name: 'Lavascale Minestrone',
+    icon: 'inv_misc_food_154_fish_77',
   },
-  SNAPPER_EXTREME: { id: 42996, name: 'Snapper Extreme', icon: 'inv_misc_food_129_fish' },
-  RHINO_DOGS: { id: 34752, name: 'Rhino Dogs', icon: 'inv_misc_food_53' },
-  GREAT_FEAST: { id: 34753, name: 'Great Feast', icon: 'ability_hunter_pet_boar' },
-  RHINOLICIOUS_WORMSTEAK: { id: 42994, name: 'Rhinolicious Wormsteak', icon: 'inv_misc_food_47' },
-  MEGA_MAMMOTH_MEAL: {
-    id: 34754,
-    name: 'Mega Mammoth Meal',
-    icon: 'inv_misc_food_108_meadcaribou',
+  MUSHROOM_SAUCE_MUDFISH: {
+    id: 62667,
+    name: 'Mushroom Sauce Mudfish',
+    icon: 'inv_misc_food_meat_cooked_01',
   },
-  IMPERIAL_MANTA_STEAK: {
-    id: 34769,
-    name: 'Imperial Manta Steak',
-    icon: 'inv_misc_food_121_buttermeat',
+  SEAFOOD_MAGNIFIQUE_FEAST: {
+    id: 62290,
+    name: 'Seafood Magnifique Feast',
+    icon: 'inv_misc_food_meat_cooked_02',
   },
-  WORG_TARTARE: { id: 44953, name: 'Worg Tartare', icon: 'inv_misc_food_71' },
-  HEARTY_RHINO: { id: 42995, name: 'Hearty Rhino', icon: 'inv_misc_food_115_condorsoup' },
-  VERY_BURNT_WORG: { id: 34757, name: 'Very Burnt Worg', icon: 'inv_misc_food_60' },
-  DALARAN_CLAM_CHOWDER: {
-    id: 43268,
-    name: 'Dalaran Clam Chowder',
-    icon: 'inv_misc_cauldron_frost',
+  SEVERED_SAGEFISH_HEAD: {
+    id: 62671,
+    name: 'Severed Sagefish Head',
+    icon: 'inv_misc_food_160_fish_87',
   },
-  POACHED_NORTHERN_SCULPIN: {
-    id: 34766,
-    name: 'Poached Northern Sculpin',
-    icon: 'inv_misc_food_77',
+  SKEWERED_EEL: {
+    id: 62669,
+    name: 'Skewered Eel',
+    icon: 'inv_misc_food_163_fish_91',
   },
-  CUTTLESTEAK: { id: 42998, name: 'Cuttlesteak', icon: 'inv_misc_food_133_meat' },
-  SHOVELTUSK_STEAK: { id: 34749, name: 'Shoveltusk Steak', icon: 'inv_misc_food_89' },
-  GRILLED_SCULPIN: { id: 34762, name: 'Grilled Sculpin', icon: 'inv_misc_food_79' },
-  SPICED_WORM_BURGER: { id: 34756, name: 'Spiced Worm Burger', icon: 'inv_misc_food_65' },
-  BAKED_MANTA_RAY: { id: 42942, name: 'Baked Manta Ray', icon: 'inv_misc_food_140_fish' },
-  SPICY_FRIED_HERRING: { id: 42993, name: 'Spicy Fried Herring', icon: 'inv_misc_food_78' },
-  MAMMOTH_MEAL: { id: 34748, name: 'Mammoth Meal', icon: 'inv_misc_food_116_condorleg' },
-  SPICY_BLUE_NETTLEFISH: {
-    id: 34768,
-    name: 'Spicy Blue Nettlefish',
-    icon: 'inv_misc_food_139_fish',
-  },
-  SMOKED_SALMON: { id: 34763, name: 'Smoked Salmon', icon: 'inv_misc_food_130_fish' },
-  POACHED_NETTLEFISH: { id: 34764, name: 'Poached Nettlefish', icon: 'inv_misc_food_138_fish' },
-  WORM_DELIGHT: { id: 34750, name: 'Worm Delight', icon: 'inv_misc_food_124_skewer' },
-  PICKLED_FANGTOOTH: { id: 34765, name: 'Pickled Fangtooth', icon: 'inv_misc_food_76' },
-  MIGHTY_RHINO_DOGS: { id: 34758, name: 'Mighty Rhino Dogs', icon: 'inv_misc_food_66' },
-  ROASTED_WORG: { id: 34751, name: 'Roasted Worg', icon: 'inv_misc_food_86_basilisk' },
 } satisfies Record<string, Item>;
 export default items;

--- a/src/parser/classic/modules/items/FoodChecker.tsx
+++ b/src/parser/classic/modules/items/FoodChecker.tsx
@@ -5,39 +5,25 @@ import SUGGESTION_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import { When, ThresholdStyle } from 'parser/core/ParseResults';
 import { ItemLink } from 'interface';
 import BaseFoodChecker from 'parser/shared/modules/items/FoodChecker';
+import items from 'common/ITEMS/classic/cooking';
 
-const FISH_FEAST = 43015; // https://www.wowhead.com/wotlk/item=43015/fish-feast
-const DRAGONFIN_FILET = 43000; // https://www.wowhead.com/wotlk/item=43000/dragonfin-filet
-const FIRECRACKER_SALMON = 34767; // https://www.wowhead.com/wotlk/item=34767/firecracker-salmon
-const TENDER_SHOVELTUSK_STEAK = 34755; // https://www.wowhead.com/wotlk/item=34755/tender-shoveltusk-steak
-const BLACKENED_DRAGONFIN = 42999; // https://www.wowhead.com/wotlk/item=42999/blackened-dragonfin
-const SPICED_MAMMOTH_TREATS = 43005; // https://www.wowhead.com/wotlk/item=43005/spiced-mammoth-treats
-const SNAPPER_EXTREME = 42996; // https://www.wowhead.com/wotlk/item=42996/snapper-extreme
-const RHINO_DOGS = 34752; // https://www.wowhead.com/wotlk/item=34752/rhino-dogs
-const GREAT_FEAST = 34753; // https://www.wowhead.com/wotlk/item=34753/great-feast
-const RHINOLICIOUS_WORMSTEAK = 42994; // https://www.wowhead.com/wotlk/item=42994/rhinolicious-wormsteak
-const MEGA_MAMMOTH_MEAL = 34754; // https://www.wowhead.com/wotlk/item=34754/mega-mammoth-meal
-const IMPERIAL_MANTA_STEAK = 34769; // https://www.wowhead.com/wotlk/item=34769/imperial-manta-steak
-const HEARTY_RHINO = 42995; // https://www.wowhead.com/wotlk/item=42995/hearty-rhino
-const VERY_BURNT_WORG = 34757; // https://www.wowhead.com/wotlk/item=34757/very-burnt-worg
-const DALARAN_CLAM_CHOWDER = 43268; // https://www.wowhead.com/wotlk/item=43268/dalaran-clam-chowder
-const POACHED_NORTHERN_SCULPIN = 34766; // https://www.wowhead.com/wotlk/item=34766/poached-northern-sculpin
-const CUTTLESTEAK = 42998; // https://www.wowhead.com/wotlk/item=42998/cuttlesteak
-const SHOVELTUSK_STEAK = 34749; // https://www.wowhead.com/wotlk/item=34749/shoveltusk-steak
-const GRILLED_SCULPIN = 34762; // https://www.wowhead.com/wotlk/item=34762/grilled-sculpin
-const SPICED_WORM_BURGER = 34756; // https://www.wowhead.com/wotlk/item=34756/spiced-worm-burger
-const BAKED_MANTA_RAY = 42942; // https://www.wowhead.com/wotlk/item=42942/baked-manta-ray
-const SPICY_FRIED_HERRING = 42993; // https://www.wowhead.com/wotlk/item=42993/spicy-fried-herring
-const MAMMOTH_MEAL = 34748; // https://www.wowhead.com/wotlk/item=34748/mammoth-meal
-const SPICY_BLUE_NETTLEFISH = 34768; // https://www.wowhead.com/wotlk/item=34768/spicy-blue-nettlefish
-const SMOKED_SALMON = 34763; // https://www.wowhead.com/wotlk/item=34763/smoked-salmon
-const POACHED_NETTLEFISH = 34764; // https://www.wowhead.com/wotlk/item=34764/poached-nettlefish
-const WORM_DELIGHT = 34750; // https://www.wowhead.com/wotlk/item=34750/worm-delight
-const PICKLED_FANGTOOTH = 34765; // https://www.wowhead.com/wotlk/item=34765/pickled-fangtooth
-const MIGHTY_RHINO_DOGS = 34758; // https://www.wowhead.com/wotlk/item=34758/mighty-rhino-dogs
-const ROASTED_WORG = 34751; // https://www.wowhead.com/wotlk/item=34751/roasted-worg
-// Shares spell ID with https://www.wowhead.com/wotlk/item=42996/snapper-extreme
-// const WORG_TARTARE = 44953;          // https://www.wowhead.com/wotlk/item=44953/worg-tartare
+const BAKED_ROCKFISH = items.BAKED_ROCKFISH.id; // https://www.wowhead.com/cata/item=62661
+const BASILISK_LIVERDOG = items.BASILISK_LIVERDOG.id; // https://www.wowhead.com/cata/item=62665
+const BEER_BASTED_CROCOLISK = items.BEER_BASTED_CROCOLISK.id; // https://www.wowhead.com/cata/item=62670
+const BLACKBELLY_SUSHI = items.BLACKBELLY_SUSHI.id; // https://www.wowhead.com/cata/item=62668
+const BROILED_DRAGON_FEAST = items.BROILED_DRAGON_FEAST.id; // https://www.wowhead.com/cata/item=62289
+const CRISPY_BAKON_SNACK = items.CRISPY_BAKON_SNACK.id; // https://www.wowhead.com/cata/item=62678
+const CROCOLISK_AU_GRATIN = items.CROCOLISK_AU_GRATIN.id; // https://www.wowhead.com/cata/item=62664
+const DELICIOUS_SAGEFISH_TAIL = items.DELICIOUS_SAGEFISH_TAIL.id; // https://www.wowhead.com/cata/item=62666
+const ENRICHED_FISH_BISCUIT = items.ENRICHED_FISH_BISCUIT.id; // https://www.wowhead.com/cata/item=62679
+const FORTUNE_COOKIE = items.FORTUNE_COOKIE.id; // https://www.wowhead.com/cata/item=62649
+const GOBLIN_BARBECUE = items.GOBLIN_BARBECUE.id; // https://www.wowhead.com/cata/item=60858
+const GRILLED_DRAGON = items.GRILLED_DRAGON.id; // https://www.wowhead.com/cata/item=62662
+const LAVASCALE_MINESTRONE = items.LAVASCALE_MINESTRONE.id; // https://www.wowhead.com/cata/item=62663
+const MUSHROOM_SAUCE_MUDFISH = items.MUSHROOM_SAUCE_MUDFISH.id; // https://www.wowhead.com/cata/item=62667
+const SEAFOOD_MAGNIFIQUE_FEAST = items.SEAFOOD_MAGNIFIQUE_FEAST.id; // https://www.wowhead.com/cata/item=62290
+const SEVERED_SAGEFISH_HEAD = items.SEVERED_SAGEFISH_HEAD.id; // https://www.wowhead.com/cata/item=62671
+const SKEWERED_EEL = items.SKEWERED_EEL.id; // https://www.wowhead.com/cata/item=62669
 
 interface FoodInfo {
   itemId: number;
@@ -45,143 +31,67 @@ interface FoodInfo {
 }
 
 const FOOD_MAPPINGS: { [spellId: number]: FoodInfo } = {
-  // 80 Attack Power, 46 Spell Power and 40 Stamina
-  57426: { itemId: FISH_FEAST }, // Cast
-  57399: { itemId: FISH_FEAST }, // Food Buff
-  57397: { itemId: FISH_FEAST }, // Eating Buff
+  // 90 Stamina + 90 of another useful stat
+  87644: { itemId: SEAFOOD_MAGNIFIQUE_FEAST }, // Cast
+  87806: { itemId: SEAFOOD_MAGNIFIQUE_FEAST }, // Eating Buff
+  87604: { itemId: FORTUNE_COOKIE }, // Cast
+  87628: { itemId: FORTUNE_COOKIE }, // Eating Buff
 
-  // 60 Attack Power, 35 Spell Power and 30 Stamina
-  57301: { itemId: GREAT_FEAST, recommendedFood: [FISH_FEAST] }, // Cast
-  58067: { itemId: DALARAN_CLAM_CHOWDER, recommendedFood: [FISH_FEAST] }, // Cast
-  57294: { itemId: DALARAN_CLAM_CHOWDER, recommendedFood: [FISH_FEAST] }, // Food Buff
+  // 90 Agility + 90 Stamina
+  87546: { itemId: SKEWERED_EEL }, // Food Buff
+  87586: { itemId: SKEWERED_EEL }, // Cast
 
-  // 40 Strength and 40 Stamina
-  57370: { itemId: DRAGONFIN_FILET }, // Cast
-  57371: { itemId: DRAGONFIN_FILET }, // Food Buff
+  // 90 Critical Strike + 90 Stamina
+  87551: { itemId: BAKED_ROCKFISH }, // Food Buff
+  87597: { itemId: BAKED_ROCKFISH }, // Cast
 
-  // 40 Agility and 40 Stamina.
-  57366: { itemId: BLACKENED_DRAGONFIN }, // Cast
-  57367: { itemId: BLACKENED_DRAGONFIN }, // Food Buff
+  // 90 Dodge Rating + 90 Stamina
+  87554: { itemId: MUSHROOM_SAUCE_MUDFISH }, // Food Buff
+  87601: { itemId: MUSHROOM_SAUCE_MUDFISH }, // Cast
 
-  // 46 Spell Power and 40 Stamina
-  57341: { itemId: FIRECRACKER_SALMON }, // Cast
-  57326: { itemId: TENDER_SHOVELTUSK_STEAK }, // Cast
-  57327: { itemId: FIRECRACKER_SALMON }, // Food Buff
-  // 35 Spell Power and 30 Stamina
-  57138: {
-    // Cast
-    itemId: SHOVELTUSK_STEAK,
-    recommendedFood: [FISH_FEAST, FIRECRACKER_SALMON, TENDER_SHOVELTUSK_STEAK],
-  },
-  57139: {
-    // Food Buff
-    itemId: SHOVELTUSK_STEAK,
-    recommendedFood: [FISH_FEAST, FIRECRACKER_SALMON, TENDER_SHOVELTUSK_STEAK],
-  },
-  // 35 Spell Power and 40 Stamina
-  57096: {
-    // Cast
-    itemId: SMOKED_SALMON,
-    recommendedFood: [FISH_FEAST, FIRECRACKER_SALMON, TENDER_SHOVELTUSK_STEAK],
-  },
+  // 90 Expertise + 90 Stamina
+  87635: { itemId: CROCOLISK_AU_GRATIN }, // Food Buff
+  87637: { itemId: CROCOLISK_AU_GRATIN }, // Cast
 
-  57097: {
-    // Food Buff
-    itemId: SMOKED_SALMON,
-    recommendedFood: [FISH_FEAST, FIRECRACKER_SALMON, TENDER_SHOVELTUSK_STEAK],
-  },
+  // 90 Haste Rating + 90 Stamina
+  87599: { itemId: BASILISK_LIVERDOG }, // Food Buff
+  87552: { itemId: BASILISK_LIVERDOG }, // Cast
 
-  // 40 Hit Rating and 40 Stamina
-  57359: { itemId: SNAPPER_EXTREME }, // Cast
-  57360: { itemId: SNAPPER_EXTREME }, // Food Buff
-  // 57359: { itemId: WORG_TARTARE },
+  // 90 Hit Rating + 90 Stamina
+  87550: { itemId: GRILLED_DRAGON }, // Food Buff
+  87595: { itemId: GRILLED_DRAGON }, // Cast
 
-  // 40 Expertise Rating and 40 Stamina
-  57355: { itemId: RHINOLICIOUS_WORMSTEAK }, // Cast
-  57356: { itemId: RHINOLICIOUS_WORMSTEAK }, // Food Buff
+  // 90 Intellect + 90 Stamina
+  87547: { itemId: SEVERED_SAGEFISH_HEAD }, // Food Buff
+  87587: { itemId: SEVERED_SAGEFISH_HEAD }, // Cast
 
-  // 40 armor penetration rating and 40 Stamina
-  57357: { itemId: HEARTY_RHINO }, // Cast
-  57358: { itemId: HEARTY_RHINO }, // Food Buff
+  // 90 Mastery + 90 Stamina
+  87549: { itemId: LAVASCALE_MINESTRONE }, // Food Buff
+  87594: { itemId: LAVASCALE_MINESTRONE }, // Cast
 
-  //  20 Mana per 5 seconds and 40 Stamina
-  57354: { itemId: SPICY_FRIED_HERRING }, // Cast
-  57333: { itemId: MIGHTY_RHINO_DOGS }, // Cast
-  57334: { itemId: SPICY_FRIED_HERRING }, // Food Buff
-  // 15 Mana per 5 seconds and 40 Stamina
-  57106: { itemId: PICKLED_FANGTOOTH, recommendedFood: [SPICY_FRIED_HERRING, MIGHTY_RHINO_DOGS] }, // Cast
-  57107: { itemId: PICKLED_FANGTOOTH, recommendedFood: [SPICY_FRIED_HERRING, MIGHTY_RHINO_DOGS] }, // Food Buff
-  // 15 Mana per 5 seconds and 30 Stamina
-  57289: { itemId: RHINO_DOGS, recommendedFood: [SPICY_FRIED_HERRING, MIGHTY_RHINO_DOGS] }, // Cast
-  57291: { itemId: RHINO_DOGS, recommendedFood: [SPICY_FRIED_HERRING, MIGHTY_RHINO_DOGS] }, // Food Buff
+  // 90 Parry Rating + 90 Stamina
+  87555: { itemId: BLACKBELLY_SUSHI }, // Food Buff
+  87602: { itemId: BLACKBELLY_SUSHI }, // Cast
 
-  // 40 Haste Rating and 40 Stamina
-  57331: { itemId: VERY_BURNT_WORG }, // Cast
-  57344: { itemId: IMPERIAL_MANTA_STEAK }, // Cast
-  57332: { itemId: IMPERIAL_MANTA_STEAK }, // Food Buff
-  // 30 Haste Rating and 40 Stamina
-  57101: { itemId: BAKED_MANTA_RAY, recommendedFood: [VERY_BURNT_WORG, IMPERIAL_MANTA_STEAK] }, // Cast
-  57102: { itemId: BAKED_MANTA_RAY, recommendedFood: [VERY_BURNT_WORG, IMPERIAL_MANTA_STEAK] }, // Food Buff
+  // 90 Spirit + 90 Stamina
+  87548: { itemId: DELICIOUS_SAGEFISH_TAIL }, // Food Buff
+  87588: { itemId: DELICIOUS_SAGEFISH_TAIL }, // Cast
 
-  // 30 Haste Rating and 30 Stamina
-  57287: { itemId: ROASTED_WORG, recommendedFood: [VERY_BURNT_WORG, IMPERIAL_MANTA_STEAK] }, // Cast
-  57288: { itemId: ROASTED_WORG, recommendedFood: [VERY_BURNT_WORG, IMPERIAL_MANTA_STEAK] }, // Food Buff
+  // 90 Strength + 90 Stamina
+  87545: { itemId: BEER_BASTED_CROCOLISK }, // Food Buff
+  87584: { itemId: BEER_BASTED_CROCOLISK }, // Cast
 
-  // 80 Attack Power and 40 Stamina
-  57324: { itemId: MEGA_MAMMOTH_MEAL }, // Cast
-  57335: { itemId: POACHED_NORTHERN_SCULPIN }, // Cast
-  57325: { itemId: POACHED_NORTHERN_SCULPIN }, // Food Buff
-  // 60 Attack Power and 40 Stamina
-  57085: {
-    // Cast
-    itemId: GRILLED_SCULPIN,
-    recommendedFood: [FISH_FEAST, MEGA_MAMMOTH_MEAL, POACHED_NORTHERN_SCULPIN],
-  },
-  57079: {
-    // Food Buff
-    itemId: GRILLED_SCULPIN,
-    recommendedFood: [FISH_FEAST, MEGA_MAMMOTH_MEAL, POACHED_NORTHERN_SCULPIN],
-  },
-  // 60 Attack Power and 30 Stamina
-  57110: {
-    // Cast
-    itemId: MAMMOTH_MEAL,
-    recommendedFood: [FISH_FEAST, MEGA_MAMMOTH_MEAL, POACHED_NORTHERN_SCULPIN],
-  },
-  57111: {
-    // Food Buff
-    itemId: MAMMOTH_MEAL,
-    recommendedFood: [FISH_FEAST, MEGA_MAMMOTH_MEAL, POACHED_NORTHERN_SCULPIN],
-  },
+  // 60 Stamina + 60 in another useful stat
+  87643: { itemId: BROILED_DRAGON_FEAST, recommendedFood: [SEAFOOD_MAGNIFIQUE_FEAST] }, // Cast
+  87915: { itemId: GOBLIN_BARBECUE, recommendedFood: [FORTUNE_COOKIE] }, // Cast
 
-  // 40 Critical Strike Rating and 40 Stamina
-  57328: { itemId: SPICED_WORM_BURGER }, // Cast
-  57343: { itemId: SPICY_BLUE_NETTLEFISH }, // Cast
-  57329: { itemId: SPICY_BLUE_NETTLEFISH }, // Food Buff
-  // 30 Critical Strike Rating and 40 Stamina
-  57098: {
-    // Cast
-    itemId: POACHED_NETTLEFISH,
-    recommendedFood: [SPICED_WORM_BURGER, SPICY_BLUE_NETTLEFISH],
-  },
-  57100: {
-    // Food Buff
-    itemId: POACHED_NETTLEFISH,
-    recommendedFood: [SPICED_WORM_BURGER, SPICY_BLUE_NETTLEFISH],
-  },
-  // 30 Critical Strike Rating and 30 Stamina
-  57285: { itemId: WORM_DELIGHT, recommendedFood: [SPICED_WORM_BURGER, SPICY_BLUE_NETTLEFISH] }, // Cast
-  57286: { itemId: WORM_DELIGHT, recommendedFood: [SPICED_WORM_BURGER, SPICY_BLUE_NETTLEFISH] }, // Food Buff
-
-  // 40 Spirit and 40 Stamina
-  57364: { itemId: CUTTLESTEAK }, // Cast
-  57365: { itemId: CUTTLESTEAK }, // Food Buff
-
-  // Strength and Stamina of your pet by 30
-  43771: { itemId: SPICED_MAMMOTH_TREATS }, // Food Buff
+  // Pet Strength +75
+  87697: { itemId: CRISPY_BAKON_SNACK }, // Food Buff
+  // Pet Stamina +110
+  87699: { itemId: ENRICHED_FISH_BISCUIT }, // Food Buff
 };
 
-// Setting this to true will replace the food suggestion with a list of the
+// Setting this to true replaces the food suggestion with a list of the
 // defined foods and their recommendedFoods. This is useful for sanity checking
 // the list of foods you are marking as upgrades.
 const DEBUG = false;


### PR DESCRIPTION
### Description

Update Classic Food Buffs for Cataclysm

### Testing

- Test report URL: `/report/Bc4NjZJLfvabrpTK/1-Heroic+Magmaw+-+Kill+(3:59)/Lotsohdots`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/65823478/8c1a4e7d-f947-46be-87fd-5b271e2d40df)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/65823478/2028147d-2655-4932-af90-e52fd7258738)
