### PR TITLE
[Resto Shaman] Fix Unleash Life for Downpour casts

### DIFF
--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -13,6 +13,7 @@ import {
 
 // prettier-ignore
 export default [
+  change(date(2024, 9, 15), <>Fixed <SpellLink spell={TALENTS_SHAMAN.DOWNPOUR_TALENT}/> and <SpellLink spell={TALENTS_SHAMAN.UNLEASH_LIFE_TALENT}/> interaction.</>, Ypp),
   change(date(2024, 8, 27), <>Updated <SpellLink spell={TALENTS_SHAMAN.ANCESTRAL_VIGOR_TALENT}/> for The War Within : one rank for the talent, for 10% max health increase. Updated Lives saved statistic, accounting for <SpellLink spell={TALENTS_SHAMAN.DOWNPOUR_TALENT}/>.</>, Ypp),
   change(date(2024, 8, 27), <>Updated <SpellLink spell={TALENTS_SHAMAN.DOWNPOUR_TALENT}/> mechanics for The War Within : no more cooldown, target cap lowered to 5 and new buff for 10% max health increase. Added <SpellLink spell={TALENTS_SHAMAN.DOWNPOUR_TALENT}/> to the healing contribution.</>, Ypp),
   change(date(2024, 8, 24), <>Statistic box for <SpellLink spell={TALENTS_SHAMAN.TIDEWATERS_TALENT}/> </>, Ypp),

--- a/src/analysis/retail/shaman/restoration/modules/talents/UnleashLife.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/UnleashLife.tsx
@@ -171,8 +171,6 @@ class UnleashLife extends Analyzer {
       TALENTS.WELLSPRING_TALENT,
       TALENTS.HEALING_RAIN_TALENT,
       SPELLS.DOWNPOUR_ABILITY,
-      SPELLS.DOWNPOUR_HEAL,
-      TALENTS.DOWNPOUR_TALENT,
     ];
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(spellFilter), this._onCast);
     this.addEventListener(

--- a/src/analysis/retail/shaman/restoration/modules/talents/UnleashLife.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/UnleashLife.tsx
@@ -114,7 +114,7 @@ class UnleashLife extends Analyzer {
       amount: 0,
       casts: 0,
     },
-    [TALENTS.DOWNPOUR_TALENT.id]: {
+    [SPELLS.DOWNPOUR_ABILITY.id]: {
       amount: 0,
       casts: 0,
     },
@@ -170,6 +170,8 @@ class UnleashLife extends Analyzer {
       SPELLS.HEALING_SURGE,
       TALENTS.WELLSPRING_TALENT,
       TALENTS.HEALING_RAIN_TALENT,
+      SPELLS.DOWNPOUR_ABILITY,
+      SPELLS.DOWNPOUR_HEAL,
       TALENTS.DOWNPOUR_TALENT,
     ];
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(spellFilter), this._onCast);
@@ -250,7 +252,7 @@ class UnleashLife extends Analyzer {
         case TALENTS.CHAIN_HEAL_TALENT.id:
           this._onChainHeal(event);
           break;
-        case TALENTS.DOWNPOUR_TALENT.id:
+        case SPELLS.DOWNPOUR_ABILITY.id:
           this._onDownpour(event);
           break;
         default:
@@ -407,7 +409,7 @@ class UnleashLife extends Analyzer {
         this.missedDownpourHits += UNLEASH_LIFE_EXTRA_TARGETS - filteredhits.length;
       }
       this.extraDownpourHits += filteredhits.length;
-      this.healingMap[TALENTS.DOWNPOUR_TALENT.id].amount += this._tallyHealing(filteredhits);
+      this.healingMap[SPELLS.DOWNPOUR_ABILITY.id].amount += this._tallyHealing(filteredhits);
     }
   }
 
@@ -521,10 +523,10 @@ class UnleashLife extends Analyzer {
         color: RESTORATION_COLORS.DOWNPOUR,
         label: <Trans id="shaman.restoration.spell.downpour">Downpour</Trans>,
         spellId: TALENTS.DOWNPOUR_TALENT.id,
-        value: this.healingMap[TALENTS.DOWNPOUR_TALENT.id].amount,
+        value: this.healingMap[SPELLS.DOWNPOUR_ABILITY.id].amount,
         valueTooltip: this._tooltip({
-          spellId: TALENTS.DOWNPOUR_TALENT.id,
-          amount: this.healingMap[TALENTS.DOWNPOUR_TALENT.id].amount,
+          spellId: SPELLS.DOWNPOUR_ABILITY.id,
+          amount: this.healingMap[SPELLS.DOWNPOUR_ABILITY.id].amount,
           active: this.selectedCombatant.hasTalent(TALENTS.DOWNPOUR_TALENT),
           extraHits: this.extraDownpourHits,
         }),

--- a/src/analysis/retail/shaman/restoration/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/shaman/restoration/normalizers/CastLinkNormalizer.ts
@@ -260,9 +260,9 @@ const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: DOWNPOUR,
     reverseLinkRelation: DOWNPOUR,
-    linkingEventId: [talents.DOWNPOUR_TALENT.id],
+    linkingEventId: [SPELLS.DOWNPOUR_HEAL.id],
     linkingEventType: EventType.Heal,
-    referencedEventId: [talents.DOWNPOUR_TALENT.id],
+    referencedEventId: [SPELLS.DOWNPOUR_ABILITY.id],
     referencedEventType: EventType.Cast,
     backwardBufferMs: CAST_BUFFER_MS,
     forwardBufferMs: CAST_BUFFER_MS,

--- a/src/analysis/retail/shaman/restoration/normalizers/UnleashLifeNormalizer.ts
+++ b/src/analysis/retail/shaman/restoration/normalizers/UnleashLifeNormalizer.ts
@@ -38,7 +38,7 @@ const EVENT_LINKS: EventLink[] = [
       SPELLS.HEALING_SURGE.id,
       talents.CHAIN_HEAL_TALENT.id,
       talents.HEALING_RAIN_TALENT.id,
-      talents.DOWNPOUR_TALENT.id,
+      SPELLS.DOWNPOUR_ABILITY.id,
       talents.WELLSPRING_TALENT.id,
     ],
     referencedEventType: [EventType.Cast],


### PR DESCRIPTION
### Description

I was notified by Impatience that the Unleash Life breakdown statistic no longer included UL-empowered Downpour casts. Looks like the TWW rework of the spell to be launched from the Healing rain broke the module, as spell ids were all wrong.

### Testing

- Test report URL: `/report/c1t43rNCDxRqzdvT/3-Normal+Ulgrax+the+Devourer+-+Kill+(7:01)/Imply/standard/about`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/59515da2-10cd-4602-97db-325666d46c8c)

