### PR TITLE
[Mistweaver] Fix mending proliferation

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date (2024, 7, 25), <>Update <SpellLink spell={TALENTS_MONK.MENDING_PROLIFERATION_TALENT}/>.</>, Vohrr),
   change(date (2024, 7, 24), <>Bump patch support to 11.0 and sample log.</>, Vohrr),
   change(date (2024, 7, 23), <>Updated Talent values per July 17th tuning.</>, Vohrr),
   change(date (2024, 7, 4), <>Added <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT}/>.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MendingProliferation.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MendingProliferation.tsx
@@ -10,6 +10,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { ENVELOPING_MIST_INCREASE, MISTWRAP_INCREASE } from '../../constants';
+import SPELLS from 'common/SPELLS';
 
 class MendingProliferation extends Analyzer {
   static dependencies = {
@@ -41,7 +42,7 @@ class MendingProliferation extends Analyzer {
     }
     if (
       this.combatants.players[targetID].hasBuff(
-        TALENTS_MONK.MENDING_PROLIFERATION_TALENT.id,
+        SPELLS.MENDING_PROLIFERATION_BUFF.id,
         event.timestamp,
         0,
         0,

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -212,6 +212,11 @@ const spells = {
     name: 'Vivifacious Vivification',
     icon: 'ability_monk_vivify',
   },
+  MENDING_PROLIFERATION_BUFF: {
+    id: 388510,
+    name: 'Mending Proliferation',
+    icon: 'inv_shoulder_inv_leather_raidmonk_s_01',
+  },
   AT_BUFF: {
     id: 388026,
     name: 'Ancient Teachings',


### PR DESCRIPTION
### Description

Looking at the talent id that the caster monk has instead of the buff id that actually gets applied
