### PR TITLE
Fix another crash in celestial conduit

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date (2024, 9, 24), <>Fix another crash condition</>, Trevor),
   change(date (2024, 9, 24), <>Fix crash again</>, Trevor),
   change(date (2024, 9, 24), <>Fix crash in <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT}/> guide section when player did not cast <SpellLink spell={TALENTS_MONK.UNITY_WITHIN_TALENT}/></>, Trevor),
   change(date (2024, 9, 22), <>Add guide section for <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT}/></>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -97,8 +97,8 @@ class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Normalizer
     castLinkNormalizer: CastLinkNormalizer,
-    conduitOfTheCelestialsEventLinks: ConduitOfTheCelestialsEventLinks,
     celestialConduitNormalizer: CelestialConduitNormalizer,
+    conduitOfTheCelestialsEventLinks: ConduitOfTheCelestialsEventLinks,
     hotApplicationNormalizer: HotApplicationNormalizer,
     hotRemovalNormalizer: HotRemovalNormalizer,
 


### PR DESCRIPTION
Fixes a crash when there was inconsistent ordering with beginchannel fabrication by changing to use applybuff for now. Will try to fine tune the normalizer in the future to ensure that beginchannel comes before heal events