### PR TITLE
[Elemental] Updating Farseer Call of the Ancestor analysis when multiple ancestors overlap

### DIFF
--- a/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
@@ -7,7 +7,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2024, 9, 21), <>Added Farseer <SpellLink spell={TALENTS.CALL_OF_THE_ANCESTORS_TALENT} /> analysis.</>, Seriousnes),
+  change(date(2024, 9, 22), <>Added Farseer <SpellLink spell={TALENTS.CALL_OF_THE_ANCESTORS_TALENT} /> analysis.</>, Seriousnes),
   change(date(2024, 9, 17), <>Updated <SpellLink spell={TALENTS.CHAIN_LIGHTNING_TALENT} /> inefficient target count from 3 -&gt; 2</>, Seriousnes),
   change(date(2024, 9, 14), <>Updating <SpellLink spell={TALENTS.STORMKEEPER_TALENT} /> and spender window analysis, added support for <SpellLink spell={TALENTS.FLASH_OF_LIGHTNING_TALENT} /> </>, Seriousnes),
   change(date(2024, 9, 12), <><SpellLink spell={TALENTS.TEMPEST_TALENT} /> now stacks up to 2 times</>, Seriousnes),

--- a/src/analysis/retail/shaman/elemental/constants.tsx
+++ b/src/analysis/retail/shaman/elemental/constants.tsx
@@ -21,3 +21,8 @@ export enum NORMALIZER_ORDER {
   Prepull = 10,
   EventOrder = 20,
 }
+
+export enum EVENT_LINKS {
+  Stormkeeper = 'stormkeeper',
+  CallOfTheAncestors = 'call-of-the-ancestor',
+}

--- a/src/analysis/retail/shaman/elemental/modules/Buffs.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/Buffs.tsx
@@ -1,9 +1,10 @@
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/shaman';
+import { SpellbookAura } from 'parser/core/modules/Aura';
 import CoreAuras from 'parser/core/modules/Auras';
 
 class Buffs extends CoreAuras {
-  auras() {
+  auras(): SpellbookAura[] {
     const combatant = this.selectedCombatant;
 
     // This should include ALL buffs that can be applied by your spec.
@@ -65,6 +66,15 @@ class Buffs extends CoreAuras {
         spellId: SPELLS.ANCESTRAL_SWIFTNESS_CAST.id,
         enabled: combatant.hasTalent(TALENTS.ANCESTRAL_SWIFTNESS_TALENT),
         triggeredBySpellId: SPELLS.ANCESTRAL_SWIFTNESS_CAST.id,
+      },
+      {
+        spellId: SPELLS.CALL_OF_THE_ANCESTORS_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS.CALL_OF_THE_ANCESTORS_TALENT),
+        triggeredBySpellId: [
+          TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT.id,
+          SPELLS.ANCESTRAL_SWIFTNESS_CAST.id,
+        ],
+        timelineHighlight: true,
       },
     ];
   }

--- a/src/analysis/retail/shaman/elemental/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/normalizers/EventLinkNormalizer.tsx
@@ -2,15 +2,15 @@ import SPELLS from 'common/SPELLS/shaman';
 import TALENTS from 'common/TALENTS/shaman';
 import { Options } from 'parser/core/Analyzer';
 import BaseEventLinkNormalizer from 'parser/core/EventLinkNormalizer';
-import { EventType } from 'parser/core/Events';
-import { NORMALIZER_ORDER } from '../../constants';
+import { AnyEvent, EventType, GetRelatedEvents } from 'parser/core/Events';
+import { EVENT_LINKS, NORMALIZER_ORDER } from '../../constants';
 
 class EventLinkNormalizer extends BaseEventLinkNormalizer {
   constructor(options: Options) {
     super(options, [
       // stormkeeper applybuff -> stormkeeper begincast
       {
-        linkRelation: 'stormkeeper',
+        linkRelation: EVENT_LINKS.Stormkeeper,
         linkingEventId: SPELLS.STORMKEEPER_BUFF_AND_CAST.id,
         linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
         referencedEventId: SPELLS.STORMKEEPER_BUFF_AND_CAST.id,
@@ -21,6 +21,24 @@ class EventLinkNormalizer extends BaseEventLinkNormalizer {
         anyTarget: true,
         maximumLinks: 1,
         isActive: (c) => c.hasTalent(TALENTS.STORMKEEPER_TALENT),
+      },
+      {
+        linkRelation: EVENT_LINKS.CallOfTheAncestors,
+        linkingEventId: SPELLS.CALL_OF_THE_ANCESTORS_SUMMON.id,
+        linkingEventType: EventType.Summon,
+        referencedEventId: [
+          TALENTS.PRIMORDIAL_WAVE_SPEC_TALENT.id,
+          SPELLS.ANCESTRAL_SWIFTNESS_CAST.id,
+        ],
+        referencedEventType: EventType.Cast,
+        forwardBufferMs: -1, // only look backwards
+        backwardBufferMs: 5,
+        anySource: true,
+        anyTarget: true,
+        maximumLinks: 1,
+        isActive: (c) => c.hasTalent(TALENTS.CALL_OF_THE_ANCESTORS_TALENT),
+        additionalCondition: (le: AnyEvent, re: AnyEvent) =>
+          GetRelatedEvents(re, EVENT_LINKS.CallOfTheAncestors).length === 0,
       },
     ]);
     this.priority = NORMALIZER_ORDER.EventLink;


### PR DESCRIPTION
### Description

* Fixing an issue where a proc of _Heed My Call_ could extend an active window rather than creating a new one

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/wtcCyQfkLqx7Z6Yj/48-Mythic+Sikran,+Captain+of+the+Sureki+-+Kill+(5:16)/Spaghey/standard/overview`
