### PR TITLE
Core - Fixed an issue where pre-pull channels could cause wildly incorrect Active Time value

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -39,6 +39,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 7, 31), 'Fixed an issue where pre-pull channels could cause wildly incorrect Active Time value', Sref),
   change(date(2024, 7, 31), 'Fixed an issue with AlwaysBeCasting over counting channels.', Vollmer),
   change(date(2024, 7, 29), 'Fixed handling of not-found and private logs.', emallson),
   change(date(2024, 7, 27), "Fixed an issue where fully supported specs on spec list weren't displaying their maintainer.", Sref),

--- a/src/parser/shared/modules/AlwaysBeCasting.tsx
+++ b/src/parser/shared/modules/AlwaysBeCasting.tsx
@@ -106,12 +106,7 @@ class AlwaysBeCasting extends Analyzer {
     this._handleNewUptimeSegment(event.timestamp, event.timestamp + event.duration);
     DEBUG &&
       console.log(
-        'Active Time: added ' +
-          event.duration +
-          ' from GCD for ' +
-          event.trigger.ability.name +
-          ' @ ' +
-          this.owner.formatTimestamp(event.trigger.timestamp),
+        `Active Time: added ${event.duration.toFixed(0)}ms from GCD for ${event.trigger.ability.name} @ ${this.owner.formatTimestamp(event.timestamp, 1)} - ${this.owner.formatTimestamp(event.timestamp + event.duration, 1)}`,
       );
     return true;
   }
@@ -132,12 +127,7 @@ class AlwaysBeCasting extends Analyzer {
     this._handleNewUptimeSegment(event.timestamp - amount, event.timestamp);
     DEBUG &&
       console.log(
-        'Active Time: added ' +
-          amount +
-          ' from Channel for ' +
-          event.ability.name +
-          ' @ ' +
-          this.owner.formatTimestamp(event.timestamp),
+        `Active Time: added ${event.duration.toFixed(0)}ms from Channel for ${event.ability.name} @ ${this.owner.formatTimestamp(event.timestamp - amount, 1)} - ${this.owner.formatTimestamp(event.timestamp, 1)}`,
       );
     return true;
   }

--- a/src/parser/shared/normalizers/Channeling.ts
+++ b/src/parser/shared/normalizers/Channeling.ts
@@ -329,7 +329,7 @@ function buffChannelSpec(spellId: number): ChannelSpec {
     eventIndex: number,
     state: ChannelState,
   ) => {
-    if (event.type === EventType.Cast) {
+    if (event.type === EventType.Cast && !event.prepull) {
       // do standard start channel stuff
       cancelCurrentChannel(event, state);
       beginCurrentChannel(event, state);


### PR DESCRIPTION
### Testing

The following log on live registers an 84 second Evocation channel, throwing off Active Time by a lot. This fixes the issue.
- Test report URL: `/report/XPdQzF34DbRMjp6v/16-Heroic+Rashok,+the+Elder+-+Kill+(2:32)/Cheekclappr/standard/overview`
