### PR TITLE
[Augmentation] Implement Rumbling Earth module

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/evoker';
 
 export default [
+  change(date(2024, 7, 21), <>Implement <SpellLink spell={TALENTS.RUMBLING_EARTH_TALENT}/> module</>, Vollmer),
   change(date(2024, 7, 19), <>Update IDs for <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /></>, Vollmer),
   change(date(2024, 7, 18), <>Add <SpellLink spell={TALENTS.MOLTEN_EMBERS_TALENT} /> module</>, Vollmer),
 ];

--- a/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
@@ -21,6 +21,7 @@ import TectonicLocus from './modules/talents/TectonicLocus';
 import Volcanism from './modules/talents/Volcanism';
 import BlisteringScales from './modules/talents/BlisteringScales';
 import MoltenEmbers from './modules/talents/MoltenEmbers';
+import RumblingEarth from './modules/talents/RumblingEarth';
 
 import BuffTrackerGraph from './modules/features/BuffTrackerGraph';
 import BuffTargetHelper from './modules/features/BuffTargetHelper/BuffTargetHelper';
@@ -112,6 +113,7 @@ class CombatLogParser extends MainCombatLogParser {
     volcanism: Volcanism,
     blisteringScales: BlisteringScales,
     moltenEmbers: MoltenEmbers,
+    rumblingEarth: RumblingEarth,
 
     // Features
     buffTrackerGraph: BuffTrackerGraph,

--- a/src/analysis/retail/evoker/augmentation/modules/talents/RumblingEarth.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/RumblingEarth.tsx
@@ -1,0 +1,55 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS/evoker';
+import TALENTS from 'common/TALENTS/evoker';
+import Events, { DamageEvent, HasRelatedEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { formatNumber } from 'common/format';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import { UPHEAVAL_RUMBLING_EARTH_LINK } from '../normalizers/CastLinkNormalizer';
+
+/**
+ * Upheaval causes an aftershock at its location, dealing 50% of its damage 2 additional time.
+ */
+class RumblingEarth extends Analyzer {
+  totalRumblingEarthDamage: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.RUMBLING_EARTH_TALENT);
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.UPHEAVAL_DAM),
+      this.onDamage,
+    );
+  }
+
+  onDamage(event: DamageEvent) {
+    if (HasRelatedEvent(event, UPHEAVAL_RUMBLING_EARTH_LINK)) {
+      this.totalRumblingEarthDamage += event.amount + (event.absorbed ?? 0);
+    }
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            <li>Damage: {formatNumber(this.totalRumblingEarthDamage)}</li>
+          </>
+        }
+      >
+        <TalentSpellText talent={TALENTS.RUMBLING_EARTH_TALENT}>
+          <ItemDamageDone amount={this.totalRumblingEarthDamage} />
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default RumblingEarth;

--- a/src/analysis/retail/evoker/shared/modules/normalizers/EmpowerNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/EmpowerNormalizer.ts
@@ -86,13 +86,19 @@ class EmpowerNormalizer extends EventLinkNormalizer {
       }
 
       const fabricatedEvent: EmpowerEndEvent = {
-        ...event,
+        ability: event.ability,
+        timestamp: event.timestamp,
+        sourceID: event.sourceID,
+        sourceIsFriendly: event.sourceIsFriendly,
+        targetID: event.targetID,
+        targetIsFriendly: event.targetIsFriendly,
         type: EventType.EmpowerEnd,
         empowermentLevel: hasFont ? 4 : 3,
         __fabricated: true,
       };
 
       AddRelatedEvent(event, EMPOWERED_CAST, fabricatedEvent);
+      AddRelatedEvent(fabricatedEvent, EMPOWERED_CAST, event);
 
       fixedEvents.push(event);
       fixedEvents.push(fabricatedEvent);


### PR DESCRIPTION
### Description

Implemented module for new talent `Rumbling Earth`.

Also changed how `EmpowerNormalizer` fabricates `EmpowerEndEvent` events to fix shallow copy issues.

### Testing

- Test report URL: `/report/hFaZ6nTr7zJL4fvK/9-Mythic+Rasha'nan+-+Kill+(5:01)/Flowchur/standard/statistics`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/c0ba5685-4bb5-4f82-8394-3f60c8d7e44e)
