### PR TITLE
do not attempt to render a probability chart when no proc attempts occurred

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 9, 12), 'Fixed crash when analyzing reports where 0 procs of certain effects ocurred.', emallson),
   change(date(2024, 9, 12), 'Add support for Earthen characters.', ToppleTheNun),
   change(date(2024, 9, 10), 'Change behavior of getLowestPerf when no perfs are provided', Trevor),
   change(date(2024, 9, 9), 'Fix character search showing UNKNOWN instead of THE WAR WITHIN.', ToppleTheNun),

--- a/src/parser/shared/modules/helpers/Probability.tsx
+++ b/src/parser/shared/modules/helpers/Probability.tsx
@@ -185,6 +185,9 @@ export function plotOneVariableBinomChart(
     title: 'Likelihood',
   },
 ) {
+  if (procAttempts < 1) {
+    return null;
+  }
   const { procProbabilities, rangeMin, rangeMax } = setMinMaxProbabilities(
     actualProcs,
     procAttempts,


### PR DESCRIPTION
this fixes a crash from attempting lookup in an empty array

test report: http://localhost:3000/report/9nqz4kVHZdFwypmW/47-Heroic+The+Bloodbound+Horror+-+Kill+(5:40)/Beigheals/standard