### PR TITLE
Add zen pulse guide section

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date (2024, 9, 11), <>Add <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT}/> guide section</>, Trevor),
   change(date (2024, 9, 10), <>Change <SpellLink spell={TALENTS_MONK.REVIVAL_TALENT}/> load conditions</>, Trevor),
   change(date (2024, 8, 1), <>Updated values from Beta tuning.</>, Vohrr),
   change(date (2024, 7, 31), <>Added <SpellLink spell={TALENTS_MONK.MENDING_PROLIFERATION_TALENT}/>, <SpellLink spell={TALENTS_MONK.TEAR_OF_MORNING_TALENT}/>, <SpellLink spell={TALENTS_MONK.CHI_HARMONY_TALENT}/>, <SpellLink spell={TALENTS_MONK.LOTUS_INFUSION_TALENT}/>, <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT}/>, and <SpellLink spell={TALENTS_MONK.CRANE_STYLE_TALENT}/> to Talent Breakdown.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CONFIG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CONFIG.tsx
@@ -1,12 +1,12 @@
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
-import { Vohrr } from 'CONTRIBUTORS';
+import { Trevor, Vohrr } from 'CONTRIBUTORS';
 import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Vohrr],
+  contributors: [Trevor, Vohrr],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '11.0.2',

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -77,6 +77,8 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           modules.chiBurst.guideSubsection}
         {info.combatant.hasTalent(TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT) &&
           modules.vivaciousVivification.guideSubsection}
+        {info.combatant.hasTalent(TALENTS_MONK.ZEN_PULSE_TALENT) &&
+          modules.zenPulse.guideSubsection}
       </Section>
       <PreparationSection />
     </>

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
@@ -107,7 +107,7 @@ class VivaciousVivification extends Analyzer {
     }
   }
 
-  //We enter unusable period if our ReM count becomes too low or if we consume the buff
+  // We enter unusable period if our ReM count becomes too low or if we consume the buff
   onRemRemove(event: RemoveBuffEvent) {
     if (this.inUsablePeriod && !this.isUsable) {
       this.endUsablePeriod(event.timestamp);

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ZenPulse.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ZenPulse.tsx
@@ -44,6 +44,7 @@ class ZenPulse extends Analyzer {
   badCasts: number = 0;
   castIncreases: number[] = [];
   entries: BoxRowEntry[] = [];
+
   constructor(options: Options) {
     super(options);
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ZenPulse.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ZenPulse.tsx
@@ -114,7 +114,6 @@ class ZenPulse extends Analyzer {
   }
 
   private startUptimeWindow(timestamp: number) {
-    console.log(`Starting uptime window at ${this.owner.formatTimestamp(timestamp)}`);
     this.uptimes.push({
       uptime: {
         start: timestamp,
@@ -126,7 +125,6 @@ class ZenPulse extends Analyzer {
 
   private endUptimeWindow(timestamp: number, expired: boolean) {
     if (this.uptimes.length) {
-      console.log(`Ending uptime window at ${this.owner.formatTimestamp(timestamp)}`);
       const cur = this.uptimes.at(-1)!;
       cur.uptime.end = timestamp;
       cur.expired = expired;

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -291,8 +291,8 @@ export function isVivaciousVivification(event: HealEvent) {
   return GetRelatedEvent(event, VIVACIOUS_VIVIFICATION);
 }
 
-export function getZenPulseHitsPerCast(event: HealEvent) {
-  return GetRelatedEvents(event, ZEN_PULSE_VIVIFY);
+export function getZenPulseHitsPerCast(event: HealEvent): HealEvent[] {
+  return GetRelatedEvents<HealEvent>(event, ZEN_PULSE_VIVIFY);
 }
 
 export function isZenPulseConsumed(event: RemoveBuffEvent | RemoveBuffStackEvent) {


### PR DESCRIPTION
### Description

Adds section to the guide to display zen pulse buff consumption and give a brief overview of how to use it. If a buff consumption expires then its red, yellow means either you didn't get full healing bonus or high overhealing, and green is good.

### Testing

- Test report URL: `report/mYBH63bQnKfc1aGF/1-Normal+Ulgrax+the+Devourer+-+Kill+(3:38)/Trevormonk/standard`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/d6508364-bfa2-43e8-9225-094b1195692e)

