### PR TITLE
7079 Affliction warlock - FIX shadow embrace

### DIFF
--- a/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Arlie, Jonfanz, Lithix, Meldris, ToppleTheNun, dodse, Gazh } from 'CONT
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 9, 28), <>Fix <SpellLink spell={TALENTS.SHADOW_EMBRACE_TALENT} /> error </>, Gazh),
   change(date(2024, 9, 26), "Add support for Hero Talents", Gazh),
   change(date(2024, 8, 10), 'Made several changes for affliction in preperation for the TWW', Lithix),
   change(date(2023, 7, 31), 'Update CDR on Dark Pact and Unending Resolve', Arlie),

--- a/src/analysis/retail/warlock/affliction/modules/spells/ShadowEmbrace.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/spells/ShadowEmbrace.tsx
@@ -32,6 +32,10 @@ class ShadowEmbrace extends Analyzer {
   };
   protected enemies!: Enemies;
 
+  SHADOW_EMBRACE_DEBUFF = this.selectedCombatant.hasTalent(TALENTS.DRAIN_SOUL_TALENT)
+    ? SPELLS.SHADOW_EMBRACE_SOULDRAIN_DEBUFF
+    : SPELLS.SHADOW_EMBRACE_SHADOWBOLT_DEBUFF;
+
   BONUS_PER_STACK_BASE = this.selectedCombatant.hasTalent(TALENTS.DRAIN_SOUL_TALENT)
     ? SHADOW_DRAIN_SOUL_EMBRACE_MODIFIER
     : SHADOW_DEFAULT_EMBRACE_MODIFIER;
@@ -63,13 +67,18 @@ class ShadowEmbrace extends Analyzer {
       count: 0,
       uptime: 0,
     },
+    4: {
+      start: null,
+      count: 0,
+      uptime: 0,
+    },
   };
 
   constructor(options: Options) {
     super(options);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
     this.addEventListener(
-      Events.changedebuffstack.by(SELECTED_PLAYER).spell(SPELLS.SHADOW_EMBRACE_DEBUFF),
+      Events.changedebuffstack.by(SELECTED_PLAYER).spell(this.SHADOW_EMBRACE_DEBUFF),
       this.onChangeDebuffStack,
     );
     this.active = this.selectedCombatant.hasTalent(TALENTS.SHADOW_EMBRACE_TALENT);
@@ -80,7 +89,7 @@ class ShadowEmbrace extends Analyzer {
     if (!enemy) {
       return;
     }
-    const shadowEmbrace = enemy.getBuff(SPELLS.SHADOW_EMBRACE_DEBUFF.id);
+    const shadowEmbrace = enemy.getBuff(this.SHADOW_EMBRACE_DEBUFF.id);
     if (!shadowEmbrace) {
       return;
     }
@@ -109,6 +118,7 @@ class ShadowEmbrace extends Analyzer {
 
     const oldStacks = this.debuffs[event.oldStacks];
     const newStacks = this.debuffs[event.newStacks];
+
     oldStacks.count = Math.max(oldStacks.count - 1, 0);
     debug && console.log(`OLD (${event.oldStacks}), count reduced to ${oldStacks.count}`);
     if (oldStacks.count === 0) {
@@ -126,7 +136,7 @@ class ShadowEmbrace extends Analyzer {
   }
 
   get totalUptimePercentage() {
-    return this.enemies.getBuffUptime(SPELLS.SHADOW_EMBRACE_DEBUFF.id) / this.owner.fightDuration;
+    return this.enemies.getBuffUptime(this.SHADOW_EMBRACE_DEBUFF.id) / this.owner.fightDuration;
   }
 
   get suggestionThresholds() {
@@ -169,11 +179,11 @@ class ShadowEmbrace extends Analyzer {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <>
-          Your <SpellLink spell={SPELLS.SHADOW_EMBRACE_DEBUFF} /> uptime can be improved. Try to pay
+          Your <SpellLink spell={this.SHADOW_EMBRACE_DEBUFF} /> uptime can be improved. Try to pay
           more attention to your Shadow Embrace on the boss, perhaps use some debuff tracker.
         </>,
       )
-        .icon(SPELLS.SHADOW_EMBRACE_DEBUFF.icon)
+        .icon(this.SHADOW_EMBRACE_DEBUFF.icon)
         .actual(
           defineMessage({
             id: 'warlock.affliction.suggestions.shadowembrace.uptime',
@@ -185,11 +195,11 @@ class ShadowEmbrace extends Analyzer {
   }
 
   subStatistic() {
-    const history = this.enemies.getDebuffHistory(SPELLS.SHADOW_EMBRACE_DEBUFF.id);
+    const history = this.enemies.getDebuffHistory(this.SHADOW_EMBRACE_DEBUFF.id);
     return (
       <div className="flex">
         <div className="flex-sub icon">
-          <SpellIcon spell={SPELLS.SHADOW_EMBRACE_DEBUFF} />
+          <SpellIcon spell={this.SHADOW_EMBRACE_DEBUFF} />
         </div>
         <div className="flex-sub value" style={{ width: 140 }}>
           {formatPercentage(this.totalUptimePercentage, 0)} % <small>uptime</small>
@@ -217,7 +227,7 @@ class ShadowEmbrace extends Analyzer {
           <TooltipElement
             content={
               <>
-                {Object.values(this.stackedUptime).map((uptime, index) => () => (
+                {Object.values(this.stackedUptime).map((uptime, index) => (
                   <div key={index}>
                     {index} stack(s): {formatPercentage(uptime)} %
                   </div>

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -295,7 +295,12 @@ const spells = {
     name: 'Phantom Singularity',
     icon: 'inv_enchant_voidsphere',
   },
-  SHADOW_EMBRACE_DEBUFF: {
+  SHADOW_EMBRACE_SOULDRAIN_DEBUFF: {
+    id: 32390,
+    name: 'Shadow Embrace',
+    icon: 'spell_shadow_shadowembrace',
+  },
+  SHADOW_EMBRACE_SHADOWBOLT_DEBUFF: {
     id: 453206,
     name: 'Shadow Embrace',
     icon: 'spell_shadow_shadowembrace',
@@ -458,6 +463,16 @@ const spells = {
     id: 267999,
     name: 'Headbutt',
     icon: 'inv_argusfelstalkermountgrey',
+  },
+  CHARHOUND_SUMMON: {
+    id: 455476,
+    name: 'Summon Charhound',
+    icon: 'inv_felhound3_shadow_fire',
+  },
+  GLOOMHOUND_SUMMON: {
+    id: 455465,
+    name: 'Summon Gloomhound',
+    icon: 'inv_felhound3_shadow_mount',
   },
   IMP_SINGE_MAGIC: {
     id: 119905,

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -464,16 +464,6 @@ const spells = {
     name: 'Headbutt',
     icon: 'inv_argusfelstalkermountgrey',
   },
-  CHARHOUND_SUMMON: {
-    id: 455476,
-    name: 'Summon Charhound',
-    icon: 'inv_felhound3_shadow_fire',
-  },
-  GLOOMHOUND_SUMMON: {
-    id: 455465,
-    name: 'Summon Gloomhound',
-    icon: 'inv_felhound3_shadow_mount',
-  },
   IMP_SINGE_MAGIC: {
     id: 119905,
     name: 'Singe Magic',


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->
this is fix of shadow embrace related to #7079 
causing this in prod : 
![image](https://github.com/user-attachments/assets/ec5f1389-c476-4f73-b7eb-d8a845c5ff32)

in TWW, there is now 2 differents shadow embrace debuffs, one for shadowbolt talent, the other for soul drain talent ( they come with 2 differents ids ) so the complete module didn't work and the tooltip of stacks uptime wasn't working too

### Testing

1 report with each talent ( souldrain + shadowbolt )

- Test report URL: 
- Soul Drain talent : /report/FV7zWnAqvyQKXGJh/7-Heroic+Ulgrax+the+Devourer+-+Kill+(3:31)/Lokryn/standard/statistics
- ShadowBolt talent: /report/3NzT7AjdkQ1CPFar/4-Heroic+Ulgrax+the+Devourer+-+Kill+(4:18)/Cordüle/standard/statistics
- Screenshot(s):

![image](https://github.com/user-attachments/assets/e1ca090f-ac3c-4684-8037-8c26eb913c0e)
![image](https://github.com/user-attachments/assets/7d719725-6bf3-4ed6-9891-23b40673573b)
![image](https://github.com/user-attachments/assets/176e6c38-137e-45cc-a6d0-cb5204a4b98a)


