### PR TITLE
look shortly before a hit for shuffle buff on overkill

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2024, 6, 28), <>Fix a bug with <SpellLink spell={SPELLS.SHUFFLE} /> detection on hits that kill you.</>, emallson),
   change(date(2024, 6, 6), <>Fix missing cooldown reduction from damage to targets debuffed by <SpellLink spell={talents.BONEDUST_BREW_TALENT} /></>, emallson),
   change(date(2024, 4, 15), <>Fix issue where <SpellLink spell={talents.CHARRED_PASSIONS_TALENT} /> was showing in the rotation when playing <SpellLink spell={talents.DRAGONFIRE_BREW_TALENT} /></>, emallson),
   change(date(2024, 2, 11), <>Add shield size to <SpellLink spell={talents.CELESTIAL_BREW_TALENT} /> mitigation breakdown.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/spells/Shuffle/index.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/Shuffle/index.tsx
@@ -95,8 +95,12 @@ export default class Shuffle extends Analyzer {
       return;
     }
 
+    // we include shuffle that expired in the last 20 ms because the combat log very consistently shows shuffle
+    // expiring before a hit that kills you.
+    const overkillBuffer = (event.overkill ?? 0) > 0 ? 20 : undefined;
+
     const wasMitigated =
-      this.selectedCombatant.hasBuff(SPELLS.SHUFFLE.id) ||
+      this.selectedCombatant.hasBuff(SPELLS.SHUFFLE.id, null, overkillBuffer) ||
       (event.unmitigatedAmount === undefined && event.amount === 0);
     const mitigated = wasMitigated ? QualitativePerformance.Good : QualitativePerformance.Fail;
 


### PR DESCRIPTION
this fixes an issue where the shuffle chart shows red for killing blows that happen to log all buff removals 1-20ms before the hit.

this was brought to my attention due to someone incorrectly getting red marks from killing blows

Log: https://wowanalyzer.com/report/RJgaQbkdTAr23qnN/1-Mythic++Halls+of+Infusion+-+Kill+(26:12)/Torpedojebo/standard/overview

## Before

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/e8081809-0f1b-4573-9ce1-53ab671b9faf)

## After
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/44434ef6-c530-4f68-a78b-16945d15648e)

