### PR TITLE
Druid Feral - updated guide text to indicate finishers should always be used with 5 CPs. Fixed a typo in Rip breakdown text

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_DRUID } from 'common/TALENTS/druid';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2024, 9, 13), <>Updated guide text to indicate finishes should always be used with 5 CPs. Fixed a typo in Rip cast breakdown.</>, Sref),
   change(date(2024, 8, 22), <><SpellLink spell={TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT}/> tracker should now correctly detect procced <SpellLink spell={TALENTS_DRUID.RAVAGE_TALENT}/> casts.</>, Sref),
   change(date(2024, 8, 22), <>Cleaner display of <SpellLink spell={SPELLS.RAKE}/>, <SpellLink spell={SPELLS.RIP}/>, <SpellLink spell={SPELLS.FEROCIOUS_BITE}/>, and <SpellLink spell={TALENTS_DRUID.SUDDEN_AMBUSH_TALENT}/> sections in Guide.</>, Sref),
   change(date(2024, 8, 17), <>Marked updated for 11.0.2 and updated the spec's 'About' page.</>, Sref),

--- a/src/analysis/retail/druid/feral/Guide.tsx
+++ b/src/analysis/retail/druid/feral/Guide.tsx
@@ -8,11 +8,7 @@ import { formatPercentage } from 'common/format';
 import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
-import {
-  ACCEPTABLE_BERSERK_CPS,
-  ACCEPTABLE_CPS,
-  cdSpell,
-} from 'analysis/retail/druid/feral/constants';
+import { ACCEPTABLE_CPS } from 'analysis/retail/druid/feral/constants';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -44,16 +40,8 @@ function ResourceUseSection({ modules, events, info }: GuideProps<typeof CombatL
       </SubSection>
       <SubSection title="Combo Points">
         <p>
-          It is acceptable to use finishers at {ACCEPTABLE_CPS} CPs regardless of talent setup. This
-          is because the gain avoiding overcap from{' '}
-          <SpellLink spell={TALENTS_DRUID.PRIMAL_FURY_TALENT} /> outweighs the loss of weaker
-          spenders. However, during <SpellLink spell={cdSpell(info.combatant)} /> you should use{' '}
-          {ACCEPTABLE_BERSERK_CPS} because of its CP overcap protection.
-        </p>
-        <p>
           Most of your abilities either <strong>build</strong> or <strong>spend</strong> Combo
-          Points. Never use a builder at max CPs, and always wait until {ACCEPTABLE_CPS} (
-          {ACCEPTABLE_BERSERK_CPS} in <SpellLink spell={cdSpell(info.combatant)} />) to use a
+          Points. Never use a builder at max CPs, and always wait until {ACCEPTABLE_CPS} to use a
           spender (with the exception of your opening <SpellLink spell={SPELLS.RIP} />
           ).
         </p>

--- a/src/analysis/retail/druid/feral/constants.ts
+++ b/src/analysis/retail/druid/feral/constants.ts
@@ -206,12 +206,11 @@ export function cdSpell(c: Combatant): Spell {
 // MISC
 //
 
-/** Minimum acceptable number of CPs to use with a finisher. */
-export function getAcceptableCps(c: Combatant): number {
-  return c.hasBuff(cdSpell(c).id) ? ACCEPTABLE_BERSERK_CPS : ACCEPTABLE_CPS;
+/** Minimum acceptable number of CPs to use with a finisher (currently always 5, leaving as function in case this changes again) */
+export function getAcceptableCps(_: Combatant): number {
+  return ACCEPTABLE_CPS;
 }
-export const ACCEPTABLE_CPS = 4;
-export const ACCEPTABLE_BERSERK_CPS = 5;
+export const ACCEPTABLE_CPS = 5;
 
 /** Effective combo points used by a Convoke'd Ferocious Bite */
 export const CONVOKE_FB_CPS = 5;

--- a/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
@@ -10,7 +10,6 @@ import RipUptimeAndSnapshots from 'analysis/retail/druid/feral/modules/spells/Ri
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { SpellLink } from 'interface';
 import {
-  ACCEPTABLE_BERSERK_CPS,
   ACCEPTABLE_CPS,
   cdSpell,
   FB_SPELLS,
@@ -157,10 +156,9 @@ class FerociousBite extends Analyzer {
           <SpellLink spell={SPELLS.FEROCIOUS_BITE} />
         </strong>{' '}
         is your direct damage finisher. Use it when you've already applied Rip to enemies. Always
-        use Bite with at least {ACCEPTABLE_CPS} CPs ({ACCEPTABLE_BERSERK_CPS} during{' '}
-        <SpellLink spell={cdSpell(this.selectedCombatant)} />
-        ). Bite can consume up to {FEROCIOUS_BITE_MAX_DRAIN} extra energy to do increased damage -
-        this boost is very efficient and you should always wait until{' '}
+        use Bite with at least {ACCEPTABLE_CPS} CPs. Bite can consume up to{' '}
+        {FEROCIOUS_BITE_MAX_DRAIN} extra energy to do increased damage - this boost is very
+        efficient and you should always wait until{' '}
         {FEROCIOUS_BITE_MAX_DRAIN + FEROCIOUS_BITE_ENERGY} energy to use Bite.{' '}
         {this.hasSotf && (
           <>

--- a/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
@@ -244,12 +244,6 @@ class RipUptimeAndSnapshots extends Snapshots {
         <CastSummaryAndBreakdown
           spell={SPELLS.RIP}
           castEntries={this.castEntries}
-          goodExtraExplanation={
-            <>
-              or a cast with problems that procced{' '}
-              <SpellLink spell={TALENTS_DRUID.BLOODTALONS_TALENT} />
-            </>
-          }
           okExtraExplanation={<>clipped duration but upgraded snapshot or missing Tigers Fury</>}
           badExtraExplanation={<>clipped duration {this.hasBt && ' or missing Bloodtalons'}</>}
         />


### PR DESCRIPTION
During Dragonflight, we sometimes wanted to use finishers at 4 CPs, but in TWW it's always 5. Updated some checks and also Guide text to account for this.