### PR TITLE
[Core] Update spellAvailable to properly adjust behaviour to inverse

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,6 +35,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 9, 16), 'Updated spellAvailable APL function to properly adjust validation behaviour based on inverse options, and turn it into an options object rather than a straight boolean', Putro),
   change(date(2024, 9, 15), 'Adding TWW weapon enchants, removing DF-specific items (e.g. Fyralath, Call To Dominance, Voice of the Silent Star, etc)', Seriousnes),
   change(date(2024, 9, 12), 'Fixed crash when analyzing reports where 0 procs of certain effects ocurred.', emallson),
   change(date(2024, 9, 12), 'Add support for Earthen characters.', ToppleTheNun),

--- a/src/parser/shared/metrics/apl/conditions/spellAvailable.tsx
+++ b/src/parser/shared/metrics/apl/conditions/spellAvailable.tsx
@@ -12,7 +12,7 @@ export default function spellAvailable(
   spell: Spell,
   options: SpellAvailableOptions = {},
 ): Condition<UpdateSpellUsableEvent | null> {
-  const inverse = !!options.inverse;
+  const inverse = Boolean(options.inverse);
 
   return {
     key: `spellAvailable-${spell.id}`,

--- a/src/parser/shared/metrics/apl/conditions/spellAvailable.tsx
+++ b/src/parser/shared/metrics/apl/conditions/spellAvailable.tsx
@@ -4,10 +4,16 @@ import { UpdateSpellUsableEvent, EventType } from 'parser/core/Events';
 
 import { Condition, tenseAlt } from '../index';
 
+interface SpellAvailableOptions {
+  inverse?: boolean;
+}
+
 export default function spellAvailable(
   spell: Spell,
-  inverse: boolean = false,
+  options: SpellAvailableOptions = {},
 ): Condition<UpdateSpellUsableEvent | null> {
+  const inverse = !!options.inverse;
+
   return {
     key: `spellAvailable-${spell.id}`,
     init: () => null,
@@ -18,7 +24,8 @@ export default function spellAvailable(
         return state;
       }
     },
-    validate: (state, _event) => state === null || state.isAvailable,
+    validate: (state, _event) =>
+      state === null || state.isAvailable || (inverse && !state.isAvailable),
     describe: (tense) => (
       <>
         <SpellLink spell={spell.id} /> {tenseAlt(tense, 'is', 'was')} {inverse ? 'on' : 'off'}{' '}

--- a/src/parser/shared/metrics/apl/conditions/spellAvailable.tsx
+++ b/src/parser/shared/metrics/apl/conditions/spellAvailable.tsx
@@ -25,7 +25,7 @@ export default function spellAvailable(
       }
     },
     validate: (state, _event) =>
-      state === null || state.isAvailable || (inverse && !state.isAvailable),
+      state === null || (!inverse && state.isAvailable) || (inverse && !state.isAvailable),
     describe: (tense) => (
       <>
         <SpellLink spell={spell.id} /> {tenseAlt(tense, 'is', 'was')} {inverse ? 'on' : 'off'}{' '}


### PR DESCRIPTION
### Description

The inverse option only changed the text, not the validation behaviour which made it require an optional not() to achieve that effect. 
I've come to prefer option objects over raw booleans that aren't descriptive of what they actually do 