### PR TITLE
fix field name in `fetchTable` to match backend

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -36,6 +36,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 9, 23), 'Fix a bug in table filtering. Notably: this fixes a bug with Brewmaster Purifying Brew active tanking time stats.', emallson),
   change(date(2024, 9, 21), 'Update all checks for enchants and consumables for The War Within. Also show more information when suggesting to improve enchants.', nullDozzer),
   change(date(2024, 9, 21), 'Fix another crash in Holy Paladin Divine Purpose.', emallson),
   change(date(2024, 9, 20), 'Ensured that LazyLoadStatisticBox is only requesting the results once.', Arlie),

--- a/src/common/fetchWclApi.ts
+++ b/src/common/fetchWclApi.ts
@@ -268,6 +268,6 @@ export async function fetchTable<T extends WCLResponseJSON>(
   return fetchWcl(`report/tables/${tableName}/${reportCode}`, {
     start: fightStart,
     end: fightEnd,
-    sourceid: sourceId,
+    actorid: sourceId,
   });
 }


### PR DESCRIPTION
This fixes a bug reported by kate this morning:

## Before
![image](https://github.com/user-attachments/assets/ce3a7b16-20ae-4d89-8817-c9fc29d1d249)

## After

![image](https://github.com/user-attachments/assets/8beeae0d-4c8d-4217-86ab-ebdcc4bcd286)
