### PR TITLE
[Restoration Shaman] Talent updates

### DIFF
--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -11,6 +11,7 @@ import {
 
 // prettier-ignore
 export default [
+  change(date(2024, 8, 21), <>Add <SpellLink spell={TALENTS_SHAMAN.STONE_BULWARK_TOTEM_TALENT} /> effective shielding done statistic and add <SpellLink spell={TALENTS_SHAMAN.DOWNPOUR_TALENT} /> procs wasted and average targets hit statistic</>, Texleretour),
   change(date(2024, 8, 18),<>Add <SpellLink spell={TALENTS_SHAMAN.CLOUDBURST_TOTEM_TALENT} /> cast breakdown based on overhealing done and new Section "Mana Efficiency" featuring cast breakdown of <SpellLink spell={TALENTS_SHAMAN.NATURES_SWIFTNESS_TALENT} /> based on mana saved.</> , Texleretour),
   change(date(2024, 8, 14), <>Added mana saved from <SpellLink spell={TALENTS_SHAMAN.SPIRITWALKERS_TIDAL_TOTEM_TALENT} /> statistic, scaled <SpellLink spell={SPELLS.HEALING_SURGE} /> mana cost for The War Within and fixed <SpellLink spell={TALENTS_SHAMAN.NATURES_SWIFTNESS_TALENT} /> statistic</>, Texleretour),
   change(date(2024, 8, 14), <>Deletion of Dragonflight tier sets from the code</>, Ypp),

--- a/src/analysis/retail/shaman/restoration/CONFIG.tsx
+++ b/src/analysis/retail/shaman/restoration/CONFIG.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro';
-import { Arlie, niseko, Vohrr, Ypp } from 'CONTRIBUTORS';
+import { Arlie, niseko, Vohrr, Ypp, Texleretour } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import { AlertWarning } from 'interface';
@@ -9,7 +9,7 @@ import CHANGELOG from './CHANGELOG';
 
 const CONFIG: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [niseko, Arlie, Vohrr, Ypp],
+  contributors: [niseko, Arlie, Vohrr, Ypp, Texleretour],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '11.0.0',

--- a/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
@@ -49,6 +49,8 @@ import NaturesSwiftness from './modules/talents/NaturesSwiftness';
 import SpiritwalkersTidalTotem from './modules/talents/SpiritwalkersTidalTotem';
 // Spells
 // Shared
+import StoneBulwarkTotem from '../shared/talents/StoneBulwarkTotem';
+
 // Normalizers
 import CloudburstNormalizer from './normalizers/CloudburstNormalizer';
 import RiptideNormalizer from './normalizers/RiptideNormalizer';
@@ -138,6 +140,7 @@ class CombatLogParser extends CoreCombatLogParser {
     astralShift: AstralShift,
     earthShield: EarthShield,
     elementalOrbit: ElementalOrbit,
+    stoneBulwarkTotem: StoneBulwarkTotem,
 
     // Normalizers
     cloudburstNormalizer: CloudburstNormalizer,

--- a/src/analysis/retail/shaman/restoration/modules/features/TalentStatisticBox.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/features/TalentStatisticBox.tsx
@@ -77,9 +77,6 @@ class TalentStatisticBox extends Analyzer {
     if (this.selectedCombatant.hasTalent(TALENTS.NATURES_GUARDIAN_TALENT)) {
       talentList.push(this.naturesGuardian.subStatistic());
     }
-    if (this.selectedCombatant.hasTalent(TALENTS.DOWNPOUR_TALENT)) {
-      talentList.push(this.downpour.subStatistic());
-    }
     if (this.selectedCombatant.hasTalent(TALENTS.CLOUDBURST_TOTEM_TALENT)) {
       talentList.push(this.cloudburstTotem.subStatistic());
     }

--- a/src/analysis/retail/shaman/restoration/modules/talents/Downpour.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/Downpour.tsx
@@ -1,168 +1,70 @@
-import { Trans } from '@lingui/macro';
-import { formatPercentage } from 'common/format';
-import SPELLS from 'common/SPELLS';
-import TALENTS from 'common/TALENTS/shaman';
-import { SpellLink } from 'interface';
-import { SpellIcon } from 'interface';
-import { TooltipElement } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { HealEvent, CastEvent } from 'parser/core/Events';
-import SpellUsable from 'parser/shared/modules/SpellUsable';
+import TALENTS from 'common/TALENTS/shaman';
+import Events from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import TalentSpellText from 'parser/ui/TalentSpellText';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import StatisticBox, { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
-import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
-
-import RestorationAbilityTracker from '../core/RestorationAbilityTracker';
-import CooldownThroughputTracker from '../features/CooldownThroughputTracker';
-
-const BUFFER = 100;
-const cooldownIncrease = 5000;
-const UNLEASH_LIFE_DURATION = 10000;
-
-/**
- * CD changes depending on amount of effective targets hit (0 = 5s, 8 = 45)
- */
+import { formatNumber, formatPercentage } from 'common/format';
+import HealingRain from '../spells/HealingRain';
+import SPELLS from 'common/SPELLS';
 
 class Downpour extends Analyzer {
   static dependencies = {
-    cooldownThroughputTracker: CooldownThroughputTracker,
-    spellUsable: SpellUsable,
-    abilityTracker: RestorationAbilityTracker,
+    healingRain: HealingRain,
   };
 
-  protected cooldownThroughputTracker!: CooldownThroughputTracker;
-  protected spellUsable!: SpellUsable;
-  protected abilityTracker!: RestorationAbilityTracker;
+  protected healingRain!: HealingRain;
 
-  healing = 0;
+  downpourCasts = 0;
   downpourHits = 0;
-  downpourHitsSum = 0;
-  downpourTimestamp = 0;
-  maxHits = 6;
-  unleashLifeRemaining = false;
-  lastUnleashLifeTimestamp: number = Number.MAX_SAFE_INTEGER;
-
-  unleashLifeSpells = {
-    [TALENTS.RIPTIDE_TALENT.id]: {},
-    [TALENTS.CHAIN_HEAL_TALENT.id]: {},
-    [TALENTS.HEALING_WAVE_TALENT.id]: {},
-    [SPELLS.HEALING_SURGE.id]: {},
-    [TALENTS.WELLSPRING_TALENT.id]: {},
-    [TALENTS.HEALING_RAIN_TALENT.id]: {},
-    [TALENTS.DOWNPOUR_TALENT.id]: {},
-  };
 
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.DOWNPOUR_TALENT);
 
-    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this._onHeal);
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this._onCast);
-  }
-
-  _onHeal(event: HealEvent) {
-    // This spells cooldown gets increased depending on how many targets you heal
-    // instead we set it to the maximum possible cooldown and reduce it by how many it fully overhealed or missed
-    if (this.downpourTimestamp && event.timestamp > this.downpourTimestamp + BUFFER) {
-      const reductionMS = (this.maxHits - this.downpourHits) * cooldownIncrease;
-      this.spellUsable.reduceCooldown(TALENTS.DOWNPOUR_TALENT.id, reductionMS);
-      this.downpourTimestamp = 0;
-      this.downpourHits = 0;
-      this.maxHits = 6;
-    }
-
-    const spellId = event.ability.guid;
-    if (spellId !== TALENTS.DOWNPOUR_TALENT.id) {
-      return;
-    }
-
-    if (event.amount) {
-      this.downpourHits += 1;
-      this.downpourHitsSum += 1;
-    }
-
-    this.downpourTimestamp = event.timestamp;
-    this.healing += event.amount + (event.absorbed || 0);
-  }
-
-  _onCast(event: CastEvent) {
-    const spellId = event.ability.guid;
-
-    if (spellId === TALENTS.DOWNPOUR_TALENT.id && this.unleashLifeRemaining === true) {
-      this.maxHits = 8;
-    }
-
-    if (spellId === TALENTS.UNLEASH_LIFE_TALENT.id) {
-      this.unleashLifeRemaining = true;
-      this.lastUnleashLifeTimestamp = event.timestamp;
-    }
-
-    if (
-      this.unleashLifeRemaining &&
-      this.lastUnleashLifeTimestamp + UNLEASH_LIFE_DURATION <= event.timestamp
-    ) {
-      this.unleashLifeRemaining = false;
-      return;
-    }
-
-    if (this.unleashLifeRemaining) {
-      if (this.unleashLifeSpells[spellId]) {
-        this.unleashLifeRemaining = false;
-      }
-    }
-  }
-
-  statistic() {
-    const downpour = this.abilityTracker.getAbility(TALENTS.DOWNPOUR_TALENT.id);
-
-    const downpourCasts = downpour.casts;
-    if (!downpourCasts) {
-      return null;
-    }
-    // downpourHits are all hits and downpourHitsSum are only the ones with effective healing done
-    const downpourHits = downpour.healingHits;
-    const downpourAverageHits = this.downpourHitsSum / downpourCasts;
-    const downpourAverageOverhealedHits = (downpourHits - this.downpourHitsSum) / downpourCasts;
-    const downpourAverageCooldown = 5 + (this.downpourHitsSum / downpourCasts) * 5;
-
-    return (
-      <StatisticBox
-        icon={<SpellIcon spell={TALENTS.DOWNPOUR_TALENT} />}
-        value={
-          <Trans id="shaman.restoration.downpour.statistic.value">
-            {downpourAverageCooldown.toFixed(1)} seconds
-          </Trans>
-        }
-        category={STATISTIC_CATEGORY.TALENTS}
-        position={STATISTIC_ORDER.OPTIONAL(90)}
-        label={
-          <TooltipElement
-            content={
-              <Trans id="shaman.restoration.downpour.statistic.label.tooltip">
-                You cast a total of {downpourCasts} Downpours, which on average hit{' '}
-                {(downpourAverageHits + downpourAverageOverhealedHits).toFixed(1)} out of 6 targets.
-                Keep in mind, that Unleash Life can increase the maximum number of targets by 2.
-                <br />
-                Of those hits, {downpourAverageHits.toFixed(1)} had effective healing and increased
-                the cooldown.
-              </Trans>
-            }
-          >
-            <Trans id="shaman.restoration.downpour.statistic.label">
-              Average Downpour cooldown
-            </Trans>
-          </TooltipElement>
-        }
-      />
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.DOWNPOUR_ABILITY),
+      this._onDownpourCast,
+    );
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.DOWNPOUR_HEAL),
+      this._onDownpourHeal,
     );
   }
 
-  subStatistic() {
+  _onDownpourCast() {
+    this.downpourCasts += 1;
+  }
+
+  _onDownpourHeal() {
+    this.downpourHits += 1;
+  }
+
+  get wastedDownpourCasts() {
+    return this.healingRain.casts - this.downpourCasts;
+  }
+
+  get wastedDownpourCastsPercent() {
+    return 1 - this.downpourCasts / this.healingRain.casts;
+  }
+
+  get averageTargetsHit() {
+    return this.downpourCasts !== 0 ? this.downpourHits / this.downpourCasts : 0;
+  }
+
+  statistic() {
     return (
-      <StatisticListBoxItem
-        title={<SpellLink spell={TALENTS.DOWNPOUR_TALENT} />}
-        value={`${formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.healing))} %`}
-      />
+      <Statistic size="flexible" category={STATISTIC_CATEGORY.TALENTS}>
+        <TalentSpellText talent={TALENTS.DOWNPOUR_TALENT}>
+          <div>
+            {formatNumber(this.wastedDownpourCasts)}{' '}
+            <small>wasted procs ({formatPercentage(this.wastedDownpourCastsPercent)}%)</small>
+          </div>
+          <div>
+            {formatNumber(this.averageTargetsHit)} <small>average targets</small>
+          </div>
+        </TalentSpellText>
+      </Statistic>
     );
   }
 }

--- a/src/analysis/retail/shaman/shared/talents/StoneBulwarkTotem.tsx
+++ b/src/analysis/retail/shaman/shared/talents/StoneBulwarkTotem.tsx
@@ -1,0 +1,62 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import TALENTS from 'common/TALENTS/shaman';
+import Events, { AbsorbedEvent } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS';
+import Statistic from 'parser/ui/Statistic';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import { formatNumber } from 'common/format';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+
+class StoneBulwarkTotem extends Analyzer {
+  totalEffectiveShielding = 0;
+  casts = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.STONE_BULWARK_TOTEM_TALENT);
+
+    this.addEventListener(
+      Events.absorbed.to(SELECTED_PLAYER).spell(SPELLS.STONE_BULWARK_CAST_BUFF),
+      this._onDamageAbsorb,
+    );
+    this.addEventListener(
+      Events.absorbed.to(SELECTED_PLAYER).spell(SPELLS.STONE_BULWARK_PULSE_BUFF),
+      this._onDamageAbsorb,
+    );
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.STONE_BULWARK_TOTEM_TALENT),
+      this._onStoneBulwarkTotemCast,
+    );
+  }
+
+  _onDamageAbsorb(event: AbsorbedEvent) {
+    this.totalEffectiveShielding += event.amount;
+  }
+
+  _onStoneBulwarkTotemCast() {
+    this.casts += 1;
+  }
+
+  get effectiveAbsorbPerCast() {
+    return this.totalEffectiveShielding / this.casts;
+  }
+
+  statistic() {
+    return (
+      <Statistic size="flexible" category={STATISTIC_CATEGORY.TALENTS}>
+        <TalentSpellText talent={TALENTS.STONE_BULWARK_TOTEM_TALENT}>
+          <div>
+            {formatNumber(this.totalEffectiveShielding)}{' '}
+            <small>effective shielding in {this.casts} casts</small>
+          </div>
+          <div>
+            {formatNumber(this.effectiveAbsorbPerCast)} <small>effective shielding per cast</small>
+          </div>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default StoneBulwarkTotem;

--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -868,6 +868,16 @@ const spells = {
     name: 'Stone Bulwark',
     icon: 'ability_shaman_stonebulwark',
   },
+  DOWNPOUR_ABILITY: {
+    id: 462603,
+    name: 'Downpour',
+    icon: 'ability_mage_waterjet',
+  },
+  DOWNPOUR_HEAL: {
+    id: 207778,
+    name: 'Downpour',
+    icon: 'ability_mage_waterjet',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;


### PR DESCRIPTION
### Description

- Add Stone Bulwark Totem effective shielding done statistic 
- Add Downpour procs wasted and average targets hit statistic

### Testing
/!\ Pre nerf log --> 2min CD on Stone Bulwark Totem (now 3 minutes)
- Test report URL: /reports/WFnABjd3RgqTDHvL#fight=16&type=healing&source=7`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/df26fb13-17c5-4adc-8b74-d213ab298654)
![image](https://github.com/user-attachments/assets/2c0d980e-16e6-4047-b684-334405c14781)

