### PR TITLE
Druid Resto: Added ability to track 'base extensions' of HoTs to HotTracker, and implemented some stats with this

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2024, 9, 13), <>Added statistics for <SpellLink spell={TALENTS_DRUID.GERMINATION_TALENT}/> and  <SpellLink spell={TALENTS_DRUID.THRIVING_VEGETATION_TALENT}/>. Fixed an issue where  <SpellLink spell={TALENTS_DRUID.RAMPANT_GROWTH_TALENT}/> statistic was undercounting. </>, Sref),
   change(date(2024, 9, 3), <>Fixed numbers for <SpellLink spell={TALENTS_DRUID.PHOTOSYNTHESIS_TALENT}/> self Lifebloom. Fixed calculation issues in <SpellLink spell={TALENTS_DRUID.ABUNDANCE_TALENT}/> statistic and updated tooltip.</>, Sref),
   change(date(2024, 8, 23), <>Cleaner display of <SpellLink spell={SPELLS.WILD_GROWTH}/>, <SpellLink spell={SPELLS.REGROWTH}/>, <SpellLink spell={SPELLS.SWIFTMEND}/>, and <SpellLink spell={TALENTS_DRUID.SOUL_OF_THE_FOREST_RESTORATION_TALENT}/> sections in Guide. Added <SpellLink spell={SPELLS.SWIFTMEND}/> cast efficiency tracking. Tweaked Guide text. </>, Sref),
   change(date(2024, 8, 17), <>Marked updated for 11.0.2 and updated the spec's 'About' page.</>, Sref),

--- a/src/analysis/retail/druid/restoration/CombatLogParser.ts
+++ b/src/analysis/retail/druid/restoration/CombatLogParser.ts
@@ -59,6 +59,8 @@ import WildGrowthPrecastOrderNormalizer from 'analysis/retail/druid/restoration/
 import WakingDream from 'analysis/retail/druid/restoration/modules/spells/WakingDream';
 import GroveGuardians from 'analysis/retail/druid/restoration/modules/spells/GroveGuardians';
 import CenariusGuidanceTol from 'analysis/retail/druid/restoration/modules/spells/CenariusGuidanceTol';
+import Germination from 'analysis/retail/druid/restoration/modules/spells/Germination';
+import ThrivingVegetation from 'analysis/retail/druid/restoration/modules/spells/ThrivingVegetation';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -124,6 +126,8 @@ class CombatLogParser extends CoreCombatLogParser {
     wakingDream: WakingDream,
     groveGuardians: GroveGuardians,
     cenariusGuidanceTol: CenariusGuidanceTol,
+    germination: Germination,
+    thrivingVegetation: ThrivingVegetation,
 
     // Mana Tab
     manaTracker: ManaTracker,

--- a/src/analysis/retail/druid/restoration/modules/Abilities.tsx
+++ b/src/analysis/retail/druid/restoration/modules/Abilities.tsx
@@ -52,7 +52,7 @@ class Abilities extends CoreAbilities {
         healSpellIds: [SPELLS.EFFLORESCENCE_HEAL.id, SPELLS.SPRING_BLOSSOMS.id],
       },
       {
-        spell: SPELLS.REJUVENATION.id,
+        spell: [SPELLS.REJUVENATION.id, SPELLS.REJUVENATION_GERMINATION.id],
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: {
           base: 1500,

--- a/src/analysis/retail/druid/restoration/modules/core/hottracking/HotAttributor.ts
+++ b/src/analysis/retail/druid/restoration/modules/core/hottracking/HotAttributor.ts
@@ -177,6 +177,9 @@ class HotAttributor extends Analyzer {
     } else if (isFromOvergrowth(event)) {
       this.hotTracker.addAttributionFromApply(this.overgrowthAttrib, event);
       this._logAttrib(event, this.overgrowthAttrib);
+    } else if (possibleRg) {
+      this.hotTracker.addAttributionFromApply(this.rampantGrowthAttrib, event);
+      this._logAttrib(event, this.rampantGrowthAttrib);
     } else if (possiblePota) {
       this.hotTracker.addAttributionFromApply(this.powerOfTheArchdruidRegrowthAttrib, event);
       this._logAttrib(event, this.powerOfTheArchdruidRegrowthAttrib);

--- a/src/analysis/retail/druid/restoration/modules/core/hottracking/HotTrackerRestoDruid.tsx
+++ b/src/analysis/retail/druid/restoration/modules/core/hottracking/HotTrackerRestoDruid.tsx
@@ -15,7 +15,9 @@ import {
 } from 'analysis/retail/druid/restoration/constants';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
-const LIVELINESS_MULT = 0.95;
+export const GERMINATION_ATT_NAME = 'Germination extension';
+export const IMP_REJUV_ATT_NAME = 'Improved Rejuvenation extension';
+export const THRIVING_VEG_ATT_NAME = 'Thriving Vegetation extension';
 
 class HotTrackerRestoDruid extends HotTracker {
   static dependencies = {
@@ -88,85 +90,95 @@ class HotTrackerRestoDruid extends HotTracker {
   }
 
   _generateHotInfo(): HotInfo[] {
-    const hasLiveliness = this.selectedCombatant.hasTalent(TALENTS_DRUID.LIVELINESS_TALENT);
-    const hasImpRejuv = this.selectedCombatant.hasTalent(
+    const impRejuvRank = this.selectedCombatant.getTalentRank(
       TALENTS_DRUID.IMPROVED_REJUVENATION_TALENT,
     );
-    const hasGermination = this.selectedCombatant.hasTalent(TALENTS_DRUID.GERMINATION_TALENT);
+    const germinationRank = this.selectedCombatant.getTalentRank(TALENTS_DRUID.GERMINATION_TALENT);
     const thrivingVegetationRank = this.selectedCombatant.getTalentRank(
       TALENTS_DRUID.THRIVING_VEGETATION_TALENT,
     );
 
-    const globalMult = hasLiveliness ? LIVELINESS_MULT : 1;
-    const rejuvDuration = 12000 + (hasImpRejuv ? 3000 : 0) + (hasGermination ? 2000 : 0);
-    const regrowthDuration = 12000 + thrivingVegetationRank * 3000;
+    const improvedRejuvenationAtt = HotTracker.getNewAttribution(IMP_REJUV_ATT_NAME);
+    const germinationAtt = HotTracker.getNewAttribution(GERMINATION_ATT_NAME);
+    const thrivingVegetationAtt = HotTracker.getNewAttribution(THRIVING_VEG_ATT_NAME);
 
     return [
       {
         spell: SPELLS.REJUVENATION,
-        duration: rejuvDuration * globalMult,
+        duration: 12000,
         tickPeriod: 3000,
+        baseExtensions: [
+          { attribution: germinationAtt, amount: germinationRank * 2000 },
+          { attribution: improvedRejuvenationAtt, amount: impRejuvRank * 3000 },
+        ],
       },
       {
         spell: SPELLS.REJUVENATION_GERMINATION,
-        duration: rejuvDuration * globalMult,
+        duration: 12000,
         tickPeriod: 3000,
+        baseExtensions: [
+          { attribution: germinationAtt, amount: germinationRank * 2000 },
+          { attribution: improvedRejuvenationAtt, amount: impRejuvRank * 3000 },
+        ],
       },
       {
         spell: SPELLS.REGROWTH,
-        duration: regrowthDuration * globalMult,
+        duration: 12000,
         tickPeriod: 2000,
+        baseExtensions: [
+          { attribution: thrivingVegetationAtt, amount: thrivingVegetationRank * 3000 },
+        ],
       },
       {
         spell: SPELLS.WILD_GROWTH,
-        duration: 7000 * globalMult,
+        duration: 7000,
         tickPeriod: 1000,
       },
       {
         spell: SPELLS.LIFEBLOOM_HOT_HEAL,
-        duration: 15000 * globalMult,
+        duration: 15000,
         tickPeriod: 1000,
       },
       {
         spell: SPELLS.LIFEBLOOM_UNDERGROWTH_HOT_HEAL,
-        duration: 15000 * globalMult,
+        duration: 15000,
         tickPeriod: 1000,
       },
       {
         spell: SPELLS.CENARION_WARD_HEAL,
-        duration: 8000 * globalMult,
+        duration: 8000,
         tickPeriod: 2000,
       },
       {
         spell: SPELLS.CULTIVATION,
-        duration: 6000 * globalMult,
+        duration: 6000,
         tickPeriod: 2000,
       },
       {
         spell: SPELLS.SPRING_BLOSSOMS,
-        duration: 6000 * globalMult,
+        duration: 6000,
         tickPeriod: 2000,
         noHaste: true,
       },
       {
         spell: SPELLS.TRANQUILITY_HEAL,
-        duration: 8000 * globalMult,
+        duration: 8000,
         tickPeriod: 2000,
         refreshNoPandemic: true,
       },
       {
         spell: SPELLS.ADAPTIVE_SWARM_HEAL,
-        duration: 12000 * globalMult,
+        duration: 12000,
         tickPeriod: 2000,
       },
       {
         spell: SPELLS.RENEWING_BLOOM,
-        duration: 8000 * globalMult,
+        duration: 8000,
         tickPeriod: 1000,
       },
       {
         spell: SPELLS.GROVE_TENDING,
-        duration: 9000 * globalMult,
+        duration: 9000,
         tickPeriod: 3000,
       },
       // Wildstalker's Symbiotic Bloom appears to largely not interact with extensions

--- a/src/analysis/retail/druid/restoration/modules/spells/Germination.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Germination.tsx
@@ -1,0 +1,92 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import HotTrackerRestoDruid, {
+  GERMINATION_ATT_NAME,
+} from 'analysis/retail/druid/restoration/modules/core/hottracking/HotTrackerRestoDruid';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import { Options } from 'parser/core/Module';
+import Events from 'parser/core/Events';
+import SPELLS from 'common/SPELLS';
+import { SpellIcon, SpellLink } from 'interface';
+import { formatPercentage } from 'common/format';
+
+export default class Germination extends Analyzer.withDependencies({
+  hotTracker: HotTrackerRestoDruid,
+}) {
+  totalRejuvs = 0;
+  germs = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.GERMINATION_TALENT);
+    this.addEventListener(
+      Events.applybuff
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.REJUVENATION, SPELLS.REJUVENATION_GERMINATION]),
+      this.onApplyAnyRejuv,
+    );
+    this.addEventListener(
+      Events.refreshbuff
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.REJUVENATION, SPELLS.REJUVENATION_GERMINATION]),
+      this.onApplyAnyRejuv,
+    );
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.REJUVENATION_GERMINATION),
+      this.onApplyGerm,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.REJUVENATION_GERMINATION),
+      this.onApplyGerm,
+    );
+  }
+
+  onApplyAnyRejuv() {
+    this.totalRejuvs += 1;
+  }
+
+  onApplyGerm() {
+    this.germs += 1;
+  }
+
+  statistic() {
+    const extraDurationHealing =
+      this.deps.hotTracker.getAttribution(GERMINATION_ATT_NAME)?.healing || 0;
+    return (
+      <Statistic
+        size="flexible"
+        position={STATISTIC_ORDER.OPTIONAL(10)} // number based on talent row
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            <p>
+              Out of <strong>{this.totalRejuvs}</strong> total{' '}
+              <SpellLink spell={SPELLS.REJUVENATION} /> applications, <strong>{this.germs}</strong>{' '}
+              were the 2nd on target (<SpellLink spell={SPELLS.REJUVENATION_GERMINATION} />)
+            </p>
+            <p>
+              <strong>
+                {formatPercentage(this.owner.getPercentageOfTotalHealingDone(extraDurationHealing))}
+                %
+              </strong>{' '}
+              is the percentage of total healing attributable specifically to the extra 2 seconds of
+              Rejuv duration.
+            </p>
+          </>
+        }
+      >
+        <BoringSpellValueText spell={TALENTS_DRUID.GERMINATION_TALENT}>
+          <SpellIcon spell={SPELLS.REJUVENATION_GERMINATION} /> {this.germs} /{' '}
+          <SpellIcon spell={SPELLS.REJUVENATION} /> {this.totalRejuvs}
+          <br />
+          <ItemPercentHealingDone amount={extraDurationHealing} />
+          <small> from +2 sec</small>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/druid/restoration/modules/spells/ThrivingVegetation.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/ThrivingVegetation.tsx
@@ -1,0 +1,68 @@
+import HotTrackerRestoDruid, {
+  THRIVING_VEG_ATT_NAME,
+} from 'analysis/retail/druid/restoration/modules/core/hottracking/HotTrackerRestoDruid';
+import Analyzer from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Module';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import SPELLS from 'common/SPELLS';
+import { SpellLink } from 'interface';
+
+/**
+ * **Thriving Vegetation**
+ * Spec Talent
+ *
+ * Rejuvenation instantly heals your target for (15/30)% of its total periodic effect and Regrowth's duration is increased by (3/6) sec.
+ */
+export default class ThrivingVegetation extends Analyzer.withDependencies({
+  hotTracker: HotTrackerRestoDruid,
+  abilityTracker: AbilityTracker,
+}) {
+  rank: number;
+
+  constructor(options: Options) {
+    super(options);
+    this.rank = this.selectedCombatant.getTalentRank(TALENTS_DRUID.THRIVING_VEGETATION_TALENT);
+    this.active = this.rank > 0;
+  }
+
+  statistic() {
+    const extraDurationHealing =
+      this.deps.hotTracker.getAttribution(THRIVING_VEG_ATT_NAME)?.healing || 0;
+    const instantRejuvHealing = this.deps.abilityTracker.getAbility(
+      SPELLS.THRIVING_VEGETATION.id,
+    ).healingEffective;
+    return (
+      <Statistic
+        size="flexible"
+        position={STATISTIC_ORDER.OPTIONAL(9)} // number based on talent row
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            This is the sum of the direct healing from Rejuvenation casts and the extra healing from
+            the extension to Regrowth.
+            <ul>
+              <li>
+                <SpellLink spell={SPELLS.REJUVENATION} /> Direct:{' '}
+                <strong>{this.owner.formatItemHealingDone(instantRejuvHealing)}</strong>
+              </li>
+              <li>
+                <SpellLink spell={SPELLS.REGROWTH} /> Extension:{' '}
+                <strong>{this.owner.formatItemHealingDone(extraDurationHealing)}</strong>
+              </li>
+            </ul>
+          </>
+        }
+      >
+        <TalentSpellText talent={TALENTS_DRUID.THRIVING_VEGETATION_TALENT}>
+          <ItemPercentHealingDone amount={extraDurationHealing + instantRejuvHealing} />
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/druid/restoration/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/druid/restoration/normalizers/CastLinkNormalizer.ts
@@ -15,7 +15,7 @@ import {
 import { Options } from 'parser/core/Module';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
-const CAST_BUFFER_MS = 65;
+const CAST_BUFFER_MS = 150;
 const TRANQ_CHANNEL_BUFFER_MS = 10_000;
 
 const APPLIED_HEAL = 'AppliedHeal';


### PR DESCRIPTION
### Description

* Added statistics for Germination and Thriving Vegetation.
* Fixed an issue where extra HoT applies from Rampant Growth were often being missed by the attributor.
* Fixed an issue where Liveliness was incorrectly messing with expected HoT duration

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/ckyCKYrtzFDZ72hL/5-Heroic+The+Silken+Court+-+Kill+(9:34)/Nicksdruidb/standard/statistics`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/e0b7a2b0-b7fc-43e2-8719-ecdae2983fb8)
![image](https://github.com/user-attachments/assets/1ed2e211-4de9-4438-86a5-e1c9bb3aaaa7)
![image](https://github.com/user-attachments/assets/ef87ec5c-90ae-411e-80f5-19705e3f1eed)
![image](https://github.com/user-attachments/assets/eb574c3d-10c7-4f86-830c-01575e3b438d)

