### PR TITLE
Fix Classic Arcane Mage active time estimation

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 8, 9), <>Fix the haste bonus of <SpellLink spell={SPELLS.BERSERKING.id} /> in Classic Cataclysm.</>, emallson),
   change(date(2024, 8, 7), 'Prepare for cleanup of Dragonflight items.', ToppleTheNun),
   change(date(2024, 8, 6), 'Update Priest spells for Classic Cataclysm', jazminite),
   change(date(2024, 8, 3), 'Update Engineering items for Classic Cataclysm', jazminite),

--- a/src/analysis/classic/druid/shared/Haste.ts
+++ b/src/analysis/classic/druid/shared/Haste.ts
@@ -1,9 +1,8 @@
-import CoreHaste, { DEFAULT_HASTE_BUFFS } from 'parser/shared/modules/Haste';
+import CoreHaste from 'parser/shared/modules/Haste';
 import SPELLS from 'common/SPELLS/classic/druid';
 
 class Haste extends CoreHaste {
-  hasteBuffs = {
-    ...DEFAULT_HASTE_BUFFS,
+  override hasteBuffOverrides = {
     [SPELLS.NATURES_GRACE_BUFF.id]: 0.2,
     [SPELLS.MOONKIN_AURA.id]: 0.03,
   };

--- a/src/analysis/classic/hunter/marksman/modules/features/Haste.ts
+++ b/src/analysis/classic/hunter/marksman/modules/features/Haste.ts
@@ -1,9 +1,8 @@
-import CoreHaste, { DEFAULT_HASTE_BUFFS } from 'parser/shared/modules/Haste';
+import CoreHaste from 'parser/shared/modules/Haste';
 import SPELLS from 'common/SPELLS/classic/hunter';
 
 class Haste extends CoreHaste {
-  hasteBuffs = {
-    ...DEFAULT_HASTE_BUFFS,
+  override hasteBuffOverrides = {
     [SPELLS.RAPID_FIRE.id]: 0.4,
   };
 }

--- a/src/analysis/classic/hunter/survival/modules/features/Haste.ts
+++ b/src/analysis/classic/hunter/survival/modules/features/Haste.ts
@@ -1,9 +1,8 @@
-import CoreHaste, { DEFAULT_HASTE_BUFFS } from 'parser/shared/modules/Haste';
+import CoreHaste from 'parser/shared/modules/Haste';
 import SPELLS from 'common/SPELLS/classic/hunter';
 
 class Haste extends CoreHaste {
-  hasteBuffs = {
-    ...DEFAULT_HASTE_BUFFS,
+  override hasteBuffOverrides = {
     [SPELLS.RAPID_FIRE.id]: 0.4,
   };
 }

--- a/src/analysis/classic/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/classic/mage/arcane/CHANGELOG.tsx
@@ -1,6 +1,10 @@
 import { change, date } from 'common/changelog';
-import { jazminite } from 'CONTRIBUTORS';
+import { emallson, jazminite } from 'CONTRIBUTORS';
+import SpellLink from 'interface/SpellLink';
+import CLASSIC_SPELLS from 'common/SPELLS/classic';
 
+// prettier-ignore
 export default [
+  change(date(2024, 8, 9), <>Correct some GCD / Channeling issues with <SpellLink spell={CLASSIC_SPELLS.ARCANE_MISSILES} /> and <SpellLink spell={CLASSIC_SPELLS.ARCANE_EXPLOSION} /></>, emallson),
   change(date(2024, 7, 23), 'Add foundation guide for Cata Classic Mage Arcane spec.', jazminite),
 ];

--- a/src/analysis/classic/mage/arcane/modules/Abilities.tsx
+++ b/src/analysis/classic/mage/arcane/modules/Abilities.tsx
@@ -7,14 +7,9 @@ class Abilities extends CoreAbilities {
     return [
       // Rotational
       {
-        spell: [SPELLS.ARCANE_MISSILES_CHANNELED.id],
-        category: SPELL_CATEGORY.ROTATIONAL,
-        gcd: { base: 1500 },
-      },
-      {
         spell: [SPELLS.ARCANE_MISSILES.id],
         category: SPELL_CATEGORY.ROTATIONAL,
-        gcd: null,
+        gcd: { base: 1500 },
       },
       {
         spell: [SPELLS.ARCANE_BLAST.id],
@@ -36,7 +31,7 @@ class Abilities extends CoreAbilities {
       {
         spell: [SPELLS.ARCANE_EXPLOSION.id],
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
-        gcd: { base: 1500 },
+        gcd: { base: 1000 },
       },
       // Cooldowns
       {

--- a/src/analysis/classic/mage/arcane/normalizers/ArcaneMissiles.tsx
+++ b/src/analysis/classic/mage/arcane/normalizers/ArcaneMissiles.tsx
@@ -31,7 +31,6 @@ function isArcaneMissilesEvent(event: AnyEvent) {
 }
 
 function createBeginChannelEvent(event: CastEvent): ArcaneMissilesBeginChannelEvent {
-  event.ability.guid = SPELLS.ARCANE_MISSILES_CHANNELED.id;
   const beginChannel: ArcaneMissilesBeginChannelEvent = {
     ...event,
     type: EventType.BeginChannel,
@@ -101,6 +100,15 @@ class ArcaneMissilesNormalizer extends EventsNormalizer {
         ) {
           const endChannelEvent = createEndChannelEvent(event, this.beginChannelEvent);
           fixedEvents.push(endChannelEvent);
+        }
+
+        // to fix an interaction with the GCD analyzer, we are going to omit all cast events except the first.
+        if (
+          event.type === EventType.Cast &&
+          this.beginChannelEvent &&
+          this.beginChannelEvent.arcaneMissilesCastEvents[0] !== event
+        ) {
+          return;
         }
       }
       if (event.type === EventType.Damage && isArcaneMissilesEvent(event)) {

--- a/src/analysis/classic/mage/shared/Haste.ts
+++ b/src/analysis/classic/mage/shared/Haste.ts
@@ -1,9 +1,8 @@
-import CoreHaste, { DEFAULT_HASTE_BUFFS } from 'parser/shared/modules/Haste';
+import CoreHaste from 'parser/shared/modules/Haste';
 import SPELLS from 'common/SPELLS/classic/mage';
 
 class Haste extends CoreHaste {
-  hasteBuffs = {
-    ...DEFAULT_HASTE_BUFFS,
+  override hasteBuffOverrides = {
     [SPELLS.ICY_VEINS.id]: 0.2,
     [SPELLS.PYROMANIAC.id]: 0.05,
   };

--- a/src/analysis/classic/priest/shared/Haste.ts
+++ b/src/analysis/classic/priest/shared/Haste.ts
@@ -1,11 +1,8 @@
-import CoreHaste, { DEFAULT_HASTE_BUFFS } from 'parser/shared/modules/Haste';
-import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
+import CoreHaste from 'parser/shared/modules/Haste';
 import SPELLS from 'common/SPELLS/classic/priest';
 
 class Haste extends CoreHaste {
-  hasteBuffs = {
-    ...DEFAULT_HASTE_BUFFS,
-    ...BLOODLUST_BUFFS,
+  override hasteBuffOverrides = {
     [SPELLS.BORROWED_TIME_7.id]: 0.07,
     [SPELLS.BORROWED_TIME_14.id]: 0.14,
   };

--- a/src/analysis/classic/warlock/shared/Haste.ts
+++ b/src/analysis/classic/warlock/shared/Haste.ts
@@ -1,11 +1,8 @@
-import CoreHaste, { DEFAULT_HASTE_BUFFS } from 'parser/shared/modules/Haste';
-import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
+import CoreHaste from 'parser/shared/modules/Haste';
 import SPELLS from 'common/SPELLS/classic/warlock';
 
 class Haste extends CoreHaste {
-  hasteBuffs = {
-    ...DEFAULT_HASTE_BUFFS,
-    ...BLOODLUST_BUFFS,
+  override hasteBuffOverrides = {
     [SPELLS.ERADICATION_BUFF_6.id]: 0.06,
     [SPELLS.ERADICATION_BUFF_12.id]: 0.12,
     [SPELLS.ERADICATION_BUFF_20.id]: 0.2,

--- a/src/analysis/retail/paladin/protection/modules/core/Haste.tsx
+++ b/src/analysis/retail/paladin/protection/modules/core/Haste.tsx
@@ -1,9 +1,7 @@
-import CoreHaste, { DEFAULT_HASTE_BUFFS } from 'parser/shared/modules/Haste';
+import CoreHaste from 'parser/shared/modules/Haste';
 
 class Haste extends CoreHaste {
-  hasteBuffs = {
-    ...DEFAULT_HASTE_BUFFS,
-  };
+  override hasteBuffOverrides = {};
 }
 
 export default Haste;

--- a/src/analysis/retail/shaman/elemental/modules/core/Haste.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/core/Haste.tsx
@@ -1,9 +1,8 @@
 import SPELLS from 'common/SPELLS';
-import CoreHaste, { DEFAULT_HASTE_BUFFS } from 'parser/shared/modules/Haste';
+import CoreHaste from 'parser/shared/modules/Haste';
 
 class Haste extends CoreHaste {
-  hasteBuffs = {
-    ...DEFAULT_HASTE_BUFFS,
+  override hasteBuffOverrides = {
     // Shaman specific
     [SPELLS.UNLIMITED_POWER_BUFF.id]: {
       hastePerStack: 0.02,

--- a/src/common/SPELLS/classic/mage.ts
+++ b/src/common/SPELLS/classic/mage.ts
@@ -31,11 +31,6 @@ const spells = {
     name: 'Arcane Missiles',
     icon: 'spell_nature_starfall.jpg',
   },
-  ARCANE_MISSILES_CHANNELED: {
-    id: 5143,
-    name: 'Arcane Missiles',
-    icon: 'spell_nature_starfall.jpg',
-  },
   BLINK: {
     id: 1953,
     name: 'Blink',

--- a/src/common/SPELLS/classic/misc.ts
+++ b/src/common/SPELLS/classic/misc.ts
@@ -6,6 +6,11 @@ const spells = {
     name: 'Nightmare Seed',
     icon: 'inv_misc_herb_nightmareseed',
   },
+  SHARD_OF_WOE_CELERITY: {
+    id: 91173,
+    name: 'Celerity',
+    icon: 'spell_livegivingspeed',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/parser/shared/modules/Haste.ts
+++ b/src/parser/shared/modules/Haste.ts
@@ -3,6 +3,8 @@ import SPELLS from 'common/SPELLS';
 import CLASSIC_SPELLS from 'common/SPELLS/classic';
 import { TALENTS_DEATH_KNIGHT, TALENTS_MAGE, TALENTS_PRIEST } from 'common/TALENTS';
 import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
+import GameBranch from 'game/GameBranch';
+import { wclGameVersionToBranch } from 'game/VERSIONS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Combatant from 'parser/core/Combatant';
 import EventFilter from 'parser/core/EventFilter';
@@ -32,7 +34,7 @@ interface HasteBuff {
 
 type HasteBuffMap = { [spellId: number]: number | HasteBuff };
 
-export const DEFAULT_HASTE_BUFFS: HasteBuffMap = {
+const DEFAULT_HASTE_BUFFS: HasteBuffMap = {
   // HASTE RATING BUFFS ARE HANDLED BY THE STATTRACKER MODULE
 
   ...BLOODLUST_BUFFS,
@@ -122,6 +124,10 @@ export const DEFAULT_HASTE_BUFFS: HasteBuffMap = {
   //endregion
 };
 
+const CLASSIC_HASTE_BUFF_OVERRIDES: HasteBuffMap = {
+  [SPELLS.BERSERKING.id]: 0.2,
+};
+
 class Haste extends Analyzer {
   static dependencies = {
     eventEmitter: EventEmitter,
@@ -131,9 +137,19 @@ class Haste extends Analyzer {
   protected statTracker!: StatTracker;
   protected eventEmitter!: EventEmitter;
 
-  protected hasteBuffs: HasteBuffMap = {
-    ...DEFAULT_HASTE_BUFFS,
-  };
+  private defaultHasteBuffs = DEFAULT_HASTE_BUFFS;
+
+  protected hasteBuffOverrides: HasteBuffMap = {};
+
+  protected getHasteBuff(spellId: number): HasteBuff | number | undefined {
+    const override = this.hasteBuffOverrides[spellId];
+
+    if (override !== undefined) {
+      return override;
+    }
+
+    return this.defaultHasteBuffs[spellId];
+  }
 
   get changehaste() {
     return new EventFilter(EventType.ChangeHaste);
@@ -143,6 +159,11 @@ class Haste extends Analyzer {
 
   constructor(options: Options) {
     super(options);
+
+    if (wclGameVersionToBranch(options.owner.report.gameVersion) === GameBranch.Classic) {
+      this.defaultHasteBuffs = Object.assign({}, DEFAULT_HASTE_BUFFS, CLASSIC_HASTE_BUFF_OVERRIDES);
+    }
+
     this.current = (options.statTracker as StatTracker).currentHastePercentage;
     debug && console.log(`Haste: Starting haste: ${formatPercentage(this.current)}%`);
     this.eventEmitter = options.eventEmitter as EventEmitter;
@@ -166,7 +187,7 @@ class Haste extends Analyzer {
     /** Either a haste rating percentage (10% = 0.1), or a {@link HasteBuff} object. */
     haste: number | HasteBuff,
   ): void {
-    this.hasteBuffs[spellId] = haste;
+    this.hasteBuffOverrides[spellId] = haste;
   }
 
   onApplyBuff(event: ApplyBuffEvent) {
@@ -277,7 +298,7 @@ class Haste extends Analyzer {
    * Gets the base Haste gain for the provided spell.
    */
   _getBaseHasteGain(spellId: number) {
-    const hasteBuff = this.hasteBuffs[spellId] || undefined;
+    const hasteBuff = this.getHasteBuff(spellId);
 
     if (typeof hasteBuff === 'number') {
       // A regular number is a static Haste percentage
@@ -315,7 +336,7 @@ class Haste extends Analyzer {
   }
 
   _getHastePerStackGain(spellId: number) {
-    const hasteBuff = this.hasteBuffs[spellId] || undefined;
+    const hasteBuff = this.getHasteBuff(spellId);
 
     if (typeof hasteBuff === 'number') {
       // hasteBuff being a number is shorthand for static haste only

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -141,6 +141,10 @@ class StatTracker extends Analyzer {
     [CLASSIC_SPELLS.HYPERSPEED_ACCELERATION.id]: { haste: 340 },
     [CLASSIC_SPELLS.POTION_OF_SPEED.id]: { haste: 500 },
     // endregion
+
+    // region Classic Cata
+    [CLASSIC_SPELLS.SHARD_OF_WOE_CELERITY.id]: { haste: 1935 },
+    // endregion
   };
 
   protected isClassic = false;


### PR DESCRIPTION
### Description

This fixes several issues with Arcane Mage in specific and Cata Classic in general. The full list is:

- Built the talent reduction of the Arcane Explosion GCD into the `Abilities` entry
- Updated the Arcane Missiles normalizer and removed the old spell entry
- Add the Shard of Woe Celerity haste buff to `StatTracker`
- Update the Berserking haste % for Cata Classic.

as part of the last bit, I refactored how we add/override spells in `Haste` so that the base module can properly handle common spells across different game versions without subclasses needing to be aware of it.

### Testing

tested on https://wowanalyzer.com/report/ADmhtCJz74qHabfX/23-Heroic+Maloriak+-+Kill+(3:46)/Thunder/standard/overview

**Before**

![image](https://github.com/user-attachments/assets/533bba6e-6f13-49d8-a5bb-af51aa9b2a77)

**After**

![image](https://github.com/user-attachments/assets/f0a0df70-3fe9-4a8e-ab72-29ba125f9464)

### Other Notes

To find the Arcane Missiles issue, I went through in 30 second increments and checked active time. That was able to narrow it down to a few Arcane Missiles casts bumping active time well above 100% after the other fixes were in place. Might be useful tech to have for future debugging 
