### PR TITLE
[Classic] Cata Priest spells

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -39,6 +39,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 8, 6), 'Update Priest spells for Classic Cataclysm', jazminite),
   change(date(2024, 8, 3), 'Update Engineering items for Classic Cataclysm', jazminite),
   change(date(2024, 8, 1), 'Load routes asynchronously.', ToppleTheNun),
   change(date(2024, 8, 1), 'Add Classic Cataclysm Phase 1 trinkets.', jazminite),

--- a/src/analysis/classic/priest/discipline/modules/features/Abilities.ts
+++ b/src/analysis/classic/priest/discipline/modules/features/Abilities.ts
@@ -47,11 +47,6 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: { base: 1500 },
       },
-      {
-        spell: SPELLS.LESSER_HEAL.id,
-        category: SPELL_CATEGORY.ROTATIONAL,
-        gcd: { base: 1500 },
-      },
       // Rotational AOE
       {
         spell: SPELLS.PRAYER_OF_HEALING.id,
@@ -149,22 +144,12 @@ class Abilities extends CoreAbilities {
       },
       // Utility
       {
-        spell: [SPELLS.ABOLISH_DISEASE.id],
-        category: SPELL_CATEGORY.UTILITY,
-        gcd: { base: 1500 },
-      },
-      {
         spell: [SPELLS.CURE_DISEASE.id],
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },
       {
         spell: [SPELLS.DISPEL_MAGIC.id],
-        category: SPELL_CATEGORY.UTILITY,
-        gcd: { base: 1500 },
-      },
-      {
-        spell: SPELLS.DIVINE_SPIRIT.id,
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },

--- a/src/analysis/classic/priest/discipline/modules/features/AlwaysBeCasting.tsx
+++ b/src/analysis/classic/priest/discipline/modules/features/AlwaysBeCasting.tsx
@@ -15,7 +15,6 @@ class AlwaysBeCasting extends CoreAlwaysBeCastingHealing {
     SPELLS.RENEW.id,
     SPELLS.GREATER_HEAL.id,
     SPELLS.HEAL.id,
-    SPELLS.LESSER_HEAL.id,
     SPELLS.PRAYER_OF_HEALING.id,
     SPELLS.HOLY_NOVA.id,
   ];

--- a/src/analysis/classic/priest/shadow/modules/features/Abilities.ts
+++ b/src/analysis/classic/priest/shadow/modules/features/Abilities.ts
@@ -81,17 +81,7 @@ class Abilities extends CoreAbilities {
       },
       // Utility
       {
-        spell: [SPELLS.ABOLISH_DISEASE.id],
-        category: SPELL_CATEGORY.UTILITY,
-        gcd: { base: 1500 },
-      },
-      {
         spell: SPELLS.DISPEL_MAGIC.id,
-        category: SPELL_CATEGORY.UTILITY,
-        gcd: { base: 1500 },
-      },
-      {
-        spell: SPELLS.DIVINE_SPIRIT.id,
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },
@@ -126,7 +116,7 @@ class Abilities extends CoreAbilities {
         gcd: { base: 1500 },
       },
       {
-        spell: SPELLS.PRAYER_OF_SHADOW_PROTECTION.id,
+        spell: SPELLS.SHADOW_PROTECTION.id,
         category: SPELL_CATEGORY.UTILITY,
         gcd: { base: 1500 },
       },

--- a/src/analysis/classic/priest/shared/Haste.ts
+++ b/src/analysis/classic/priest/shared/Haste.ts
@@ -6,7 +6,8 @@ class Haste extends CoreHaste {
   hasteBuffs = {
     ...DEFAULT_HASTE_BUFFS,
     ...BLOODLUST_BUFFS,
-    [SPELLS.BORROWED_TIME.id]: 0.25,
+    [SPELLS.BORROWED_TIME_7.id]: 0.07,
+    [SPELLS.BORROWED_TIME_14.id]: 0.14,
   };
 }
 

--- a/src/common/SPELLS/classic/priest.ts
+++ b/src/common/SPELLS/classic/priest.ts
@@ -1,5 +1,5 @@
 /**
- * All WotLK Priest spells (including talent spells) go here.
+ * All Classic Priest spells (including talent spells) go here.
  * You need to do this manually by opening a WCL report and clicking the icons of spells to open the relevant Wowhead page. Here, you can get the icon name by clicking the icon, copy the name of the spell, and the ID is in the URL.
  * You can access these entries like other entries in the spells files by importing `common/SPELLS/classic` and using the assigned property on the SPELLS object. Please try to avoid abbreviating properties.
  */
@@ -10,323 +10,321 @@ const spells = {
   // --------
   // SHARED
   // --------
-  ABOLISH_DISEASE: {
-    id: 552,
-    name: 'Abolish Disease',
-    icon: 'spell_nature_nullifydisease',
-  },
   BINDING_HEAL: {
-    id: 48120,
+    id: 32546,
     name: 'Binding Heal',
-    icon: 'spell_holy_blindingheal',
+    icon: 'spell_holy_blindingheal.jpg',
   },
   BLESSED_HEALING: {
     id: 70772,
     name: 'Blessed Healing',
-    icon: 'spell_holy_flashheal',
+    icon: 'spell_holy_flashheal.jpg',
   },
   CURE_DISEASE: {
     id: 528,
     name: 'Cure Disease',
-    icon: 'spell_holy_nullifydisease',
+    icon: 'spell_holy_nullifydisease.jpg',
   },
   DEVOURING_PLAGUE: {
     id: 2944,
     name: 'Devouring Plague',
-    icon: 'spell_shadow_devouringplague',
+    icon: 'spell_shadow_devouringplague.jpg',
   },
   DISPEL_MAGIC: {
-    id: 988,
+    id: 527,
     name: 'Dispel Magic',
-    icon: 'spell_holy_dispelmagic',
+    icon: 'spell_holy_dispelmagic.jpg',
   },
   DIVINE_HYMN: {
     id: 64843,
     name: 'Divine Hymn',
-    icon: 'spell_holy_divinehymn',
+    icon: 'spell_holy_divinehymn.jpg',
   },
   DIVINE_HYMN_HEAL: {
     id: 64844,
     name: 'Divine Hymn',
-    icon: 'spell_holy_divinehymn',
+    icon: 'spell_holy_divineprovidence.jpg',
   },
-  DIVINE_SPIRIT: {
-    id: 48073,
-    name: 'Divine Spirit',
-    icon: 'spell_holy_divinespirit',
-  },
-  EMPOWERED_RENEW: {
+  DIVINE_TOUCH: {
     id: 63544,
-    name: 'Empowered Renew',
-    icon: 'ability_paladin_infusionoflight',
+    name: 'Divine Touch',
+    icon: 'ability_paladin_infusionoflight.jpg',
   },
   FADE: {
     id: 586,
     name: 'Fade',
-    icon: 'spell_magic_lesserinvisibilty',
+    icon: 'spell_magic_lesserinvisibilty.jpg',
   },
   FEAR_WARD: {
     id: 6346,
     name: 'Fear Ward',
-    icon: 'spell_holy_excorcism',
+    icon: 'spell_holy_excorcism.jpg',
   },
   FLASH_HEAL: {
     id: 2061,
     name: 'Flash Heal',
-    icon: 'spell_holy_flashheal',
+    icon: 'spell_holy_flashheal.jpg',
   },
   // Separate spell when Surge of Light is active
   FLASH_HEAL_SURGE_OF_LIGHT: {
     id: 101062,
     name: 'Flash Heal',
-    icon: 'spell_holy_flashheal',
+    icon: 'spell_holy_flashheal.jpg',
   },
   GREATER_HEAL: {
-    id: 48063,
+    id: 2060,
     name: 'Greater Heal',
-    icon: 'spell_holy_greaterheal',
+    icon: 'spell_holy_greaterheal.jpg',
   },
   HEAL: {
     id: 2050,
     name: 'Heal',
-    icon: 'spell_holy_heal02',
+    icon: 'spell_holy_lesserheal.jpg',
   },
   HOLY_FIRE: {
     id: 14914,
     name: 'Holy Fire',
-    icon: 'spell_holy_searinglight',
+    icon: 'spell_holy_searinglight.jpg',
   },
   HOLY_NOVA: {
-    id: 48078,
+    id: 15237,
     name: 'Holy Nova',
-    icon: 'spell_holy_holynova',
+    icon: 'spell_holy_holynova.jpg',
   },
   HYMN_OF_HOPE: {
     id: 64901,
     name: 'Hymn of Hope',
-    icon: 'spell_holy_symbolofhope',
+    icon: 'spell_holy_symbolofhope.jpg',
   },
   HYMN_OF_HOPE_BUFF: {
     id: 64904,
     name: 'Hymn of Hope',
-    icon: 'spell_holy_rapture',
+    icon: 'spell_holy_rapture.jpg',
   },
   INNER_FIRE: {
     id: 588,
     name: 'Inner Fire',
-    icon: 'spell_holy_innerfire',
+    icon: 'spell_holy_innerfire.jpg',
   },
-  INNER_FOCUS: {
-    id: 89485,
-    name: 'Inner Focus',
-    icon: 'spell_frost_windwalkon',
+  INNER_WILL: {
+    id: 73413,
+    name: 'Inner Will',
+    icon: 'priest_icon_innewill.jpg',
   },
-  LESSER_HEAL: {
-    id: 2053,
-    name: 'Lesser Heal',
-    icon: 'spell_holy_lesserheal',
+  LEAP_OF_FAITH: {
+    id: 73325,
+    name: 'Leap of Faith',
+    icon: 'priest_spell_leapoffaith_a.jpg',
   },
   LEVITATE: {
     id: 1706,
     name: 'Levitate',
-    icon: 'spell_holy_layonhands',
+    icon: 'spell_holy_layonhands.jpg',
   },
   MANA_BURN: {
     id: 8129,
     name: 'Mana Burn',
-    icon: 'spell_shadow_manaburn',
+    icon: 'spell_shadow_manaburn.jpg',
   },
   MASS_DISPEL: {
     id: 32375,
     name: 'Mass Dispel',
-    icon: 'spell_arcane_massdispel',
+    icon: 'spell_arcane_massdispel.jpg',
   },
   MIND_BLAST: {
     id: 8092,
     name: 'Mind Blast',
-    icon: 'spell_shadow_unholyfrenzy',
+    icon: 'spell_shadow_unholyfrenzy.jpg',
   },
   MIND_CONTROL: {
     id: 605,
     name: 'Mind Control',
-    icon: 'spell_shadow_shadowworddominate',
+    icon: 'spell_shadow_shadowworddominate.jpg',
   },
   MIND_SEAR: {
-    id: 53023,
+    id: 48045,
     name: 'Mind Sear',
-    icon: 'spell_shadow_mindshear',
+    icon: 'spell_shadow_mindshear.jpg',
   },
   MIND_SOOTHE: {
     id: 453,
     name: 'Mind Soothe',
-    icon: 'spell_holy_mindsooth',
+    icon: 'spell_holy_mindsooth.jpg',
+  },
+  MIND_SPIKE: {
+    id: 73510,
+    name: 'Mind Spike',
+    icon: 'spell_priest_mindspike.jpg',
   },
   MIND_VISION: {
-    id: 10909,
+    id: 2096,
     name: 'Mind Vision',
-    icon: 'spell_holy_mindvision',
+    icon: 'spell_holy_mindvision.jpg',
   },
   POWER_WORD_FORTITUDE: {
     id: 21562,
     name: 'Power Word: Fortitude',
-    icon: 'spell_holy_wordfortitude',
+    icon: 'spell_holy_wordfortitude.jpg',
   },
   POWER_WORD_SHIELD: {
     id: 17,
     name: 'Power Word Shield',
-    icon: 'spell_holy_powerwordshield',
+    icon: 'spell_holy_powerwordshield.jpg',
   },
   PRAYER_OF_HEALING: {
     id: 596,
     name: 'Prayer of Healing',
-    icon: 'spell_holy_prayerofhealing02',
+    icon: 'spell_holy_prayerofhealing02.jpg',
   },
   PRAYER_OF_MENDING: {
     id: 33076,
     name: 'Prayer of Mending',
-    icon: 'spell_holy_prayerofmendingtga',
+    icon: 'spell_holy_prayerofmendingtga.jpg',
   },
   PRAYER_OF_MENDING_HEAL: {
     id: 33110,
     name: 'Prayer of Mending',
-    icon: 'spell_holy_prayerofmendingtga',
-  },
-  PRAYER_OF_SHADOW_PROTECTION: {
-    id: 48170,
-    name: 'Prayer of Shadow Protection',
-    icon: 'spell_holy_prayerofshadowprotection',
-  },
-  PRAYER_OF_SPIRIT: {
-    id: 48074,
-    name: 'Prayer of Spirit',
-    icon: 'spell_holy_prayerofspirit',
+    icon: 'spell_holy_prayerofmendingtga.jpg',
   },
   PSYCHIC_SCREAM: {
-    id: 10890,
+    id: 8122,
     name: 'Psychic Scream',
-    icon: 'spell_shadow_psychicscream',
+    icon: 'spell_shadow_psychicscream.jpg',
   },
   RENEW: {
     id: 139,
     name: 'Renew',
-    icon: 'spell_holy_renew',
+    icon: 'spell_holy_renew.jpg',
   },
   SHACKLE_UNDEAD: {
-    id: 10955,
+    id: 9484,
     name: 'Shackle Undead',
-    icon: 'spell_nature_slow',
+    icon: 'spell_nature_slow.jpg',
   },
   SHADOW_PROTECTION: {
-    id: 48169,
+    id: 27683,
     name: 'Shadow Protection',
-    icon: 'spell_shadow_antishadow',
+    icon: 'spell_holy_prayerofshadowprotection.jpg',
   },
   SHADOW_WORD_DEATH: {
-    id: 48158,
+    id: 32379,
     name: 'Shadow Word Death',
-    icon: 'spell_shadow_demonicfortitude',
+    icon: 'spell_shadow_demonicfortitude.jpg',
   },
   SHADOW_WORD_PAIN: {
     id: 589,
     name: 'Shadow Word Pain',
-    icon: 'spell_shadow_shadowwordpain',
+    icon: 'spell_shadow_shadowwordpain.jpg',
   },
   SHADOW_FIEND: {
     id: 34433,
     name: 'Shadowfiend',
-    icon: 'spell_shadow_shadowfiend',
+    icon: 'spell_shadow_shadowfiend.jpg',
   },
   SMITE: {
     id: 585,
     name: 'Smite',
-    icon: 'spell_holy_holysmite',
+    icon: 'spell_holy_holysmite.jpg',
   },
   // ---------
   // TALENTS
   // ---------
   // Discipline
-  BORROWED_TIME: {
-    id: 59891,
+  ARCHANGEL: {
+    id: 87151,
+    name: 'Archangel',
+    icon: 'ability_priest_archangel.jpg',
+  },
+  BORROWED_TIME_7: {
+    id: 59887,
     name: 'Borrowed Time',
-    icon: 'spell_holy_borrowedtime',
+    icon: 'spell_holy_borrowedtime.jpg',
+  },
+  BORROWED_TIME_14: {
+    id: 59888,
+    name: 'Borrowed Time',
+    icon: 'spell_holy_borrowedtime.jpg',
+  },
+  INNER_FOCUS: {
+    id: 89485,
+    name: 'Inner Focus',
+    icon: 'spell_frost_windwalkon.jpg',
   },
   PAIN_SUPPRESSION: {
     id: 33206,
     name: 'Pain Suppression',
-    icon: 'spell_holy_painsupression',
+    icon: 'spell_holy_painsupression.jpg',
   },
   PENANCE: {
-    id: 53007,
+    id: 47540,
     name: 'Penance',
-    icon: 'spell_holy_penance',
+    icon: 'spell_holy_penance.jpg',
   },
   PENANCE_DAMAGE: {
-    id: 53000,
+    id: 47666,
     name: 'Penance',
-    icon: 'spell_holy_penance',
+    icon: 'spell_holy_penance.jpg',
   },
   PENANCE_HEALING: {
-    id: 52985,
+    id: 47750,
     name: 'Penance',
-    icon: 'spell_holy_penance',
+    icon: 'spell_holy_penance.jpg',
   },
   POWER_INFUSION: {
     id: 10060,
     name: 'Power Infusion',
-    icon: 'spell_holy_powerinfusion',
+    icon: 'spell_holy_powerinfusion.jpg',
   },
   RAPTURE: {
-    id: 63654,
+    id: 47755,
     name: 'Rapture',
-    icon: 'spell_holy_rapture',
+    icon: 'spell_holy_rapture.jpg',
   },
-  RENEWED_HOPE_TALENT: {
-    id: 57470,
-    name: 'Renewed Hope',
+  POWER_WORD_BARRIER: {
+    id: 62618,
+    name: 'Power Word: Barrier',
     icon: 'spell_holy_holyprotection',
   },
   // Holy
-
-  CHAKRA: { id: 14751, name: 'Chakra', icon: 'spell_frost_windwalkon.jpg' },
-  CHAKRA_SERENITY_BUFF: {
-    id: 81208,
-    name: 'Chakra: Serenity',
-    icon: 'priest_icon_chakra',
-  },
-  CHAKRA_SANCTUARY_BUFF: {
-    id: 81206,
-    name: 'Chakra: Sanctuary',
-    icon: 'priest_icon_chakra_blue',
+  CHAKRA: {
+    id: 14751,
+    name: 'Chakra',
+    icon: 'spell_frost_windwalkon.jpg',
   },
   CHAKRA_CHASTISE_BUFF: {
     id: 81209,
     name: 'Chakra: Chastise',
-    icon: 'priest_icon_chakra_red',
+    icon: 'priest_icon_chakra_red.jpg',
+  },
+  CHAKRA_SANCTUARY_BUFF: {
+    id: 81206,
+    name: 'Chakra: Sanctuary',
+    icon: 'priest_icon_chakra_blue.jpg',
+  },
+  CHAKRA_SERENITY_BUFF: {
+    id: 81208,
+    name: 'Chakra: Serenity',
+    icon: 'priest_icon_chakra.jpg',
   },
   CIRCLE_OF_HEALING: {
     id: 34861,
     name: 'Circle of Healing',
-    icon: 'spell_holy_circleofrenewal',
+    icon: 'spell_holy_circleofrenewal.jpg',
   },
   DESPERATE_PRAYER: {
     id: 19236,
     name: 'Desperate Prayer',
-    icon: 'spell_holy_restoration',
+    icon: 'spell_holy_restoration.jpg',
   },
   GUARDIAN_SPIRIT: {
     id: 47788,
     name: 'Guardian Spirit',
-    icon: 'spell_holy_guardianspirit',
+    icon: 'spell_holy_guardianspirit.jpg',
   },
-  LIGHTWELL: {
-    id: 724,
-    name: 'Lightwell',
-    icon: 'spell_holy_summonlightwell',
-  },
-  LIGHTWELL_HEAL: {
-    id: 7001,
-    name: 'Lightwell',
-    icon: 'spell_holy_summonlightwell',
+  HOLY_WORD_CHASTISE: {
+    id: 88625,
+    name: 'Holy Word: Chastise',
+    icon: 'spell_holy_chastise.jpg',
   },
   HOLY_WORD_SANCTUARY: {
     id: 88685,
@@ -343,39 +341,50 @@ const spells = {
     name: 'Holy Word: Serenity',
     icon: 'spell_holy_persuitofjustice.jpg',
   },
-  HOLY_WORD_CHASTISE: { id: 88625, name: 'Holy Word: Chastise', icon: 'spell_holy_chastise.jpg' },
+  LIGHTWELL: {
+    id: 724,
+    name: 'Lightwell',
+    icon: 'spell_holy_summonlightwell.jpg',
+  },
+  LIGHTWELL_HEAL: {
+    id: 7001,
+    name: 'Lightwell',
+    icon: 'spell_holy_summonlightwell.jpg',
+  },
   // Shadow
   DISPERSION: {
     id: 47585,
     name: 'Dispersion',
-    icon: 'spell_shadow_dispersion',
+    icon: 'spell_shadow_dispersion.jpg',
   },
   MIND_FLAY: {
-    id: 48156,
+    id: 15407,
     name: 'Mind Flay',
-    icon: 'spell_shadow_siphonmana',
+    icon: 'spell_shadow_siphonmana.jpg',
   },
   PAIN_AND_SUFFERING_TALENT: {
-    id: 47582,
-    name: 'Pain and Suffering',
-    icon: 'spell_shadow_painandsuffering',
+    id: 47581,
+    name: 'Pain and Suffering.jpg',
+    icon: 'spell_shadow_painandsuffering.jpg',
   },
   PSYCHIC_HORROR: {
     id: 64044,
     name: 'Psychic Horror',
-    icon: 'spell_shadow_psychichorrors',
+    icon: 'spell_shadow_psychichorrors.jpg',
   },
   SHADOWFORM: {
     id: 15473,
     name: 'Shadowform',
-    icon: 'spell_shadow_shadowform',
+    icon: 'spell_shadow_shadowform.jpg',
   },
   SHADOW_WEAVING_BUFF: {
+    // TODO: Remove when updating Shadow spec
     id: 15258,
     name: 'Shadow Weaving',
     icon: 'spell_shadow_blackplague',
   },
   SHADOW_WEAVING_TALENT: {
+    // TODO: Remove when updating Shadow spec
     id: 15332,
     name: 'Shadow Weaving',
     icon: 'spell_shadow_blackplague',
@@ -383,17 +392,17 @@ const spells = {
   SILENCE: {
     id: 15487,
     name: 'Silence',
-    icon: 'spell_shadow_impphaseshift',
+    icon: 'ability_priest_silence.jpg',
   },
   VAMPIRIC_EMBRACE: {
     id: 15286,
     name: 'Vampiric Embrace',
-    icon: 'spell_shadow_unsummonbuilding',
+    icon: 'spell_shadow_unsummonbuilding.jpg',
   },
   VAMPIRIC_TOUCH: {
-    id: 48160,
+    id: 34914,
     name: 'Vampiric Touch',
-    icon: 'spell_holy_stoicism',
+    icon: 'spell_holy_stoicism.jpg',
   },
   // -----
   // PET
@@ -401,7 +410,7 @@ const spells = {
   SHADOW_FIEND_MANA_LEECH: {
     id: 34650,
     name: 'Shadow Fiend Mana Leech',
-    icon: 'spell_shadow_siphonmana',
+    icon: 'spell_shadow_shadowmend.jpg',
   },
 } satisfies Record<string, Spell>;
 

--- a/src/interface/ReportRaidBuffList.tsx
+++ b/src/interface/ReportRaidBuffList.tsx
@@ -67,8 +67,6 @@ const CLASSIC_RAID_BUFFS = new Map<Spell, Array<Class | object>>([
   // BUFFS
   // Stamina
   [CLASSIC_SPELLS.POWER_WORD_FORTITUDE, [Class.Priest]],
-  // Spirit
-  [CLASSIC_SPELLS.PRAYER_OF_SPIRIT, [Class.Priest]],
   // Intellect
   [CLASSIC_SPELLS.ARCANE_BRILLIANCE, [Class.Mage]],
   // Stats


### PR DESCRIPTION
### Description
- Update Priest spells for Classic Cataclysm
- Remove Prayer of Spirit Raid buff (removed in Cata)

### Testing
N/A
