### PR TITLE
Druid Feral - CastSummaryAndBreakdown in guide + minor improvements

### DIFF
--- a/src/analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown.tsx
+++ b/src/analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown.tsx
@@ -1,9 +1,7 @@
 import { Fragment, useState } from 'react';
 import { ControlledExpandable } from 'interface';
 import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
-import GradiatedPerformanceBar, {
-  GradiatedPerformanceBarInfo,
-} from 'interface/guide/components/GradiatedPerformanceBar';
+import GradiatedPerformanceBar from 'interface/guide/components/GradiatedPerformanceBar';
 import Spell from 'common/SPELLS/Spell';
 import SpellLink from 'interface/SpellLink';
 import { ClickToExpand, MouseoverForMoreDetails } from './CommonLinguiTranslations';
@@ -15,34 +13,45 @@ const CastSummaryAndBreakdownContainer = styled.div`
   margin-bottom: 10px;
 `;
 
-const toGradiatedPerformanceBarProp = (
-  count: number,
-  label: string | undefined,
-): number | GradiatedPerformanceBarInfo => {
-  if (label) {
-    return { count, label };
-  }
-  return count;
-};
-
 interface Props {
+  /** The spell ID or Spell object being represented, used in explanatory text */
   spell: number | Spell;
+  /** A per-cast evaluation of the data to be displayed */
   castEntries: BoxRowEntry[];
+  /** A label to include when mousing over the 'perfect' section of the Performance Bar */
   perfectLabel?: string;
+  /** A brief explanation of what makes a cast 'perfect', included in explanatory text */
   perfectExtraExplanation?: string;
+  /** If set, text with the percentage of perfect casts is shown before the Performance Bar */
   includePerfectCastPercentage?: boolean;
+  /** A label to include when mousing over the 'good' section of the Performance Bar */
   goodLabel?: string;
+  /** A brief explanation of what makes a cast 'good', included in explanatory text */
   goodExtraExplanation?: string;
+  /** If set, text with the percentage of good casts is shown before the Performance Bar */
   includeGoodCastPercentage?: boolean;
+  /** A label to include when mousing over the 'ok' section of the Performance Bar */
   okLabel?: string;
+  /** A brief explanation of what makes a cast 'ok', included in explanatory text */
   okExtraExplanation?: string;
+  /** If set, text with the percentage of ok casts is shown before the Performance Bar */
   includeOkCastPercentage?: boolean;
+  /** A label to include when mousing over the 'bad' section of the Performance Bar */
   badLabel?: string;
+  /** A brief explanation of what makes a cast 'bad', included in explanatory text */
   badExtraExplanation?: string;
+  /** If set, text with the percentage of bad casts is shown before the Performance Bar */
   includeBadCastPercentage?: boolean;
+  /** If set, explanatory text uses the word 'use' instead of 'cast'. Useful if data is evaluating
+   *  procs instead of casts */
+  usesInsteadOfCasts?: boolean;
+  /** A callback to use when the Performance Box with the given index is clicked */
   onClickBox?: (index: number) => void;
 }
 
+/**
+ * A {@link GradiatedPerformanceBar} that can be clicked to expand into a {@link PerformanceBoxRow}.
+ */
 const CastSummaryAndBreakdown = ({
   spell,
   castEntries,
@@ -58,6 +67,7 @@ const CastSummaryAndBreakdown = ({
   badLabel,
   badExtraExplanation,
   includeBadCastPercentage,
+  usesInsteadOfCasts,
   onClickBox,
 }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -72,25 +82,35 @@ const CastSummaryAndBreakdown = ({
   const hasOkCasts = ok !== 0;
   const hasBadCasts = bad !== 0;
 
+  const instanceWord = usesInsteadOfCasts ? 'use' : 'cast';
+
   const perfectExplanation = !perfectExtraExplanation ? (
-    <>Blue is a perfect cast</>
+    <>Blue is a perfect {instanceWord}</>
   ) : (
-    <>Blue is a perfect cast ({perfectExtraExplanation})</>
+    <>
+      Blue is a perfect {instanceWord} ({perfectExtraExplanation})
+    </>
   );
   const goodExplanation = !goodExtraExplanation ? (
-    <>Green is a good cast</>
+    <>Green is a good {instanceWord}</>
   ) : (
-    <>Green is a good cast ({goodExtraExplanation})</>
+    <>
+      Green is a good {instanceWord} ({goodExtraExplanation})
+    </>
   );
   const okExplanation = !okExtraExplanation ? (
-    <>Yellow is an ok cast</>
+    <>Yellow is an ok {instanceWord}</>
   ) : (
-    <>Yellow is an ok cast ({okExtraExplanation})</>
+    <>
+      Yellow is an ok {instanceWord} ({okExtraExplanation})
+    </>
   );
   const badExplanation = !badExtraExplanation ? (
-    <>Red is a bad cast</>
+    <>Red is a bad {instanceWord}</>
   ) : (
-    <>Red is a bad cast ({badExtraExplanation})</>
+    <>
+      Red is a bad {instanceWord} ({badExtraExplanation})
+    </>
   );
 
   const performanceExplanation = [
@@ -106,6 +126,11 @@ const CastSummaryAndBreakdown = ({
         {explanation}
       </Fragment>
     ));
+
+  const perfectBarLabel = perfectLabel || `Perfect ${instanceWord}s`;
+  const goodBarLabel = goodLabel || `Good ${instanceWord}s`;
+  const okBarLabel = okLabel || `Ok ${instanceWord}s`;
+  const badBarLabel = badLabel || `Bad ${instanceWord}s`;
 
   return (
     <CastSummaryAndBreakdownContainer>
@@ -150,10 +175,10 @@ const CastSummaryAndBreakdown = ({
       <ControlledExpandable
         header={
           <GradiatedPerformanceBar
-            perfect={toGradiatedPerformanceBarProp(perfect, perfectLabel)}
-            good={toGradiatedPerformanceBarProp(good, goodLabel)}
-            ok={toGradiatedPerformanceBarProp(ok, okLabel)}
-            bad={toGradiatedPerformanceBarProp(bad, badLabel)}
+            perfect={{ count: perfect, label: perfectBarLabel }}
+            good={{ count: good, label: goodBarLabel }}
+            ok={{ count: ok, label: okBarLabel }}
+            bad={{ count: bad, label: badBarLabel }}
           />
         }
         element="section"

--- a/src/analysis/retail/demonhunter/shared/guide/CommonLinguiTranslations.tsx
+++ b/src/analysis/retail/demonhunter/shared/guide/CommonLinguiTranslations.tsx
@@ -1,3 +1,0 @@
-export const MouseoverForMoreDetails = () => <>Mouseover for more details.</>;
-
-export const ClickToExpand = () => <>Click to expand.</>;

--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -2,8 +2,10 @@ import { change, date } from 'common/changelog';
 import { Sref } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import { TALENTS_DRUID } from 'common/TALENTS/druid';
+import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2024, 8, 22), <>Cleaner display of <SpellLink spell={SPELLS.RAKE}/>, <SpellLink spell={SPELLS.RIP}/>, <SpellLink spell={SPELLS.FEROCIOUS_BITE}/>, and <SpellLink spell={TALENTS_DRUID.SUDDEN_AMBUSH_TALENT}/> sections in Guide.</>, Sref),
   change(date(2024, 8, 17), <>Marked updated for 11.0.2 and updated the spec's 'About' page.</>, Sref),
   change(date(2024, 8, 14), <>Updated spells to account for 11.0.2 balance patch.</>, Sref),
   change(date(2024, 7, 22), <>Refactored various modules to correctly handle <SpellLink spell={TALENTS_DRUID.RAVAGE_TALENT}/>. More updates for The War Within talent changes.</>, Sref),

--- a/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
@@ -5,7 +5,7 @@ import Events, { CastEvent, DamageEvent, EventType, TargettedEvent } from 'parse
 
 import { getAdditionalEnergyUsed } from '../../normalizers/FerociousBiteDrainLinkNormalizer';
 import { TALENTS_DRUID } from 'common/TALENTS';
-import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
 import RipUptimeAndSnapshots from 'analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { SpellLink } from 'interface';
@@ -25,6 +25,7 @@ import { BadColor, OkColor } from 'interface/guide';
 import { getHits } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
 import HIT_TYPES from 'game/HIT_TYPES';
 import { addInefficientCastReason } from 'parser/core/EventMetaLib';
+import CastSummaryAndBreakdown from 'analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown';
 
 const MIN_ACCEPTABLE_TIME_LEFT_ON_RIP_MS = 5000;
 
@@ -182,14 +183,12 @@ class FerociousBite extends Analyzer {
             <br />
           </>
         )}
-        <strong>Ferocious Bite casts</strong>
-        <small>
-          {' '}
-          - Green is a good cast , Yellow is an questionable cast (used on target with low duration
-          Rip), Red is a bad cast (&lt;25 extra energy + not during Berserk, or low CPs). Mouseover
-          for more details.
-        </small>
-        <PerformanceBoxRow values={this.castEntries} />
+        <CastSummaryAndBreakdown
+          spell={SPELLS.FEROCIOUS_BITE}
+          castEntries={this.castEntries}
+          okExtraExplanation={<>used on target with low duration Rip</>}
+          badExtraExplanation={<>&lt;25 extra energy + not during Berserk, or low CPs</>}
+        />
       </div>
     );
 

--- a/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
@@ -25,7 +25,7 @@ import { BadColor, OkColor } from 'interface/guide';
 import { getHits } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
 import HIT_TYPES from 'game/HIT_TYPES';
 import { addInefficientCastReason } from 'parser/core/EventMetaLib';
-import CastSummaryAndBreakdown from 'analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown';
+import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
 
 const MIN_ACCEPTABLE_TIME_LEFT_ON_RIP_MS = 5000;
 

--- a/src/analysis/retail/druid/feral/modules/spells/RakeUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RakeUptimeAndSnapshots.tsx
@@ -23,7 +23,7 @@ import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { BadColor, OkColor } from 'interface/guide';
-import CastSummaryAndBreakdown from 'analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown';
+import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
 
 /** Tracking code for everything Rake related */
 class RakeUptimeAndSnapshots extends Snapshots {

--- a/src/analysis/retail/druid/feral/modules/spells/RakeUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RakeUptimeAndSnapshots.tsx
@@ -18,11 +18,12 @@ import Snapshots, {
 } from 'analysis/retail/druid/feral/modules/core/Snapshots';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import { proccedBloodtalons } from 'analysis/retail/druid/feral/normalizers/BloodtalonsLinkNormalizer';
-import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { BadColor, OkColor } from 'interface/guide';
+import CastSummaryAndBreakdown from 'analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown';
 
 /** Tracking code for everything Rake related */
 class RakeUptimeAndSnapshots extends Snapshots {
@@ -197,20 +198,18 @@ class RakeUptimeAndSnapshots extends Snapshots {
           {this.subStatistic()}
         </RoundedPanel>
         <br />
-        <strong>Rake casts</strong>
-        <small>
-          {' '}
-          - Green is a good cast{' '}
-          {hasBt && (
+        <CastSummaryAndBreakdown
+          spell={SPELLS.RAKE}
+          castEntries={this.castEntries}
+          goodExtraExplanation={
             <>
-              (or a cast with problems that procced{' '}
-              <SpellLink spell={TALENTS_DRUID.BLOODTALONS_TALENT} />)
+              or a cast with problems that procced{' '}
+              <SpellLink spell={TALENTS_DRUID.BLOODTALONS_TALENT} />
             </>
-          )}
-          , Yellow is an ok cast (clipped duration but upgraded snapshot), Red is a bad cast
-          (clipped duration or downgraded snapshot w/ &gt;2s remaining). Mouseover for more details.
-        </small>
-        <PerformanceBoxRow values={this.castEntries} />
+          }
+          okExtraExplanation={<>clipped duration but upgraded snapshot</>}
+          badExtraExplanation={<>clipped duration or downgraded snapshot w/ &gt;2s remaining</>}
+        />
       </div>
     );
 

--- a/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
@@ -32,7 +32,7 @@ import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { BadColor, OkColor } from 'interface/guide';
 import { addInefficientCastReason } from 'parser/core/EventMetaLib';
-import CastSummaryAndBreakdown from 'analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown';
+import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
 
 class RipUptimeAndSnapshots extends Snapshots {
   static dependencies = {

--- a/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
@@ -27,11 +27,12 @@ import getResourceSpent from 'parser/core/getResourceSpent';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { SpellLink } from 'interface';
-import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { BadColor, OkColor } from 'interface/guide';
 import { addInefficientCastReason } from 'parser/core/EventMetaLib';
+import CastSummaryAndBreakdown from 'analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown';
 
 class RipUptimeAndSnapshots extends Snapshots {
   static dependencies = {
@@ -240,14 +241,18 @@ class RipUptimeAndSnapshots extends Snapshots {
           {this.subStatistic()}
         </RoundedPanel>
         <br />
-        <strong>Rip casts</strong>
-        <small>
-          {' '}
-          - Green is a good cast, Yellow is an ok cast (clipped duration but upgraded snapshot or
-          missing Tigers Fury), Red is a bad cast (clipped duration
-          {this.hasBt && ' or missing Bloodtalons'}). Mouseover for more details.
-        </small>
-        <PerformanceBoxRow values={this.castEntries} />
+        <CastSummaryAndBreakdown
+          spell={SPELLS.RIP}
+          castEntries={this.castEntries}
+          goodExtraExplanation={
+            <>
+              or a cast with problems that procced{' '}
+              <SpellLink spell={TALENTS_DRUID.BLOODTALONS_TALENT} />
+            </>
+          }
+          okExtraExplanation={<>clipped duration but upgraded snapshot or missing Tigers Fury</>}
+          badExtraExplanation={<>clipped duration {this.hasBt && ' or missing Bloodtalons'}</>}
+        />
       </div>
     );
 

--- a/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
@@ -40,7 +40,7 @@ import Snapshots, {
   TIGERS_FURY_SPEC,
 } from 'analysis/retail/druid/feral/modules/core/Snapshots';
 import { getHardcast } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
-import CastSummaryAndBreakdown from 'analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown';
+import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
 
 /**
  * **Sudden Ambush**

--- a/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
@@ -31,7 +31,7 @@ import UptimeIcon from 'interface/icons/Uptime';
 import { formatPercentage } from 'common/format';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
-import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
 import { BadColor, OkColor } from 'interface/guide';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import Snapshots, {
@@ -40,6 +40,7 @@ import Snapshots, {
   TIGERS_FURY_SPEC,
 } from 'analysis/retail/druid/feral/modules/core/Snapshots';
 import { getHardcast } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
+import CastSummaryAndBreakdown from 'analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown';
 
 /**
  * **Sudden Ambush**
@@ -380,13 +381,12 @@ class SuddenAmbush extends Snapshots {
 
     const data = (
       <div>
-        <strong>Sudden Ambush uses</strong>
-        <small>
-          {' '}
-          - Green is a good use, Red is an incorrect use or a wasted proc, and Yellow is a
-          questionable use. Mouseover for more details.
-        </small>
-        <PerformanceBoxRow values={this.useEntries} />
+        <CastSummaryAndBreakdown
+          spell={TALENTS_DRUID.SUDDEN_AMBUSH_TALENT}
+          castEntries={this.useEntries}
+          badExtraExplanation={<>or an expired proc</>}
+          usesInsteadOfCasts
+        />
       </div>
     );
 

--- a/src/analysis/retail/hunter/beastmastery/modules/talents/BarbedShot.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/talents/BarbedShot.tsx
@@ -1,5 +1,4 @@
 import { t, Trans } from '@lingui/macro';
-import CastSummaryAndBreakdown from 'analysis/retail/demonhunter/shared/guide/CastSummaryAndBreakdown';
 import { MS_BUFFER_250 } from 'analysis/retail/hunter/shared/constants';
 import { formatDuration, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
@@ -32,6 +31,7 @@ import {
 } from '../../constants';
 import GlobalCooldown from '../core/GlobalCooldown';
 import SpellUsable from '../core/SpellUsable';
+import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
 
 /**
  * Fire a shot that tears through your enemy, causing them to bleed for X damage over 8 sec. Sends your pet into a frenzy, increasing attack speed by 30% for 8 sec, stacking up to 3 times.

--- a/src/interface/guide/components/CastSummaryAndBreakdown.tsx
+++ b/src/interface/guide/components/CastSummaryAndBreakdown.tsx
@@ -4,7 +4,6 @@ import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/Perfo
 import GradiatedPerformanceBar from 'interface/guide/components/GradiatedPerformanceBar';
 import Spell from 'common/SPELLS/Spell';
 import SpellLink from 'interface/SpellLink';
-import { ClickToExpand, MouseoverForMoreDetails } from './CommonLinguiTranslations';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import CastPerformanceSummary from 'analysis/retail/demonhunter/shared/guide/CastPerformanceSummary';
 import styled from '@emotion/styled';
@@ -170,7 +169,8 @@ const CastSummaryAndBreakdown = ({
         <SpellLink spell={spell} /> casts
       </strong>{' '}
       <small>
-        - {performanceExplanation}. <MouseoverForMoreDetails /> <ClickToExpand />
+        - {performanceExplanation}. Mouseover for more details. Click to see per-{instanceWord}{' '}
+        details.
       </small>
       <ControlledExpandable
         header={
@@ -185,9 +185,7 @@ const CastSummaryAndBreakdown = ({
         expanded={isExpanded}
         inverseExpanded={() => setIsExpanded(!isExpanded)}
       >
-        <small>
-          <MouseoverForMoreDetails />
-        </small>
+        <small>Mouseover for more details.</small>
         <PerformanceBoxRow onClickBox={onClickBox} values={castEntries} />
       </ControlledExpandable>
     </CastSummaryAndBreakdownContainer>

--- a/src/interface/guide/components/CastSummaryAndBreakdown.tsx
+++ b/src/interface/guide/components/CastSummaryAndBreakdown.tsx
@@ -18,27 +18,27 @@ interface Props {
   /** A per-cast evaluation of the data to be displayed */
   castEntries: BoxRowEntry[];
   /** A label to include when mousing over the 'perfect' section of the Performance Bar */
-  perfectLabel?: string;
+  perfectLabel?: React.ReactNode;
   /** A brief explanation of what makes a cast 'perfect', included in explanatory text */
-  perfectExtraExplanation?: string;
+  perfectExtraExplanation?: React.ReactNode;
   /** If set, text with the percentage of perfect casts is shown before the Performance Bar */
   includePerfectCastPercentage?: boolean;
   /** A label to include when mousing over the 'good' section of the Performance Bar */
-  goodLabel?: string;
+  goodLabel?: React.ReactNode;
   /** A brief explanation of what makes a cast 'good', included in explanatory text */
-  goodExtraExplanation?: string;
+  goodExtraExplanation?: React.ReactNode;
   /** If set, text with the percentage of good casts is shown before the Performance Bar */
   includeGoodCastPercentage?: boolean;
   /** A label to include when mousing over the 'ok' section of the Performance Bar */
-  okLabel?: string;
+  okLabel?: React.ReactNode;
   /** A brief explanation of what makes a cast 'ok', included in explanatory text */
-  okExtraExplanation?: string;
+  okExtraExplanation?: React.ReactNode;
   /** If set, text with the percentage of ok casts is shown before the Performance Bar */
   includeOkCastPercentage?: boolean;
   /** A label to include when mousing over the 'bad' section of the Performance Bar */
-  badLabel?: string;
+  badLabel?: React.ReactNode;
   /** A brief explanation of what makes a cast 'bad', included in explanatory text */
-  badExtraExplanation?: string;
+  badExtraExplanation?: React.ReactNode;
   /** If set, text with the percentage of bad casts is shown before the Performance Bar */
   includeBadCastPercentage?: boolean;
   /** If set, explanatory text uses the word 'use' instead of 'cast'. Useful if data is evaluating

--- a/src/interface/guide/components/GradiatedPerformanceBar.tsx
+++ b/src/interface/guide/components/GradiatedPerformanceBar.tsx
@@ -33,7 +33,7 @@ export default function GradiatedPerformanceBar({
         <Tooltip
           content={
             <>
-              {perfectObj.label && `${perfectObj.label} - `}
+              {perfectObj.label && <>{perfectObj.label} - </>}
               <strong>
                 {perfectObj.count} / {total}
               </strong>
@@ -50,7 +50,7 @@ export default function GradiatedPerformanceBar({
         <Tooltip
           content={
             <>
-              {goodObj.label && `${goodObj.label} - `}
+              {goodObj.label && <>{goodObj.label} - </>}
               <strong>
                 {goodObj.count} / {total}
               </strong>
@@ -64,7 +64,7 @@ export default function GradiatedPerformanceBar({
         <Tooltip
           content={
             <>
-              {okObj.label && `${okObj.label} - `}
+              {okObj.label && <>{okObj.label} - </>}
               <strong>
                 {okObj.count} / {total}
               </strong>
@@ -78,7 +78,7 @@ export default function GradiatedPerformanceBar({
         <Tooltip
           content={
             <>
-              {badObj.label && `${badObj.label} - `}
+              {badObj.label && <>{badObj.label} - </>}
               <strong>
                 {badObj.count} / {total}
               </strong>
@@ -104,5 +104,5 @@ function getDefaultInfo(val?: number | GradiatedPerformanceBarInfo) {
 
 export type GradiatedPerformanceBarInfo = {
   count: number;
-  label: string;
+  label: React.ReactNode;
 };


### PR DESCRIPTION
### Description

* Migrated Rake, Rip, FB, and SA sections in Feral guide to use CastSummaryAndBreakdown component
* Added docs to CastSummaryAndBreakdown
* Added a couple minor improvements to CastSummaryAndBreakdown - `usesInsteadOfCasts` option and default mouseover text on the Bar 

### Testing
- Test report URL: `/report/wzmkrAF4WXbGBqZd/31-Mythic+Fyrakk+the+Blazing+-+Kill+(6:29)/Boogiecat/standard`

