### PR TITLE
fully fix talent entries on retail character parse lists

### DIFF
--- a/src/common/TALENTS/getTalentFromEntry.ts
+++ b/src/common/TALENTS/getTalentFromEntry.ts
@@ -16,5 +16,6 @@ for (const table of Object.values(talent_tables)) {
   }
 }
 
-const getTalentFromEntry = (entry: TalentEntry): Talent | undefined => TALENTS[entry.id];
+const getTalentFromEntry = (entry: Pick<TalentEntry, 'id'>): Talent | undefined =>
+  TALENTS[entry.id];
 export default getTalentFromEntry;

--- a/src/interface/CharacterParsesList.tsx
+++ b/src/interface/CharacterParsesList.tsx
@@ -10,6 +10,7 @@ import { PureComponent } from 'react';
 import { Link } from 'react-router-dom';
 import { Item } from 'parser/core/Events';
 import Spell from 'common/SPELLS/Spell';
+import getTalentFromEntry from 'common/TALENTS/getTalentFromEntry';
 
 const TRINKET_SLOTS = [GEAR_SLOTS.TRINKET1, GEAR_SLOTS.TRINKET2];
 
@@ -20,6 +21,11 @@ const styles = {
     marginRight: 2,
   },
 };
+
+interface ParseTalentEntry {
+  entryID: number;
+  rank: number;
+}
 
 export interface Parse {
   encounterId: number;
@@ -33,7 +39,7 @@ export interface Parse {
   persecondamount: number;
   start_time: number;
   character_name: string;
-  talents: Spell[];
+  talents: (Spell | ParseTalentEntry)[];
   gear: Item[];
   advanced: boolean;
 }
@@ -105,8 +111,8 @@ class CharacterParsesList extends PureComponent<CharacterParsesListProps> {
           {elem.advanced &&
             Array.isArray(elem.talents) &&
             elem.talents.slice(0, 8).map((talent) => (
-              <div key={talent.id} className="flex-sub">
-                <SpellIcon spell={talent} style={styles.icon} />
+              <div key={'id' in talent ? talent.id : talent.entryID} className="flex-sub">
+                <RetailTalentIcon {...talent} />
               </div>
             ))}
         </div>
@@ -161,6 +167,15 @@ class CharacterParsesList extends PureComponent<CharacterParsesListProps> {
       </ul>
     );
   }
+}
+
+function RetailTalentIcon(value: ParseTalentEntry | Spell): JSX.Element | null {
+  if ('id' in value) {
+    return <SpellIcon spell={value} />;
+  }
+
+  const spell = getTalentFromEntry({ id: value.entryID });
+  return spell ? <SpellIcon spell={spell} /> : null;
 }
 
 export default CharacterParsesList;


### PR DESCRIPTION
Closes https://github.com/WoWAnalyzer/WoWAnalyzer/issues/6786

still not the best display of talents, but at least returns to the status quo

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/b002a086-44fd-4ba0-b0c7-05d6d00dddda)
