### PR TITLE
remove supported specs from tsconfig

### DIFF
--- a/src/analysis/retail/shaman/elemental/guide/MaelstromSubSection.tsx
+++ b/src/analysis/retail/shaman/elemental/guide/MaelstromSubSection.tsx
@@ -13,7 +13,7 @@ export const MaelstromSubSection = ({ modules }: GuideProps<typeof CombatLogPars
       <p>
         Maelstrom is the primary resource of elemental shamans. It empowers our most powerful
         spells: <SpellLink spell={TALENTS_SHAMAN.EARTH_SHOCK_TALENT} />,
-        <SpellLink spell={TALENTS_SHAMAN.EARTHQUAKE_TALENT} /> and{' '}
+        <SpellLink spell={TALENTS_SHAMAN.EARTHQUAKE_1_ELEMENTAL_TALENT} /> and{' '}
         <SpellLink spell={TALENTS_SHAMAN.ELEMENTAL_BLAST_ELEMENTAL_TALENT} />. These spells are
         almost always more powerful than the alternatives so you will want to cast them as much as
         possible.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,12 +41,6 @@
   "exclude": [
     "src/analysis/retail/deathknight/frost",
     "src/analysis/retail/deathknight/unholy",
-    "src/analysis/retail/druid/balance",
-    "src/analysis/retail/druid/guardian",
-    "src/analysis/retail/druid/feral",
-    "src/analysis/retail/druid/restoration",
-    "src/analysis/retail/druid/shared",
-    "src/analysis/retail/mage/frost",
     "src/analysis/retail/monk/windwalker",
     "src/analysis/retail/paladin/holy",
     "src/analysis/retail/priest/shadow",
@@ -68,18 +62,11 @@
     "src/analysis/retail/hunter/marksmanship",
     "src/analysis/retail/hunter/survival",
     "src/analysis/retail/hunter/shared",
-    "src/analysis/retail/shaman/elemental",
-    "src/analysis/retail/shaman/enhancement",
     "src/analysis/retail/shaman/restoration",
     "src/analysis/retail/shaman/shared"
   ],
   "files": [
-    "./src/analysis/retail/deathknight/frost/CONFIG.tsx",
     "./src/analysis/retail/deathknight/unholy/CONFIG.tsx",
-    "./src/analysis/retail/druid/balance/CONFIG.tsx",
-    "./src/analysis/retail/druid/guardian/CONFIG.tsx",
-    "./src/analysis/retail/druid/feral/CONFIG.tsx",
-    "./src/analysis/retail/druid/restoration/CONFIG.tsx",
     "./src/analysis/retail/mage/frost/CONFIG.tsx",
     "./src/analysis/retail/paladin/holy/CONFIG.tsx",
     "./src/analysis/retail/priest/shadow/CONFIG.tsx",
@@ -97,8 +84,6 @@
     "./src/analysis/retail/hunter/beastmastery/CONFIG.tsx",
     "./src/analysis/retail/hunter/marksmanship/CONFIG.tsx",
     "./src/analysis/retail/hunter/survival/CONFIG.tsx",
-    "./src/analysis/retail/shaman/elemental/CONFIG.tsx",
-    "./src/analysis/retail/shaman/enhancement/CONFIG.tsx",
     "./src/analysis/retail/shaman/restoration/CONFIG.tsx"
   ]
 }


### PR DESCRIPTION
i *suspect* that this is causing errors where parsers don't load due to them being excluded from the module tree by the combination of dynamic imports + tsconfig exclusions

