### PR TITLE
adjust the Active Time section for Arms War to have lower downtime

### DIFF
--- a/src/analysis/classic/warrior/arms/CHANGELOG.tsx
+++ b/src/analysis/classic/warrior/arms/CHANGELOG.tsx
@@ -3,5 +3,6 @@ import { emallson } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 8, 8), 'Adjust active time section of the Arms Warrior guide', emallson),
   change(date(2024, 8, 4), 'Added foundational support for Arms Warrior', emallson),
 ];

--- a/src/analysis/classic/warrior/arms/CombatLogParser.ts
+++ b/src/analysis/classic/warrior/arms/CombatLogParser.ts
@@ -9,7 +9,8 @@ import CooldownThroughputTracker from './modules/features/CooldownThroughputTrac
 import Overpower from '../shared/Overpower';
 import Execute from '../shared/Execute';
 import SuddenDeath from './modules/spells/SuddenDeath';
-import FoundationGuide from 'interface/guide/foundation/FoundationGuide';
+import Guide from './Guide';
+import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 
 class CombatLogParser extends BaseCombatLogParser {
   static specModules = {
@@ -18,13 +19,14 @@ class CombatLogParser extends BaseCombatLogParser {
     abilities: Abilities,
     buffs: Buffs,
     cooldownThroughputTracker: CooldownThroughputTracker,
+    alwaysBeCasting: AlwaysBeCasting,
     // Spells
     overpower: Overpower,
     execute: Execute,
     suddenDeath: SuddenDeath,
   };
 
-  static guide = FoundationGuide;
+  static guide = Guide;
 }
 
 export default CombatLogParser;

--- a/src/analysis/classic/warrior/arms/Guide.tsx
+++ b/src/analysis/classic/warrior/arms/Guide.tsx
@@ -1,0 +1,84 @@
+import { Section, SubSection, useAnalyzer, useInfo } from 'interface/guide';
+import Para from 'interface/guide/Para';
+import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
+import { FoundationCooldownSection } from 'interface/guide/foundation/FoundationCooldownSection';
+import { useExpansionContext } from 'interface/report/ExpansionContext';
+import { FoundationHighlight as HL } from 'interface/guide/foundation/shared';
+import Explanation from 'interface/guide/components/Explanation';
+import ResourceLink from 'interface/ResourceLink';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { TooltipElement } from 'interface/Tooltip';
+import PerformanceStrong from 'interface/PerformanceStrong';
+import { formatPercentage } from 'common/format';
+import AlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
+import ActiveTimeGraph from 'parser/ui/ActiveTimeGraph';
+
+export default function Guide(): JSX.Element {
+  const { expansion } = useExpansionContext();
+  return (
+    <>
+      <Section title="Core Skills">
+        <ArmsDowntimeSection />
+        <FoundationCooldownSection />
+      </Section>
+      <PreparationSection expansion={expansion} />
+    </>
+  );
+}
+
+function ArmsDowntimeSection() {
+  const info = useInfo();
+  const alwaysBeCasting = useAnalyzer(AlwaysBeCasting);
+
+  if (!info || !alwaysBeCasting) {
+    return null;
+  }
+
+  return (
+    <SubSection title="Always Be Casting">
+      <Explanation>
+        <Para>
+          The foundation of good play in <em>World of Warcraft</em> is having low downtime. The
+          first step is to <strong>Always Be Casting</strong>. It is better to use the wrong spell
+          and keep going than it is to stop and think between each cast&mdash;using nothing does no
+          damage or healing, but using anything (even if it isn't the <em>best</em> choice) will at
+          least do <em>something.</em>
+        </Para>
+        <Para>
+          In Cataclysm, Arms Warrior does not have enough abilities or{' '}
+          <ResourceLink id={RESOURCE_TYPES.RAGE.id} /> to fill every GCD. This means that you will
+          have lower{' '}
+          <TooltipElement content={<>The percentage of time spent using spells and abilities.</>}>
+            Active Time
+          </TooltipElement>{' '}
+          than other specs.
+        </Para>
+        <Para>
+          With practice, you can keep active <em>and</em> pick the right spells for each moment, but
+          remember that <strong>doing something is better than doing nothing</strong>.
+        </Para>
+      </Explanation>
+
+      <Para>
+        Active Time:{' '}
+        <PerformanceStrong performance={alwaysBeCasting.DowntimePerformance}>
+          {formatPercentage(alwaysBeCasting.activeTimePercentage, 1)}%
+        </PerformanceStrong>{' '}
+      </Para>
+      <Para>
+        <ActiveTimeGraph
+          activeTimeSegments={alwaysBeCasting.activeTimeSegments}
+          fightStart={info.fightStart}
+          fightEnd={info.fightEnd}
+        />
+      </Para>
+      <Para>
+        As a general guideline,{' '}
+        <HL>
+          you should have <strong>70%+</strong> active time during normal phases of a boss fight.
+        </HL>{' '}
+        Exceptional players will often hit <em>nearly 100%</em> during these periods.
+      </Para>
+    </SubSection>
+  );
+}

--- a/src/analysis/classic/warrior/arms/modules/features/AlwaysBeCasting.ts
+++ b/src/analysis/classic/warrior/arms/modules/features/AlwaysBeCasting.ts
@@ -1,0 +1,16 @@
+import { ThresholdStyle, type NumberThreshold } from 'parser/core/ParseResults';
+import CoreAlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
+
+export default class AlwaysBeCasting extends CoreAlwaysBeCasting {
+  get downtimeSuggestionThresholds(): NumberThreshold {
+    return {
+      actual: this.downtimePercentage,
+      isGreaterThan: {
+        minor: 0.25,
+        average: 0.3,
+        major: 0.35,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+}


### PR DESCRIPTION
Arms does not have enough abilities (due to cooldowns) or resources to fill every GCD. Slam is the on-GCD filler but since everything costs Rage, you can end up without rage to use it (either literally unable, or only able if you were to delay your next cooldown-based rage spender)

## Before
![image](https://github.com/user-attachments/assets/63d82651-c9d1-4f54-bf75-359baf4ebd92)


## After

![image](https://github.com/user-attachments/assets/80b33449-5d0d-47e4-8929-2ae09e9401c5)
