### PR TITLE
Add debug annotations view

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2024, 6, 6), <>Fix missing cooldown reduction from damage to targets debuffed by <SpellLink spell={talents.BONEDUST_BREW_TALENT} /></>, emallson),
   change(date(2024, 4, 15), <>Fix issue where <SpellLink spell={talents.CHARRED_PASSIONS_TALENT} /> was showing in the rotation when playing <SpellLink spell={talents.DRAGONFIRE_BREW_TALENT} /></>, emallson),
   change(date(2024, 2, 11), <>Add shield size to <SpellLink spell={talents.CELESTIAL_BREW_TALENT} /> mitigation breakdown.</>, emallson),
   change(date(2024, 1, 17), 'Update Brewmaster compatibility to 10.2.5', emallson),

--- a/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
+++ b/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
@@ -58,6 +58,7 @@ import SpinningCraneKickLinkNormalizer from './normalizers/SpinningCraneKick';
 import CallToDominance from 'parser/retail/modules/items/dragonflight/CallToDominance';
 import PressTheAdvantage from './modules/talents/PressTheAdvantage';
 import PressTheAdvantageNormalizer from './modules/talents/PressTheAdvantage/normalizer';
+import BonedustBrew from './modules/talents/BonedustBrew';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -128,6 +129,7 @@ class CombatLogParser extends CoreCombatLogParser {
     anvilStave: AnvilStave,
     chiSurge: ChiSurge,
     pta: PressTheAdvantage,
+    bdb: BonedustBrew,
 
     apl: AplCheck,
 

--- a/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
@@ -186,7 +186,7 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.FORTIFYING_BREW_BRM.id,
         buffSpellId: SPELLS.FORTIFYING_BREW_BRM_BUFF.id,
         category: SPELL_CATEGORY.DEFENSIVE,
-        cooldown: combatant.hasTalent(talents.EXPEDITIOUS_FORTIFICATION_TALENT) ? 300 : 420,
+        cooldown: combatant.hasTalent(talents.EXPEDITIOUS_FORTIFICATION_TALENT) ? 240 : 360,
         gcd: null,
       },
       {
@@ -286,7 +286,7 @@ class Abilities extends CoreAbilities {
       {
         spell: talents.PARALYSIS_TALENT.id,
         category: SPELL_CATEGORY.UTILITY,
-        cooldown: 45,
+        cooldown: combatant.hasTalent(talents.IMPROVED_PARALYSIS_TALENT) ? 30 : 45,
         gcd: {
           static: 1000,
         },

--- a/src/analysis/retail/monk/brewmaster/modules/core/BrewCDR.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/BrewCDR.tsx
@@ -15,6 +15,7 @@ import KegSmash from '../spells/KegSmash';
 import TigerPalm from '../spells/TigerPalm';
 import AnvilStave from '../talents/AnvilStave';
 import PressTheAdvantage from '../talents/PressTheAdvantage';
+import BonedustBrew from '../talents/BonedustBrew';
 
 const deps = {
   ks: KegSmash,
@@ -23,6 +24,7 @@ const deps = {
   anvilStave: AnvilStave,
   abilities: Abilities,
   pta: PressTheAdvantage,
+  bdb: BonedustBrew,
 };
 
 class BrewCDR extends Analyzer.withDependencies(deps) {
@@ -43,7 +45,7 @@ class BrewCDR extends Analyzer.withDependencies(deps) {
   }
 
   get totalCDR() {
-    const { ks, tp, bob, anvilStave, pta } = this.deps;
+    const { bdb, ks, tp, bob, anvilStave, pta } = this.deps;
     let totalCDR = 0;
     // add in KS CDR...
     totalCDR += ks.cdr;
@@ -54,11 +56,12 @@ class BrewCDR extends Analyzer.withDependencies(deps) {
     totalCDR += bob.cdr[talents.PURIFYING_BREW_TALENT.id];
     totalCDR += anvilStave.cdr;
     totalCDR += pta.brewCDRTotal;
+    totalCDR += bdb.effectiveCdr;
     return totalCDR;
   }
 
   get maxTotalCDR() {
-    const { ks, tp, bob, pta } = this.deps;
+    const { bdb, ks, tp, bob, pta } = this.deps;
     // some passive talents like anvil & stave don't track wasted cdr (yet?)
     return (
       ks.wastedCDR +
@@ -66,6 +69,7 @@ class BrewCDR extends Analyzer.withDependencies(deps) {
       tp.wastedCDR +
       bob.wastedCDR[talents.PURIFYING_BREW_TALENT.id] +
       pta.wastedBrewCDR +
+      bdb.wastedCdr +
       this.totalCDR
     );
   }
@@ -99,7 +103,7 @@ class BrewCDR extends Analyzer.withDependencies(deps) {
   }
 
   statistic() {
-    const { ks, pta, tp, bob, anvilStave } = this.deps;
+    const { ks, pta, tp, bob, anvilStave, bdb } = this.deps;
     return (
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL()}
@@ -147,6 +151,13 @@ class BrewCDR extends Analyzer.withDependencies(deps) {
                   {pta.meleeCount} Press the Advantage triggers -{' '}
                   <strong>{(pta.brewCDRTotal / 1000).toFixed(2)}s</strong> (
                   <strong>{(pta.wastedBrewCDR / 1000).toFixed(2)}s</strong> wasted)
+                </li>
+              )}
+              {bdb.active && (
+                <li>
+                  {bdb.triggers} casts with Bonedust Brew's bonus CDR -{' '}
+                  <strong>{(bdb.effectiveCdr / 1000).toFixed(2)}s</strong> (
+                  <strong>{(bdb.wastedCdr / 1000).toFixed(2)}s</strong> wasted) )
                 </li>
               )}
             </ul>

--- a/src/analysis/retail/monk/brewmaster/modules/core/SharedBrews.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/core/SharedBrews.ts
@@ -1,3 +1,4 @@
+import SPELLS from 'common/SPELLS';
 import talents from 'common/TALENTS/monk';
 import Analyzer from 'parser/core/Analyzer';
 import SpellHistory from 'parser/shared/modules/SpellHistory';
@@ -6,7 +7,7 @@ import SpellUsable from 'parser/shared/modules/SpellUsable';
 const BREWS = [
   talents.BONEDUST_BREW_TALENT,
   talents.BLACK_OX_BREW_TALENT,
-  talents.FORTIFYING_BREW_TALENT,
+  SPELLS.FORTIFYING_BREW_BRM,
   talents.CELESTIAL_BREW_TALENT,
   talents.PURIFYING_BREW_TALENT,
 ];

--- a/src/analysis/retail/monk/brewmaster/modules/talents/BonedustBrew/index.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/BonedustBrew/index.ts
@@ -1,0 +1,81 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SharedBrews from '../../core/SharedBrews';
+import talents from 'common/TALENTS/monk';
+import Events, { AnyEvent, CastEvent, DamageEvent } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS';
+import Enemies from 'parser/shared/modules/Enemies';
+import { formatDuration } from 'common/format';
+import { GoodColor } from 'interface/guide';
+
+const BONUS_CDR = 1000;
+const KS_BUFFER = 250;
+
+export default class BonedustBrew extends Analyzer.withDependencies({
+  brews: SharedBrews,
+  enemies: Enemies,
+}) {
+  private totalCdr = 0;
+  private _wastedCdr = 0;
+  private lastKsTriggerTimestamp = -Infinity;
+  public triggers = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(talents.BONEDUST_BREW_TALENT);
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.TIGER_PALM),
+      this.onTigerPalm,
+    );
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(talents.KEG_SMASH_TALENT),
+      this.onKegSmash,
+    );
+  }
+
+  private onTigerPalm(event: CastEvent) {
+    // the TP case is easy: check if the target has BDB and apply CDR if so
+    this.reduceCooldown(event);
+  }
+
+  private onKegSmash(event: DamageEvent) {
+    // Keg Smash is more complicated: we need to check if *any damaged target* has it.
+    // travel time is *usually* so short that we can rely on the cast time, and bdb is removed in tww anyway
+
+    // not using event links because (again) this is going away in TWW
+    if (Math.abs(event.timestamp - this.lastKsTriggerTimestamp) < KS_BUFFER) {
+      // last trigger was from the same cast
+      this.addDebugAnnotation(event, {
+        color: '#666',
+        summary: `Keg Smash damage did not gain BDB CDR due to gain ${formatDuration(event.timestamp - this.lastKsTriggerTimestamp, 2)} ago`,
+      });
+      return;
+    }
+
+    if (this.reduceCooldown(event)) {
+      this.lastKsTriggerTimestamp = event.timestamp;
+    }
+  }
+
+  private reduceCooldown(event: AnyEvent) {
+    const enemy = this.deps.enemies.getEntity(event);
+    if (enemy?.hasBuff(talents.BONEDUST_BREW_TALENT.id, null, 100, 0, this.selectedCombatant.id)) {
+      const cdr = this.deps.brews.reduceCooldown(BONUS_CDR);
+      this.totalCdr += cdr;
+      this._wastedCdr += BONUS_CDR - cdr;
+      this.triggers += 1;
+      this.addDebugAnnotation(event, {
+        color: GoodColor,
+        summary: `Reduced cooldown of brews by ${BONUS_CDR}ms (${cdr}ms actual, ${BONUS_CDR - cdr} wasted)`,
+      });
+      return true;
+    }
+    return false;
+  }
+
+  get effectiveCdr() {
+    return this.totalCdr;
+  }
+  get wastedCdr() {
+    return this._wastedCdr;
+  }
+}

--- a/src/interface/App.tsx
+++ b/src/interface/App.tsx
@@ -16,6 +16,7 @@ import RouterErrorBoundary from 'interface/RouterErrorBoundary';
 import {
   AboutTab,
   CharacterTab,
+  DebugAnnotationsTab,
   DefaultTab,
   EventsTab,
   OverviewTab,
@@ -95,6 +96,7 @@ const appRoutes = createRoutesFromElements(
       <Route path="statistics" element={<StatisticsTab />} />
       <Route path="timeline" element={<TimelineTab />} />
       <Route path="events" element={<EventsTab />} />
+      <Route path="debug" element={<DebugAnnotationsTab />} />
       <Route path="character" element={<CharacterTab />} />
       <Route path="about" element={<AboutTab />} />
       <Route path=":resultTab" element={<DefaultTab />} />

--- a/src/interface/DebugAnnotationsTab.tsx
+++ b/src/interface/DebugAnnotationsTab.tsx
@@ -1,0 +1,192 @@
+import CombatLogParser from 'parser/core/CombatLogParser';
+import DebugAnnotations, {
+  AnnotatedEvent,
+  ModuleAnnotations,
+} from 'parser/core/modules/DebugAnnotations';
+import Tooltip from './Tooltip';
+import styled from '@emotion/styled';
+import { AnyEvent, HasAbility, HasSource, HasTarget } from 'parser/core/Events';
+import { useMemo, useState } from 'react';
+import { useCombatLogParser } from './report/CombatLogParserContext';
+import { formatDuration } from 'common/format';
+import SpellLink from './SpellLink';
+
+export default function DebugAnnotationsTab({ parser }: { parser: CombatLogParser }) {
+  const annotations = parser.getModule(DebugAnnotations);
+  return (
+    <div className="panel">
+      <div className="panel-heading">
+        <h1>Debug Annotations</h1>
+      </div>
+      <div className="panel-body flex" style={{ padding: '1em 2em' }}>
+        {annotations.getAll().map((props) => (
+          <ModuleDebugAnnotations {...props} key={props.module.constructor.name} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ModuleDebugAnnotations({ module, annotations }: ModuleAnnotations) {
+  const { combatLogParser: parser } = useCombatLogParser();
+  const [selected, setSelected] = useState<AnnotatedEvent | null>(null);
+  return (
+    <div>
+      <h3>{module.constructor.name}</h3>
+      <div>Recorded annotations for {annotations.length} events</div>
+      <DotContainer>
+        {intoRows(annotations, parser.fight.start_time).map((row, index) => (
+          <Row key={index}>
+            {row.map((props, index) => (
+              <AnnotationDot {...props} key={index} onClick={() => setSelected(props)} />
+            ))}
+          </Row>
+        ))}
+      </DotContainer>
+      {selected && <EventDetails {...selected} />}
+    </div>
+  );
+}
+
+function EventDetails({ event, annotations }: AnnotatedEvent) {
+  const { combatLogParser } = useCombatLogParser();
+  return (
+    <div>
+      <hr />
+      <h4>Event Details</h4>
+      <EventDetailsColumns>
+        <div>
+          <dl>
+            <dt>Timestamp</dt>
+            <dd>{formatDuration(event.timestamp - combatLogParser.fight.start_time)}</dd>
+            <dt>Type</dt>
+            <dd>{event.type}</dd>
+            {HasAbility(event) && (
+              <>
+                <dt>Ability</dt>
+                <dd>
+                  <SpellLink spell={event.ability.guid} />
+                </dd>
+              </>
+            )}
+            {HasSource(event) && (
+              <>
+                <dt>Source</dt>
+                <dd>
+                  {combatLogParser.getSourceName(event)} (ID: {event.sourceID})
+                </dd>
+              </>
+            )}
+            {HasTarget(event) && (
+              <>
+                <dt>Target</dt>
+                <dd>
+                  {combatLogParser.getTargetName(event)} (ID: {event.targetID})
+                </dd>
+              </>
+            )}
+          </dl>
+          {annotations.map(({ summary, details }, index) => (
+            <div key={index}>
+              <hr />
+              <h5>{summary}</h5>
+              {details}
+            </div>
+          ))}
+        </div>
+        <EventPre>
+          {JSON.stringify(
+            event,
+            function (k, v) {
+              if (!k) {
+                return v;
+              }
+              if (v && typeof v === 'object' && 'timestamp' in v) {
+                // if we find another event-like object that isn't the top-level event, skip it
+                return { '...': 'truncated' };
+              }
+              return v;
+            },
+            2,
+          )}
+        </EventPre>
+      </EventDetailsColumns>
+    </div>
+  );
+}
+
+const EventDetailsColumns = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: min-content;
+  grid-gap: 1em;
+`;
+
+const EventPre = styled.pre`
+  background-color: #333;
+  color: #eee;
+  font-family: monospace, Courier;
+`;
+
+const AnnotationDot = ({
+  event,
+  annotations,
+  onClick,
+}: AnnotatedEvent & { onClick: () => void }) => {
+  const annotation = useMemo(() => {
+    let result = annotations[0];
+    for (const annotation of annotations.slice(1)) {
+      if ((annotation.priority ?? 0) > (result.priority ?? 0)) {
+        result = annotation;
+      }
+    }
+    return result;
+  }, [annotations]);
+
+  const { combatLogParser } = useCombatLogParser();
+
+  return (
+    <Tooltip
+      content={`${formatDuration(event.timestamp - combatLogParser.fight.start_time)} - ${annotation.summary}`}
+    >
+      <Dot color={annotation.color} onClick={onClick} />
+    </Tooltip>
+  );
+};
+
+const Dot = styled('div')<{ color: string }>`
+  background-color: ${(props) => props.color};
+  height: 1em;
+  width: 1em;
+  border-radius: 50%;
+  cursor: pointer;
+`;
+
+const DotContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+
+  font-size: 75%;
+`;
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 2px;
+`;
+
+function intoRows<T extends { event: AnyEvent }>(data: Array<T>, startTime: number): Array<T[]> {
+  const rows: Array<T[]> = [[]];
+  let currentIndex = 0;
+  for (const datum of data) {
+    const index = Math.floor((datum.event.timestamp - startTime) / 60000);
+    if (currentIndex !== index) {
+      currentIndex = index;
+      rows.push([]);
+    }
+    rows.at(-1)?.push(datum);
+  }
+
+  return rows;
+}

--- a/src/interface/DebugAnnotationsTab.tsx
+++ b/src/interface/DebugAnnotationsTab.tsx
@@ -41,22 +41,42 @@ function ModuleDebugAnnotations({ module, annotations }: ModuleAnnotations) {
         {intoRows(annotations, parser.fight.start_time).map((row, index) => (
           <Row key={index}>
             {row.map((props, index) => (
-              <AnnotationDot {...props} key={index} onClick={() => setSelected(props)} />
+              <AnnotationDot
+                {...props}
+                key={index}
+                onClick={() => setSelected((current) => (current === props ? null : props))}
+                selected={selected === props}
+              />
             ))}
           </Row>
         ))}
       </DotContainer>
-      {selected && <EventDetails {...selected} />}
+      {selected && <EventDetails {...selected} clearSelection={() => setSelected(null)} />}
     </div>
   );
 }
 
-function EventDetails({ event, annotations }: AnnotatedEvent) {
+function EventDetails({
+  event,
+  annotations,
+  clearSelection,
+}: AnnotatedEvent & { clearSelection: () => void }) {
   const { combatLogParser } = useCombatLogParser();
   return (
     <div>
       <hr />
-      <h4>Event Details</h4>
+      <div>
+        <h4>
+          Event Details
+          <button
+            className="btn btn-link"
+            style={{ display: 'inline-block' }}
+            onClick={clearSelection}
+          >
+            <small>(Clear Selection)</small>
+          </button>
+        </h4>{' '}
+      </div>
       <EventDetailsColumns>
         <div>
           <dl>
@@ -135,7 +155,8 @@ const AnnotationDot = ({
   event,
   annotations,
   onClick,
-}: AnnotatedEvent & { onClick: () => void }) => {
+  selected,
+}: AnnotatedEvent & { onClick: () => void; selected?: boolean }) => {
   const annotation = useMemo(() => {
     let result = annotations[0];
     for (const annotation of annotations.slice(1)) {
@@ -152,17 +173,21 @@ const AnnotationDot = ({
     <Tooltip
       content={`${formatDuration(event.timestamp - combatLogParser.fight.start_time)} - ${annotation.summary}`}
     >
-      <Dot color={annotation.color} onClick={onClick} />
+      <Dot color={annotation.color} onClick={onClick} selected={selected} />
     </Tooltip>
   );
 };
 
-const Dot = styled('div')<{ color: string }>`
+const Dot = styled('div')<{ color: string; selected?: boolean }>`
   background-color: ${(props) => props.color};
   height: 1em;
   width: 1em;
   border-radius: 50%;
   cursor: pointer;
+  box-sizing: border-box;
+  border-width: 2px;
+  border-style: solid;
+  border-color: ${(props) => (props.selected ? 'white' : props.color)};
 `;
 
 const DotContainer = styled.div`

--- a/src/interface/DebugAnnotationsTab.tsx
+++ b/src/interface/DebugAnnotationsTab.tsx
@@ -18,7 +18,10 @@ export default function DebugAnnotationsTab({ parser }: { parser: CombatLogParse
       <div className="panel-heading">
         <h1>Debug Annotations</h1>
       </div>
-      <div className="panel-body flex" style={{ padding: '1em 2em' }}>
+      <div
+        className="panel-body flex"
+        style={{ padding: '1em 2em', flexDirection: 'column', gap: '1em' }}
+      >
         {annotations.getAll().map((props) => (
           <ModuleDebugAnnotations {...props} key={props.module.constructor.name} />
         ))}

--- a/src/interface/report/Results/About.tsx
+++ b/src/interface/report/Results/About.tsx
@@ -31,12 +31,16 @@ const About = ({ config }: Props) => {
       }
       actions={
         <>
-          <Link to="../events">
-            <Trans id="interface.report.results.about.viewEvents">View all events</Trans>
-          </Link>
-          <Link to="../debug">
-            <Trans id="interface.report.results.about.viewDebug">View debug info</Trans>
-          </Link>
+          <div>
+            <Link to="../events">
+              <Trans id="interface.report.results.about.viewEvents">View all events</Trans>
+            </Link>
+          </div>
+          <div>
+            <Link to="../debug">
+              <Trans id="interface.report.results.about.viewDebug">View debug info</Trans>
+            </Link>
+          </div>
         </>
       }
     >

--- a/src/interface/report/Results/About.tsx
+++ b/src/interface/report/Results/About.tsx
@@ -30,9 +30,14 @@ const About = ({ config }: Props) => {
         </Trans>
       }
       actions={
-        <Link to="../events">
-          <Trans id="interface.report.results.about.viewEvents">View all events</Trans>
-        </Link>
+        <>
+          <Link to="../events">
+            <Trans id="interface.report.results.about.viewEvents">View all events</Trans>
+          </Link>
+          <Link to="../debug">
+            <Trans id="interface.report.results.about.viewDebug">View debug info</Trans>
+          </Link>
+        </>
       }
     >
       {description}

--- a/src/interface/report/Results/NavigationBar.tsx
+++ b/src/interface/report/Results/NavigationBar.tsx
@@ -10,6 +10,7 @@ import { ComponentType, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { isMessageDescriptor } from 'localization/isMessageDescriptor';
 import { i18n } from '@lingui/core';
+import { InsanityIcon } from 'interface/icons';
 
 interface Props {
   makeTabUrl: (url: string) => string;
@@ -66,6 +67,14 @@ const NavigationBar = ({ makeTabUrl, tabs, selectedTab }: Props) => {
       icon: EventsIcon,
       name: <Trans id="interface.report.results.navigationBar.events">Events</Trans>,
       url: 'events',
+    });
+  }
+
+  if (selectedTab === 'debug') {
+    pages.push({
+      icon: InsanityIcon,
+      name: <Trans id="interface.report.results.navigationBar.debug">Debug</Trans>,
+      url: 'debug',
     });
   }
 

--- a/src/interface/report/Results/ResultsContent.tsx
+++ b/src/interface/report/Results/ResultsContent.tsx
@@ -33,6 +33,11 @@ const LazyEventsTab = lazyLoadComponent(() =>
     ),
   ),
 );
+const LazyDebugAnnotationsTab = lazyLoadComponent(() =>
+  retryingPromise(() =>
+    import('interface/DebugAnnotationsTab').then(({ default: Component }) => Component),
+  ),
+);
 
 export const OverviewTab = () => {
   const { combatLogParser: parser } = useCombatLogParser();
@@ -96,6 +101,20 @@ export const EventsTab = () => {
   return (
     <div className="container">
       <LazyEventsTab parser={parser} />
+    </div>
+  );
+};
+
+export const DebugAnnotationsTab = () => {
+  const { combatLogParser } = useCombatLogParser();
+  const { isLoading } = useResults();
+
+  if (isLoading) {
+    return <ResultsLoadingIndicator />;
+  }
+  return (
+    <div className="container">
+      <LazyDebugAnnotationsTab parser={combatLogParser} />
     </div>
   );
 };

--- a/src/parser/core/Analyzer.ts
+++ b/src/parser/core/Analyzer.ts
@@ -8,6 +8,8 @@ import { Info, Metric } from './metric';
 import Module from './Module';
 import { When } from './ParseResults';
 import { MessageDescriptor } from '@lingui/core';
+import type { Annotation } from './modules/DebugAnnotations';
+import DebugAnnotations from './modules/DebugAnnotations';
 
 export const SELECTED_PLAYER = 1;
 export const SELECTED_PLAYER_PET = 2;
@@ -37,6 +39,12 @@ class Analyzer extends EventSubscriber {
     listener: EventListener<ET, E>,
   ) {
     super.addEventListener(eventFilter, listener);
+  }
+  /**
+   * Add an annotation which will be displayed on the /debug view.
+   */
+  addDebugAnnotation(event: AnyEvent, annotation: Annotation): void {
+    this.owner.getModule(DebugAnnotations)?.addAnnotation(this, event, annotation);
   }
 
   // Override these with functions that return info about their rendering in the specific slots

--- a/src/parser/core/Analyzer.ts
+++ b/src/parser/core/Analyzer.ts
@@ -40,8 +40,13 @@ class Analyzer extends EventSubscriber {
   ) {
     super.addEventListener(eventFilter, listener);
   }
+
   /**
-   * Add an annotation which will be displayed on the /debug view.
+   * Add an annotation which will be displayed on the /debug view. Multiple annotations
+   * can be added to the same event.
+   *
+   * Annotations are automatically broken down by analyzer. You don't need to split them
+   * up yourself.
    */
   addDebugAnnotation(event: AnyEvent, annotation: Annotation): void {
     this.owner.getModule(DebugAnnotations)?.addAnnotation(this, event, annotation);

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -78,6 +78,7 @@ import { EventListener } from './EventSubscriber';
 import Fight from './Fight';
 import { Info } from './metric';
 import Module, { Options } from './Module';
+import DebugAnnotations from './modules/DebugAnnotations';
 import Abilities from './modules/Abilities';
 import Auras from './modules/Auras';
 import EventEmitter from './modules/EventEmitter';
@@ -148,6 +149,7 @@ class CombatLogParser {
     spellInfo: SpellInfo,
     enemies: Enemies,
     friendlyCompat: FriendlyCompatNormalizer,
+    debugAnnotations: DebugAnnotations,
   };
   static defaultModules: DependenciesDefinition = {
     // Normalizers

--- a/src/parser/core/modules/DebugAnnotations.ts
+++ b/src/parser/core/modules/DebugAnnotations.ts
@@ -4,13 +4,28 @@ import Module from '../Module';
 type AnnotationSet = Map<AnyEvent, Annotation[]>;
 
 export interface Annotation {
+  /**
+   * CSS Color string. This is the color of the dot shown in the UI.
+   */
   color: string;
+  /**
+   * A brief text-only description of the annotation. This is shown in the tooltip.
+   */
   summary: string;
+  /**
+   * (Optional) added details about the event. This can use JSX, but it does NOT
+   * (currently) render inside the guide context (so `useInfo` won't work, but
+   * `useAnalyzer` might).
+   */
   details?: JSX.Element | string;
   /**
-   * Used to determine which color and summary to display for an event when multiple annotations are present in the same module.
+   * Used to determine which color and summary to display for an event when multiple
+   * annotations are present in the same module.
    *
    * Higher number = higher priority.
+   *
+   * If you want an easy way to make a "default" annotation get overridden by any
+   * other annotation, use `priority: -Infinity`.
    */
   priority?: number;
 }

--- a/src/parser/core/modules/DebugAnnotations.ts
+++ b/src/parser/core/modules/DebugAnnotations.ts
@@ -1,0 +1,62 @@
+import { AnyEvent } from '../Events';
+import Module from '../Module';
+
+type AnnotationSet = Map<AnyEvent, Annotation[]>;
+
+export interface Annotation {
+  color: string;
+  summary: string;
+  details?: JSX.Element | string;
+  /**
+   * Used to determine which color and summary to display for an event when multiple annotations are present in the same module.
+   *
+   * Higher number = higher priority.
+   */
+  priority?: number;
+}
+
+export interface AnnotatedEvent {
+  event: AnyEvent;
+  annotations: Annotation[];
+}
+
+export interface ModuleAnnotations {
+  module: Module;
+  annotations: Array<AnnotatedEvent>;
+}
+
+export default class DebugAnnotations extends Module {
+  private annotations: Map<Module, AnnotationSet> = new Map();
+
+  addAnnotation(module: Module, event: AnyEvent, annotation: Annotation) {
+    const ann = this.moduleAnnotations(module);
+    appendAnnotation(ann, event, annotation);
+  }
+
+  private moduleAnnotations(module: Module): AnnotationSet {
+    if (!this.annotations.has(module)) {
+      this.annotations.set(module, new Map());
+    }
+    return this.annotations.get(module)!;
+  }
+
+  getModuleAnnotations(module: Module): ModuleAnnotations {
+    return {
+      module,
+      annotations: Array.from(this.moduleAnnotations(module).entries()).map(
+        ([event, annotations]) => ({ event, annotations }),
+      ),
+    };
+  }
+
+  getAll(): ModuleAnnotations[] {
+    return Array.from(this.annotations.keys()).map(this.getModuleAnnotations.bind(this));
+  }
+}
+
+function appendAnnotation(set: AnnotationSet, event: AnyEvent, annotation: Annotation) {
+  if (!set.has(event)) {
+    set.set(event, []);
+  }
+  set.get(event)?.push(annotation);
+}

--- a/src/parser/shared/modules/SpellUsable.test.jsx
+++ b/src/parser/shared/modules/SpellUsable.test.jsx
@@ -110,7 +110,7 @@ describe('core/Modules/SpellUsable', () => {
       expect(module.isAvailable(SPELLS.FAKE_SPELL.id)).toBe(true);
     });
     it('casting a spell already on cooldown before the cooldown runs out restarts the cooldown (and reports)', () => {
-      console.error = jest.fn();
+      module.addDebugAnnotation = jest.fn();
       triggerCast(SPELLS.FAKE_SPELL.id);
       parser.currentTimestamp = 5000;
       triggerCast(SPELLS.FAKE_SPELL.id);
@@ -118,7 +118,7 @@ describe('core/Modules/SpellUsable', () => {
       // It's still on cooldown
       expect(module.isOnCooldown(SPELLS.FAKE_SPELL.id)).toBe(true);
       // It reports when this happens, as it's not supposed to happen normally.
-      expect(console.error).toHaveBeenCalled();
+      expect(module.addDebugAnnotation).toHaveBeenCalled();
       // Its cooldown is based on the timestamp of the second cast, as the log results are leading over our predictions
       expect(module.cooldownRemaining(SPELLS.FAKE_SPELL.id)).toBe(7500);
     });

--- a/src/parser/shared/modules/SpellUsable.ts
+++ b/src/parser/shared/modules/SpellUsable.ts
@@ -226,34 +226,6 @@ class SpellUsable extends Analyzer {
         cdInfo,
       );
     } else {
-      // Spell shouldn't be available right now... if outside the lag margin, log an error.
-      // In any event, the spell clearly *is* available, so we'll create a simultaneous
-      // end cooldown and begin cooldown to represent what happened
-      const remainingCooldown = cdInfo.expectedEnd - triggeringEvent.timestamp;
-      if (remainingCooldown > COOLDOWN_LAG_MARGIN) {
-        console.error(
-          'Cooldown error - ' +
-            spellName(cdSpellId) +
-            ' ID=' +
-            cdSpellId +
-            " was used while SpellUsable's tracker thought it had no available charges. " +
-            'This could happen due to missing haste buffs, missing CDR, missing reductions/resets, ' +
-            'or incorrect ability config.\n' +
-            'Expected time left on CD: ' +
-            remainingCooldown +
-            '\n' +
-            'Current Time: ' +
-            triggeringEvent.timestamp +
-            ' (' +
-            this.owner.formatTimestamp(triggeringEvent.timestamp, 3) +
-            ')' +
-            '\n' +
-            'CooldownInfo object before update: ' +
-            JSON.stringify(cdInfo) +
-            '\n',
-        );
-      }
-
       // trigger an end cooldown and then immediately a begin cooldown
       // we're treating this as a missed natural CD expiration, so pass true to 'reset cooldown'
       this.endCooldown(cdSpellId, triggeringEvent.timestamp, true);

--- a/src/parser/shared/modules/SpellUsable/SpellUsableDebugDescription.tsx
+++ b/src/parser/shared/modules/SpellUsable/SpellUsableDebugDescription.tsx
@@ -1,0 +1,40 @@
+import { AnyEvent } from 'parser/core/Events';
+import type { CooldownInfo } from '../SpellUsable';
+import CombatLogParser from 'parser/core/CombatLogParser';
+import { formatDuration } from 'common/format';
+
+interface Props {
+  cdInfo: CooldownInfo;
+  event: AnyEvent;
+  parser: CombatLogParser;
+}
+
+export default function SpellUsableDebugDescription({ cdInfo, event, parser }: Props): JSX.Element {
+  return (
+    <dl>
+      <dt>Cooldown Started</dt>
+      <dd>
+        {formatDuration(cdInfo.overallStart - parser.fight.start_time)} (
+        {formatDuration(event.timestamp - cdInfo.overallStart)} before this event)
+      </dd>
+      {cdInfo.maxCharges && (
+        <>
+          <dt>Most Recent Charge Started</dt>
+          <dd>
+            {formatDuration(cdInfo.chargeStart - parser.fight.start_time)} (
+            {formatDuration(event.timestamp - cdInfo.chargeStart)} before this event)
+          </dd>
+          <dt>Max Charges</dt>
+          <dd>{cdInfo.maxCharges}</dd>
+        </>
+      )}
+      <dt>Expected Cooldown End</dt>
+      <dd>
+        {formatDuration(cdInfo.expectedEnd - parser.fight.start_time)} (
+        {formatDuration(cdInfo.expectedEnd - event.timestamp, 2)} after this event)
+      </dd>
+      <dt>Current Expected Cooldown</dt>
+      <dd>{formatDuration(cdInfo.currentRechargeDuration)}</dd>
+    </dl>
+  );
+}


### PR DESCRIPTION
### Description

This adds a debug annotations tab accessible from the About page (much like events), along with infrastructure for adding debug annotations from both core and spec modules.

The idea is that an analyzer can add annotations that can be inspected with extra information attached rather than dumping to `console.log`. This will hopefully reduce log spam and make it easier to see what is actually going on.

This draft includes an implementation for `SpellUsable` that replaces the old `console.error` message with an annotation that can be viewed by going to `/debug`. All relevant events handled by `SpellUsable` are shown, with good ones in green and bad ones in red. Unknown ones are shown in yellow.

### Testing

Go to any fight and then navigate to `/debug` (either by editing the URL or going About -> View debug info)

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/5f82b493-0c6a-4252-b884-2576420c26ab)

