### PR TITLE
Increase time window for linking t32 heal events

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import { Trevor} from 'CONTRIBUTORS';
 
 export default [
+  change(date(2024, 6, 19), <>Improve accuracy of T32 tier set module</>, Trevor),
   change(date(2024, 6, 16), <>Add T32 tier set module</>, Trevor),
   change(date(2024, 6, 16), <>Split up linking normalizer files</>, Trevor),
   change(date(2024, 6, 16), <>Cleanup old tier sets</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/normalizers/EventLinking/TierEventLinks.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EventLinking/TierEventLinks.ts
@@ -17,7 +17,7 @@ export const TIER_EVENT_LINKS: EventLink[] = [
     linkingEventType: EventType.Heal,
     referencedEventId: SPELLS.EPOCH_FRAGMENT.id,
     referencedEventType: EventType.Heal,
-    forwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS * 5,
     anyTarget: true,
     maximumLinks: 1,
     additionalCondition(linkingEvent, refEvent) {


### PR DESCRIPTION
### Description

In some cases it can take 300-400ms for the heal to come through because wow is a good video game so increasing the window. It only links 1 event so it won't sacrifice any accuracy by increasing the window while accounting for the extra lag.
