### PR TITLE
[Restoration Shaman] Hotfix : Cloudburst Totem module crashing if cast prepull

### DIFF
--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -11,6 +11,7 @@ import {
 
 // prettier-ignore
 export default [
+  change(date(2024, 8, 21), <>Fixed an error causing the Cloudburst Totem module to crash if one was cast prepull</>, Texleretour),
   change(date(2024, 8, 18),<>Add <SpellLink spell={TALENTS_SHAMAN.CLOUDBURST_TOTEM_TALENT} /> cast breakdown based on overhealing done and new Section "Mana Efficiency" featuring cast breakdown of <SpellLink spell={TALENTS_SHAMAN.NATURES_SWIFTNESS_TALENT} /> based on mana saved.</> , Texleretour),
   change(date(2024, 8, 14), <>Added mana saved from <SpellLink spell={TALENTS_SHAMAN.SPIRITWALKERS_TIDAL_TOTEM_TALENT} /> statistic, scaled <SpellLink spell={SPELLS.HEALING_SURGE} /> mana cost for The War Within and fixed <SpellLink spell={TALENTS_SHAMAN.NATURES_SWIFTNESS_TALENT} /> statistic</>, Texleretour),
   change(date(2024, 8, 14), <>Deletion of Dragonflight tier sets from the code</>, Ypp),

--- a/src/analysis/retail/shaman/restoration/modules/talents/CloudburstTotem.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/CloudburstTotem.tsx
@@ -81,6 +81,14 @@ class CloudburstTotem extends Analyzer {
     const healing = event.amount + (event.absorbed || 0);
     const overhealing = event.overheal || 0;
 
+    if (this.CBTCasts.length === 0) {
+      // If CBT was cast prepull
+      this.CBTCasts.push({
+        healingDone: 0,
+        overhealingDone: 0,
+      });
+    }
+
     this.CBTCasts[this.CBTCasts.length - 1].healingDone += healing;
     this.CBTCasts[this.CBTCasts.length - 1].overhealingDone += overhealing;
   }


### PR DESCRIPTION
### Description

Fixed an issue causing the Cloudburst Totem module to crash if one was cast prepull

### Testing

- Test report URL: `/report/rbBNdRmxJV8pTL6c/12-Mythic+Sikran,+Captain+of+the+Sureki+-+Wipe+12+(3:21)/Renozerotz/standard/overview`
