### PR TITLE
[BDK] fix crash in CastEfficiency when Rapid Decomp is not selected

### DIFF
--- a/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
@@ -1,7 +1,10 @@
 import { change, date } from 'common/changelog';
+import talents from 'common/TALENTS/deathknight';
 import { emallson } from 'CONTRIBUTORS';
+import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 8, 12), <>Fix crash when <SpellLink spell={talents.RAPID_DECOMPOSITION_TALENT} /> was not selected.</>, emallson),
   change(date(2024, 7, 28), 'Basic updates for The War Within', emallson),
 ];

--- a/src/analysis/retail/deathknight/blood/modules/Abilities.ts
+++ b/src/analysis/retail/deathknight/blood/modules/Abilities.ts
@@ -223,12 +223,10 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         cooldown: 15,
-        castEfficiency: combatant.hasTalent(TALENTS.RAPID_DECOMPOSITION_TALENT)
-          ? {
-              suggestion: true,
-              recommendedEfficiency: 0.8, //reduced because of proc resets
-            }
-          : undefined,
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.8, //reduced because of proc resets
+        },
         charges: combatant.hasTalent(TALENTS.DEATHS_ECHO_TALENT) ? 2 : 1,
         timelineSortIndex: 5,
       },


### PR DESCRIPTION
completely omitting `castEfficiency` works so idk what is going on, but people should really be pushing D&D anyway
