### PR TITLE
[Deva/Aug] Implement Imminent Destruction module

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import TALENTS from 'common/TALENTS/evoker';
 export default [
   change(date(2024, 7, 22), <>Update <SpellLink spell={TALENTS.REACTIVE_HIDE_TALENT}/> multiplier</>, Vollmer),
   change(date(2024, 7, 21), <>Implement <SpellLink spell={TALENTS.RUMBLING_EARTH_TALENT}/> module</>, Vollmer),
+  change(date(2024, 7, 21), <>Implement <SpellLink spell={TALENTS.IMMINENT_DESTRUCTION_AUGMENTATION_TALENT}/> module</>, Vollmer),
   change(date(2024, 7, 19), <>Update IDs for <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /></>, Vollmer),
   change(date(2024, 7, 18), <>Add <SpellLink spell={TALENTS.MOLTEN_EMBERS_TALENT} /> module</>, Vollmer),
 ];

--- a/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
@@ -56,6 +56,7 @@ import {
   DefensiveCastLinkNormalizer,
   TwinGuardian,
   RenewingBlaze,
+  ImminentDestruction,
 } from 'analysis/retail/evoker/shared';
 
 class CombatLogParser extends MainCombatLogParser {
@@ -77,6 +78,7 @@ class CombatLogParser extends MainCombatLogParser {
     essenceGraph: EssenceGraph,
     sourceOfMagic: SourceOfMagic,
     potentMana: PotentMana,
+    imminentDestruction: ImminentDestruction,
 
     obsidianScales: ObsidianScales,
     defensiveCastLinkNormalizer: DefensiveCastLinkNormalizer,

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SPELLS from 'common/SPELLS/evoker';
 export default [
   change(date(2024, 7, 22), <>Update <SpellLink spell={TALENTS_EVOKER.HEAT_WAVE_TALENT}/> and <SpellLink spell={TALENTS_EVOKER.HONED_AGGRESSION_TALENT}/> multipliers</>, Vollmer),
   change(date(2024, 7, 21), <>Implement <SpellLink spell={TALENTS_EVOKER.SCORCHING_EMBERS_TALENT} /> module</>, Vollmer),
+  change(date(2024, 7, 21), <>Implement <SpellLink spell={TALENTS_EVOKER.IMMINENT_DESTRUCTION_DEVASTATION_TALENT}/> module</>, Vollmer),
   change(date(2024, 7, 19), <>Update IDs for <SpellLink spell={SPELLS.DEEP_BREATH} /></>, Vollmer),
   change(date(2024, 6, 30), <>Update periodic IDs for <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT} /> module</>, Vollmer),
   change(date(2024, 6, 22), <>Add <SpellLink spell={TALENTS_EVOKER.RED_HOT_TALENT} /> module</>, Trevor),

--- a/src/analysis/retail/evoker/devastation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/devastation/CombatLogParser.ts
@@ -56,6 +56,7 @@ import {
   TwinGuardian,
   RenewingBlaze,
   Engulf,
+  ImminentDestruction,
 } from 'analysis/retail/evoker/shared';
 import ExpandedLungs from '../shared/modules/talents/hero/flameshaper/ExpandedLungs';
 import FanTheFlames from '../shared/modules/talents/hero/flameshaper/FanTheFlames';
@@ -80,6 +81,7 @@ class CombatLogParser extends MainCombatLogParser {
     essenceGraph: EssenceGraph,
     sourceOfMagic: SourceOfMagic,
     potentMana: PotentMana,
+    imminentDestruction: ImminentDestruction,
 
     obsidianScales: ObsidianScales,
     defensiveCastLinkNormalizer: DefensiveCastLinkNormalizer,

--- a/src/analysis/retail/evoker/devastation/modules/abilities/EssenceBurst.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/abilities/EssenceBurst.tsx
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ApplyBuffEvent, ApplyBuffStackEvent, CastEvent } from 'parser/core/Events';
-import { isFromEssenceBurst } from '../normalizers/CastLinkNormalizer';
+import { isCastFromEB } from 'analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer';
 
 class EssenceBurst extends Analyzer {
   procs: number = 0;
@@ -40,7 +40,7 @@ class EssenceBurst extends Analyzer {
   }
 
   onEssenceSpend(event: CastEvent) {
-    if (isFromEssenceBurst(event)) {
+    if (isCastFromEB(event)) {
       this.consumedProcs += 1;
     }
   }

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
@@ -11,7 +11,6 @@ import {
 } from 'parser/core/Events';
 import { encodeEventTargetString } from 'parser/shared/modules/Enemies';
 
-export const ESSENCE_BURST_CONSUME = 'EssenceBurstConsumption';
 const BURNOUT_CONSUME = 'BurnoutConsumption';
 const SNAPFIRE_CONSUME = 'SnapfireConsumption';
 export const IRIDESCENCE_RED_CONSUME = 'IridescentRedConsumption';
@@ -25,29 +24,6 @@ export const PYRE_MIN_TRAVEL_TIME = 950;
 export const PYRE_MAX_TRAVEL_TIME = 1_050;
 const CAST_BUFFER_MS = 100;
 const EVENT_LINKS: EventLink[] = [
-  {
-    linkRelation: ESSENCE_BURST_CONSUME,
-    reverseLinkRelation: ESSENCE_BURST_CONSUME,
-    linkingEventId: [TALENTS.RUBY_ESSENCE_BURST_TALENT.id, SPELLS.ESSENCE_BURST_DEV_BUFF.id],
-    linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
-    referencedEventId: SPELLS.DISINTEGRATE.id,
-
-    referencedEventType: EventType.Cast,
-    anyTarget: true,
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
-  },
-  {
-    linkRelation: ESSENCE_BURST_CONSUME,
-    reverseLinkRelation: ESSENCE_BURST_CONSUME,
-    linkingEventId: [TALENTS.RUBY_ESSENCE_BURST_TALENT.id, SPELLS.ESSENCE_BURST_DEV_BUFF.id],
-    linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
-    referencedEventId: [SPELLS.PYRE.id, SPELLS.PYRE_DENSE_TALENT.id],
-    referencedEventType: EventType.Cast,
-    anyTarget: true,
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
-  },
   {
     linkRelation: BURNOUT_CONSUME,
     reverseLinkRelation: BURNOUT_CONSUME,
@@ -186,10 +162,6 @@ class CastLinkNormalizer extends EventLinkNormalizer {
 // region HELPERS
 export function isFromBurnout(event: CastEvent) {
   return HasRelatedEvent(event, BURNOUT_CONSUME);
-}
-
-export function isFromEssenceBurst(event: CastEvent) {
-  return HasRelatedEvent(event, ESSENCE_BURST_CONSUME);
 }
 
 export function isFromSnapfire(event: CastEvent) {

--- a/src/analysis/retail/evoker/devastation/modules/talents/TitanicWrath.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/talents/TitanicWrath.tsx
@@ -23,8 +23,8 @@ import {
   DISINTEGRATE_TICKS,
 } from 'analysis/retail/evoker/devastation/constants';
 import { SpellLink } from 'interface';
-import { ESSENCE_BURST_CONSUME } from '../normalizers/CastLinkNormalizer';
 import TalentSpellText from 'parser/ui/TalentSpellText';
+import { ESSENCE_BURST_CONSUME } from 'analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer';
 
 const { DISINTEGRATE, PYRE, ESSENCE_BURST_DEV_BUFF } = SPELLS;
 

--- a/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
@@ -12,10 +12,10 @@ import Events, {
 } from 'parser/core/Events';
 import {
   didSparkProcEssenceBurst,
-  getEssenceBurstConsumeAbility,
   isEbFromHardcast,
   isEbFromReversion,
 } from '../../normalizers/EventLinking/helpers';
+import { getEssenceBurstConsumeAbility } from 'analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 import { SPELL_COLORS } from 'analysis/retail/evoker/preservation/constants';
 import DonutChart from 'parser/ui/DonutChart';

--- a/src/analysis/retail/evoker/preservation/modules/talents/SparkOfInsight.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/SparkOfInsight.tsx
@@ -17,9 +17,9 @@ import TalentSpellText from 'parser/ui/TalentSpellText';
 import {
   didEbConsumeSparkProc,
   didSparkProcEssenceBurst,
-  getEssenceBurstConsumeAbility,
   wasEbConsumed,
 } from '../../normalizers/EventLinking/helpers';
+import { getEssenceBurstConsumeAbility } from 'analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer';
 import { ESSENCE_COSTS, MANA_COSTS } from './EssenceBurst';
 
 class SparkOfInsight extends Analyzer {

--- a/src/analysis/retail/evoker/preservation/modules/talents/TitansGift.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/TitansGift.tsx
@@ -13,11 +13,11 @@ import {
   getReversionHealing,
   getEchoAplication,
   getHealEvents,
-  isCastFromBurst,
 } from '../../normalizers/EventLinking/helpers';
 import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
 import { TITANS_GIFT_INC } from '../../normalizers/EventLinking/constants';
 import { formatPercentage } from 'common/format';
+import { isCastFromEB } from 'analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer';
 
 class TitansGift extends Analyzer {
   //Blossom
@@ -92,7 +92,7 @@ class TitansGift extends Analyzer {
   //Track blossom healing added
   emeraldBlossomHeal(event: HealEvent) {
     const blossomCast = getBlossomCast(event);
-    if (blossomCast && isCastFromBurst(blossomCast)) {
+    if (blossomCast && isCastFromEB(blossomCast)) {
       this.buffedBlossoms += 1;
       const blossomHeals = getHealEvents(event);
       for (const blossomHeal of blossomHeals) {
@@ -104,7 +104,7 @@ class TitansGift extends Analyzer {
   //Track echo healing added
   echoHeal(event: HealEvent | ApplyBuffEvent | RefreshBuffEvent) {
     const echoApplication = getEchoAplication(event);
-    if (echoApplication && isCastFromBurst(echoApplication)) {
+    if (echoApplication && isCastFromEB(echoApplication)) {
       this.buffedEchoes += 1;
       if (event.type === EventType.Heal) {
         this.healingAddedToEcho += calculateEffectiveHealing(event, TITANS_GIFT_INC);

--- a/src/analysis/retail/evoker/preservation/normalizers/EventLinking/EssenceBurstEventLinks.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EventLinking/EssenceBurstEventLinks.ts
@@ -3,8 +3,6 @@ import { TALENTS_EVOKER } from 'common/TALENTS';
 import { EventLink } from 'parser/core/EventLinkNormalizer';
 import { EventType, HasRelatedEvent } from 'parser/core/Events';
 import {
-  ESSENCE_BURST_CONSUME,
-  CAST_BUFFER_MS,
   ESSENCE_BURST_LINK,
   MAX_ESSENCE_BURST_DURATION,
   EB_REVERSION,
@@ -14,25 +12,6 @@ import {
 } from './constants';
 
 export const ESSENCE_BURST_EVENT_LINKS: EventLink[] = [
-  // link essence burst remove to a cast to track expirations vs consumptions
-  {
-    linkRelation: ESSENCE_BURST_CONSUME,
-    reverseLinkRelation: ESSENCE_BURST_CONSUME,
-    linkingEventId: SPELLS.ESSENCE_BURST_BUFF.id,
-    linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
-    referencedEventId: [
-      SPELLS.EMERALD_BLOSSOM_CAST.id,
-      SPELLS.DISINTEGRATE.id,
-      TALENTS_EVOKER.ECHO_TALENT.id,
-    ],
-    referencedEventType: EventType.Cast,
-    anyTarget: true,
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
-    isActive(c) {
-      return c.hasTalent(TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT);
-    },
-  },
   {
     linkRelation: ESSENCE_BURST_LINK,
     reverseLinkRelation: ESSENCE_BURST_LINK,

--- a/src/analysis/retail/evoker/preservation/normalizers/EventLinking/constants.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EventLinking/constants.ts
@@ -8,7 +8,6 @@ export const ECHO_TEMPORAL_ANOMALY = 'TemporalAnomaly'; // for linking BuffApply
 export const ECHO = 'Echo'; // for linking BuffApply/Heal to echo removal
 // END ECHO constants
 export const ESSENCE_BURST_LINK = 'EssenceBurstLink'; // link eb removal to apply
-export const ESSENCE_BURST_CONSUME = 'EssenceBurstConsumption'; // link essence cast to removing the essence burst buff
 export const DREAM_BREATH_CALL_OF_YSERA = 'DreamBreathCallOfYsera'; // link DB hit to buff removal
 export const DREAM_BREATH_CALL_OF_YSERA_HOT = 'DreamBreathCallOfYseraHoT'; // link DB hot to buff removal
 export const FIELD_OF_DREAMS_PROC = 'FromFieldOfDreams'; // link EB heal to fluttering heal

--- a/src/analysis/retail/evoker/preservation/normalizers/EventLinking/helpers.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EventLinking/helpers.ts
@@ -23,7 +23,6 @@ import {
   LIVING_FLAME_CALL_OF_YSERA,
   DREAM_BREATH_CALL_OF_YSERA_HOT,
   FIELD_OF_DREAMS_PROC,
-  ESSENCE_BURST_CONSUME,
   LIFEBIND_HEAL,
   ECHO_TYPE,
   LIFEBIND,
@@ -77,12 +76,6 @@ export function isFromFieldOfDreams(event: HealEvent) {
 
 export function didEchoExpire(event: RemoveBuffEvent) {
   return !HasRelatedEvent(event, ECHO) && !HasRelatedEvent(event, ECHO_TEMPORAL_ANOMALY);
-}
-
-export function getEssenceBurstConsumeAbility(
-  event: RemoveBuffEvent | RemoveBuffStackEvent,
-): null | CastEvent {
-  return GetRelatedEvent<CastEvent>(event, ESSENCE_BURST_CONSUME) ?? null;
 }
 
 export function getHealForLifebindHeal(event: HealEvent): HealEvent | null {
@@ -240,11 +233,6 @@ export function isT32ProcWasted(event: RemoveBuffEvent | RefreshBuffEvent): bool
 //Gets the cast event from a blossom heal
 export function getBlossomCast(event: HealEvent) {
   return GetRelatedEvent<CastEvent>(event, EMERALD_BLOSSOM_CAST);
-}
-
-//Find if a cast was from an essence burst
-export function isCastFromBurst(event: CastEvent) {
-  return HasRelatedEvent(event, ESSENCE_BURST_CONSUME);
 }
 
 export function getEchoAplication(event: HealEvent | ApplyBuffEvent | RefreshBuffEvent) {

--- a/src/analysis/retail/evoker/shared/constants.ts
+++ b/src/analysis/retail/evoker/shared/constants.ts
@@ -73,3 +73,6 @@ export const RED_HOT_INCREASE = 0.2;
 // Scalecommander changes ID for deep breath
 export const DEEP_BREATH_SPELLS = [SPELLS.DEEP_BREATH, SPELLS.DEEP_BREATH_SCALECOMMANDER];
 export const DEEP_BREATH_SPELL_IDS = DEEP_BREATH_SPELLS.map((spell) => spell.id);
+
+export const IMMINENT_DESTRUCTION_MULTIPLIER = 0.1;
+export const IMMINENT_DESTRUCTION_ESSENCE_REDUCTION = 1;

--- a/src/analysis/retail/evoker/shared/index.ts
+++ b/src/analysis/retail/evoker/shared/index.ts
@@ -19,4 +19,5 @@ export { default as TwinGuardian } from './modules/MajorDefensives/TwinGuardian'
 export { default as RenewingBlaze } from './modules/MajorDefensives/RenewingBlaze';
 export { default as Engulf } from './modules/talents/hero/flameshaper/Engulf';
 export { default as Panacea } from './modules/talents/Panacea';
+export { default as ImminentDestruction } from './modules/talents/ImminentDestruction';
 export * from './constants';

--- a/src/analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer.ts
@@ -5,6 +5,7 @@ import {
   AnyEvent,
   ApplyBuffEvent,
   ApplyBuffStackEvent,
+  CastEvent,
   EventType,
   GetRelatedEvent,
   GetRelatedEvents,
@@ -40,6 +41,8 @@ export const EB_FROM_LF_HEAL = 'ebFromLFHeal'; // Specifically used for Leaping 
 const ESSENCE_BURST_BUFFER = 40; // Sometimes the EB comes a bit early/late
 const EB_LF_CAST_BUFFER = 1_000;
 const EMERALD_TRANCE_BUFFER = 5_000;
+
+export const ESSENCE_BURST_CONSUME = 'EssenceBurstConsume';
 
 /** More deterministic links should be placed above less deterministic links
  * eg.
@@ -180,6 +183,18 @@ const EVENT_LINKS: EventLink[] = [
       return healProcDiff < castProcDiff;
     },
   },
+  {
+    linkRelation: ESSENCE_BURST_CONSUME,
+    reverseLinkRelation: ESSENCE_BURST_CONSUME,
+    linkingEventId: [SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF.id, SPELLS.ESSENCE_BURST_DEV_BUFF.id],
+    linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
+    referencedEventId: [TALENTS.PYRE_TALENT.id, SPELLS.DISINTEGRATE.id, TALENTS.ERUPTION_TALENT.id],
+    referencedEventType: EventType.Cast,
+    anyTarget: true,
+    forwardBufferMs: ESSENCE_BURST_BUFFER,
+    backwardBufferMs: ESSENCE_BURST_BUFFER,
+    maximumLinks: 1,
+  },
 ];
 
 class EssenceBurstCastLinkNormalizer extends EventLinkNormalizer {
@@ -302,6 +317,11 @@ export function eventWastedEB(event: AnyEvent, source?: EBSourceType) {
 function hasNoGenerationLink(event: AnyBuffEvent) {
   const curLink = getEBSource(event);
   return !curLink || curLink === EBSource.LivingFlameCast;
+}
+
+/** Check if Spender consumed EB */
+export function isCastFromEB(event: CastEvent) {
+  return HasRelatedEvent(event, ESSENCE_BURST_CONSUME);
 }
 
 export default EssenceBurstCastLinkNormalizer;

--- a/src/analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer.ts
@@ -186,9 +186,19 @@ const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: ESSENCE_BURST_CONSUME,
     reverseLinkRelation: ESSENCE_BURST_CONSUME,
-    linkingEventId: [SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF.id, SPELLS.ESSENCE_BURST_DEV_BUFF.id],
+    linkingEventId: [
+      SPELLS.ESSENCE_BURST_BUFF.id,
+      SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF.id,
+      SPELLS.ESSENCE_BURST_DEV_BUFF.id,
+    ],
     linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
-    referencedEventId: [TALENTS.PYRE_TALENT.id, SPELLS.DISINTEGRATE.id, TALENTS.ERUPTION_TALENT.id],
+    referencedEventId: [
+      TALENTS.PYRE_TALENT.id,
+      SPELLS.DISINTEGRATE.id,
+      TALENTS.ERUPTION_TALENT.id,
+      TALENTS.ECHO_TALENT.id,
+      SPELLS.EMERALD_BLOSSOM_CAST.id,
+    ],
     referencedEventType: EventType.Cast,
     anyTarget: true,
     forwardBufferMs: ESSENCE_BURST_BUFFER,
@@ -204,6 +214,10 @@ class EssenceBurstCastLinkNormalizer extends EventLinkNormalizer {
   };
   constructor(options: Options) {
     super(options, EVENT_LINKS);
+    this.active =
+      this.selectedCombatant.hasTalent(TALENTS.ESSENCE_BURST_PRESERVATION_TALENT) ||
+      this.selectedCombatant.hasTalent(TALENTS.ESSENCE_BURST_AUGMENTATION_TALENT) ||
+      this.selectedCombatant.hasTalent(TALENTS.RUBY_ESSENCE_BURST_TALENT);
   }
 }
 
@@ -322,6 +336,13 @@ function hasNoGenerationLink(event: AnyBuffEvent) {
 /** Check if Spender consumed EB */
 export function isCastFromEB(event: CastEvent) {
   return HasRelatedEvent(event, ESSENCE_BURST_CONSUME);
+}
+
+/** Get the event that consumed EB */
+export function getEssenceBurstConsumeAbility(
+  event: RemoveBuffEvent | RemoveBuffStackEvent,
+): null | CastEvent {
+  return GetRelatedEvent<CastEvent>(event, ESSENCE_BURST_CONSUME) ?? null;
 }
 
 export default EssenceBurstCastLinkNormalizer;

--- a/src/analysis/retail/evoker/shared/modules/talents/ImminentDestruction.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/ImminentDestruction.tsx
@@ -21,7 +21,7 @@ import SPECS from 'game/SPECS';
 import { isCastFromEB } from '../normalizers/EssenceBurstCastLinkNormalizer';
 
 /**
- * Deep Breath reduces the Essence costs of Disintegrate and Pyre by 1
+ * Deep Breath/Breath of Eons reduces the Essence costs of Disintegrate, Pyre and Eruption by 1
  * and increases their damage by 10% for 12 sec after you land.
  */
 class ImminentDestruction extends Analyzer {

--- a/src/analysis/retail/evoker/shared/modules/talents/ImminentDestruction.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/ImminentDestruction.tsx
@@ -1,0 +1,170 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS/evoker';
+import TALENTS from 'common/TALENTS/evoker';
+import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
+import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import SpellLink from 'interface/SpellLink';
+import { formatNumber } from 'common/format';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import Soup from 'interface/icons/Soup';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import ResourceLink from 'interface/ResourceLink';
+import {
+  IMMINENT_DESTRUCTION_ESSENCE_REDUCTION,
+  IMMINENT_DESTRUCTION_MULTIPLIER,
+} from '../../constants';
+import SPECS from 'game/SPECS';
+import { isCastFromEB } from '../normalizers/EssenceBurstCastLinkNormalizer';
+
+/**
+ * Deep Breath reduces the Essence costs of Disintegrate and Pyre by 1
+ * and increases their damage by 10% for 12 sec after you land.
+ */
+class ImminentDestruction extends Analyzer {
+  disintegrateDamage = 0;
+  pyreDamage = 0;
+  eruptionDamage = 0;
+
+  disintegrateEssenceReduction = 0;
+  pyreEssenceReduction = 0;
+  eruptionEssenceReduction = 0;
+
+  imminentDestructionBuffId = 0;
+  isDeva = this.selectedCombatant.spec === SPECS.DEVASTATION_EVOKER;
+
+  constructor(options: Options) {
+    super(options);
+    this.active =
+      this.selectedCombatant.hasTalent(TALENTS.IMMINENT_DESTRUCTION_DEVASTATION_TALENT) ||
+      this.selectedCombatant.hasTalent(TALENTS.IMMINENT_DESTRUCTION_AUGMENTATION_TALENT);
+
+    this.imminentDestructionBuffId = this.isDeva
+      ? SPELLS.IMMINENT_DESTRUCTION_DEV_BUFF.id
+      : SPELLS.IMMINENT_DESTRUCTION_AUG_BUFF.id;
+
+    this.addEventListener(
+      Events.cast
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.DISINTEGRATE, TALENTS.PYRE_TALENT, TALENTS.ERUPTION_TALENT]),
+      this.onCast,
+    );
+
+    this.addEventListener(
+      Events.damage
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.DISINTEGRATE, SPELLS.PYRE, TALENTS.ERUPTION_TALENT]),
+      this.onDamage,
+    );
+  }
+
+  onCast(event: CastEvent) {
+    if (isCastFromEB(event) || !this.selectedCombatant.hasBuff(this.imminentDestructionBuffId)) {
+      return;
+    }
+
+    switch (event.ability.guid) {
+      case SPELLS.DISINTEGRATE.id: {
+        this.disintegrateEssenceReduction += IMMINENT_DESTRUCTION_ESSENCE_REDUCTION;
+        break;
+      }
+      case TALENTS.PYRE_TALENT.id: {
+        this.pyreEssenceReduction += IMMINENT_DESTRUCTION_ESSENCE_REDUCTION;
+        break;
+      }
+      case TALENTS.ERUPTION_TALENT.id: {
+        this.eruptionEssenceReduction += IMMINENT_DESTRUCTION_ESSENCE_REDUCTION;
+        break;
+      }
+    }
+  }
+
+  onDamage(event: DamageEvent) {
+    if (!this.selectedCombatant.hasBuff(this.imminentDestructionBuffId)) {
+      return;
+    }
+
+    const effAmount = calculateEffectiveDamage(event, IMMINENT_DESTRUCTION_MULTIPLIER);
+
+    switch (event.ability.guid) {
+      case SPELLS.DISINTEGRATE.id: {
+        this.disintegrateDamage += effAmount;
+        break;
+      }
+      case SPELLS.PYRE.id: {
+        this.pyreDamage += effAmount;
+        break;
+      }
+      case TALENTS.ERUPTION_TALENT.id: {
+        this.eruptionDamage += effAmount;
+        break;
+      }
+    }
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            {this.isDeva ? (
+              <>
+                <li>
+                  <SpellLink spell={SPELLS.DISINTEGRATE} /> Damage:{' '}
+                  {formatNumber(this.disintegrateDamage)}
+                </li>
+                <li>
+                  <ResourceLink id={RESOURCE_TYPES.ESSENCE.id} /> saved:{' '}
+                  {formatNumber(this.disintegrateEssenceReduction)}
+                </li>
+                <br />
+
+                <li>
+                  <SpellLink spell={SPELLS.PYRE} /> Damage: {formatNumber(this.pyreDamage)}
+                </li>
+                <li>
+                  <ResourceLink id={RESOURCE_TYPES.ESSENCE.id} /> saved:{' '}
+                  {formatNumber(this.pyreEssenceReduction)}
+                </li>
+              </>
+            ) : (
+              <>
+                <li>
+                  <SpellLink spell={TALENTS.ERUPTION_TALENT} /> Damage:{' '}
+                  {formatNumber(this.eruptionDamage)}
+                </li>
+              </>
+            )}
+          </>
+        }
+      >
+        <TalentSpellText
+          talent={
+            this.isDeva
+              ? TALENTS.IMMINENT_DESTRUCTION_DEVASTATION_TALENT
+              : TALENTS.IMMINENT_DESTRUCTION_AUGMENTATION_TALENT
+          }
+        >
+          <ItemDamageDone
+            amount={this.disintegrateDamage + this.pyreDamage + this.eruptionDamage}
+          />
+          <Soup />{' '}
+          {this.disintegrateEssenceReduction +
+            this.pyreEssenceReduction +
+            this.eruptionEssenceReduction}{' '}
+          <small>
+            <ResourceLink id={RESOURCE_TYPES.ESSENCE.id} /> saved
+          </small>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default ImminentDestruction;

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -603,6 +603,16 @@ const spells = {
     name: 'Threads of Fate',
     icon: 'ability_evoker_sandsoftime',
   },
+  IMMINENT_DESTRUCTION_DEV_BUFF: {
+    id: 411055,
+    name: 'Imminent Destruction',
+    icon: 'spell_burningbladeshaman_blazing_radiance',
+  },
+  IMMINENT_DESTRUCTION_AUG_BUFF: {
+    id: 459574,
+    name: 'Imminent Destruction',
+    icon: 'spell_burningbladeshaman_blazing_radiance',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;


### PR DESCRIPTION
### Description

Implemented module for new talent `Imminent Destruction`.

Also made `ESSENCE_BURST_CONSUME` castlinks shared between Deva, Pres and Aug.

Re-making PR due to worktree getting whonky in #6877 when trying to rebase :>

### Testing

- Test report URL: 
deva: `/report/zTcHDqpnvtbwBVZf/5-Mythic++The+Necrotic+Wake+-+Wipe+1+(7:26)/Lfcutedaddy/standard/statistics`
aug: `/report/hFaZ6nTr7zJL4fvK/9-Mythic+Rasha'nan+-+Kill+(5:01)/Flowchur/standard/statistics`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/a328eb3f-e5c1-4fce-bdfb-b1ea576cb471)
