### PR TITLE
fix crash in celestial conduit when player didnt cast unity within

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date (2024, 9, 24), <>Fix crash in <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT}/> guide section when player did not cast <SpellLink spell={TALENTS_MONK.UNITY_WITHIN_TALENT}/></>, Trevor),
   change(date (2024, 9, 22), <>Add guide section for <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT}/></>, Trevor),
   change(date (2024, 9, 17), <>Add check for <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> to <SpellLink spell={TALENTS_MONK.STRENGTH_OF_THE_BLACK_OX_TALENT}/> module</>, Trevor),
   change(date (2024, 9, 15), <>Fix <SpellLink spell={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT}/> cooldown duration</>, Trevor),


### PR DESCRIPTION
### Description

Adds checklist item to make sure player cast unity within and hides the cooldown perfs if they didn't

### Testing

![image](https://github.com/user-attachments/assets/480ab938-1422-4605-aee5-b369f2c1ec61)