### PR TITLE
[Mistweaver] Update Tear of Morning Add Restore Balance

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date (2024, 6, 29), <>Added <SpellLink spell={TALENTS_MONK.RESTORE_BALANCE_TALENT}/> module.</>, Vohrr),
   change(date (2024, 6, 29), <>Updated <SpellLink spell={TALENTS_MONK.TEAR_OF_MORNING_TALENT}/> module</>, Vohrr),
   change(date (2024, 6, 28), <>Added <SpellLink spell={TALENTS_MONK.HEART_OF_THE_JADE_SERPENT_TALENT}/> and updated healing efficiency metrics.</>, Vohrr),
   change(date (2024, 6, 20), <>Added <SpellLink spell={TALENTS_MONK.POOL_OF_MISTS_TALENT}/>.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date (2024, 6, 29), <>Updated <SpellLink spell={TALENTS_MONK.TEAR_OF_MORNING_TALENT}/> module</>, Vohrr),
   change(date (2024, 6, 28), <>Added <SpellLink spell={TALENTS_MONK.HEART_OF_THE_JADE_SERPENT_TALENT}/> and updated healing efficiency metrics.</>, Vohrr),
   change(date (2024, 6, 20), <>Added <SpellLink spell={TALENTS_MONK.POOL_OF_MISTS_TALENT}/>.</>, Vohrr),
   change(date (2024, 6, 18), <>Updated <SpellLink spell={TALENTS_MONK.RISING_MIST_TALENT}/>, <SpellLink spell={TALENTS_MONK.RAPID_DIFFUSION_TALENT}/>, and <SpellLink spell={TALENTS_MONK.DANCING_MISTS_TALENT}/> to include healing contribution from <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT}/>.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -88,11 +88,14 @@ import ZenPulse from './modules/spells/ZenPulse';
 import T32TierSet from './modules/tier/T32TierSet';
 import PoolOfMists from './modules/spells/PoolOfMists';
 import HeartOfTheJadeSerpent from '../shared/hero/conduit/HeartOfTheJadeSerpent';
+import RestoreBalance from '../shared/hero/conduit/RestoreBalance';
+import ConduitOfTheCelestialsEventLinks from '../shared/hero/conduit/ConduitOfTheCelestialsEventLinks';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Normalizer
     castLinkNormalizer: CastLinkNormalizer,
+    conduitOfTheCelestialsEventLinks: ConduitOfTheCelestialsEventLinks,
     hotApplicationNormalizer: HotApplicationNormalizer,
     hotRemovalNormalizer: HotRemovalNormalizer,
 
@@ -188,7 +191,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Hero Talents
     //Conduit
     heartOfTheJadeSerpent: HeartOfTheJadeSerpent,
-
+    restoreBalance: RestoreBalance,
     apl: AplCheck,
 
     // Borrowed Power

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -108,7 +108,7 @@ export const ATTRIBUTION_STRINGS = {
     RD_SOURCE_RSK: 'Rapid Diffusion Source - Rising Sun Kick',
     RD_SOURCE_ENV: 'Rapid Diffusion Source - Enveloping Mist',
   },
-  YULON: "Hardcast During Yu'lon",
+  YULON: "Yu'lon",
 };
 
 export const SECRET_INFUSION_BUFFS = [

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
@@ -36,6 +36,41 @@ class HotTrackerMW extends HotTracker {
     this.risingMistActive = this.owner.selectedCombatant.hasTalent(TALENTS_MONK.RISING_MIST_TALENT);
   }
 
+  getAverageHealingForAttribution(
+    spellId: number,
+    attribution: string,
+    excludeDancingMist: boolean = false,
+    filteredHistory?: Tracker[],
+  ): number {
+    if (!filteredHistory) {
+      filteredHistory = this.getHistoryForSpellAndAttribution(
+        spellId,
+        attribution,
+        excludeDancingMist,
+      );
+    }
+    return (
+      filteredHistory.filter((hot) =>
+        hot.attributions.filter((attr) => attr.name === attribution),
+      )[0].attributions[0].healing / filteredHistory.length
+    );
+  }
+
+  getHistoryForSpellAndAttribution(
+    spellId: number,
+    attribution: string,
+    excludeDancingMist: boolean,
+  ): Tracker[] {
+    return this.hotHistory.filter(
+      (tracker) =>
+        tracker.spellId === spellId &&
+        tracker.attributions.some((attr) => {
+          return attr.name === attribution;
+        }) &&
+        (excludeDancingMist ? !this.fromDancingMists(tracker) : true),
+    );
+  }
+
   /**
    * Checks if the target of the event currently has the specified HoT on them
    * @param event the healing event to check

--- a/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/MistweaverHealingEfficiencyTracker.tsx
@@ -19,6 +19,7 @@ import RisingMist from '../spells/RisingMist';
 import ShaohaosLessons from '../spells/ShaohaosLessons';
 import CraneStyle from '../spells/CraneStyle';
 import ZenPulse from '../spells/ZenPulse';
+import TearOfMorning from '../spells/TearOfMorning';
 
 class MistweaverHealingEfficiencyTracker extends HealingEfficiencyTracker {
   static dependencies = {
@@ -40,6 +41,7 @@ class MistweaverHealingEfficiencyTracker extends HealingEfficiencyTracker {
     shaohaosLessons: ShaohaosLessons,
     craneStyle: CraneStyle,
     zenPulse: ZenPulse,
+    tearOfMorning: TearOfMorning,
   };
 
   protected envelopingMists!: EnvelopingMists;
@@ -57,6 +59,7 @@ class MistweaverHealingEfficiencyTracker extends HealingEfficiencyTracker {
   protected shaohaosLessons!: ShaohaosLessons;
   protected craneStyle!: CraneStyle;
   protected zenPulse!: ZenPulse;
+  protected tearOfMorning!: TearOfMorning;
 
   getCustomSpellStats(spellInfo: SpellInfoDetails, spellId: number) {
     if (spellId === TALENTS_MONK.ENVELOPING_MIST_TALENT.id) {
@@ -104,7 +107,10 @@ class MistweaverHealingEfficiencyTracker extends HealingEfficiencyTracker {
       this.rapidDiffusion.mistyPeakHealingFromEnvRem +
       this.envelopingMists.gustsHealing +
       this.rapidDiffusion.remHealingFromEnv +
-      this.envelopingMists.healingIncrease;
+      this.envelopingMists.healingIncrease +
+      this.tearOfMorning.tftCleaveHealing +
+      this.healingDone.byAbility(SPELLS.ENVELOPING_MIST_TFT.id).effective;
+
     return spellInfo;
   }
 
@@ -148,7 +154,6 @@ class MistweaverHealingEfficiencyTracker extends HealingEfficiencyTracker {
   }
 
   getRisingSunKickDetails(spellInfo: SpellInfoDetails) {
-    // Since I don't want messy code right now it will only give the rising mist healing not any of the other fun stuff it gives indirectly
     spellInfo.healingDone =
       this.risingMist.totalHealing +
       this.rapidDiffusion.remHealingFromRSK +

--- a/src/analysis/retail/monk/mistweaver/modules/spells/EnvelopingMists.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/EnvelopingMists.tsx
@@ -76,7 +76,7 @@ class EnvelopingMists extends Analyzer {
       >
         <BoringSpellValueText spell={TALENTS_MONK.ENVELOPING_MIST_TALENT}>
           <>
-            {formatNumber(this.healingIncrease)} <small>healing contributed by the buff</small>
+            {formatNumber(this.healingIncrease)} <small>healing from the buff</small>
           </>
         </BoringSpellValueText>
       </Statistic>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RisingMist.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RisingMist.tsx
@@ -446,7 +446,17 @@ class RisingMist extends Analyzer {
           title={
             hotSpan.call(this, hotId) +
             (attribution.length > 0 ? ' - ' + attribution : '') +
-            this.getAverageDuration(hotHistory)
+            this.getAverageDuration(hotHistory) +
+            ' (' +
+            formatNumber(
+              this.hotTracker.getAverageHealingForAttribution(
+                hotId,
+                attribution,
+                undefined,
+                hotHistory,
+              ),
+            ) +
+            ' Average)'
           }
         >
           <SubSection>
@@ -508,51 +518,46 @@ class RisingMist extends Analyzer {
   }
 
   entries() {
-    const rementries = this.hotTable(
+    const remHardcastHistory = this.hotTracker.getHistoryForSpellAndAttribution(
       SPELLS.RENEWING_MIST_HEAL.id,
-      this.hotTracker.hotHistory.filter(
-        (tracker) =>
-          tracker.spellId === SPELLS.RENEWING_MIST_HEAL.id &&
-          this.hotTracker.fromHardcast(tracker) &&
-          !this.hotTracker.fromDancingMists(tracker),
-      ),
-      'Hardcast',
+      ATTRIBUTION_STRINGS.HARDCAST_RENEWING_MIST,
+      true,
+    );
+    const rementries = this.hotTable(SPELLS.RENEWING_MIST_HEAL.id, remHardcastHistory, 'Hardcast');
+    const rdRemHistory = this.hotTracker.getHistoryForSpellAndAttribution(
+      SPELLS.RENEWING_MIST_HEAL.id,
+      ATTRIBUTION_STRINGS.RAPID_DIFFUSION_RENEWING_MIST,
+      true,
     );
     const rdRemEntries = this.hotTable(
       SPELLS.RENEWING_MIST_HEAL.id,
-      this.hotTracker.hotHistory.filter(
-        (tracker) =>
-          tracker.spellId === SPELLS.RENEWING_MIST_HEAL.id &&
-          this.hotTracker.fromRapidDiffusion(tracker) &&
-          !this.hotTracker.fromDancingMists(tracker),
-      ),
+      rdRemHistory,
       'Rapid Diffusion',
     );
-    const dmRemEntries = this.hotTable(
+    const dmRemHistory = this.hotTracker.getHistoryForSpellAndAttribution(
       SPELLS.RENEWING_MIST_HEAL.id,
-      this.hotTracker.hotHistory.filter(
-        (tracker) =>
-          tracker.spellId === SPELLS.RENEWING_MIST_HEAL.id &&
-          this.hotTracker.fromDancingMists(tracker),
-      ),
-      'Dancing Mist',
+      ATTRIBUTION_STRINGS.DANCING_MIST_RENEWING_MIST,
+      false,
+    );
+    const dmRemEntries = this.hotTable(SPELLS.RENEWING_MIST_HEAL.id, dmRemHistory, 'Dancing Mist');
+    const mistyPeaksHistory = this.hotTracker.getHistoryForSpellAndAttribution(
+      TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
+      ATTRIBUTION_STRINGS.MISTY_PEAKS_ENVELOPING_MIST,
+      false,
     );
     const mistyPeaksentries = this.hotTable(
       TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
-      this.hotTracker.hotHistory.filter(
-        (tracker) =>
-          tracker.spellId === TALENTS_MONK.ENVELOPING_MIST_TALENT.id &&
-          this.hotTracker.fromMistyPeaks(tracker),
-      ),
+      mistyPeaksHistory,
       'Misty Peaks',
+    );
+    const envHardcastHistory = this.hotTracker.getHistoryForSpellAndAttribution(
+      TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
+      ATTRIBUTION_STRINGS.HARDCAST_ENVELOPING_MIST,
+      false,
     );
     const envEntries = this.hotTable(
       TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
-      this.hotTracker.hotHistory.filter(
-        (tracker) =>
-          tracker.spellId === TALENTS_MONK.ENVELOPING_MIST_TALENT.id &&
-          this.hotTracker.fromHardcast(tracker),
-      ),
+      envHardcastHistory,
       'Hardcast',
     );
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/TearOfMorning.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/TearOfMorning.tsx
@@ -1,23 +1,32 @@
-import talents from 'common/TALENTS/monk';
+import talents, { TALENTS_MONK } from 'common/TALENTS/monk';
 import spells from 'common/SPELLS/monk';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { HealEvent } from 'parser/core/Events';
+import Events, { CastEvent, GetRelatedEvents, HealEvent } from 'parser/core/Events';
 import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
 import Statistic from 'parser/ui/Statistic';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import { SpellLink } from 'interface';
+import { SpellLink, TooltipElement } from 'interface';
 import { formatNumber } from 'common/format';
 import TalentSpellText from 'parser/ui/TalentSpellText';
+import HotTrackerMW from '../core/HotTrackerMW';
+import { ATTRIBUTION_STRINGS } from '../../constants';
+import { TFT_ENV_TOM } from '../../normalizers/EventLinks/EventLinkConstants';
 
 const TEAR_OF_MORNING_INCREASE = 0.2;
 class TearOfMorning extends Analyzer {
-  static dependencies = {};
+  static dependencies = {
+    hotTracker: HotTrackerMW,
+  };
+
+  protected hotTracker!: HotTrackerMW;
 
   duplicatedRems: number = 0;
   invigoratingMistHealing: number = 0;
   envelopingMisthealing: number = 0;
+  envelopCasts: number = 0;
+  tftCleaveHealing: number = 0;
 
   constructor(options: Options) {
     super(options);
@@ -30,10 +39,59 @@ class TearOfMorning extends Analyzer {
       Events.heal.by(SELECTED_PLAYER).spell(talents.ENVELOPING_MIST_TALENT),
       this.handleEnv,
     );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(talents.ENVELOPING_MIST_TALENT),
+      this.onCast,
+    );
   }
 
   get totalHealing() {
-    return this.invigoratingMistHealing + this.envelopingMisthealing;
+    return this.invigoratingMistHealing + this.envelopingMisthealing + this.tftCleaveHealing;
+  }
+
+  get avgHealingPerCast() {
+    return (
+      this.hotTracker.getAverageHealingForAttribution(
+        TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
+        ATTRIBUTION_STRINGS.HARDCAST_ENVELOPING_MIST,
+      ) +
+      (this.envelopingMisthealing + this.tftCleaveHealing) / this.envelopCasts
+    );
+  }
+
+  onCast(event: CastEvent) {
+    this.envelopCasts += 1;
+    const tftEnvHits = GetRelatedEvents(event, TFT_ENV_TOM);
+
+    if (tftEnvHits.length === 0) {
+      return;
+    }
+
+    //cleave hits are the same spell id as the primary cast hit
+    //so we need to check for more than 1 heal instance on the same target and
+    //filter out the larger hit (it will always be larger) if necessary
+    const empty: HealEvent[] = []; //eslint....
+    const filteredCleaves = Object.values(
+      tftEnvHits.reduce((tftCleaves, cleave) => {
+        cleave = cleave as HealEvent;
+        if (
+          !tftCleaves[cleave.targetID] ||
+          this._getraw(tftCleaves[cleave.targetID]) > this._getraw(cleave)
+        ) {
+          tftCleaves[cleave.targetID] = cleave;
+        }
+        return tftCleaves;
+      }, empty),
+    );
+
+    this.tftCleaveHealing += filteredCleaves.reduce(
+      (sum, heal) => (sum += heal.amount + (heal.absorbed || 0)),
+      0,
+    );
+  }
+
+  _getraw(event: HealEvent) {
+    return event.amount + (event.overheal || 0) + (event.absorbed || 0);
   }
 
   handleVivify(event: HealEvent) {
@@ -56,19 +114,41 @@ class TearOfMorning extends Analyzer {
         tooltip={
           <ul>
             <li>
-              <SpellLink spell={spells.INVIGORATING_MISTS_HEAL} /> healing:{' '}
+              <SpellLink spell={spells.INVIGORATING_MISTS_HEAL} /> additional healing:{' '}
               {formatNumber(this.invigoratingMistHealing)}
             </li>
             <li>
-              <SpellLink spell={talents.ENVELOPING_MIST_TALENT} /> healing:{' '}
-              {formatNumber(this.envelopingMisthealing)}
+              <SpellLink spell={talents.ENVELOPING_MIST_TALENT} /> cleave healing:{' '}
+              {formatNumber(this.envelopingMisthealing)} (
+              {formatNumber(this.envelopingMisthealing / this.envelopCasts)} per cast)
             </li>
+            {this.tftCleaveHealing > 0 && (
+              <li>
+                <SpellLink spell={talents.THUNDER_FOCUS_TEA_TALENT} />{' '}
+                <SpellLink spell={talents.ENVELOPING_MIST_TALENT} /> cleave healing:{' '}
+                {formatNumber(this.tftCleaveHealing)}
+              </li>
+            )}
           </ul>
         }
       >
         <TalentSpellText talent={talents.TEAR_OF_MORNING_TALENT}>
           <ItemHealingDone amount={this.totalHealing} />
           <br />
+          <TooltipElement
+            content={
+              <>
+                This is the average effective healing done per cast of{' '}
+                <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT} />, excluding any healing
+                contributed by <SpellLink spell={TALENTS_MONK.MISTY_PEAKS_TALENT} />, if talented.
+              </>
+            }
+          >
+            {formatNumber(this.avgHealingPerCast)}{' '}
+            <small>
+              healing per <SpellLink spell={talents.ENVELOPING_MIST_TALENT} />
+            </small>
+          </TooltipElement>
         </TalentSpellText>
       </Statistic>
     );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
@@ -35,6 +35,7 @@ class Vivify extends Analyzer {
 
   protected spellUsable!: SpellUsable;
   protected upliftedSpirits!: UpliftedSpirits;
+
   casts: number = 0;
   healsPerPlayer: InvigoratingMistHealPerPlayer = {};
   mainTargetHealing: number = 0;
@@ -231,19 +232,18 @@ class Vivify extends Analyzer {
             <ul>
               <li>
                 {formatNumber(this.mainTargetHealing + this.cleaveHealing)} overall healing from
-                <SpellLink spell={SPELLS.VIVIFY} />.
+                casting <SpellLink spell={SPELLS.VIVIFY} />.
               </li>
               <li>
-                {formatNumber(this.cleaveHealing)} portion of your{' '}
-                <SpellLink spell={SPELLS.VIVIFY} /> healing to{' '}
-                <SpellLink spell={TALENTS_MONK.RENEWING_MIST_TALENT} /> targets.
+                {formatNumber(this.cleaveHealing)} healing from{' '}
+                <SpellLink spell={TALENTS_MONK.INVIGORATING_MISTS_TALENT} />
               </li>
               <li>{formatNumber(this.fullOverhealCleaves)} cleaves that were 100% overheal.</li>
             </ul>
           </>
         }
       >
-        <TalentSpellText talent={TALENTS_MONK.RENEWING_MIST_TALENT}>
+        <TalentSpellText talent={TALENTS_MONK.INVIGORATING_MISTS_TALENT}>
           <>
             {this.averageRemPerVivify.toFixed(2)}{' '}
             <small>

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EnvelopingMistEventLinks.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EnvelopingMistEventLinks.ts
@@ -7,6 +7,7 @@ import {
   FROM_HARDCAST,
   APPLIED_HEAL,
   CAST_BUFFER_MS,
+  TFT_ENV_TOM,
 } from './EventLinkConstants';
 
 export const ENVELOPING_MIST_EVENT_LINKS: EventLink[] = [
@@ -35,5 +36,19 @@ export const ENVELOPING_MIST_EVENT_LINKS: EventLink[] = [
     referencedEventType: EventType.Cast,
     forwardBufferMs: CAST_BUFFER_MS,
     backwardBufferMs: CAST_BUFFER_MS,
+  },
+  //TFT Enveloping Mist - Tear Of Morning Cleave Link
+  {
+    linkRelation: TFT_ENV_TOM,
+    linkingEventId: [TALENTS_MONK.ENVELOPING_MIST_TALENT.id],
+    linkingEventType: [EventType.Cast],
+    referencedEventId: [SPELLS.ENVELOPING_MIST_TFT.id],
+    referencedEventType: [EventType.Heal],
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
+    isActive(c) {
+      return c.hasTalent(TALENTS_MONK.TEAR_OF_MORNING_TALENT);
+    },
   },
 ];

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants.ts
@@ -14,6 +14,7 @@ export const MAX_REM_DURATION = 77000;
 
 //Enveloping Mist
 export const FROM_MISTY_PEAKS = 'FromMistyPeaks';
+export const TFT_ENV_TOM = 'TFTEnvTom';
 
 //Mastery
 export const ENVELOPING_MIST_GOM = 'EnvGOM';

--- a/src/analysis/retail/monk/shared/hero/conduit/ConduitOfTheCelestialsEventLinks.ts
+++ b/src/analysis/retail/monk/shared/hero/conduit/ConduitOfTheCelestialsEventLinks.ts
@@ -1,0 +1,79 @@
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import talents from 'common/TALENTS/monk';
+import { DamageEvent, EventType, HasRelatedEvent, HealEvent } from 'parser/core/Events';
+import { CAST_BUFFER_MS } from 'analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants';
+import SPELLS from 'common/SPELLS';
+import { Options } from 'parser/core/Module';
+
+export const RESTORE_BALANCE_APPLY = 'restoreBalanceApply';
+export const RESTORE_BALANCE = 'restoreBalance';
+
+const RJW_MAX_DURATION = 25000;
+
+const CELESTIAL_CONDUIT_EVENT_LINKS: EventLink[] = [
+  //windwalker
+  {
+    linkRelation: RESTORE_BALANCE_APPLY,
+    reverseLinkRelation: RESTORE_BALANCE_APPLY,
+    linkingEventId: talents.RUSHING_JADE_WIND_WINDWALKER_TALENT.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    referencedEventId: talents.INVOKE_XUEN_THE_WHITE_TIGER_TALENT.id,
+    referencedEventType: EventType.Cast,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    isActive(c) {
+      return c.hasTalent(talents.RESTORE_BALANCE_TALENT);
+    },
+  },
+  //mistweaver
+  {
+    linkRelation: RESTORE_BALANCE_APPLY,
+    reverseLinkRelation: RESTORE_BALANCE_APPLY,
+    linkingEventId: SPELLS.REFRESHING_JADE_WIND_BUFF.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    referencedEventId: [
+      talents.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id,
+      talents.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id,
+    ],
+    referencedEventType: EventType.Cast,
+    anyTarget: true,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    isActive(c) {
+      return c.hasTalent(talents.RESTORE_BALANCE_TALENT);
+    },
+  },
+  {
+    linkRelation: RESTORE_BALANCE,
+    reverseLinkRelation: RESTORE_BALANCE,
+    linkingEventId: SPELLS.REFRESHING_JADE_WIND_HEAL.id,
+    linkingEventType: EventType.Heal,
+    referencedEventId: [
+      talents.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id,
+      talents.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id,
+    ],
+    referencedEventType: EventType.Cast,
+    anyTarget: true,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: RJW_MAX_DURATION,
+    isActive(c) {
+      return c.hasTalent(talents.RESTORE_BALANCE_TALENT);
+    },
+    //
+    // additionalCondition(referencedEvent) {
+    //     return !HasRelatedEvent(referencedEvent, RJW_TFT);
+    // },
+  },
+];
+
+class ConduitOfTheCelestialsEventLinks extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, CELESTIAL_CONDUIT_EVENT_LINKS);
+  }
+}
+
+export function isFromRestoreBalance(event: HealEvent | DamageEvent): boolean {
+  return HasRelatedEvent(event, RESTORE_BALANCE);
+}
+
+export default ConduitOfTheCelestialsEventLinks;

--- a/src/analysis/retail/monk/shared/hero/conduit/RestoreBalance.tsx
+++ b/src/analysis/retail/monk/shared/hero/conduit/RestoreBalance.tsx
@@ -1,0 +1,77 @@
+import SPELLS from 'common/SPELLS';
+import Spell from 'common/SPELLS/Spell';
+import { TALENTS_MONK } from 'common/TALENTS';
+import SPECS from 'game/SPECS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent, DamageEvent, HealEvent } from 'parser/core/Events';
+import { isFromRestoreBalance } from './ConduitOfTheCelestialsEventLinks';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import Statistic from 'parser/ui/Statistic';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+//rushing jade wind for ww -- refreshing jade wind for mw
+
+//xuen trigger for ww -- yulon/chiji trigger for mw
+const TRIGGER_SPELLS = [
+  TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT,
+  TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT,
+  TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT,
+];
+
+class RestoreBalance extends Analyzer {
+  spell: Spell;
+  casts: number = 0;
+  healing: number = 0;
+  overheal: number = 0;
+
+  damage: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.RESTORE_BALANCE_TALENT);
+    this.spell =
+      this.selectedCombatant.specId === SPECS.MISTWEAVER_MONK.id
+        ? SPELLS.REFRESHING_JADE_WIND_HEAL
+        : TALENTS_MONK.RUSHING_JADE_WIND_WINDWALKER_TALENT;
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(TRIGGER_SPELLS), this.onCast);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(this.spell), this.onDamage);
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(this.spell), this.onHeal);
+  }
+
+  private onCast(event: CastEvent) {
+    this.casts += 1;
+  }
+
+  private onDamage(event: DamageEvent) {
+    if (isFromRestoreBalance(event)) {
+      this.damage += event.amount + (event.absorbed || 0);
+    }
+  }
+
+  private onHeal(event: HealEvent) {
+    if (isFromRestoreBalance(event)) {
+      this.healing += event.amount + (event.absorbed || 0);
+      this.overheal += event.overheal || 0;
+    }
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(0)}
+        category={STATISTIC_CATEGORY.HERO_TALENTS}
+        size="flexible"
+      >
+        <TalentSpellText talent={TALENTS_MONK.RESTORE_BALANCE_TALENT}>
+          <ItemHealingDone amount={this.healing} />
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default RestoreBalance;

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -405,6 +405,11 @@ const spells = {
     name: 'Refreshing Jade Wind',
     icon: 'ability_monk_rushingjadewind',
   },
+  REFRESHING_JADE_WIND_BUFF: {
+    id: 196725,
+    name: 'Refreshing Jade Wind',
+    icon: 'ability_monk_rushingjadewind',
+  },
   INVOKE_CHIJI_THE_RED_CRANE_BUFF: {
     id: 343820,
     name: 'Invoke Chi-Ji, the Red Crane',


### PR DESCRIPTION
### Description

Added some additional analysis to Tear of Morning:

- Average healing per cast
- Include cleaves from TFT Enveloping mist

Refactored some rising mist code into the MW HotTracker

Implemented Restore Balance for mistweaver, windwalker was partially implemented but left disabled until the spec gets reactived

### Screenshots
Tear of Morning
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/26779541/da86064f-4dba-4512-a8f6-b7250a9d4767)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/26779541/58713d8a-defc-463e-bfd2-cf67ef3cbb60)




Restore Balance
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/26779541/9d5be363-c115-455a-b207-750bee951de1)


