### PR TITLE
Add debug annotations for core GCD module

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -36,6 +36,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 7, 10), 'Improve debugging information for Global Cooldown tracking', emallson),
   change(date(2024, 7, 8), 'Rewrite Premium page in TypeScript.', ToppleTheNun),
   change(date(2024, 7, 6), 'Update Foundation Guides to use div instead of p (DOM warnings)', jazminite),
   change(date(2024, 7, 5), <>Update Haste and GCD tracking for Classic.</>, emallson),

--- a/src/parser/shared/modules/GlobalCooldown.tsx
+++ b/src/parser/shared/modules/GlobalCooldown.tsx
@@ -1,4 +1,4 @@
-import { formatMilliseconds } from 'common/format';
+import { formatDuration } from 'common/format';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import CASTS_THAT_ARENT_CASTS from 'parser/core/CASTS_THAT_ARENT_CASTS';
 import Events, {
@@ -16,6 +16,8 @@ import Haste from 'parser/shared/modules/Haste';
 import Abilities from '../../core/modules/Abilities';
 import { wclGameVersionToBranch } from 'game/VERSIONS';
 import GameBranch from 'game/GameBranch';
+import { BadColor, GoodColor, OkColor } from 'interface/guide';
+import SpellLink from 'interface/SpellLink';
 const INVALID_GCD_CONFIG_LAG_MARGIN = 150; // not sure what this is based around, but <150 seems to catch most false positives
 const MIN_GCD = 750; // Minimum GCD for most abilities is 750ms.
 const MIN_GCD_CLASSIC = 1000; // Minimum regular GCD was 1s until Legion
@@ -127,15 +129,10 @@ class GlobalCooldown extends Analyzer {
       this.lastGlobalCooldown.timestamp === event.timestamp &&
       this.lastGlobalCooldown.ability.guid === event.ability.guid
     ) {
-      console.warn(
-        'GlobalCooldown module attempted to trigger duplicate GCDs for ability ' +
-          event.ability.name +
-          '(' +
-          event.ability.guid +
-          ') @ ' +
-          event.timestamp +
-          ' - duplicate will be ignored. This is probably due to an event ordering issue not being handled correctly by this module.',
-      );
+      this.addDebugAnnotation(event, {
+        summary: 'Attempted to trigger duplicate GCD for ability',
+        color: OkColor,
+      });
       return undefined;
     }
     return this.eventEmitter.fabricateEvent(
@@ -198,26 +195,45 @@ class GlobalCooldown extends Analyzer {
     if (this.lastGlobalCooldown) {
       const timeSince = event.timestamp - this.lastGlobalCooldown.timestamp;
       const remainingDuration = this.lastGlobalCooldown.duration - timeSince;
+      // the debug annotations are attached to the triggering event so that other annotations (like duplicate gcds) work
       if (remainingDuration > INVALID_GCD_CONFIG_LAG_MARGIN) {
         this._errors += 1;
-        console.error(
-          formatMilliseconds(this.owner.fightDuration),
-          'GlobalCooldown',
-          event.trigger?.ability.name,
-          event.trigger?.ability.guid,
-          `was cast while the Global Cooldown from`,
-          this.lastGlobalCooldown.ability.name,
-          this.lastGlobalCooldown.ability.guid,
-          `was already running. There's probably a Haste buff missing from StatTracker or the Haste module, this spell has a GCD different from the default, or the base GCD for this spec is different from default.`,
-          'time passed:',
-          timeSince,
-          'cooldown remaining:',
-          remainingDuration,
-          'expectedDuration:',
-          this.lastGlobalCooldown.duration,
-          'errors:',
-          this._errors,
-        );
+        this.addDebugAnnotation(event.trigger, {
+          summary: `GCD for ${event.trigger?.ability.name} triggered while GCD from ${this.lastGlobalCooldown.ability.name} was active`,
+          details: (
+            <div>
+              <h4>Previous GCD</h4>
+              <dl>
+                <dt>Timestamp</dt>
+                <dd>
+                  {formatDuration(this.lastGlobalCooldown.timestamp - this.owner.fight.start_time)}
+                </dd>
+                <dt>Ability</dt>
+                <dd>
+                  <SpellLink spell={this.lastGlobalCooldown.ability.guid} />
+                </dd>
+                <dt>Expected GCD Duration</dt>
+                <dd>{(this.lastGlobalCooldown.duration / 1000).toFixed(2)}s</dd>
+                <dt>Expected GCD End Timestamp</dt>
+                <dd>
+                  {formatDuration(
+                    this.lastGlobalCooldown.timestamp +
+                      this.lastGlobalCooldown.duration -
+                      this.owner.fight.start_time,
+                  )}{' '}
+                  ({(remainingDuration / 1000).toFixed(2)}s after this event)
+                </dd>
+              </dl>
+            </div>
+          ),
+          color: BadColor,
+        });
+      } else {
+        this.addDebugAnnotation(event.trigger, {
+          summary: `GCD for ${event.trigger?.ability.name}`,
+          color: GoodColor,
+          priority: -Infinity,
+        });
       }
     }
     this.lastGlobalCooldown = event;

--- a/src/parser/shared/modules/GlobalCooldown.tsx
+++ b/src/parser/shared/modules/GlobalCooldown.tsx
@@ -206,7 +206,10 @@ class GlobalCooldown extends Analyzer {
               <dl>
                 <dt>Timestamp</dt>
                 <dd>
-                  {formatDuration(this.lastGlobalCooldown.timestamp - this.owner.fight.start_time)}
+                  {formatDuration(
+                    this.lastGlobalCooldown.timestamp - this.owner.fight.start_time,
+                    2,
+                  )}
                 </dd>
                 <dt>Ability</dt>
                 <dd>
@@ -220,6 +223,7 @@ class GlobalCooldown extends Analyzer {
                     this.lastGlobalCooldown.timestamp +
                       this.lastGlobalCooldown.duration -
                       this.owner.fight.start_time,
+                    2,
                   )}{' '}
                   ({(remainingDuration / 1000).toFixed(2)}s after this event)
                 </dd>

--- a/src/parser/shared/modules/SpellUsable.tsx
+++ b/src/parser/shared/modules/SpellUsable.tsx
@@ -765,7 +765,9 @@ class SpellUsable extends Analyzer {
         color: BadColor,
         summary: `${spellName(spellId)} (ID=${spellId}) was used while SpellUsable's tracker thought it had no available charges`,
         // note: we are making a copy of `info` so that later display is not muddled by mutation
-        details: SpellUsableDebugDescription({ cdInfo: { ...info }, event, parser: this.owner }),
+        details: (
+          <SpellUsableDebugDescription cdInfo={{ ...info }} event={event} parser={this.owner} />
+        ),
       };
     } else if (!ability && HasAbility(event)) {
       annotation = {


### PR DESCRIPTION
### Description

This adds debug annotations for the core `GlobalCooldown` module, replacing old `console.error` calls.

![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/e910cedd-6834-427c-a30f-c67f59f9ea49)
![image](https://github.com/WoWAnalyzer/WoWAnalyzer/assets/4909458/d9574411-cbfc-4285-80f6-8a733b409052)

### Testing

I tested on sample reports for a number of specs. The above screenshots are the Brewmaster sample report and `/report/jdDvFX2k9nByPWLh/23-Mythic+Terros+-+Kill+(6:18)/Brewsquare/standard/debug`
