### PR TITLE
[Mage] Add Warning Banners

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { change, date } from 'common/changelog';
 import { Sharrq, Sref } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2024, 9, 18), <>Updated the Warning Banner explaining the current state of Arcane Mage.</>, Sharrq),
   change(date(2024, 8, 20), <>Improvements to <SpellLink spell={TALENTS.ARCANE_TEMPO_TALENT} /> and <SpellLink spell={SPELLS.ARCANE_ORB} /> stats. Cleaned up Cooldown bars section to only include relevant spells. Removed <SpellLink spell={SPELLS.SIPHON_STORM_BUFF} /> section from Guide, as it was redundant with the text and tracking in <SpellLink spell={TALENTS.ARCANE_SURGE_TALENT} /> section.</>, Sref),
   change(date(2024, 8, 18), <>Bumped Arcane Mage to Full Support for 11.0.2</>, Sharrq),
   change(date(2024, 8, 18), <>Completely removed the old Checklist view.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CONFIG.tsx
+++ b/src/analysis/retail/mage/arcane/CONFIG.tsx
@@ -50,9 +50,11 @@ const config: Config = {
       frontmatterType: 'guide',
       notes: (
         <AlertWarning>
-          This analysis is in preparation for The War Within and Nerub'ar Palace. It is not intended
-          to be accurate for Prepatch. If anything is missing or innacurate please ping{' '}
-          <code>@Sharrq</code> in the Mage Discord.
+          This analysis is a Work in Progress. It was last updated just before launch and Blizzard
+          has made multiple changes since then that are yet to be implemented. Once Blizzard stops
+          changing things every week, and once the theorycrafters finish running numbers, then I
+          will update this. Apologies for the delays, I promise I am working on it. Ping me in the
+          Mage Discord if you have questions about this. <code>@Sharrq</code>
         </AlertWarning>
       ),
     },

--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Sharrq } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 9, 18), <>Updated the Warning Banner explaining the current state of Fire Mage.</>, Sharrq),
   change(date(2024, 6, 16), <>Added support for <SpellLink spell={TALENTS.EXCESS_FIRE_TALENT} />, <SpellLink spell={TALENTS.EXCESS_FROST_TALENT} />, <SpellLink spell={TALENTS.FLAME_AND_FROST_TALENT} />, <SpellLink spell={TALENTS.MANA_CASCADE_TALENT} />, and <SpellLink spell={TALENTS.GLORIOUS_INCANDESCENCE_TALENT} />.</>, Sharrq),
   change(date(2024, 6, 16), <>Updated the Fire Spec Spellbook and the Mage Class Spellbook.</>, Sharrq),
   change(date(2024, 6, 16), <>Remove Living Bomb, Searing Touch, and Charring Embers</>, Sharrq),

--- a/src/analysis/retail/mage/fire/CONFIG.tsx
+++ b/src/analysis/retail/mage/fire/CONFIG.tsx
@@ -4,6 +4,7 @@ import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
+import AlertWarning from 'interface/AlertWarning';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
@@ -32,6 +33,20 @@ const config: Config = {
       <br />
     </>
   ),
+  pages: {
+    overview: {
+      frontmatterType: 'guide',
+      notes: (
+        <AlertWarning>
+          This analysis is a Work in Progress. I have done some minor updates to Fire, but there are
+          still things that have yet to be implemented or added. Once Blizzard stops changing things
+          every week, and once the theorycrafters finish running numbers, then I will update this.
+          Apologies for the delays, I promise I am working on it. Ping me in the Mage Discord if you
+          have questions about this. <code>@Sharrq</code>
+        </AlertWarning>
+      ),
+    },
+  },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
     'report/XLj7amG2gr4Hwdb3/30-Heroic+Rashok,+the+Elder+-+Kill+(4:35)/Pyrenn/standard',

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import { SpellLink } from 'interface';
-import { Earosselot } from 'CONTRIBUTORS';
+import { Sharrq, Earosselot } from 'CONTRIBUTORS';
 import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore
 export default [
+  change(date(2024, 9, 18), <>Updated the Warning Banner explaining the current state of Frost Mage.</>, Sharrq),
   change(date(2024, 8, 25), <>Added support for <SpellLink spell={TALENTS.SPELLFROST_TEACHINGS_TALENT} />.</>, Earosselot),
   change(date(2024, 8, 23), <>Adding APL for Spellslinger Frost.</>, Earosselot),
   change(date(2024, 7, 30), <>Solved bug when not taking <SpellLink spell={TALENTS.RAY_OF_FROST_TALENT} />.</>, Earosselot),

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -3,6 +3,7 @@ import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
 import CHANGELOG from './CHANGELOG';
+import AlertWarning from 'interface/AlertWarning';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
@@ -38,6 +39,20 @@ const config: Config = {
       <br />
     </>
   ),
+  pages: {
+    overview: {
+      frontmatterType: 'guide',
+      notes: (
+        <AlertWarning>
+          This analysis is a Work in Progress. Some minor changes have been added for Frost, but
+          there are still things that have yet to be implemented or added. Once Blizzard stops
+          changing things every week, and once the theorycrafters finish running numbers, then I
+          will update this. Apologies for the delays, I promise I am working on it. Ping me in the
+          Mage Discord if you have questions about this. <code>@Sharrq</code>
+        </AlertWarning>
+      ),
+    },
+  },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport: '/report/RJ1MXnb2zymgQ8pF/49/20',
   // Don't change anything below this line;


### PR DESCRIPTION
I added some warnings to each of the mage specs to explain the current state of it. 

This is partially in response to the number of questions that come up in the mage discord about it every day. Additionally, Blizzard has been changing things for mage quite a bit lately and a lot of it (mostly for arcane) has had impacts on the rotation. I was about to update Arcane to get it back in line but then blizzard changed even more stuff which potentially reverts the apl changes .... but also some things are bugged now so I am anticipating more changes. So I am waiting until Blizzard chills out a bit before I update things further. 