### PR TITLE
[core] add support for Earthen characters

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 9, 12), 'Add support for Earthen characters.', ToppleTheNun),
   change(date(2024, 9, 10), 'Change behavior of getLowestPerf when no perfs are provided', Trevor),
   change(date(2024, 9, 9), 'Fix character search showing UNKNOWN instead of THE WAR WITHIN.', ToppleTheNun),
   change(date(2024, 9, 8), "Add Nerub'ar Palace bosses and season 1 M+ dungeons.", ToppleTheNun),

--- a/src/game/RACES.ts
+++ b/src/game/RACES.ts
@@ -168,6 +168,16 @@ const RACES: {
     side: 'horde',
     name: 'Dracthyr',
   },
+  EarthenHorde: {
+    id: 84,
+    name: 'Earthen',
+    side: 'horde',
+  },
+  EarthenAlliance: {
+    id: 85,
+    name: 'Earthen',
+    side: 'alliance',
+  },
 };
 
 export default RACES;


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

Add support for Earthen.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/wfkjdxgF8aZznv24/16-Normal+Ulgrax+the+Devourer+-+Kill+(3:22)/Ochaa/standard`
- Screenshot(s):
