### PR TITLE
feature: TWW Surging Totem PrePull Normalizer

### DIFF
--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -8,11 +8,13 @@ import {
   Seriousnes,
   Ypp,
   Texleretour,
+  Vetyst,
 } from 'CONTRIBUTORS';
 
 
 // prettier-ignore
 export default [
+  change(date(2024, 9, 26), <>Fixed <SpellLink spell={TALENTS_SHAMAN.SURGING_TOTEM_TALENT}/> when used on pre-pull.</>, Vetyst),
   change(date(2024, 9, 15), <>Fixed <SpellLink spell={TALENTS_SHAMAN.DOWNPOUR_TALENT}/> and <SpellLink spell={TALENTS_SHAMAN.UNLEASH_LIFE_TALENT}/> interaction.</>, Ypp),
   change(date(2024, 8, 27), <>Updated <SpellLink spell={TALENTS_SHAMAN.ANCESTRAL_VIGOR_TALENT}/> for The War Within : one rank for the talent, for 10% max health increase. Updated Lives saved statistic, accounting for <SpellLink spell={TALENTS_SHAMAN.DOWNPOUR_TALENT}/>.</>, Ypp),
   change(date(2024, 8, 27), <>Updated <SpellLink spell={TALENTS_SHAMAN.DOWNPOUR_TALENT}/> mechanics for The War Within : no more cooldown, target cap lowered to 5 and new buff for 10% max health increase. Added <SpellLink spell={TALENTS_SHAMAN.DOWNPOUR_TALENT}/> to the healing contribution.</>, Ypp),

--- a/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
@@ -74,6 +74,7 @@ import ElementalOrbit from '../shared/talents/ElementalOrbit';
 import Guide from './Guide';
 import Riptide from './modules/talents/Riptide';
 import ManaSpring from 'analysis/retail/shaman/shared/talents/ManaSpring';
+import SurgingTotemPrePullNormalizer from 'analysis/retail/shaman/restoration/normalizers/SurgingTotemPrePullNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -151,6 +152,7 @@ class CombatLogParser extends CoreCombatLogParser {
     stoneBulwarkTotem: StoneBulwarkTotem,
 
     // Normalizers
+    surgingTotemPrePullNormalizer: SurgingTotemPrePullNormalizer,
     cloudburstNormalizer: CloudburstNormalizer,
     riptideNormalizer: RiptideNormalizer,
     castLinkNormalizer: CastLinkNormalizer,

--- a/src/analysis/retail/shaman/restoration/modules/Abilities.ts
+++ b/src/analysis/retail/shaman/restoration/modules/Abilities.ts
@@ -79,7 +79,9 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: TALENTS.HEALING_RAIN_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.HEALING_RAIN_TALENT),
+        enabled:
+          combatant.hasTalent(TALENTS.HEALING_RAIN_TALENT) &&
+          !combatant.hasTalent(TALENTS.SURGING_TOTEM_TALENT),
         category: SPELL_CATEGORY.ROTATIONAL,
         cooldown: 10,
         timelineSortIndex: 17,
@@ -100,9 +102,7 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.ROTATIONAL,
         cooldown: combatant.hasTalent(TALENTS.TOTEMIC_SURGE_TALENT) ? 24 : 30,
         timelineSortIndex: 17,
-        gcd: {
-          base: 1500,
-        },
+        gcd: null,
         castEfficiency: {
           suggestion: false,
           // majorIssueEfficiency: 0.3,
@@ -599,6 +599,17 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.UTILITY,
         gcd: null,
         cooldown: 60,
+      },
+      {
+        spell: SPELLS.SURGING_TOTEM.id,
+        enabled: combatant.hasTalent(TALENTS.SURGING_TOTEM_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: combatant.hasTalent(TALENTS.TOTEMIC_SURGE_TALENT) ? 24 : 30,
+        timelineSortIndex: 17,
+        gcd: {
+          base: 1000,
+        },
+        healSpellIds: [SPELLS.HEALING_RAIN_TOTEMIC.id],
       },
     ];
   }

--- a/src/analysis/retail/shaman/restoration/normalizers/SurgingTotemPrePullNormalizer.ts
+++ b/src/analysis/retail/shaman/restoration/normalizers/SurgingTotemPrePullNormalizer.ts
@@ -1,0 +1,113 @@
+import SPELLS from 'common/SPELLS/shaman';
+import { AnyEvent, CastEvent, EventType, SummonEvent } from 'parser/core/Events';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+import MAGIC_SCHOOLS from 'game/MAGIC_SCHOOLS';
+import Combatants from 'parser/shared/modules/Combatants';
+
+/**
+ * We detect the totem based on the NPC id used in the death event.
+ *
+ * https://www.wowhead.com/npc=225409/surging-totem
+ */
+const SURGING_TOTEM_NPC_ID = 225409;
+const SURGING_TOTEM_DURATION_MS = 24000;
+
+class SurgingTotemPrePullNormalizer extends EventsNormalizer {
+  static dependencies = {
+    ...EventsNormalizer.dependencies,
+    combatants: Combatants,
+  };
+
+  protected combatants!: Combatants;
+  normalize(events: AnyEvent[]) {
+    // Find the Surging Totem based on NPC id from the current player's pet list.
+    const targetNPC = this.owner.playerPets.find(
+      (npc: { guid: number | undefined }) => npc.guid === SURGING_TOTEM_NPC_ID,
+    );
+
+    // Ensure the player has used Surging totem before going through the Pre Pull Normalizer.
+    if (!targetNPC) {
+      return events;
+    }
+
+    for (let eventIdx = 0; eventIdx < events.length; eventIdx += 1) {
+      const event = events[eventIdx];
+
+      // The totem 'dies' upon expiration.
+      if (event.type !== EventType.Death || event.targetID !== targetNPC.id) {
+        continue;
+      }
+
+      // Stop parsing events after the duration of the totem has elapsed.
+      if (event.timestamp > this.owner.fight.start_time + SURGING_TOTEM_DURATION_MS) {
+        break;
+      }
+
+      // Start time should be before the start of the fight.
+      const startTime =
+        this.owner.fight.start_time -
+        (SURGING_TOTEM_DURATION_MS - (event.timestamp - this.owner.fight.start_time));
+
+      // Fabricate a casts as they happen when a Surging Totem is placed.
+      const castHealingRainEvent: CastEvent = {
+        ability: {
+          guid: SPELLS.HEALING_RAIN_TOTEMIC.id,
+          name: SPELLS.HEALING_RAIN_TOTEMIC.name,
+          abilityIcon: SPELLS.HEALING_RAIN_TOTEMIC.icon,
+          type: MAGIC_SCHOOLS.ids.NATURE,
+        },
+        type: EventType.Cast,
+        timestamp: startTime,
+        sourceID: this.owner.playerId,
+        sourceIsFriendly: true,
+        targetIsFriendly: true,
+        targetID: -1,
+        __fabricated: true,
+        prepull: true,
+      };
+
+      const castSurgingTotemEvent: CastEvent = {
+        ability: {
+          guid: SPELLS.SURGING_TOTEM.id,
+          name: SPELLS.SURGING_TOTEM.name,
+          abilityIcon: SPELLS.SURGING_TOTEM.icon,
+          type: MAGIC_SCHOOLS.ids.NATURE,
+        },
+        type: EventType.Cast,
+        timestamp: startTime,
+        sourceID: this.owner.playerId,
+        sourceIsFriendly: true,
+        targetIsFriendly: true,
+        targetID: -1,
+        __fabricated: true,
+        prepull: true,
+      };
+
+      const summonSurgingTotemEvent: SummonEvent = {
+        ability: {
+          guid: SPELLS.SURGING_TOTEM.id,
+          name: SPELLS.SURGING_TOTEM.name,
+          abilityIcon: SPELLS.SURGING_TOTEM.icon,
+          type: MAGIC_SCHOOLS.ids.NATURE,
+        },
+        targetInstance: 2,
+        type: EventType.Summon,
+        timestamp: startTime,
+        sourceID: this.owner.playerId,
+        sourceIsFriendly: true,
+        targetIsFriendly: true,
+        targetID: -1,
+        __fabricated: true,
+        prepull: true,
+      };
+
+      events.splice(0, 0, castHealingRainEvent);
+      events.splice(0, 0, castSurgingTotemEvent);
+      events.splice(0, 0, summonSurgingTotemEvent);
+      break;
+    }
+
+    return events;
+  }
+}
+export default SurgingTotemPrePullNormalizer;

--- a/src/interface/report/Results/enchantIdMap.ts
+++ b/src/interface/report/Results/enchantIdMap.ts
@@ -289,6 +289,9 @@ const enchantIdMap: { [key: number]: string } = {
   7423: 'Defenders March',
   7424: 'Defenders March',
 
+  7437: "Council's Guile",
+  7438: "Council's Guile",
+  7439: "Council's Guile",
   7440: "Stormrider's Fury",
   7441: "Stormrider's Fury",
   7442: "Stormrider's Fury",


### PR DESCRIPTION
As reported by Unreality/Killashaman over on discord. Surging Totem is not properly loaded. Upon investigation this seems to be caused because the ability was used just before the pull and was still active once the pull started. To solve this i've added a normalizer that based on the totem's death event will add a prepull cast event. The death event allowes  for correct calculation of when the totem was placed.

You can use the following report to test this yourselves;
https://wowanalyzer.com/report/Cj4AFaK7Y6DQwXmN/51-Heroic+The+Bloodbound+Horror+-+Kill+(4:45)/Killashaman/standard/character