### PR TITLE
[Mistweaver] Fix vivify cast entries bug caused by vivacious vivification change.

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2024, 6, 17), <>Bug fix for <SpellLink spell={SPELLS.VIVIFY}/> cast entry section of the guide.</>, Vohrr),
   change(date(2024, 6, 16), <>Added <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT}/>.</>, Vohrr),
   change(date(2024, 6, 16), <>Removed old checklist and suggestion thresholds. Updated <SpellLink spell={SPELLS.VIVIFY}/> event linking to fix cast entry bugs. Added healing boost statistic for <SpellLink spell={TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT}/>.</>, Vohrr),
   change(date(2024, 6, 14), <>Added <SpellLink spell={TALENTS_MONK.CRANE_STYLE_TALENT}/> analysis.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
@@ -79,11 +79,16 @@ class RisingSunKick extends Analyzer {
         <b>
           <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT} />
         </b>{' '}
-        is one of your primary damaging spells but is also the 2nd highest priority healing spell{' '}
-        {'(behind '} <SpellLink spell={TALENTS_MONK.RENEWING_MIST_TALENT} />
-        {') '}due to its synergy with <SpellLink spell={TALENTS_MONK.RISING_MIST_TALENT} /> and{' '}
-        <SpellLink spell={TALENTS_MONK.RAPID_DIFFUSION_TALENT} />. Using it as much as possible is
-        essential for maintaining high counts of{' '}
+        is one of your primary damaging spells but is also you highest priority healing spell{' '}
+        {'(alongside '} <SpellLink spell={TALENTS_MONK.RENEWING_MIST_TALENT} />
+        {') '}due to its synergy with <SpellLink spell={TALENTS_MONK.RISING_MIST_TALENT} />{' '}
+        {this.selectedCombatant.hasTalent(TALENTS_MONK.POOL_OF_MISTS_TALENT) && (
+          <>
+            , <SpellLink spell={TALENTS_MONK.POOL_OF_MISTS_TALENT} />,{' '}
+          </>
+        )}
+        and <SpellLink spell={TALENTS_MONK.RAPID_DIFFUSION_TALENT} />. Using it as much as possible
+        is essential for maintaining high counts of{' '}
         <SpellLink spell={TALENTS_MONK.RENEWING_MIST_TALENT} />
       </p>
     );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
@@ -275,7 +275,7 @@ class Vivify extends Analyzer {
     }
   }
 
-  private _makeID(event: HealEvent): string {
+  private _makeHealId(event: HealEvent): string {
     return (
       event.targetID + '_' + event.timestamp + '_' + event.amount + '_' + (event.overheal || 0)
     );
@@ -298,10 +298,10 @@ class Vivify extends Analyzer {
      */
     invigoratingMistHits.forEach((invigHeal) => {
       const targetId = invigHeal.targetID;
-      const uuid = this._makeID(invigHeal);
+      const heal_id = this._makeHealId(invigHeal);
 
       if (
-        (!this.healsPerPlayer[targetId] || !this.healsPerPlayer[targetId].has(uuid)) &&
+        (!this.healsPerPlayer[targetId] || !this.healsPerPlayer[targetId].has(heal_id)) &&
         !targetsInGrouping.find((id) => id === targetId)
       ) {
         const effective = invigHeal.amount + (invigHeal.absorbed || 0);
@@ -312,8 +312,8 @@ class Vivify extends Analyzer {
 
         this._tallyUpliftedSpiritsCDR(invigHeal);
         this.healsPerPlayer[targetId]
-          ? this.healsPerPlayer[targetId].add(uuid)
-          : (this.healsPerPlayer[targetId] = new Set<string>().add(uuid));
+          ? this.healsPerPlayer[targetId].add(heal_id)
+          : (this.healsPerPlayer[targetId] = new Set<string>().add(heal_id));
 
         targetsInGrouping.push(targetId);
         rems += 1;


### PR DESCRIPTION
### Description

Vivacious Vivification can proc during a hardcasted vivify and is not consumed until the following vivify cast. This is often causing two vivify casts and their subsequent eventlinked healing to occur simultaneously. 
This PR fixes that and does some Guide section verbiage updates

### Screenshots
Log Events Example (
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/26779541/29bf1593-0c44-40ca-b865-8e1752426597)

Before:
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/26779541/6472e2d3-84af-4155-8111-86f829a3dbd8)

After: 
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/26779541/b24c537a-47f6-4277-a240-01cce962a0d9)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/26779541/9c6e2635-1bd7-4767-b18c-d44b13a14b30)



