### PR TITLE
fix: Disc priest changelog

### DIFF
--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -2,6 +2,6 @@ import { change, date } from 'common/changelog';
 import { Hana } from 'CONTRIBUTORS';
 
 export default [
-  change(date(2024, 23, 9), <>Add void blast to weal and woe</>, Hana),
+  change(date(2024, 9, 23), <>Add void blast to weal and woe</>, Hana),
   change(date(2024, 3, 9), <>The War Within Clean up.</>, Hana),
 ];


### PR DESCRIPTION
I noticed that the retail disc priest ChangeLog had a wrongly formatted date, Which caused the date to appear in the far future: 2025. This PR corrects this mistake.

<img width="388" alt="image" src="https://github.com/user-attachments/assets/b0669024-0620-4e4f-85a4-b84f0074cfe7">
