### PR TITLE
Druid Guardian - readded defensives buffs list, and included Lunar Beam in defensives list

### DIFF
--- a/src/analysis/retail/druid/guardian/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/guardian/CHANGELOG.tsx
@@ -2,8 +2,10 @@ import { change, date } from 'common/changelog';
 import { Sref } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
+import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2024, 9, 23), <>Fixed an issue where active defensives weren't showing on the Timeline or Death Recap views. Added <SpellLink spell={TALENTS_DRUID.LUNAR_BEAM_TALENT} /> to the defensives list.</>, Sref),
   change(date(2024, 8, 17), <>Marked updated for 11.0.2 and updated the spec's 'About' page.</>, Sref),
   change(date(2024, 8, 14), <>Updated spells to account for 11.0.2 balance patch.</>, Sref),
   change(date(2024, 8, 3), <>Added Offensive Cooldowns section to Guide.</>, Sref),

--- a/src/analysis/retail/druid/guardian/CombatLogParser.tsx
+++ b/src/analysis/retail/druid/guardian/CombatLogParser.tsx
@@ -20,11 +20,13 @@ import Barkskin from 'analysis/retail/druid/guardian/modules/spells/Barkskin';
 import RageOfTheSleeper from 'analysis/retail/druid/guardian/modules/spells/RageOfTheSleeper';
 import SurvivalInstincts from 'analysis/retail/druid/guardian/modules/spells/SurvivalInstincts';
 import Pulverize from 'analysis/retail/druid/guardian/modules/spells/Pulverize';
+import Buffs from 'analysis/retail/druid/guardian/modules/Buffs';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Core
     abilities: Abilities,
+    buffs: Buffs,
     activeDruidForm: ActiveDruidForm,
     rageTracker: RageTracker,
     rageGraph: RageGraph,

--- a/src/analysis/retail/druid/guardian/modules/Abilities.ts
+++ b/src/analysis/retail/druid/guardian/modules/Abilities.ts
@@ -177,6 +177,7 @@ class Abilities extends CoreAbilities {
         },
         cooldown: 60,
         timelineSortIndex: 8,
+        isDefensive: true,
       },
       ...super.spellbook(),
     ];

--- a/src/analysis/retail/druid/guardian/modules/Buffs.ts
+++ b/src/analysis/retail/druid/guardian/modules/Buffs.ts
@@ -1,0 +1,48 @@
+import Auras from 'parser/core/modules/Auras';
+import SPELLS from 'common/SPELLS';
+import { TALENTS_DRUID } from 'common/TALENTS';
+
+/**
+ * Guardian Druid's defensives, for timeline and death recap display.
+ */
+export default class Buffs extends Auras {
+  auras() {
+    const combatant = this.selectedCombatant;
+    return [
+      {
+        spellId: SPELLS.IRONFUR.id,
+      },
+      {
+        spellId: SPELLS.FRENZIED_REGENERATION.id,
+      },
+      {
+        spellId: SPELLS.BARKSKIN.id,
+        timelineHighlight: true,
+      },
+      {
+        spellId: SPELLS.SURVIVAL_INSTINCTS.id,
+        timelineHighlight: true,
+      },
+      {
+        spellId: TALENTS_DRUID.RAGE_OF_THE_SLEEPER_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS_DRUID.RAGE_OF_THE_SLEEPER_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: TALENTS_DRUID.LUNAR_BEAM_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS_DRUID.LUNAR_BEAM_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: SPELLS.BERSERK_BEAR.id,
+        enabled: !combatant.hasTalent(TALENTS_DRUID.INCARNATION_GUARDIAN_OF_URSOC_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: TALENTS_DRUID.INCARNATION_GUARDIAN_OF_URSOC_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS_DRUID.INCARNATION_GUARDIAN_OF_URSOC_TALENT),
+        timelineHighlight: true,
+      },
+    ];
+  }
+}


### PR DESCRIPTION

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/MkP4dH8RfDG2AnBa/3-Mythic++Grim+Batol+-+Kill+(43:00)/Orutou/standard/death-recap`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/b0ffbda6-52e6-4160-89a8-4f67a9c56d83)
