### PR TITLE
[Arcane Mage] Rearrange Touch Resource Gain

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { change, date } from 'common/changelog';
 import { Sharrq, Sref } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2024, 8, 10), <>Fixed an issue that was causing <SpellLink spell={TALENTS.TOUCH_OF_THE_MAGI_TALENT} /> to always say it had 4 <SpellLink spell={SPELLS.ARCANE_CHARGE} />s due to an issue with the way the combat log orders events.</>, Sref),
   change(date(2024, 7, 29), <>Enhanced Guide view for <SpellLink spell={TALENTS.SHIFTING_POWER_TALENT} /></>, Sref),
   change(date(2024, 7, 29), <>Removed ability to load Checklist.</>, Sharrq),
   change(date(2024, 7, 29), <>Increased spec support to 11.0, Partial Support.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CombatLogParser.ts
+++ b/src/analysis/retail/mage/arcane/CombatLogParser.ts
@@ -56,6 +56,7 @@ import ArcaneTempo from './talents/ArcaneTempo';
 //Normalizers
 import ArcaneChargesNormalizer from './normalizers/ArcaneCharges';
 import ArcaneSurgeNormalizer from './normalizers/ArcaneSurge';
+import TouchOfTheMagiNormalizer from './normalizers/TouchOfTheMagi';
 import CastLinkNormalizer from './normalizers/CastLinkNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -63,6 +64,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Normalizers
     arcaneChargesNormalizer: ArcaneChargesNormalizer,
     arcaneSurgeNormalizer: ArcaneSurgeNormalizer,
+    touchOfTheMagiNormalizer: TouchOfTheMagiNormalizer,
     castLinkNormalizer: CastLinkNormalizer,
 
     //Core

--- a/src/analysis/retail/mage/arcane/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/arcane/normalizers/CastLinkNormalizer.ts
@@ -121,6 +121,18 @@ const EVENT_LINKS: EventLink[] = [
     reverseLinkRelation: DEBUFF_APPLY,
     linkingEventId: SPELLS.TOUCH_OF_THE_MAGI_DEBUFF.id,
     linkingEventType: EventType.ApplyDebuff,
+    linkRelation: ENERGIZE,
+    referencedEventId: TALENTS.TOUCH_OF_THE_MAGI_TALENT.id,
+    referencedEventType: EventType.ResourceChange,
+    maximumLinks: 1,
+    anyTarget: true,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+  },
+  {
+    reverseLinkRelation: DEBUFF_APPLY,
+    linkingEventId: SPELLS.TOUCH_OF_THE_MAGI_DEBUFF.id,
+    linkingEventType: EventType.ApplyDebuff,
     linkRelation: SPELL_DAMAGE,
     referencedEventId: [
       SPELLS.ARCANE_BLAST.id,

--- a/src/analysis/retail/mage/arcane/normalizers/TouchOfTheMagi.ts
+++ b/src/analysis/retail/mage/arcane/normalizers/TouchOfTheMagi.ts
@@ -1,0 +1,30 @@
+import TALENTS from 'common/TALENTS/mage';
+import EventOrderNormalizer, { EventOrder } from 'parser/core/EventOrderNormalizer';
+import { EventType } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+
+const EVENT_ORDERS: EventOrder[] = [
+  {
+    beforeEventId: [TALENTS.TOUCH_OF_THE_MAGI_TALENT.id],
+    beforeEventType: EventType.Cast,
+    afterEventId: [TALENTS.TOUCH_OF_THE_MAGI_TALENT.id],
+    afterEventType: EventType.ResourceChange,
+    bufferMs: 50,
+    anyTarget: true,
+    updateTimestamp: true,
+  },
+];
+
+/**
+ * Ensures that the Energize events to give the player Arcane Charges is always after the Cast event if they happen at the same time.
+ * This is primarily because when the cast completes it calculates damage based on the charges the player had when the spell completed,
+ * not including the one that they just gained (even though they happen at the same timestamp). Therefore the energize needs to happen
+ * after the cast and not before it.
+ */
+class TouchOfTheMagi extends EventOrderNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_ORDERS);
+  }
+}
+
+export default TouchOfTheMagi;

--- a/src/analysis/retail/mage/arcane/talents/TouchOfTheMagi.tsx
+++ b/src/analysis/retail/mage/arcane/talents/TouchOfTheMagi.tsx
@@ -6,6 +6,7 @@ import Events, {
   DamageEvent,
   ApplyDebuffEvent,
   RemoveDebuffEvent,
+  ResourceChangeEvent,
   GetRelatedEvent,
   GetRelatedEvents,
 } from 'parser/core/Events';
@@ -55,13 +56,15 @@ class TouchOfTheMagi extends Analyzer {
   onTouch(event: ApplyDebuffEvent) {
     const removeDebuff: RemoveDebuffEvent | undefined = GetRelatedEvent(event, 'DebuffRemove');
     const damageEvents: DamageEvent[] = GetRelatedEvents(event, 'SpellDamage');
+    const resourceChange: ResourceChangeEvent | undefined = GetRelatedEvent(event, 'Energize');
+    const wastedCharges = resourceChange && resourceChange.waste;
     let damage = 0;
     damageEvents.forEach((d) => (damage += d.amount + (d.absorb || 0)));
 
     this.touchCasts.push({
       applied: event.timestamp,
       removed: removeDebuff?.timestamp || this.owner.fight.end_time,
-      charges: this.chargeTracker.charges,
+      charges: wastedCharges !== undefined ? 0 + wastedCharges : 4,
       damage: damageEvents || [],
       totalDamage: damage,
     });

--- a/src/analysis/retail/mage/arcane/talents/TouchOfTheMagi.tsx
+++ b/src/analysis/retail/mage/arcane/talents/TouchOfTheMagi.tsx
@@ -57,7 +57,9 @@ class TouchOfTheMagi extends Analyzer {
     const removeDebuff: RemoveDebuffEvent | undefined = GetRelatedEvent(event, 'DebuffRemove');
     const damageEvents: DamageEvent[] = GetRelatedEvents(event, 'SpellDamage');
     const resourceChange: ResourceChangeEvent | undefined = GetRelatedEvent(event, 'Energize');
+    this.log(resourceChange);
     const wastedCharges = resourceChange && resourceChange.waste;
+    this.log(wastedCharges);
     let damage = 0;
     damageEvents.forEach((d) => (damage += d.amount + (d.absorb || 0)));
 

--- a/src/analysis/retail/mage/arcane/talents/TouchOfTheMagi.tsx
+++ b/src/analysis/retail/mage/arcane/talents/TouchOfTheMagi.tsx
@@ -57,9 +57,7 @@ class TouchOfTheMagi extends Analyzer {
     const removeDebuff: RemoveDebuffEvent | undefined = GetRelatedEvent(event, 'DebuffRemove');
     const damageEvents: DamageEvent[] = GetRelatedEvents(event, 'SpellDamage');
     const resourceChange: ResourceChangeEvent | undefined = GetRelatedEvent(event, 'Energize');
-    this.log(resourceChange);
     const wastedCharges = resourceChange && resourceChange.waste;
-    this.log(wastedCharges);
     let damage = 0;
     damageEvents.forEach((d) => (damage += d.amount + (d.absorb || 0)));
 


### PR DESCRIPTION
Fixes the event order for the resource gain from Touch of the Magi so that it is after the Touch of the Magi cast. Because the resource change was happening 1ms before the Touch of the Magi cast, every Touch of the Magi cast was getting marked as bad for having 4 Arcane Charges. So this ensures the cast happens first.