### PR TITLE
Fix a crash that occurs when invalid data is fed to `Probability` helpers

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -36,6 +36,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 9, 21), 'Fix another crash in Holy Paladin Divine Purpose.', emallson),
   change(date(2024, 9, 20), 'Ensured that LazyLoadStatisticBox is only requesting the results once.', Arlie),
   change(date(2024, 9, 17), 'Updated Class Guide links for Wowhead to point to correct link.', Taevis),
   change(date(2024, 9, 16), 'Updated spellAvailable APL function to properly adjust validation behaviour based on inverse options, and turn it into an options object rather than a straight boolean', Putro),

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -43,6 +43,8 @@ export enum EventType {
   EmpowerStart = 'empowerstart',
   EmpowerEnd = 'empowerend',
   Leech = 'leech',
+  StaggerClear = 'staggerclear',
+  StaggerPrevented = 'staggerprevented',
 
   // Fabricated:
   Event = 'event', // everything

--- a/src/parser/shared/modules/helpers/Probability.tsx
+++ b/src/parser/shared/modules/helpers/Probability.tsx
@@ -185,6 +185,14 @@ export function plotOneVariableBinomChart(
     title: 'Likelihood',
   },
 ) {
+  if (procAttempts < actualProcs) {
+    console.warn(
+      'Cannot generate probability charts with invalid data: # of procs > # possible procs',
+      actualProcs,
+      procAttempts,
+    );
+    return null;
+  }
   if (procAttempts < 1) {
     return null;
   }


### PR DESCRIPTION
This currently occurs in `DivinePurpose` for HPal. The issue is that the number of possible procs is less than the number of actual procs, which then breaks the probability code.