### PR TITLE
Add Chronoflame support to Leaping Flame module

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_EVOKER } from 'common/TALENTS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 9, 21), <>Update <SpellLink spell={TALENTS_EVOKER.LEAPING_FLAMES_TALENT}/> to work with <SpellLink spell={TALENTS_EVOKER.CHRONO_FLAME_TALENT}/></>, Harrek),
   change(date(2024, 9, 14), <>Update <SpellLink spell={TALENTS_EVOKER.SOURCE_OF_MAGIC_TALENT}/> for TWW</>, Trevor),
   change(date(2024, 9, 14), <>Add <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT}/> to Stasis spells</>, Trevor),
   change(date(2024, 8, 22), <>Bumped Preservation to full support for 11.0.2</>, Harrek),

--- a/src/analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer.ts
@@ -158,7 +158,7 @@ const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: EB_FROM_LF_CAST,
     reverseLinkRelation: EB_FROM_LF_CAST,
-    linkingEventId: SPELLS.LIVING_FLAME_CAST.id,
+    linkingEventId: [SPELLS.LIVING_FLAME_CAST.id, SPELLS.CHRONO_FLAME_CAST.id],
     linkingEventType: EventType.Cast,
     referencedEventId: EB_BUFF_IDS,
     referencedEventType: EB_GENERATION_EVENT_TYPES,
@@ -173,7 +173,7 @@ const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: EB_FROM_LF_HEAL,
     reverseLinkRelation: EB_FROM_LF_HEAL,
-    linkingEventId: SPELLS.LIVING_FLAME_HEAL.id,
+    linkingEventId: [SPELLS.LIVING_FLAME_HEAL.id, SPELLS.CHRONO_FLAME_HEAL.id],
     linkingEventType: EventType.Heal,
     referencedEventId: EB_BUFF_IDS,
     referencedEventType: EB_GENERATION_EVENT_TYPES,

--- a/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/LeapingFlamesNormalizer.ts
@@ -36,7 +36,7 @@ const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: LEAPING_FLAMES_CONSUME,
     reverseLinkRelation: LEAPING_FLAMES_CONSUME,
-    linkingEventId: SPELLS.LIVING_FLAME_CAST.id,
+    linkingEventId: [SPELLS.LIVING_FLAME_CAST.id, SPELLS.CHRONO_FLAME_CAST.id],
     linkingEventType: EventType.Cast,
     referencedEventId: SPELLS.LEAPING_FLAMES_BUFF.id,
     referencedEventType: EventType.RemoveBuff,
@@ -100,7 +100,7 @@ const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: LEAPING_FLAMES_HITS,
     reverseLinkRelation: LEAPING_FLAMES_HITS,
-    linkingEventId: SPELLS.LIVING_FLAME_CAST.id,
+    linkingEventId: [SPELLS.LIVING_FLAME_CAST.id, SPELLS.CHRONO_FLAME_CAST.id],
     linkingEventType: EventType.Cast,
     referencedEventId: [SPELLS.LIVING_FLAME_DAMAGE.id, SPELLS.LIVING_FLAME_HEAL.id],
     referencedEventType: [EventType.Damage, EventType.Heal],

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -588,6 +588,11 @@ const spells = {
     name: 'Spiritbloom',
     icon: 'ability_evoker_spiritbloom2',
   },
+  CHRONO_FLAME_CAST: {
+    id: 431443,
+    name: 'Chronoflame',
+    icon: 'inv_ability_chronowardenevoker_chronoflame',
+  },
   CHRONO_FLAME_HEAL: {
     id: 431483,
     name: 'Chronoflame',


### PR DESCRIPTION
### Description

Chronowarden changes Living Flame to Chrono Flame, the Leaping Flames module stopped working for Chrono because it was looking for Living Flame casts, this fixes that

### Testing

- Test report URL: `/report/3DXCLt9pwK42Pkgj/33-Mythic+Ulgrax+the+Devourer+-+Kill+(9:57)/Evoulker/standard/statistics.`