### PR TITLE
Necessary fixes to let Fury parser run

### DIFF
--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -1,12 +1,6 @@
+import { nullDozzer } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
-import { Listefano, CodersKitchen, ToppleTheNun, Ahri } from 'CONTRIBUTORS';
-import SpellLink from 'interface/SpellLink';
-import TALENTS from 'common/TALENTS/warrior';
 
 export default [
-  change(date(2023, 7, 23), <>Normalize extra casts from <SpellLink spell={TALENTS.BERSERKERS_TORMENT_TALENT}/>.</>, ToppleTheNun),
-  change(date(2023, 7, 22), 'Update default Fury Warrior log.', Ahri),
-  change(date(2023, 7, 8), 'Update SpellLink usage.', ToppleTheNun),
-  change(date(2023, 6, 25), 'Reduce CD of Raging Blow, when Honed Reflexes is skilled.', CodersKitchen),
-  change(date(2022, 10, 1), 'Dragonflight initial cleanup', Listefano),
+  change(date(2024, 8, 26), 'Prepare Fury for War Within. Update talents, spells and cooldowns.', nullDozzer),
 ];

--- a/src/analysis/retail/warrior/fury/CONFIG.tsx
+++ b/src/analysis/retail/warrior/fury/CONFIG.tsx
@@ -1,26 +1,23 @@
-import { Listefano, Tyndi } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
+import CHANGELOG from './CHANGELOG';
 
 // import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Tyndi, Listefano],
+  contributors: [],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.0.0',
-  supportLevel: SupportLevel.MaintainedPartial,
+  patchCompatibility: '11.0.2',
+  supportLevel: SupportLevel.Unmaintained,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      While most features for Fury have been implemented, there are a few that are still to come. If
-      you find any issues or if there is something missing that you would like to see added, please
-      open an Issue on <a href="https://github.com/WoWAnalyzer/WoWAnalyzer/issues/new">GitHub</a> or
-      send a message to Tyndi on Discord (Tyndi#9039). <br /> <br />
-      Make sure to check out the{' '}
+      WowAnalyzer for Fury has only limited ability to parse logs and provides no accurate guidance
+      to players. For guidance right now, make sure to check out the{' '}
       <a href="https://discordapp.com/invite/Skyhold">Warrior Class Discord</a> if you need more
       specific advice or a more detailed guide than the ones available on{' '}
       <a href="https://www.icy-veins.com/wow/fury-warrior-pve-dps-guide">Icy-Veins</a> and{' '}
@@ -35,12 +32,12 @@ const config: Config = {
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.FURY_WARRIOR,
   // The contents of your changelog.
-  // changelog: CHANGELOG,
+  changelog: CHANGELOG,
   // The CombatLogParser class for your spec.
-  // parser: () =>
-  //   import('./CombatLogParser' /* webpackChunkName: "FuryWarrior" */).then(
-  //     (exports) => exports.default,
-  //   ),
+  parser: () =>
+    import('./CombatLogParser' /* webpackChunkName: "FuryWarrior" */).then(
+      (exports) => exports.default,
+    ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: import.meta.url,
 };

--- a/src/analysis/retail/warrior/fury/modules/Abilities.ts
+++ b/src/analysis/retail/warrior/fury/modules/Abilities.ts
@@ -1,11 +1,8 @@
-import SPELLS from 'common/SPELLS';
-import talents from 'common/TALENTS/warrior';
+import SPELLS from 'common/SPELLS/warrior';
+import TALENTS from 'common/TALENTS/warrior';
 import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import CoreAbilities from 'parser/core/modules/Abilities';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
-import TALENTS from 'common/TALENTS/warrior';
-
-//https://www.warcraftlogs.com/reports/9Vw8TvjHNfXgWyP7#fight=19&type=summary&source=21 2+ cold steel hot blood
 
 class Abilities extends CoreAbilities {
   spellbook() {
@@ -13,34 +10,37 @@ class Abilities extends CoreAbilities {
     return [
       // Rotational
       {
-        spell: SPELLS.BLOODTHIRST.id,
+        spell: SPELLS.RAMPAGE.id,
+        enabled: combatant.hasTalent(TALENTS.RAMPAGE_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.ONSLAUGHT.id,
+        enabled: combatant.hasTalent(TALENTS.ONSLAUGHT_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: (haste: number) => 18 / (1 + haste),
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: [SPELLS.RAGING_BLOW.id, SPELLS.CRUSHING_BLOW.id],
+        enabled: combatant.hasTalent(TALENTS.RAGING_BLOW_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: (haste: number) => 8 / (1 + haste),
+        charges: 1 + (combatant.hasTalent(TALENTS.IMPROVED_RAGING_BLOW_TALENT) ? 1 : 0),
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: [SPELLS.BLOODTHIRST.id, SPELLS.BLOODBATH.id],
+        enabled: combatant.hasTalent(TALENTS.BLOODTHIRST_TALENT),
         category: SPELL_CATEGORY.ROTATIONAL,
         cooldown: (haste: number) => 4.5 / (1 + haste),
-        gcd: {
-          base: 1500,
-        },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.3,
-        },
-      },
-      {
-        spell: SPELLS.RAGING_BLOW.id,
-        category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: (haste: number) => {
-          if (combatant.hasTalent(TALENTS.HONED_REFLEXES_FURY_TALENT)) {
-            return 8 / (1 + haste);
-          }
-          return 9 / (1 + haste);
-        },
-        charges: 2,
-        gcd: {
-          base: 1500,
-        },
-      },
-      {
-        spell: SPELLS.RAMPAGE.id,
-        category: SPELL_CATEGORY.ROTATIONAL, // Needs 85 rage, if using Frothing Berserker one should only Rampage whilst at 100 rage.
         gcd: {
           base: 1500,
         },
@@ -48,11 +48,18 @@ class Abilities extends CoreAbilities {
       {
         spell: [SPELLS.EXECUTE_FURY.id, SPELLS.EXECUTE_FURY_MASSACRE.id],
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: (haste: number) => 6 / (1 + haste),
+        cooldown: (haste: number) =>
+          (6 - (combatant.hasTalent(TALENTS.MASSACRE_FURY_TALENT) ? 1.5 : 0)) / (1 + haste),
         gcd: {
           base: 1500,
         },
-        enabled: !false,
+      },
+      {
+        spell: SPELLS.SLAM.id,
+        category: SPELL_CATEGORY.ROTATIONAL,
+        gcd: {
+          base: 1500,
+        },
       },
       // Rotational AOE
       {
@@ -62,36 +69,51 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
       },
-      {
-        spell: talents.CHAMPIONS_SPEAR_TALENT.id,
-        category: SPELL_CATEGORY.ROTATIONAL_AOE,
-        cooldown: 90,
-        gcd: {
-          base: 1500,
-        },
-        enabled: combatant.hasTalent(talents.CHAMPIONS_SPEAR_TALENT),
-      },
       // Others
       {
-        spell: SPELLS.VICTORY_RUSH.id,
-        category: SPELL_CATEGORY.OTHERS,
-        gcd: {
-          base: 1500,
-        },
-        enabled: !combatant.hasTalent(talents.IMPENDING_VICTORY_TALENT),
-      },
-      {
+        enabled: combatant.hasTalent(TALENTS.IMPENDING_VICTORY_TALENT),
         spell: SPELLS.IMPENDING_VICTORY_TALENT_HEAL.id,
         category: SPELL_CATEGORY.OTHERS,
         cooldown: 30,
         gcd: {
           base: 1500,
         },
-        enabled: combatant.hasTalent(talents.IMPENDING_VICTORY_TALENT),
+      },
+      {
+        enabled: !combatant.hasTalent(TALENTS.IMPENDING_VICTORY_TALENT),
+        spell: SPELLS.VICTORY_RUSH.id,
+        category: SPELL_CATEGORY.OTHERS,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.THUNDER_CLAP.id,
+        enabled: combatant.hasTalent(TALENTS.THUNDER_CLAP_TALENT),
+        category: SPELL_CATEGORY.OTHERS,
+        cooldown: 6,
+        gcd: {
+          base: 1500,
+        },
       },
       // Cooldown
       {
         spell: SPELLS.RECKLESSNESS.id,
+        enabled:
+          combatant.hasTalent(TALENTS.RECKLESSNESS_TALENT) ||
+          combatant.hasTalent(TALENTS.BERSERKERS_TORMENT_TALENT),
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 90,
+        gcd: null,
+        castEfficiency: {
+          suggestion: true,
+          importance: ISSUE_IMPORTANCE.MAJOR,
+          recommendedEfficiency: 0.95,
+        },
+      },
+      {
+        spell: TALENTS.RAVAGER_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.RAVAGER_TALENT),
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: 90,
         gcd: {
@@ -99,15 +121,79 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
+          importance: ISSUE_IMPORTANCE.MAJOR,
+          recommendedEfficiency: 0.95,
+        },
+      },
+      {
+        spell: SPELLS.AVATAR_SHARED.id,
+        enabled: combatant.hasTalent(TALENTS.AVATAR_SHARED_TALENT),
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 90,
+        gcd: null,
+        castEfficiency: {
+          suggestion: true,
+          importance: ISSUE_IMPORTANCE.MAJOR,
+          recommendedEfficiency: 0.95,
+        },
+      },
+      {
+        spell: TALENTS.THUNDEROUS_ROAR_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.THUNDEROUS_ROAR_TALENT),
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 90 - (combatant.hasTalent(TALENTS.UPROAR_TALENT) ? 45 : 0),
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          importance: ISSUE_IMPORTANCE.MAJOR,
+          recommendedEfficiency: 0.95,
+        },
+      },
+      {
+        spell: TALENTS.CHAMPIONS_SPEAR_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.CHAMPIONS_SPEAR_TALENT),
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 90,
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          importance: ISSUE_IMPORTANCE.MAJOR,
+          recommendedEfficiency: 0.95,
+        },
+      },
+      {
+        spell: SPELLS.ODYNS_FURY.id,
+        enabled: combatant.hasTalent(TALENTS.ODYNS_FURY_TALENT),
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 45,
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          importance: ISSUE_IMPORTANCE.MAJOR,
           recommendedEfficiency: 0.95,
         },
       },
       // Defensive
       {
+        spell: SPELLS.SPELL_REFLECTION.id,
+        enabled: combatant.hasTalent(TALENTS.SPELL_REFLECTION_TALENT),
+        category: SPELL_CATEGORY.DEFENSIVE,
+        buffSpellId: SPELLS.SPELL_REFLECTION.id,
+        cooldown: 25 * (combatant.hasTalent(TALENTS.HONED_REFLEXES_TALENT) ? 0.95 : 1),
+        gcd: null,
+      },
+      {
         spell: SPELLS.ENRAGED_REGENERATION.id,
+        enabled: combatant.hasTalent(TALENTS.ENRAGED_REGENERATION_TALENT),
         category: SPELL_CATEGORY.DEFENSIVE,
         buffSpellId: SPELLS.ENRAGED_REGENERATION.id,
-        cooldown: 120,
+        cooldown: 120 * (combatant.hasTalent(TALENTS.HONED_REFLEXES_TALENT) ? 0.95 : 1),
         gcd: null,
         castEfficiency: {
           suggestion: true,
@@ -116,7 +202,16 @@ class Abilities extends CoreAbilities {
         },
       },
       {
+        spell: TALENTS.BITTER_IMMUNITY_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.BITTER_IMMUNITY_TALENT),
+        category: SPELL_CATEGORY.DEFENSIVE,
+        buffSpellId: TALENTS.BITTER_IMMUNITY_TALENT.id,
+        cooldown: 3 * 60,
+        gcd: null,
+      },
+      {
         spell: SPELLS.RALLYING_CRY.id,
+        enabled: combatant.hasTalent(TALENTS.RALLYING_CRY_TALENT),
         category: SPELL_CATEGORY.DEFENSIVE,
         buffSpellId: SPELLS.RALLYING_CRY_BUFF.id,
         cooldown: 180,
@@ -135,21 +230,30 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.CHARGE.id,
         category: SPELL_CATEGORY.UTILITY,
-        cooldown: 20 - (combatant.hasTalent(talents.DOUBLE_TIME_TALENT) ? 3 : 0),
-        charges: 1 + (combatant.hasTalent(talents.DOUBLE_TIME_TALENT) ? 1 : 0),
+        cooldown: 20 - (combatant.hasTalent(TALENTS.DOUBLE_TIME_TALENT) ? 3 : 0),
+        charges: 1 + (combatant.hasTalent(TALENTS.DOUBLE_TIME_TALENT) ? 1 : 0),
       },
       {
         spell: SPELLS.HEROIC_LEAP.id,
+        enabled: combatant.hasTalent(TALENTS.HEROIC_LEAP_TALENT),
         category: SPELL_CATEGORY.UTILITY,
         buffSpellId: SPELLS.BOUNDING_STRIDE_BUFF.id,
-        cooldown: 45 - (combatant.hasTalent(talents.BOUNDING_STRIDE_TALENT) ? 15 : 0),
+        cooldown: 45 - (combatant.hasTalent(TALENTS.BOUNDING_STRIDE_TALENT) ? 15 : 0),
         charges: 1,
         gcd: null,
       },
       {
-        spell: talents.STORM_BOLT_TALENT.id,
+        spell: SPELLS.INTERVENE_CAST.id,
+        enabled: combatant.hasTalent(TALENTS.INTERVENE_TALENT),
         category: SPELL_CATEGORY.UTILITY,
-        cooldown: 30,
+        cooldown: 30 * (combatant.hasTalent(TALENTS.HONED_REFLEXES_TALENT) ? 0.95 : 1),
+        gcd: null,
+      },
+      {
+        spell: TALENTS.STORM_BOLT_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.STORM_BOLT_TALENT),
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 30 * (combatant.hasTalent(TALENTS.HONED_REFLEXES_TALENT) ? 0.95 : 1),
         gcd: {
           base: 1500,
         },
@@ -159,18 +263,36 @@ class Abilities extends CoreAbilities {
           extraSuggestion:
             "If you're picking a utility talent over something that increases your mobility or survivability, you better use it.",
         },
-        enabled: combatant.hasTalent(talents.STORM_BOLT_TALENT),
+      },
+      {
+        spell: TALENTS.SHOCKWAVE_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.SHOCKWAVE_TALENT),
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 40,
+        gcd: {
+          base: 1500,
+        },
       },
       {
         spell: SPELLS.PUMMEL.id,
         category: SPELL_CATEGORY.UTILITY,
-        cooldown: 15,
+        cooldown:
+          (15 - (combatant.hasTalent(TALENTS.CONCUSSIVE_BLOWS_TALENT) ? 1 : 0)) *
+          (combatant.hasTalent(TALENTS.HONED_REFLEXES_TALENT) ? 0.95 : 1),
         gcd: null,
       },
       {
         spell: SPELLS.BERSERKER_RAGE.id,
         category: SPELL_CATEGORY.UTILITY,
         buffSpellId: SPELLS.BERSERKER_RAGE.id,
+        cooldown: 60,
+        gcd: null,
+      },
+      {
+        spell: TALENTS.BERSERKER_SHOUT_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.BERSERKER_SHOUT_TALENT),
+        category: SPELL_CATEGORY.UTILITY,
+        buffSpellId: TALENTS.BERSERKER_SHOUT_TALENT.id,
         cooldown: 60,
         gcd: null,
       },
@@ -183,7 +305,26 @@ class Abilities extends CoreAbilities {
         },
       },
       {
+        spell: TALENTS.WRECKING_THROW_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.WRECKING_THROW_TALENT),
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 45,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.SHATTERING_THROW.id,
+        enabled: combatant.hasTalent(TALENTS.SHATTERING_THROW_TALENT),
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 45,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
         spell: SPELLS.INTIMIDATING_SHOUT.id,
+        enabled: combatant.hasTalent(TALENTS.INTIMIDATING_SHOUT_TALENT),
         category: SPELL_CATEGORY.UTILITY,
         cooldown: 90,
         gcd: {
@@ -192,7 +333,9 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.PIERCING_HOWL.id,
+        enabled: combatant.hasTalent(TALENTS.PIERCING_HOWL_TALENT),
         category: SPELL_CATEGORY.UTILITY,
+        cooldown: 30,
         gcd: {
           base: 1500,
         },
@@ -210,6 +353,14 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.UTILITY,
         cooldown: 8,
         gcd: null,
+      },
+      {
+        spell: SPELLS.IMPENDING_VICTORY.id,
+        category: SPELL_CATEGORY.SEMI_DEFENSIVE,
+        cooldown: 25,
+        gcd: {
+          base: 1500,
+        },
       },
     ];
   }

--- a/src/analysis/retail/warrior/fury/modules/talents/ChampionsSpear.tsx
+++ b/src/analysis/retail/warrior/fury/modules/talents/ChampionsSpear.tsx
@@ -14,7 +14,7 @@ class ChampionsSpear extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(TALENTS.CHAMPIONS_SPEAR_TALENT);
 
     this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SPEAR_OF_BASTION),
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.CHAMPIONS_SPEAR),
       this.onSpearDamage,
     );
   }

--- a/src/common/SPELLS/warrior.ts
+++ b/src/common/SPELLS/warrior.ts
@@ -233,6 +233,11 @@ const spells = {
     name: 'Whirlwind',
     icon: 'ability_whirlwind',
   },
+  ONSLAUGHT: {
+    id: 315720,
+    name: 'Onslaught',
+    icon: 'ability_warrior_trauma',
+  },
 
   // Arms/Fury:
   PIERCING_HOWL: {
@@ -274,10 +279,40 @@ const spells = {
     name: 'Impending Victory',
     icon: 'spell_impending_victory',
   },
-  SPEAR_OF_BASTION: {
-    id: 376080,
-    name: 'Spear of Bastion',
+  IMPENDING_VICTORY: {
+    id: 202168,
+    name: 'Impending Victory',
+    icon: 'spell_impending_victory',
+  },
+  CHAMPIONS_SPEAR: {
+    id: 376079,
+    name: "Champion's Spear",
     icon: 'ability_bastion_warrior',
+  },
+  CHAMPIONS_SPEAR_DAMAGE: {
+    id: 376080,
+    name: "Champion's Spear",
+    icon: 'ability_bastion_warrior',
+  },
+  CHAMPIONS_MIGHT: {
+    id: 386286,
+    name: "Champion's Might",
+    icon: 'ability_bastion_warrior',
+  },
+  WILD_STRIKES: {
+    id: 392778,
+    name: 'Wild Strikes',
+    icon: 'ability_ghoulfrenzy',
+  },
+  AVATAR_SHARED: {
+    id: 107574,
+    name: 'Avatar',
+    icon: 'warrior_talent_icon_avatar',
+  },
+  AVATAR_PROTECTION: {
+    id: 401150,
+    name: 'Avatar',
+    icon: 'warrior_talent_icon_avatar',
   },
 
   // Arms:
@@ -321,6 +356,11 @@ const spells = {
     id: 7384,
     name: 'Overpower',
     icon: 'ability_meleedamage',
+  },
+  SEASONED_SOLDIER: {
+    id: 279423,
+    name: 'Seasoned Soldier',
+    icon: 'inv_axe_09',
   },
   SWEEPING_STRIKES: {
     id: 260708,
@@ -454,6 +494,31 @@ const spells = {
     id: 335096,
     name: 'Bloodbath',
     icon: 'ability_warrior_bloodbath',
+  },
+  ODYNS_FURY: {
+    id: 385060,
+    name: "Odyn's Fury",
+    icon: 'inv_sword_1h_artifactvigfus_d_01',
+  },
+  ODYNS_FURY_1: {
+    id: 385059,
+    name: "Odyn's Fury",
+    icon: 'inv_sword_1h_artifactvigfus_d_01',
+  },
+  ODYNS_FURY_2: {
+    id: 385061,
+    name: "Odyn's Fury",
+    icon: 'inv_sword_1h_artifactvigfus_d_01',
+  },
+  ODYNS_FURY_3: {
+    id: 385062,
+    name: "Odyn's Fury",
+    icon: 'inv_sword_1h_artifactvigfus_d_01',
+  },
+  FRENZY: {
+    id: 335082,
+    name: 'Frenzy',
+    icon: 'ability_rogue_bloodyeye',
   },
 
   // Protection:

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -105,6 +105,9 @@ const spells: number[] = [
   SPELLS.RAMPAGE_2.id,
   SPELLS.RAMPAGE_3.id,
   SPELLS.RAMPAGE_4.id,
+  SPELLS.ODYNS_FURY_1.id,
+  SPELLS.ODYNS_FURY_2.id,
+  SPELLS.ODYNS_FURY_3.id,
   SPELLS.HACK_AND_SLASH.id,
   SPELLS.WRATH_AND_FURY.id,
   //endregion


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

I have worked for a long time for a very ambitious rewrite of Fury Warrior, including correct haste and rage tracking, at [oBusk/WoWAnalyzer/dps-warrior-tww](https://github.com/oBusk/WoWAnalyzer/tree/dps-warrior-tww). However, I've realized that I need to get parts of it in PRs, otherwise it will be unreviewable. 

So in preparation for more work on Fury (and arms) Warrior, here is a commit that simply enables Fury so that upcoming changes are easier to actually see

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/...`
- Screenshot(s):
