### PR TITLE
handle report not found errors

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 7, 29), 'Fixed handling of not-found and private logs.', emallson),
   change(date(2024, 7, 27), "Fixed an issue where fully supported specs on spec list weren't displaying their maintainer.", Sref),
   change(date(2024, 7, 22), 'Fix partial support indication on spec list.', ToppleTheNun),
   change(date(2024, 7, 22), 'Update Paladin spells for Classic Cataclysm', Ethelis),

--- a/src/common/fetchWclApi.ts
+++ b/src/common/fetchWclApi.ts
@@ -33,6 +33,7 @@ const HTTP_CODES = {
   OK: 200,
   BAD_REQUEST: 400,
   UNAUTHORIZED: 401,
+  NOT_FOUND: 404,
   CLOUDFLARE: {
     UNKNOWN_ERROR: 520,
     WEB_SERVER_IS_DOWN: 521,
@@ -116,6 +117,12 @@ async function rawFetchWcl(endpoint: string, queryParams: QueryParams, noCache: 
     }
     throw new Error(message || json.error);
   }
+
+  if (response.status === HTTP_CODES.NOT_FOUND) {
+    // TODO: this doesn't handle character/guild not found
+    throw new LogNotFoundError();
+  }
+
   if (!response.ok) {
     if (json.error === WCL_API_ERROR_TEXT) {
       throw new WclApiError(`${response.status}: ${json.message}`);


### PR DESCRIPTION
This restores our "Report Not Found" page to a functioning condition, in combination with [this PR](https://github.com/WoWAnalyzer/server/pull/63)

![image](https://github.com/user-attachments/assets/227df7ca-6975-41c4-a444-7d3340249184)
