### PR TITLE
add a fast path to `Entity.hasBuff` to improve runtime

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -36,6 +36,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 7, 15), 'Significantly improve loading time for M+ logs', emallson),
   change(date(2024, 7, 10), 'Improve debugging information for Global Cooldown tracking', emallson),
   change(date(2024, 7, 8), 'Rewrite Premium page in TypeScript.', ToppleTheNun),
   change(date(2024, 7, 6), 'Update Foundation Guides to use div instead of p (DOM warnings)', jazminite),

--- a/src/parser/core/Entity.ts
+++ b/src/parser/core/Entity.ts
@@ -72,11 +72,11 @@ class Entity {
     bufferTime = 0,
     minimalActiveTime = 0,
     sourceID: number | null = null,
-  ) {
+  ): boolean {
     if (forTimestamp === null && bufferTime === 0 && minimalActiveTime === 0) {
       // fast-path for common case
       if (sourceID !== null) {
-        return this.activeBuffSet.get(spellId)?.has(sourceID);
+        return this.activeBuffSet.get(spellId)?.has(sourceID) ?? false;
       } else {
         return (this.activeBuffSet.get(spellId)?.size ?? 0) > 0;
       }

--- a/src/parser/shared/modules/DeathRecapTracker.jsx
+++ b/src/parser/shared/modules/DeathRecapTracker.jsx
@@ -74,15 +74,20 @@ class DeathRecapTracker extends Analyzer {
     }));
     if (event.hitPoints > 0) {
       this.lastBuffs = this.buffs.filter((e) => {
-        const buff = this.selectedCombatant.getBuff(e.id);
-        const hasBuff = buff !== undefined;
-        if (!hasBuff) {
-          return false;
-        }
         if (e.id === TALENTS.BLESSING_OF_SACRIFICE_TALENT.id) {
-          return buff.sourceID === this.selectedCombatant.id;
+          // handle sac jank. this technically breaks when you both have given and are receiving sac, but it breaks in-game too so w/e
+          return (
+            this.selectedCombatant.hasBuff(e.id) &&
+            !this.selectedCombatant.hasBuff(
+              e.id,
+              null,
+              undefined,
+              undefined,
+              this.selectedCombatant.id,
+            )
+          );
         }
-        return true;
+        return this.selectedCombatant.hasBuff(e.id);
       });
     }
     extendedEvent.buffsUp = this.lastBuffs;

--- a/src/parser/shared/modules/Entities.ts
+++ b/src/parser/shared/modules/Entities.ts
@@ -190,6 +190,7 @@ abstract class Entities<T extends Entity> extends Analyzer {
         item.end === null &&
         event.sourceID === item.sourceID,
     );
+    entity.removeBuffSource(event.ability.guid, event.sourceID);
     if (existingBuff) {
       existingBuff.end = event.timestamp;
       existingBuff.stackHistory.push({ stacks: 0, timestamp: event.timestamp });


### PR DESCRIPTION
this reduces the runtime of `/report/JBka7NCwgvR9VGWL/63-Mythic++Brackenhide+Hollow+-+Kill+(32:19)/Полински/standard` from almost 90s to ~4s. (hopefully, without impacting correctness)

this code is used to display active buffs on the death recap next to each damage/heal event

I don't have a great reference for testing the correctness of it, but tbh it has bitrotted enough that I'm not sure the *existing* behavior is correct (e.g. BM Hunter has Bestial Wrath and Dire Beast shown in prod which...are not defensives)