### PR TITLE
Spellslinger Frost apl

### DIFF
--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore
 export default [
+  change(date(2024, 8, 23), <>Adding APL for Spellslinger Frost.</>, Earosselot),
   change(date(2024, 7, 30), <>Solved bug when not taking <SpellLink spell={TALENTS.RAY_OF_FROST_TALENT} />.</>, Earosselot),
   change(date(2024, 7, 30), <>Added Icy Veins to guides on About Section.</>, Earosselot),
   change(date(2024, 7, 30), <>Initial The War Within support</>, Earosselot),

--- a/src/analysis/retail/mage/frost/Guide.tsx
+++ b/src/analysis/retail/mage/frost/Guide.tsx
@@ -8,6 +8,8 @@ import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/mage';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
 import { HideExplanationsToggle } from 'interface/guide/components/HideExplanationsToggle';
+import { AplSectionData } from 'interface/guide/components/Apl';
+import * as ssApl from 'src/analysis/retail/mage/frost/apl/SpellslingerAplCheck';
 
 export const GUIDE_CORE_EXPLANATION_PERCENT = 50;
 
@@ -52,6 +54,11 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
     <>
       <Section title="Core">
         <HideExplanationsToggle id="hide-explanations-core" />
+        <SubSection title="Action Priority List (APL)">
+          {info.combatant.hasTalent(TALENTS.SPLINTERSTORM_TALENT) && (
+            <AplSectionData checker={ssApl.spellslingerCheck} apl={ssApl.spellslingerApl} />
+          )}
+        </SubSection>
         {alwaysBeCastingSubsection}
         {modules.wintersChill.guideSubsection}
         {modules.flurry.guideSubsection}

--- a/src/analysis/retail/mage/frost/apl/SpellslingerAplCheck.tsx
+++ b/src/analysis/retail/mage/frost/apl/SpellslingerAplCheck.tsx
@@ -19,12 +19,12 @@ export const spellslingerApl = build([
     ),
   },
   {
-    spell: TALENTS.FLURRY_TALENT,
-    condition: cnd.buffPresent(TALENTS.ICY_VEINS_TALENT),
-  },
-  {
     spell: TALENTS.GLACIAL_SPIKE_TALENT,
     condition: cnd.buffStacks(SPELLS.ICICLES_BUFF, { atLeast: 5 }),
+  },
+  {
+    spell: TALENTS.FLURRY_TALENT,
+    condition: cnd.buffPresent(TALENTS.ICY_VEINS_TALENT),
   },
   SPELLS.FROSTBOLT,
 ]);

--- a/src/analysis/retail/mage/frost/apl/SpellslingerAplCheck.tsx
+++ b/src/analysis/retail/mage/frost/apl/SpellslingerAplCheck.tsx
@@ -1,0 +1,32 @@
+import aplCheck, { build } from 'parser/shared/metrics/apl';
+import TALENTS from 'common/TALENTS/mage';
+import * as cnd from 'parser/shared/metrics/apl/conditions';
+import SPELLS from 'common/SPELLS';
+
+export const spellslingerApl = build([
+  {
+    spell: TALENTS.FLURRY_TALENT,
+    condition: cnd.and(
+      cnd.debuffMissing(SPELLS.WINTERS_CHILL),
+      cnd.or(cnd.lastSpellCast(SPELLS.FROSTBOLT), cnd.lastSpellCast(TALENTS.GLACIAL_SPIKE_TALENT)),
+    ),
+  },
+  {
+    spell: TALENTS.ICE_LANCE_TALENT,
+    condition: cnd.or(
+      cnd.debuffPresent(SPELLS.WINTERS_CHILL),
+      cnd.buffPresent(TALENTS.FINGERS_OF_FROST_TALENT),
+    ),
+  },
+  {
+    spell: TALENTS.FLURRY_TALENT,
+    condition: cnd.buffPresent(TALENTS.ICY_VEINS_TALENT),
+  },
+  {
+    spell: TALENTS.GLACIAL_SPIKE_TALENT,
+    condition: cnd.buffStacks(SPELLS.ICICLES_BUFF, { atLeast: 5 }),
+  },
+  SPELLS.FROSTBOLT,
+]);
+
+export const spellslingerCheck = aplCheck(spellslingerApl);


### PR DESCRIPTION
### Description

Added spellslinger frost apl.

APL:
1. Flurry if not Winter's Chill on target and prev cast wasFrostbolt or Glacial Spike.
2. Ice Lance with Winter's Chill or Fingers of Frost.
3. Glacial Spike
4. Flurry if IV active
5. Fb

- Test report URL: [report](https://www.warcraftlogs.com/reports/dBFcvg71ntG3YPJH/#fight=6&source=13)
- Screenshot(s):

![image](https://github.com/user-attachments/assets/669053eb-4529-4a43-8e98-c0b87d06789d)

