### PR TITLE
[Shared] Request data once on click in LazyLoadStatisticBox

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -36,6 +36,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 9, 20), 'Ensured that LazyLoadStatisticBox is only requesting the results once.', Arlie),
   change(date(2024, 9, 17), 'Updated Class Guide links for Wowhead to point to correct link.', Taevis),
   change(date(2024, 9, 16), 'Updated spellAvailable APL function to properly adjust validation behaviour based on inverse options, and turn it into an options object rather than a straight boolean', Putro),
   change(date(2024, 9, 15), 'Adding TWW weapon enchants, removing DF-specific items (e.g. Fyralath, Call To Dominance, Voice of the Silent Star, etc)', Seriousnes),

--- a/src/parser/ui/LazyLoadStatisticBox.tsx
+++ b/src/parser/ui/LazyLoadStatisticBox.tsx
@@ -35,7 +35,7 @@ const LazyLoadStatisticBox = ({ loader, value, children, ...others }: Props) => 
   const { generateResults } = useResults();
 
   const handleClick = () => {
-    if (loaded) {
+    if (loaded || loading) {
       return;
     }
     setLoading(true);


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->
Blocks the loader function from executing while loading - it was only doing it when the data was loaded. I know this component is deprecated but it is still used across the repo.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/qfLWYgGAaF6xKzb4/15-Normal+Queen+Ansurek+-+Kill+(4:53)/Faithwhisper/standard/statistics`
- Screenshot(s):
