### PR TITLE
temporary workaround for wcl talent breakage

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,8 +35,9 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2022, 6, 5), 'Update Classic Food Buffs for Cataclysm', jazminite),
-  change(date(2022, 6, 3), 'Update Classic Flasks for Cataclysm', jazminite),
+  change(date(2024, 6, 6), 'Temporary workaround for talent breakage on the character parses page. Talents have been disabled for the moment.', emallson),
+  change(date(2024, 6, 5), 'Update Classic Food Buffs for Cataclysm', jazminite),
+  change(date(2024, 6, 3), 'Update Classic Flasks for Cataclysm', jazminite),
   change(date(2024, 6, 3), 'Update event meta usage.', ToppleTheNun),
   change(date(2024, 5, 31), 'Update Classic Enchants for Cataclysm', jazminite),
   change(date(2024, 5, 31), "Add Cataclysm patch 4.4.0.", Putro),

--- a/src/interface/CharacterParsesList.tsx
+++ b/src/interface/CharacterParsesList.tsx
@@ -103,6 +103,7 @@ class CharacterParsesList extends PureComponent<CharacterParsesListProps> {
       detailIcons = (elem: Parse) => (
         <div className="col-md-4 flex wrapable">
           {elem.advanced &&
+            Array.isArray(elem.talents) &&
             elem.talents.slice(0, 8).map((talent) => (
               <div key={talent.id} className="flex-sub">
                 <SpellIcon spell={talent} style={styles.icon} />


### PR DESCRIPTION
the story is that WCL has changed its internal representation of talents to no longer include the talent's ability id (since that can be retrieved via the entry id). in the process, the character page was changed to handle this and that had unexpected ramifications on this api that need to be partially reverted.

this patch lets the page continue working (but without talent display) until that happens
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/de0c7788-831f-4351-906e-e61735867c16)

