### PR TITLE
force certain modules (StatTracker) to have hash-only names

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,9 +52,9 @@ export default defineConfig((env) => ({
       output: {
         chunkFileNames: (chunkInfo) => {
           if (HASH_ONLY_CHUNKS.has(chunkInfo.name)) {
-            return '[hash].[format]';
+            return '[hash].js';
           }
-          return '[name]-[hash].[format]';
+          return '[name]-[hash].js';
         },
       },
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,11 +41,23 @@ gtag('event', 'ramp_js', { send_to: 'G-E0TKKBEXVD', pageview_id: window._pwGA4Pa
 </head>
 `.trim();
 
+const HASH_ONLY_CHUNKS = new Set(['StatTracker']);
+
 // https://vitejs.dev/config/
 export default defineConfig((env) => ({
   build: {
     cssMinify: env.mode === 'production',
     sourcemap: env.mode === 'production',
+    rollupOptions: {
+      output: {
+        chunkFileNames: (chunkInfo) => {
+          if (HASH_ONLY_CHUNKS.has(chunkInfo.name)) {
+            return '[hash].[format]';
+          }
+          return '[name]-[hash].[format]';
+        },
+      },
+    },
   },
   plugins: [
     tsconfigPaths(),


### PR DESCRIPTION
this should (hopefully) fix the uBlock Origin / EasyPrivacy issue without users needing to add a whitelist or the extension publishing a fix


Confirmed that this fix does not produce a file named `StatTracker-*` by running `vite build` and then:

- `find dist -name 'StatTracker*'` (no results)
- `rg -l StatTracker dist` (produces a list of files referencing it, including `dist/Bg92Bl7u.es` on this particulary build. inspecting that reveals that it contains the `StatTracker` code)