### PR TITLE
[core] Fix Active Time double dipping on channels

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -39,6 +39,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 7, 31), 'Fixed an issue with AlwaysBeCasting over counting channels.', Vollmer),
   change(date(2024, 7, 29), 'Fixed handling of not-found and private logs.', emallson),
   change(date(2024, 7, 27), "Fixed an issue where fully supported specs on spec list weren't displaying their maintainer.", Sref),
   change(date(2024, 7, 22), 'Fix partial support indication on spec list.', ToppleTheNun),

--- a/src/parser/shared/modules/AlwaysBeCasting.tsx
+++ b/src/parser/shared/modules/AlwaysBeCasting.tsx
@@ -89,7 +89,7 @@ class AlwaysBeCasting extends Analyzer {
       // Ignore prepull casts for active time since active time should only include casts during the
       return false;
     }
-    if (event.trigger.type === EventType.BeginChannel) {
+    if (event.trigger.type === EventType.BeginChannel || event.trigger.channel) {
       // Only add active time for this channel, we do this when the channel is finished and use the highest of the GCD and channel time
       return false;
     }
@@ -122,6 +122,12 @@ class AlwaysBeCasting extends Analyzer {
     if (this.globalCooldown.isOnGlobalCooldown(event.ability.guid)) {
       amount = Math.max(amount, this._lastGlobalCooldownDuration);
     }
+
+    // check if the initial channel is from pre-pull, if it is, only count active time from the beginning of the fight
+    if (!this.activeTimeSegments.length) {
+      amount = Math.min(amount, event.timestamp - this.owner.fight.start_time);
+    }
+
     this.activeTime += amount;
     this._handleNewUptimeSegment(event.timestamp - amount, event.timestamp);
     DEBUG &&


### PR DESCRIPTION
### Description

`AlwaysBeCasting` was double dipping on both `GCD` and `endChannel` for active time, this fixes that.
Also prevented overcounting on `prePull` `endChannel`.

### Testing

- Test report URL: `/report/76abxPF2BjrK83Yg/6-Mythic+Volcoross+-+Kill+(2:23)/Dwx/standard/events`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/7fd64723-c65f-4a48-868d-77e5e5204599)
![image](https://github.com/user-attachments/assets/45fa8fa6-5c8b-40c2-ac38-2e41b252b506)

