### PR TITLE
Add basic support for Cata BDK

### DIFF
--- a/src/analysis/classic/_templates/melee/modules/features/Abilities.ts
+++ b/src/analysis/classic/_templates/melee/modules/features/Abilities.ts
@@ -7,7 +7,7 @@ class Abilities extends CoreAbilities {
     return [
       // Rotational
       {
-        spell: [SPELLS.DEATH_COIL_DK.id, ...SPELLS.DEATH_COIL_DK.lowRanks],
+        spell: SPELLS.DEATH_COIL_DK.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },

--- a/src/analysis/classic/deathknight/blood/CHANGELOG.tsx
+++ b/src/analysis/classic/deathknight/blood/CHANGELOG.tsx
@@ -1,0 +1,8 @@
+import { change, date } from 'common/changelog';
+import { jazminite } from 'CONTRIBUTORS';
+
+export default [
+  // Remove these entries and add your own
+  change(date(2023, 2, 3), 'Small text update to Component Checklist.', jazminite),
+  change(date(2023, 2, 3), 'Add Classic Melee spec template.', jazminite),
+];

--- a/src/analysis/classic/deathknight/blood/CHANGELOG.tsx
+++ b/src/analysis/classic/deathknight/blood/CHANGELOG.tsx
@@ -1,8 +1,4 @@
 import { change, date } from 'common/changelog';
-import { jazminite } from 'CONTRIBUTORS';
+import { emallson } from 'CONTRIBUTORS';
 
-export default [
-  // Remove these entries and add your own
-  change(date(2023, 2, 3), 'Small text update to Component Checklist.', jazminite),
-  change(date(2023, 2, 3), 'Add Classic Melee spec template.', jazminite),
-];
+export default [change(date(2024, 6, 17), 'Added basic ability list for Cataclysm', emallson)];

--- a/src/analysis/classic/deathknight/blood/CONFIG.tsx
+++ b/src/analysis/classic/deathknight/blood/CONFIG.tsx
@@ -1,0 +1,55 @@
+import { emallson } from 'CONTRIBUTORS';
+import GameBranch from 'game/GameBranch';
+import SPECS from 'game/SPECS';
+import type Config from 'parser/Config';
+import CHANGELOG from './CHANGELOG';
+
+const config: Config = {
+  // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
+  contributors: [emallson],
+  branch: GameBranch.Classic,
+  // The WoW client patch this spec was last updated.
+  patchCompatibility: '4.4.0',
+  // Update to false when the spec is mostly complete (and safe to use)
+  isPartial: true,
+  // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
+  // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
+  description: (
+    <>
+      Welcome! Thanks for checking out WoWAnalyzer. This guide is seeking a maintainer.
+      <br />
+      See the public GitHub repo or join our community Discord for information about contributing.
+      Thanks!
+    </>
+  ),
+  pages: {
+    overview: {
+      hideChecklist: false,
+      text: (
+        <>
+          Classic Cataclysm support is still a Work in Progress. This spec guide is a stub. See the
+          "About" tab for information on contributing.
+        </>
+      ),
+      type: 'warning', // info, warning, or danger
+    },
+  },
+  // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
+  exampleReport: '/report/<UPDATE_THIS>',
+  // Add spells to display separately on the timeline
+  timeline: {
+    separateCastBars: [[]],
+  },
+  // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
+  spec: SPECS.CLASSIC_DEATH_KNIGHT_BLOOD, // UPDATE THIS
+
+  // USE CAUTION when changing anything below this line.
+  // The contents of your changelog.
+  changelog: CHANGELOG,
+  // The CombatLogParser class for your spec.
+  parser: () => import('./CombatLogParser').then((exports) => exports.default),
+  // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
+  path: import.meta.url,
+};
+
+export default config;

--- a/src/analysis/classic/deathknight/blood/CONFIG.tsx
+++ b/src/analysis/classic/deathknight/blood/CONFIG.tsx
@@ -35,7 +35,7 @@ const config: Config = {
     },
   },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/<UPDATE_THIS>',
+  exampleReport: '/report/whg9yZrGNjzDWLX7/30-Heroic+Magmaw+-+Kill+(3:59)/Nezter/standard/overview',
   // Add spells to display separately on the timeline
   timeline: {
     separateCastBars: [[]],

--- a/src/analysis/classic/deathknight/blood/CombatLogParser.ts
+++ b/src/analysis/classic/deathknight/blood/CombatLogParser.ts
@@ -1,0 +1,25 @@
+// Base file
+import BaseCombatLogParser from 'parser/classic/CombatLogParser';
+// Features
+import Abilities from './modules/features/Abilities';
+import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
+import Buffs from './modules/features/Buffs';
+import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
+import Checklist from './modules/checklist/Module';
+// Spells
+// import SpellName from './modules/spells';
+
+class CombatLogParser extends BaseCombatLogParser {
+  static specModules = {
+    // Features
+    abilities: Abilities,
+    alwaysBeCasting: AlwaysBeCasting,
+    buffs: Buffs,
+    cooldownThroughputTracker: CooldownThroughputTracker,
+    checklist: Checklist,
+    // Spells
+    // spellName: SpellName,
+  };
+}
+
+export default CombatLogParser;

--- a/src/analysis/classic/deathknight/blood/index.ts
+++ b/src/analysis/classic/deathknight/blood/index.ts
@@ -1,0 +1,2 @@
+// Reference this file in src\parser\index.ts
+export { default } from './CONFIG';

--- a/src/analysis/classic/deathknight/blood/modules/checklist/Component.tsx
+++ b/src/analysis/classic/deathknight/blood/modules/checklist/Component.tsx
@@ -25,10 +25,9 @@ const MeleeChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistProp
         name="Avoid Downtime"
         description={
           <>
-            Avoid unnecessary downtime during the fight. If you have to move, try casting instant
-            spells such as
-            {/* UPDATE THE SPELL BELOW */}
-            <SpellLink spell={SPELLS.DEATH_COIL_DK} />.
+            Avoid unnecessary downtime during the fight. If you have to be out of range, try casting
+            instant spells such as <SpellLink spell={SPELLS.DEATH_COIL_DK} /> or refresh your
+            diseases with <SpellLink spell={SPELLS.ICY_TOUCH} />.
           </>
         }
       >
@@ -38,9 +37,10 @@ const MeleeChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistProp
         name="Use Cooldowns Effectively"
         description={<>Use your cooldowns as often as possible to maximize your damage output.</>}
       >
-        {/* SPELLS listed here must be in ../features/Abilities */}
-        {/* UPDATE THE ABILITIES BELOW */}
-        <AbilityRequirement spell={SPELLS.SUMMON_GARGOYLE.id} />
+        <AbilityRequirement spell={SPELLS.DANCING_RUNE_WEAPON.id} />
+        <AbilityRequirement spell={SPELLS.EMPOWER_RUNE_WEAPON.id} />
+        <AbilityRequirement spell={SPELLS.BONE_SHIELD.id} />
+        <AbilityRequirement spell={SPELLS.BLOOD_TAP.id} />
       </Rule>
       {/* Enchants and Consumes */}
       <PreparationRule thresholds={thresholds} />

--- a/src/analysis/classic/deathknight/blood/modules/checklist/Component.tsx
+++ b/src/analysis/classic/deathknight/blood/modules/checklist/Component.tsx
@@ -1,0 +1,51 @@
+import { SpellLink } from 'interface';
+import Checklist from 'parser/shared/modules/features/Checklist';
+import {
+  AbilityRequirementProps,
+  ChecklistProps,
+} from 'parser/shared/modules/features/Checklist/ChecklistTypes';
+import GenericCastEfficiencyRequirement from 'parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement';
+import Requirement from 'parser/shared/modules/features/Checklist/Requirement';
+import Rule from 'parser/shared/modules/features/Checklist/Rule';
+import PreparationRule from 'parser/classic/modules/features/Checklist/PreparationRule';
+import SPELLS from 'common/SPELLS/classic';
+
+const MeleeChecklist = ({ combatant, castEfficiency, thresholds }: ChecklistProps) => {
+  const AbilityRequirement = (props: AbilityRequirementProps) => (
+    <GenericCastEfficiencyRequirement
+      castEfficiency={castEfficiency.getCastEfficiencyForSpellId(props.spell)}
+      {...props}
+    />
+  );
+
+  return (
+    <Checklist>
+      {/* Downtime */}
+      <Rule
+        name="Avoid Downtime"
+        description={
+          <>
+            Avoid unnecessary downtime during the fight. If you have to move, try casting instant
+            spells such as
+            {/* UPDATE THE SPELL BELOW */}
+            <SpellLink spell={SPELLS.DEATH_COIL_DK} />.
+          </>
+        }
+      >
+        <Requirement name="Downtime" thresholds={thresholds.downtimeSuggestionThresholds} />
+      </Rule>
+      <Rule
+        name="Use Cooldowns Effectively"
+        description={<>Use your cooldowns as often as possible to maximize your damage output.</>}
+      >
+        {/* SPELLS listed here must be in ../features/Abilities */}
+        {/* UPDATE THE ABILITIES BELOW */}
+        <AbilityRequirement spell={SPELLS.SUMMON_GARGOYLE.id} />
+      </Rule>
+      {/* Enchants and Consumes */}
+      <PreparationRule thresholds={thresholds} />
+    </Checklist>
+  );
+};
+
+export default MeleeChecklist;

--- a/src/analysis/classic/deathknight/blood/modules/checklist/Module.tsx
+++ b/src/analysis/classic/deathknight/blood/modules/checklist/Module.tsx
@@ -1,0 +1,52 @@
+// Core
+import BaseChecklist from 'parser/shared/modules/features/Checklist/Module';
+import Component from './Component';
+// Shared
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import Combatants from 'parser/shared/modules/Combatants';
+import CombatPotionChecker from 'parser/classic/modules/items/CombatPotionChecker';
+import PreparationRuleAnalyzer from 'parser/classic/modules/features/Checklist/PreparationRuleAnalyzer';
+// Features
+import AlwaysBeCasting from '../features/AlwaysBeCasting';
+// Spells
+// import SpellName from './modules/spells';
+
+class Checklist extends BaseChecklist {
+  static dependencies = {
+    ...BaseChecklist.dependencies,
+    // Shared
+    castEfficiency: CastEfficiency,
+    combatants: Combatants,
+    combatPotionChecker: CombatPotionChecker,
+    preparationRuleAnalyzer: PreparationRuleAnalyzer,
+    // Features
+    alwaysBeCasting: AlwaysBeCasting,
+    // Spells
+  };
+
+  // Shared
+  protected castEfficiency!: CastEfficiency;
+  protected combatants!: Combatants;
+  protected combatPotionChecker!: CombatPotionChecker;
+  protected preparationRuleAnalyzer!: PreparationRuleAnalyzer;
+  // Features
+  protected alwaysBeCasting!: AlwaysBeCasting;
+  // Spells
+
+  render() {
+    return (
+      <Component
+        combatant={this.combatants.selected}
+        castEfficiency={this.castEfficiency}
+        thresholds={{
+          ...this.preparationRuleAnalyzer.thresholds,
+          downtimeSuggestionThresholds: this.alwaysBeCasting.downtimeSuggestionThresholds,
+          // Spells
+          // spellName: this.spellName.uptimeSuggestionThresholds,
+        }}
+      />
+    );
+  }
+}
+
+export default Checklist;

--- a/src/analysis/classic/deathknight/blood/modules/features/Abilities.ts
+++ b/src/analysis/classic/deathknight/blood/modules/features/Abilities.ts
@@ -1,0 +1,36 @@
+import SPELLS from 'common/SPELLS/classic';
+import CoreAbilities from 'parser/core/modules/Abilities';
+import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+
+class Abilities extends CoreAbilities {
+  spellbook() {
+    return [
+      // Rotational
+      {
+        spell: [SPELLS.DEATH_COIL_DK.id, ...SPELLS.DEATH_COIL_DK.lowRanks],
+        category: SPELL_CATEGORY.ROTATIONAL,
+        gcd: { base: 1500 },
+      },
+      // Rotational AOE
+
+      // Cooldowns
+      {
+        spell: [SPELLS.SUMMON_GARGOYLE.id],
+        category: SPELL_CATEGORY.COOLDOWNS,
+        gcd: { base: 1500 },
+        cooldown: 180,
+      },
+      // Defensive
+
+      // Other spells (not apart of the normal rotation)
+
+      // Utility
+
+      // Pet Related
+
+      // Consumable
+    ];
+  }
+}
+
+export default Abilities;

--- a/src/analysis/classic/deathknight/blood/modules/features/Abilities.ts
+++ b/src/analysis/classic/deathknight/blood/modules/features/Abilities.ts
@@ -101,6 +101,18 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.DEFENSIVE,
         cooldown: 180,
       },
+      {
+        spell: SPELLS.RUNE_TAP.id,
+        gcd: null,
+        category: SPELL_CATEGORY.DEFENSIVE,
+        cooldown: 0, // 3/3 Improved Rune Tap makes this a 0s cooldown, but it costs a rune still
+      },
+      {
+        spell: SPELLS.DEATH_PACT.id,
+        gcd: null,
+        category: SPELL_CATEGORY.DEFENSIVE,
+        cooldown: 120,
+      },
 
       // Other spells (not apart of the normal rotation)
       {
@@ -119,6 +131,27 @@ class Abilities extends CoreAbilities {
         gcd: { base: 1500 },
         category: SPELL_CATEGORY.OTHERS,
       },
+      {
+        spell: SPELLS.DARK_SIMULACRUM.id,
+        gcd: null,
+        category: SPELL_CATEGORY.OTHERS,
+        cooldown: 60,
+      },
+      {
+        spell: SPELLS.FROST_PRESENCE.id,
+        gcd: null,
+        category: SPELL_CATEGORY.OTHERS,
+      },
+      {
+        spell: SPELLS.UNHOLY_PRESENCE.id,
+        gcd: null,
+        category: SPELL_CATEGORY.OTHERS,
+      },
+      {
+        spell: SPELLS.BLOOD_PRESENCE.id,
+        gcd: null,
+        category: SPELL_CATEGORY.OTHERS,
+      },
 
       // Utility
       {
@@ -126,6 +159,12 @@ class Abilities extends CoreAbilities {
         gcd: null,
         category: SPELL_CATEGORY.UTILITY,
         cooldown: 25, // 2/2 Unholy Command reduces it to 25s
+      },
+      {
+        spell: SPELLS.MIND_FREEZE.id,
+        gcd: null,
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 10,
       },
 
       // Pet Related

--- a/src/analysis/classic/deathknight/blood/modules/features/Abilities.ts
+++ b/src/analysis/classic/deathknight/blood/modules/features/Abilities.ts
@@ -7,24 +7,126 @@ class Abilities extends CoreAbilities {
     return [
       // Rotational
       {
-        spell: [SPELLS.DEATH_COIL_DK.id, ...SPELLS.DEATH_COIL_DK.lowRanks],
+        spell: SPELLS.RUNE_STRIKE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
-      // Rotational AOE
-
-      // Cooldowns
       {
-        spell: [SPELLS.SUMMON_GARGOYLE.id],
-        category: SPELL_CATEGORY.COOLDOWNS,
+        spell: SPELLS.DEATH_STRIKE.id,
+        category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
+      },
+      {
+        spell: SPELLS.HEART_STRIKE.id,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.ROTATIONAL,
+      },
+      {
+        spell: SPELLS.BLOOD_BOIL.id,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.ROTATIONAL,
+      },
+      {
+        spell: SPELLS.HORN_OF_WINTER.id,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: 20,
+      },
+      {
+        spell: SPELLS.ICY_TOUCH.id,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.ROTATIONAL,
+      },
+      // Rotational AOE
+      {
+        spell: SPELLS.DEATH_AND_DECAY.id,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.ROTATIONAL_AOE,
+        cooldown: 30,
+      },
+      // Cooldowns
+
+      {
+        spell: SPELLS.DANCING_RUNE_WEAPON.id,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 90,
+      },
+      {
+        spell: SPELLS.BLOOD_TAP.id,
+        gcd: null,
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 30, // base 60s, but 2/2 Improved Blood Tap makes it 30s
+      },
+      {
+        spell: SPELLS.BONE_SHIELD.id,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 60,
+      },
+      {
+        spell: SPELLS.OUTBREAK.id,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 30, // Blood has a passive that reduces the CD to 30s
+      },
+      {
+        spell: SPELLS.EMPOWER_RUNE_WEAPON.id,
+        gcd: null,
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 300,
+      },
+      {
+        spell: SPELLS.PLAGUE_STRIKE.id,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.ROTATIONAL,
+      },
+
+      // Defensive
+      {
+        spell: SPELLS.VAMPIRIC_BLOOD.id,
+        gcd: null,
+        category: SPELL_CATEGORY.DEFENSIVE,
+        cooldown: 60,
+      },
+      {
+        spell: SPELLS.ANTI_MAGIC_SHELL.id,
+        gcd: null,
+        category: SPELL_CATEGORY.DEFENSIVE,
+        cooldown: 45,
+      },
+      {
+        spell: SPELLS.ICEBOUND_FORTITUDE.id,
+        gcd: null,
+        category: SPELL_CATEGORY.DEFENSIVE,
         cooldown: 180,
       },
-      // Defensive
 
       // Other spells (not apart of the normal rotation)
+      {
+        spell: SPELLS.DARK_COMMAND.id,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.OTHERS,
+        cooldown: 8,
+      },
+      {
+        spell: SPELLS.PESTILENCE.id,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.OTHERS,
+      },
+      {
+        spell: SPELLS.DEATH_COIL_DK,
+        gcd: { base: 1500 },
+        category: SPELL_CATEGORY.OTHERS,
+      },
 
       // Utility
+      {
+        spell: SPELLS.DEATH_GRIP.id,
+        gcd: null,
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 25, // 2/2 Unholy Command reduces it to 25s
+      },
 
       // Pet Related
 

--- a/src/analysis/classic/deathknight/blood/modules/features/Abilities.ts
+++ b/src/analysis/classic/deathknight/blood/modules/features/Abilities.ts
@@ -115,7 +115,7 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.OTHERS,
       },
       {
-        spell: SPELLS.DEATH_COIL_DK,
+        spell: SPELLS.DEATH_COIL_DK.id,
         gcd: { base: 1500 },
         category: SPELL_CATEGORY.OTHERS,
       },

--- a/src/analysis/classic/deathknight/blood/modules/features/AlwaysBeCasting.tsx
+++ b/src/analysis/classic/deathknight/blood/modules/features/AlwaysBeCasting.tsx
@@ -1,0 +1,43 @@
+import { defineMessage } from '@lingui/macro';
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS/classic';
+import { SpellLink } from 'interface';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import CoreAlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
+
+class AlwaysBeCasting extends CoreAlwaysBeCasting {
+  get downtimeSuggestionThresholds() {
+    return {
+      actual: this.downtimePercentage,
+      isGreaterThan: {
+        minor: 0.25,
+        average: 0.3,
+        major: 0.35,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.downtimeSuggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <span>
+          Your downtime can be improved. Try to reduce time away from the boss. If you have to move,
+          use instant cast abilities, such as
+          {/* UPDATE THE SPELLS BELOW */}
+          <SpellLink spell={SPELLS.DEATH_COIL_DK} />.
+        </span>,
+      )
+        .icon('spell_mage_altertime')
+        .actual(
+          defineMessage({
+            id: 'shared.suggestions.alwaysBeCasting.downtime',
+            message: `${formatPercentage(actual)}% downtime`,
+          }),
+        )
+        .recommended(`<${formatPercentage(recommended)}% is recommended`),
+    );
+  }
+}
+
+export default AlwaysBeCasting;

--- a/src/analysis/classic/deathknight/blood/modules/features/Buffs.tsx
+++ b/src/analysis/classic/deathknight/blood/modules/features/Buffs.tsx
@@ -1,0 +1,28 @@
+import CoreAuras from 'parser/core/modules/Auras';
+import SPELLS from 'common/SPELLS/classic';
+import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
+import ITEM_BUFFS from 'game/classic/ITEM_BUFFS';
+
+class Buffs extends CoreAuras {
+  // A list of Buffs (on the current player) to highlight on the Timeline
+  auras() {
+    return [
+      // Update and Add to the spells below
+      {
+        spellId: SPELLS.UNHOLY_PRESENCE.id,
+        timelineHighlight: true,
+      },
+      // Do not adjust the lines below
+      {
+        spellId: Object.keys(BLOODLUST_BUFFS).map((item) => Number(item)),
+        timelineHighlight: true,
+      },
+      {
+        spellId: Object.keys(ITEM_BUFFS).map((item) => Number(item)),
+        timelineHighlight: true,
+      },
+    ];
+  }
+}
+
+export default Buffs;

--- a/src/analysis/classic/deathknight/blood/modules/features/CooldownThroughputTracker.ts
+++ b/src/analysis/classic/deathknight/blood/modules/features/CooldownThroughputTracker.ts
@@ -1,0 +1,17 @@
+import SPELLS from 'common/SPELLS/classic';
+import CoreCooldownThroughputTracker, {
+  BUILT_IN_SUMMARY_TYPES,
+} from 'parser/shared/modules/CooldownThroughputTracker';
+
+class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
+  static castCooldowns = [
+    ...CoreCooldownThroughputTracker.castCooldowns,
+    // Add Cooldown Spells specific to Spec
+    {
+      spell: SPELLS.BLOOD_TAP.id,
+      summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
+    },
+  ];
+}
+
+export default CooldownThroughputTracker;

--- a/src/analysis/classic/deathknight/frost/modules/features/Abilities.ts
+++ b/src/analysis/classic/deathknight/frost/modules/features/Abilities.ts
@@ -7,27 +7,27 @@ class Abilities extends CoreAbilities {
     return [
       // Rotational
       {
-        spell: [SPELLS.OBLITERATE.id, ...SPELLS.OBLITERATE.lowRanks],
+        spell: SPELLS.OBLITERATE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.FROST_STRIKE.id, ...SPELLS.FROST_STRIKE.lowRanks],
+        spell: SPELLS.FROST_STRIKE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.BLOOD_STRIKE.id, ...SPELLS.BLOOD_STRIKE.lowRanks],
+        spell: SPELLS.BLOOD_STRIKE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.ICY_TOUCH.id, ...SPELLS.ICY_TOUCH.lowRanks],
+        spell: SPELLS.ICY_TOUCH.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.PLAGUE_STRIKE.id, ...SPELLS.PLAGUE_STRIKE.lowRanks],
+        spell: SPELLS.PLAGUE_STRIKE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
@@ -37,13 +37,13 @@ class Abilities extends CoreAbilities {
         gcd: null,
       },
       {
-        spell: [SPELLS.DEATH_STRIKE.id, ...SPELLS.DEATH_STRIKE.lowRanks],
+        spell: SPELLS.DEATH_STRIKE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
       // Rotational AOE
       {
-        spell: [SPELLS.HOWLING_BLAST.id, ...SPELLS.HOWLING_BLAST.lowRanks],
+        spell: SPELLS.HOWLING_BLAST.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         gcd: { base: 1500 },
       },
@@ -53,12 +53,12 @@ class Abilities extends CoreAbilities {
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.BLOOD_BOIL.id, ...SPELLS.BLOOD_BOIL.lowRanks],
+        spell: SPELLS.BLOOD_BOIL.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.DEATH_AND_DECAY.id, ...SPELLS.DEATH_AND_DECAY.lowRanks],
+        spell: SPELLS.DEATH_AND_DECAY.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         gcd: { base: 1500 },
       },
@@ -112,7 +112,7 @@ class Abilities extends CoreAbilities {
       },
       // Other spells (not apart of the normal rotation)
       {
-        spell: [SPELLS.DEATH_COIL_DK.id, ...SPELLS.DEATH_COIL_DK.lowRanks],
+        spell: SPELLS.DEATH_COIL_DK.id,
         category: SPELL_CATEGORY.OTHERS,
         gcd: { base: 1500 },
       },
@@ -133,7 +133,7 @@ class Abilities extends CoreAbilities {
         gcd: null,
       },
       {
-        spell: [SPELLS.HORN_OF_WINTER.id, ...SPELLS.HORN_OF_WINTER.lowRanks],
+        spell: SPELLS.HORN_OF_WINTER.id,
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },

--- a/src/analysis/classic/deathknight/unholy/modules/features/Abilities.ts
+++ b/src/analysis/classic/deathknight/unholy/modules/features/Abilities.ts
@@ -7,7 +7,7 @@ class Abilities extends CoreAbilities {
     return [
       // Rotational
       {
-        spell: [SPELLS.DEATH_COIL_DK.id, ...SPELLS.DEATH_COIL_DK.lowRanks],
+        spell: SPELLS.DEATH_COIL_DK.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },

--- a/src/analysis/classic/deathknight/unholy/modules/features/Abilities.ts
+++ b/src/analysis/classic/deathknight/unholy/modules/features/Abilities.ts
@@ -12,17 +12,17 @@ class Abilities extends CoreAbilities {
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.ICY_TOUCH.id, ...SPELLS.ICY_TOUCH.lowRanks],
+        spell: SPELLS.ICY_TOUCH.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.PLAGUE_STRIKE.id, ...SPELLS.PLAGUE_STRIKE.lowRanks],
+        spell: SPELLS.PLAGUE_STRIKE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.BLOOD_STRIKE.id, ...SPELLS.BLOOD_STRIKE.lowRanks],
+        spell: SPELLS.BLOOD_STRIKE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
@@ -32,18 +32,18 @@ class Abilities extends CoreAbilities {
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.SCOURGE_STRIKE.id, ...SPELLS.SCOURGE_STRIKE.lowRanks],
+        spell: SPELLS.SCOURGE_STRIKE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
       // Rotational AOE
       {
-        spell: [SPELLS.DEATH_AND_DECAY.id, ...SPELLS.DEATH_AND_DECAY.lowRanks],
+        spell: SPELLS.DEATH_AND_DECAY.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.BLOOD_BOIL.id, ...SPELLS.BLOOD_BOIL.lowRanks],
+        spell: SPELLS.BLOOD_BOIL.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         gcd: { base: 1500 },
       },
@@ -53,7 +53,7 @@ class Abilities extends CoreAbilities {
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.CORPSE_EXPLOSION.id, ...SPELLS.CORPSE_EXPLOSION.lowRanks],
+        spell: SPELLS.CORPSE_EXPLOSION.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         gcd: { base: 1500 },
       },
@@ -137,12 +137,12 @@ class Abilities extends CoreAbilities {
         gcd: null,
       },
       {
-        spell: [SPELLS.DEATH_STRIKE.id, ...SPELLS.DEATH_STRIKE.lowRanks],
+        spell: SPELLS.DEATH_STRIKE.id,
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },
       {
-        spell: [SPELLS.HORN_OF_WINTER.id, ...SPELLS.HORN_OF_WINTER.lowRanks],
+        spell: SPELLS.HORN_OF_WINTER.id,
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },

--- a/src/common/SPELLS/classic/deathknight.ts
+++ b/src/common/SPELLS/classic/deathknight.ts
@@ -21,10 +21,9 @@ const spells = {
     icon: 'spell_deathknight_armyofthedead',
   },
   BLOOD_BOIL: {
-    id: 49941,
+    id: 48721,
     name: 'Blood Boil',
     icon: 'spell_deathknight_bloodboil',
-    lowRanks: [49940, 49939, 48721],
   },
   BLOOD_PRESENCE: {
     id: 48266,
@@ -64,10 +63,9 @@ const spells = {
     icon: 'spell_nature_shamanrage',
   },
   DEATH_AND_DECAY: {
-    id: 49938,
+    id: 43265,
     name: 'Death and Decay',
     icon: 'spell_shadow_deathanddecay',
-    lowRanks: [49937, 49936, 43265],
   },
   DEATH_COIL_DK: {
     id: 49895,
@@ -86,10 +84,9 @@ const spells = {
     icon: 'spell_shadow_deathpact',
   },
   DEATH_STRIKE: {
-    id: 49924,
+    id: 49998,
     name: 'Death Strike',
     icon: 'spell_deathknight_butcher2',
-    lowRanks: [49923, 45463, 49999, 49998],
   },
   EMPOWER_RUNE_WEAPON: {
     id: 47568,
@@ -107,10 +104,9 @@ const spells = {
     icon: 'spell_deathknight_frozenruneweapon',
   },
   HORN_OF_WINTER: {
-    id: 57623,
+    id: 57330,
     name: 'Horn of Winter',
     icon: 'inv_misc_horn_02',
-    lowRanks: [57330],
   },
   ICEBOUND_FORTITUDE: {
     id: 48792,
@@ -118,10 +114,9 @@ const spells = {
     icon: 'spell_deathknight_iceboundfortitude',
   },
   ICY_TOUCH: {
-    id: 49909,
+    id: 45477,
     name: 'Icy Touch',
     icon: 'spell_deathknight_icetouch',
-    lowRanks: [49904, 49903, 49896, 45477],
   },
   MIND_FREEZE: {
     id: 47528,
@@ -145,10 +140,9 @@ const spells = {
     icon: 'spell_shadow_plaguecloud',
   },
   PLAGUE_STRIKE: {
-    id: 49921,
+    id: 45462,
     name: 'Plague Strike',
     icon: 'spell_deathknight_empowerruneblade',
-    lowRanks: [49920, 49919, 49918, 49917, 45462],
   },
   RAISE_ALLY: {
     id: 61999,
@@ -225,6 +219,11 @@ const spells = {
     name: 'Unholy Presence',
     icon: 'spell_deathknight_unholypresence',
   },
+  OUTBREAK: {
+    id: 77575,
+    name: 'Outbreak',
+    icon: 'spell_deathvortex',
+  },
 
   // ---------
   // TALENTS
@@ -243,10 +242,9 @@ const spells = {
     lowRanks: [50033],
   },
   HEART_STRIKE: {
-    id: 55262,
+    id: 55050,
     name: 'Heart Strike',
     icon: 'inv_weapon_shortblade_40',
-    lowRanks: [55261, 55260, 55259, 55258, 55050],
   },
   MARK_OF_BLOOD: {
     id: 49005,

--- a/src/common/SPELLS/classic/deathknight.ts
+++ b/src/common/SPELLS/classic/deathknight.ts
@@ -26,7 +26,7 @@ const spells = {
     icon: 'spell_deathknight_bloodboil',
   },
   BLOOD_PRESENCE: {
-    id: 48266,
+    id: 48263,
     name: 'Blood Presence',
     icon: 'spell_deathknight_bloodpresence',
   },
@@ -62,16 +62,20 @@ const spells = {
     name: 'Dark Command',
     icon: 'spell_nature_shamanrage',
   },
+  DARK_SIMULACRUM: {
+    id: 77606,
+    name: 'Dark Simulacrum',
+    icon: 'spell_holy_consumemagic',
+  },
   DEATH_AND_DECAY: {
     id: 43265,
     name: 'Death and Decay',
     icon: 'spell_shadow_deathanddecay',
   },
   DEATH_COIL_DK: {
-    id: 49895,
+    id: 47541,
     name: 'Death Coil',
     icon: 'spell_shadow_deathcoil',
-    lowRanks: [49894, 49893, 49892, 47541],
   },
   DEATH_GRIP: {
     id: 49576,
@@ -94,7 +98,7 @@ const spells = {
     icon: 'inv_sword_62',
   },
   FROST_PRESENCE: {
-    id: 48263,
+    id: 48266,
     name: 'Frost Presence',
     icon: 'spell_deathknight_frostpresence',
   },

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -38,6 +38,7 @@ import DevastationEvoker from 'analysis/retail/evoker/devastation';
 import PreservationEvoker from 'analysis/retail/evoker/preservation';
 import AugmentationEvoker from 'analysis/retail/evoker/augmentation';
 // Classic
+import ClassicDeathKnightBlood from 'analysis/classic/deathknight/blood';
 import ClassicDeathKnightFrost from 'analysis/classic/deathknight/frost';
 import ClassicDeathKnightUnholy from 'analysis/classic/deathknight/unholy';
 import ClassicDruidBalance from 'analysis/classic/druid/balance';
@@ -115,6 +116,7 @@ const configs: Config[] = [
   FuryWarrior,
 
   // Classic
+  ClassicDeathKnightBlood,
   ClassicDeathKnightFrost,
   ClassicDeathKnightUnholy,
 

--- a/src/parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement.tsx
+++ b/src/parser/shared/modules/features/Checklist/GenericCastEfficiencyRequirement.tsx
@@ -1,4 +1,3 @@
-import { captureException } from 'common/errorLogger';
 import { SpellLink } from 'interface';
 import { ThresholdStyle } from 'parser/core/ParseResults';
 import { AbilityCastEfficiency } from 'parser/shared/modules/CastEfficiency';
@@ -23,11 +22,6 @@ interface Props {
 class GenericCastEfficiencyRequirement extends PureComponent<Props> {
   get thresholds(): RequirementThresholds | null {
     if (!this.props.castEfficiency) {
-      captureException(
-        new Error(
-          `GenericCastEfficiencyRequirement requires that you pass the castEfficiency object yourself. Spell: ${this.props.spell}`,
-        ),
-      );
       return null;
     }
 


### PR DESCRIPTION
### Description

this adds basic BDK support, implementing a rudimentary spellbook (enough to cover the pulls in the sample report) and enabling the spec.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `http://localhost:3000/report/whg9yZrGNjzDWLX7/30-Heroic+Magmaw+-+Kill+(3:59)/Nezter/standard/overview`
- Screenshot(s):
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/3af386a4-bcf0-4209-be26-13aaafa6cbce)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/815aeead-7b82-4897-87ff-3fad59537e5e)

the remaining `spellUsable` issues are consumables / racials
