### PR TITLE
use WCL's built-in pagination rather than our 5m-page system

### DIFF
--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -43,7 +43,7 @@ const ResultsLoader = () => {
   const parserClass = useParser(config);
   const isLoadingParser = !parserClass;
 
-  const { events, pageCount, pagesLoaded } = useEvents({ report, fight, player });
+  const { events, currentTime } = useEvents({ report, fight, player });
   const isLoadingEvents = events == null;
 
   const {
@@ -160,7 +160,7 @@ const ResultsLoader = () => {
   });
   const parsingState = isParsingEvents ? EVENT_PARSING_STATE.PARSING : EVENT_PARSING_STATE.DONE;
 
-  const pageProgress = pagesLoaded / pageCount;
+  const pageProgress = (currentTime - fight.start_time) / (fight.end_time - fight.start_time);
 
   const progress =
     (!isLoadingParser ? 0.05 : 0) +

--- a/src/interface/selectors/url/report/getPlayerName.ts
+++ b/src/interface/selectors/url/report/getPlayerName.ts
@@ -13,7 +13,7 @@ export const getPlayerNameFromParam = (param: string | null | undefined) => {
       return player.replace('+', ' ');
     }
     if (!Number.isInteger(player)) {
-      return player;
+      return decodeURIComponent(player);
     }
     return null;
   }


### PR DESCRIPTION
this fixes issues with m+ mass pulls like in Algathar Academy that front-load a huge number of events (the first 5m of a high algethars can be 80+ mb of json)

this requires both [server](https://github.com/WoWAnalyzer/server/pull/62) and WCL changes so unfortunately the ability of people to test this out is going to be limited til at least the WCL change is in
