### PR TITLE
[pres] add engulf to echo tracking and some echo cleanup

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { Trevor} from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2024, 6, 19), <>Add <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT}/> to <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT}/> modules</>, Trevor),
   change(date(2024, 6, 19), <>Implement <SpellLink spell={TALENTS_EVOKER.EXPANDED_LUNGS_TALENT}/> module</>, Trevor),
   change(date(2024, 6, 19), <>Remove <SpellLink spell={TALENTS_EVOKER.REWIND_TALENT}/> from <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT}/> module</>, Trevor),
   change(date(2024, 6, 19), <>Improve accuracy of T32 tier set module</>, Trevor),

--- a/src/analysis/retail/evoker/preservation/constants.ts
+++ b/src/analysis/retail/evoker/preservation/constants.ts
@@ -1,4 +1,5 @@
 import SPELLS from 'common/SPELLS';
+import Spell from 'common/SPELLS/Spell';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 
 export const SPELL_COLORS = {
@@ -46,11 +47,12 @@ export const DUPLICATION_SPELLS = [
 ]; // common spell ids that trigger heal duplication for Cycle of Life and Lifebind
 
 // heal events that can be caused by an echo heal
-export const ECHO_HEALS = [
+export const HOT_ECHO_HEALS = [SPELLS.REVERSION_ECHO, SPELLS.DREAM_BREATH_ECHO];
+
+export const HIT_ECHO_HEALS = [
   SPELLS.DREAM_BREATH_ECHO,
   SPELLS.EMERALD_BLOSSOM_ECHO,
   SPELLS.LIVING_FLAME_HEAL,
-  SPELLS.REVERSION_ECHO,
   SPELLS.SPIRITBLOOM_SPLIT,
   SPELLS.SPIRITBLOOM_FONT,
   SPELLS.SPIRITBLOOM,
@@ -59,6 +61,8 @@ export const ECHO_HEALS = [
   SPELLS.GOLDEN_HOUR_HEAL,
   SPELLS.ENGULF_HEAL,
 ];
+
+export const ECHO_HEALS = [...HOT_ECHO_HEALS, ...HIT_ECHO_HEALS];
 
 export const STASIS_CAST_IDS = [
   SPELLS.LIVING_FLAME_CAST.id,
@@ -92,3 +96,7 @@ export const LIFESPARK_INCREASE = 0.5;
 export const RENEWING_BREATH_INCREASE = 0.15;
 export const TIMELESS_MAGIC = 0.15;
 export const TIMELORD_INCREASE = 0.25;
+
+export function getSpellIds(spells: Spell[]) {
+  return spells.map((spell) => spell.id);
+}

--- a/src/analysis/retail/evoker/preservation/modules/talents/Echo.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/Echo.tsx
@@ -1,7 +1,5 @@
-import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_EVOKER } from 'common/TALENTS';
-import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   CastEvent,
@@ -10,11 +8,7 @@ import Events, {
   RemoveBuffEvent,
 } from 'parser/core/Events';
 import { ThresholdStyle } from 'parser/core/ParseResults';
-import DonutChart from 'parser/ui/DonutChart';
-import Statistic from 'parser/ui/Statistic';
-import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import { ECHO_HEALS, SPELL_COLORS } from '../../constants';
+import { ECHO_HEALS } from '../../constants';
 import {
   didEchoExpire,
   getEchoTypeForGoldenHour,
@@ -173,126 +167,6 @@ class Echo extends Analyzer {
     return isHardcast
       ? this.hardcastEchoHealingForSpell(spellId)
       : this.taEchoHealingForSpell(spellId);
-  }
-
-  renderDonutChart() {
-    const items = [
-      {
-        color: SPELL_COLORS.DREAM_BREATH,
-        label: 'Dream Breath',
-        spellId: TALENTS_EVOKER.DREAM_BREATH_TALENT.id,
-        value: this.totalEchoHealingForSpell(SPELLS.DREAM_BREATH_ECHO.id),
-        valueTooltip:
-          formatNumber(this.totalEchoHealingForSpell(SPELLS.DREAM_BREATH_ECHO.id)) +
-          ' in ' +
-          this.consumptionsBySpell.get(SPELLS.DREAM_BREATH_ECHO.id) +
-          ' consumptions',
-      },
-      {
-        color: SPELL_COLORS.SPIRITBLOOM,
-        label: 'Spiritbloom',
-        spellId: TALENTS_EVOKER.SPIRITBLOOM_TALENT.id,
-        value:
-          this.totalEchoHealingForSpell(SPELLS.SPIRITBLOOM.id) +
-          this.totalEchoHealingForSpell(SPELLS.SPIRITBLOOM_SPLIT.id) +
-          this.totalEchoHealingForSpell(SPELLS.SPIRITBLOOM_FONT.id),
-        valueTooltip:
-          formatNumber(
-            this.totalEchoHealingForSpell(SPELLS.SPIRITBLOOM.id) +
-              this.totalEchoHealingForSpell(SPELLS.SPIRITBLOOM_SPLIT.id) +
-              this.totalEchoHealingForSpell(SPELLS.SPIRITBLOOM_FONT.id),
-          ) +
-          ' in ' +
-          (this.consumptionsBySpell.get(SPELLS.SPIRITBLOOM.id)! +
-            this.consumptionsBySpell.get(SPELLS.SPIRITBLOOM_SPLIT.id)! +
-            this.consumptionsBySpell.get(SPELLS.SPIRITBLOOM_FONT.id)!) +
-          ' consumptions',
-      },
-      {
-        color: SPELL_COLORS.LIVING_FLAME,
-        label: 'Living Flame',
-        spellId: SPELLS.LIVING_FLAME_HEAL.id,
-        value: this.totalEchoHealingForSpell(SPELLS.LIVING_FLAME_HEAL.id),
-        valueTooltip:
-          formatNumber(this.totalEchoHealingForSpell(SPELLS.LIVING_FLAME_HEAL.id)) +
-          ' in ' +
-          this.consumptionsBySpell.get(SPELLS.LIVING_FLAME_HEAL.id) +
-          ' consumptions',
-      },
-      {
-        color: SPELL_COLORS.REVERSION,
-        label: 'Reversion',
-        spellId: TALENTS_EVOKER.REVERSION_TALENT.id,
-        value:
-          this.totalEchoHealingForSpell(SPELLS.REVERSION_ECHO.id) +
-          this.totalEchoHealingForSpell(SPELLS.GOLDEN_HOUR_HEAL.id),
-        valueTooltip: (
-          <>
-            <SpellLink spell={TALENTS_EVOKER.REVERSION_TALENT} /> healing:{' '}
-            {formatNumber(this.totalEchoHealingForSpell(SPELLS.REVERSION_ECHO.id))} <br />
-            and <SpellLink spell={TALENTS_EVOKER.GOLDEN_HOUR_TALENT} /> healing:{' '}
-            {formatNumber(this.totalEchoHealingForSpell(SPELLS.GOLDEN_HOUR_HEAL.id))} <br />
-            in {this.consumptionsBySpell.get(SPELLS.REVERSION_ECHO.id) + ' consumptions'}
-          </>
-        ),
-      },
-      {
-        color: SPELL_COLORS.EMERALD_BLOSSOM,
-        label: 'Emerald Blossom',
-        spellId: SPELLS.EMERALD_BLOSSOM.id,
-        value: this.totalEchoHealingForSpell(SPELLS.EMERALD_BLOSSOM_ECHO.id),
-        valueTooltip:
-          formatNumber(this.totalEchoHealingForSpell(SPELLS.EMERALD_BLOSSOM_ECHO.id)) +
-          ' in ' +
-          this.consumptionsBySpell.get(SPELLS.EMERALD_BLOSSOM_ECHO.id) +
-          ' consumptions',
-      },
-      {
-        color: SPELL_COLORS.VERDANT_EMBRACE,
-        label: 'Verdant Embrace',
-        spellId: SPELLS.VERDANT_EMBRACE_HEAL.id,
-        value:
-          this.totalEchoHealingForSpell(SPELLS.VERDANT_EMBRACE_HEAL.id) +
-          this.totalEchoHealingForSpell(SPELLS.LIFEBIND_HEAL.id),
-        valueTooltip: (
-          <>
-            <SpellLink spell={TALENTS_EVOKER.VERDANT_EMBRACE_TALENT} /> healing:{' '}
-            {formatNumber(this.totalEchoHealingForSpell(SPELLS.VERDANT_EMBRACE_HEAL.id))} <br />
-            and <SpellLink spell={TALENTS_EVOKER.LIFEBIND_TALENT} /> healing:{' '}
-            {formatNumber(this.totalEchoHealingForSpell(SPELLS.LIFEBIND_HEAL.id))} <br />
-            in {this.consumptionsBySpell.get(SPELLS.VERDANT_EMBRACE_HEAL.id) + ' consumptions'}
-          </>
-        ),
-      },
-    ]
-      .filter((item) => {
-        return item.value > 0;
-      })
-      .sort((a, b) => {
-        return Math.sign(b.value - a.value);
-      });
-    return items.length > 0 ? <DonutChart items={items} /> : null;
-  }
-
-  statistic() {
-    const chart = this.renderDonutChart();
-    if (!chart) {
-      return null;
-    }
-    return (
-      <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(13)}
-        size="flexible"
-        category={STATISTIC_CATEGORY.TALENTS}
-      >
-        <div className="pad">
-          <label>
-            <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT} /> healing breakdown by spell
-          </label>
-          {chart}
-        </div>
-      </Statistic>
-    );
   }
 }
 

--- a/src/analysis/retail/evoker/preservation/modules/talents/EchoBreakdown.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EchoBreakdown.tsx
@@ -154,6 +154,28 @@ class EchoBreakdown extends Analyzer {
           },
         ],
       },
+      {
+        spell: SPELLS.ENGULF_HEAL,
+        amount: this.echo.hardcastEchoHealingForSpell(SPELLS.ENGULF_HEAL.id),
+        color: SPELL_COLORS.ECHO,
+        tooltip: this.genericTooltipForSpell(
+          true,
+          SPELLS.ENGULF_HEAL.id,
+          this.echo.hardcastEchoHealingForSpell(SPELLS.ENGULF_HEAL.id),
+        ),
+        subSpecs: [
+          {
+            spell: SPELLS.ENGULF_HEAL,
+            amount: this.echo.taEchoHealingForSpell(SPELLS.ENGULF_HEAL.id),
+            color: SPELL_COLORS.TA_ECHO,
+            tooltip: this.genericTooltipForSpell(
+              false,
+              SPELLS.ENGULF_HEAL.id,
+              this.echo.taEchoHealingForSpell(SPELLS.ENGULF_HEAL.id),
+            ),
+          },
+        ],
+      },
     ].filter((info) => {
       return info.amount > 0;
     });
@@ -269,7 +291,7 @@ class EchoBreakdown extends Analyzer {
             <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT} /> <small>breakdown by spell</small>
           </>
         }
-        position={STATISTIC_ORDER.OPTIONAL(13)}
+        position={STATISTIC_ORDER.CORE(1)}
         category={STATISTIC_CATEGORY.TALENTS}
         smallTitle
         wide

--- a/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
@@ -44,8 +44,7 @@ enum EB_SOURCE {
 
 export const MANA_COSTS: { [name: string]: number } = {
   'Emerald Blossom': SPELLS.EMERALD_BLOSSOM_CAST.manaCost,
-  Echo: 0,
-  // Echo: TALENTS_EVOKER.ECHO_TALENT.manaCost?,
+  Echo: TALENTS_EVOKER.ECHO_TALENT.manaCost,
   Disintegrate: 0,
 };
 

--- a/src/analysis/retail/evoker/preservation/modules/tier/T32TierSet.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/tier/T32TierSet.tsx
@@ -119,7 +119,7 @@ class T32Prevoker extends Analyzer {
         valueTooltip: formatNumber(this.twoPcHealingBySpell.get(0) || 0),
       });
     }
-    return <DonutChart items={items} />;
+    return <DonutChart items={items.filter((item) => item.value > 0)} />;
   }
 
   statistic() {

--- a/src/analysis/retail/evoker/preservation/normalizers/EventLinking/EchoEventLinks.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EventLinking/EchoEventLinks.ts
@@ -7,7 +7,6 @@ import {
   ECHO_REMOVAL,
   ECHO_TEMPORAL_ANOMALY,
   FROM_HARDCAST,
-  FROM_TEMPORAL_ANOMALY,
   MAX_ECHO_DURATION,
   SHIELD_FROM_TA_CAST,
   TA_BUFFER_MS,
@@ -43,26 +42,6 @@ export const ECHO_EVENT_LINKS: EventLink[] = [
     forwardBufferMs: CAST_BUFFER_MS,
     backwardBufferMs: CAST_BUFFER_MS,
   },
-  //link echo apply to the Temporal Anomaly shield application
-  {
-    linkRelation: FROM_TEMPORAL_ANOMALY,
-    reverseLinkRelation: FROM_TEMPORAL_ANOMALY,
-    linkingEventId: [TALENTS_EVOKER.ECHO_TALENT.id],
-    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
-    referencedEventId: SPELLS.TEMPORAL_ANOMALY_SHIELD.id,
-    referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
-    isActive(c) {
-      return (
-        c.hasTalent(TALENTS_EVOKER.TEMPORAL_ANOMALY_TALENT) &&
-        c.hasTalent(TALENTS_EVOKER.RESONATING_SPHERE_TALENT)
-      );
-    },
-    additionalCondition(linkedEvent, referencedEvent) {
-      return !HasRelatedEvent(linkedEvent, FROM_HARDCAST);
-    },
-  },
   /* ECHO APPLY TO ECHO REMOVAL LINKING */
   // link echo removal to echo apply
   {
@@ -87,7 +66,7 @@ export const ECHO_EVENT_LINKS: EventLink[] = [
     referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
     backwardBufferMs: MAX_ECHO_DURATION,
     additionalCondition(linkedEvent, referencedEvent) {
-      return HasRelatedEvent(referencedEvent, FROM_TEMPORAL_ANOMALY);
+      return !HasRelatedEvent(referencedEvent, FROM_HARDCAST);
     },
   },
   /* ECHO REMOVAL TO HOT APPLY */
@@ -144,6 +123,7 @@ export const ECHO_EVENT_LINKS: EventLink[] = [
       SPELLS.SPIRITBLOOM_FONT.id,
       SPELLS.SPIRITBLOOM.id,
       SPELLS.VERDANT_EMBRACE_HEAL.id,
+      SPELLS.ENGULF_HEAL.id,
     ],
     referencedEventType: EventType.Heal,
     forwardBufferMs: ECHO_BUFFER,
@@ -180,6 +160,7 @@ export const ECHO_EVENT_LINKS: EventLink[] = [
       SPELLS.DREAM_BREATH_ECHO.id,
       SPELLS.LIVING_FLAME_HEAL.id,
       SPELLS.VERDANT_EMBRACE_HEAL.id,
+      SPELLS.ENGULF_HEAL.id,
     ],
     referencedEventType: EventType.Heal,
     maximumLinks: 1,
@@ -187,8 +168,7 @@ export const ECHO_EVENT_LINKS: EventLink[] = [
     additionalCondition(linkingEvent, referencedEvent) {
       return (
         HasRelatedEvent(linkingEvent, TA_ECHO_REMOVAL) &&
-        HasRelatedEvent(linkingEvent, FROM_TEMPORAL_ANOMALY) &&
-        HasRelatedEvent(linkingEvent, FROM_TEMPORAL_ANOMALY) &&
+        !HasRelatedEvent(linkingEvent, FROM_HARDCAST) &&
         !HasRelatedEvent(linkingEvent, ECHO_REMOVAL) &&
         !HasRelatedEvent(referencedEvent, ECHO)
       );

--- a/src/analysis/retail/evoker/preservation/normalizers/EventLinking/EchoEventLinks.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EventLinking/EchoEventLinks.ts
@@ -15,6 +15,7 @@ import {
 import SPELLS from 'common/SPELLS';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 import { EventType, HasRelatedEvent } from 'parser/core/Events';
+import { HIT_ECHO_HEALS, HOT_ECHO_HEALS, getSpellIds } from '../../constants';
 
 export const ECHO_EVENT_LINKS: EventLink[] = [
   /* ECHO CAST TO ECHO APPLY LINKING */
@@ -76,7 +77,7 @@ export const ECHO_EVENT_LINKS: EventLink[] = [
     reverseLinkRelation: ECHO,
     linkingEventId: TALENTS_EVOKER.ECHO_TALENT.id,
     linkingEventType: [EventType.RemoveBuff],
-    referencedEventId: [SPELLS.REVERSION_ECHO.id, SPELLS.DREAM_BREATH_ECHO.id],
+    referencedEventId: getSpellIds(HOT_ECHO_HEALS),
     referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
     forwardBufferMs: ECHO_BUFFER,
     maximumLinks: 1,
@@ -90,7 +91,7 @@ export const ECHO_EVENT_LINKS: EventLink[] = [
     reverseLinkRelation: ECHO_TEMPORAL_ANOMALY,
     linkingEventId: TALENTS_EVOKER.ECHO_TALENT.id,
     linkingEventType: [EventType.RemoveBuff],
-    referencedEventId: [SPELLS.REVERSION_ECHO.id, SPELLS.DREAM_BREATH_ECHO.id],
+    referencedEventId: getSpellIds(HOT_ECHO_HEALS),
     referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
     forwardBufferMs: ECHO_BUFFER,
     maximumLinks: 1,
@@ -115,16 +116,7 @@ export const ECHO_EVENT_LINKS: EventLink[] = [
     reverseLinkRelation: ECHO,
     linkingEventId: TALENTS_EVOKER.ECHO_TALENT.id,
     linkingEventType: [EventType.RemoveBuff],
-    referencedEventId: [
-      SPELLS.DREAM_BREATH_ECHO.id,
-      SPELLS.EMERALD_BLOSSOM_ECHO.id,
-      SPELLS.LIVING_FLAME_HEAL.id,
-      SPELLS.SPIRITBLOOM_SPLIT.id,
-      SPELLS.SPIRITBLOOM_FONT.id,
-      SPELLS.SPIRITBLOOM.id,
-      SPELLS.VERDANT_EMBRACE_HEAL.id,
-      SPELLS.ENGULF_HEAL.id,
-    ],
+    referencedEventId: getSpellIds(HIT_ECHO_HEALS),
     referencedEventType: EventType.Heal,
     forwardBufferMs: ECHO_BUFFER,
     maximumLinks: 1,
@@ -152,16 +144,7 @@ export const ECHO_EVENT_LINKS: EventLink[] = [
     reverseLinkRelation: ECHO_TEMPORAL_ANOMALY,
     linkingEventId: TALENTS_EVOKER.ECHO_TALENT.id,
     linkingEventType: EventType.RemoveBuff,
-    referencedEventId: [
-      SPELLS.EMERALD_BLOSSOM_ECHO.id,
-      SPELLS.SPIRITBLOOM_SPLIT.id,
-      SPELLS.SPIRITBLOOM.id,
-      SPELLS.SPIRITBLOOM_FONT.id,
-      SPELLS.DREAM_BREATH_ECHO.id,
-      SPELLS.LIVING_FLAME_HEAL.id,
-      SPELLS.VERDANT_EMBRACE_HEAL.id,
-      SPELLS.ENGULF_HEAL.id,
-    ],
+    referencedEventId: getSpellIds(HIT_ECHO_HEALS),
     referencedEventType: EventType.Heal,
     maximumLinks: 1,
     forwardBufferMs: ECHO_BUFFER,

--- a/src/analysis/retail/evoker/preservation/normalizers/EventLinking/constants.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EventLinking/constants.ts
@@ -2,9 +2,8 @@ export const ANCIENT_FLAME = 'AncientFlame'; // links cast to buff apply
 export const ANCIENT_FLAME_CONSUME = 'AncientFlameConnsume'; // links buff remove to buff apply
 // BEGIN ECHO constants
 export const FROM_HARDCAST = 'FromHardcast'; // for linking a buffapply or heal to its cast
-export const FROM_TEMPORAL_ANOMALY = 'FromTemporalAnomaly'; // for linking TA echo apply to TA shield apply
 export const ECHO_REMOVAL = 'EchoRemoval'; // for linking echo removal to echo apply
-export const TA_ECHO_REMOVAL = 'TaEchoTemoval'; // for linking TA echo removal to echo apply
+export const TA_ECHO_REMOVAL = 'TaEchoRemoval'; // for linking TA echo removal to echo apply
 export const ECHO_TEMPORAL_ANOMALY = 'TemporalAnomaly'; // for linking BuffApply/Heal to echo removal
 export const ECHO = 'Echo'; // for linking BuffApply/Heal to echo removal
 // END ECHO constants


### PR DESCRIPTION
### Description

- Previously TA echo attribution depended on a shield being applied but this is no longer a requirement so changing it to just require not being from a casted echo
- Adds Engulf to echo tracking
- Gets rid of a duplicate echo chart in favor of the bar based one

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/11250934/c216b234-1c20-4c87-985e-e8e0679329a0)
