### PR TITLE
Warlock - Re-enabled Demonology + Destruction + Demonic Healthstone support

### DIFF
--- a/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Arlie, Jonfanz, Lithix, Meldris, ToppleTheNun, dodse, Gazh } from 'CONT
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 10, 1), <>Add support for <SpellLink spell={SPELLS.DEMONIC_HEALTHSTONE} /> </>, Gazh),
   change(date(2024, 9, 28), <>Fix <SpellLink spell={TALENTS.SHADOW_EMBRACE_TALENT} /> error </>, Gazh),
   change(date(2024, 9, 26), "Add support for Hero Talents", Gazh),
   change(date(2024, 8, 10), 'Made several changes for affliction in preperation for the TWW', Lithix),

--- a/src/analysis/retail/warlock/affliction/CONFIG.tsx
+++ b/src/analysis/retail/warlock/affliction/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Jonfanz } from 'CONTRIBUTORS';
+import { Gazh } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import type Config from 'parser/Config';
@@ -8,11 +8,11 @@ import { SupportLevel } from 'parser/Config';
 
 const CONFIG: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Jonfanz],
+  contributors: [Gazh],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: null,
-  supportLevel: SupportLevel.Unmaintained,
+  patchCompatibility: '11.0.2',
+  supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -43,7 +43,7 @@ const CONFIG: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/JGFabW3gfqrtynX1/5-Normal+Eranog+-+Kill+(5:08)/Crunky',
+  exampleReport: '/report/mQMF8YnCpTctZK7w/44-Heroic+The+Silken+Court+-+Kill+(7:53)/Desolater',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/warlock/affliction/modules/checklist/Component.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/checklist/Component.tsx
@@ -80,6 +80,9 @@ const AfflictionWarlockChecklist = ({ combatant, castEfficiency, thresholds }: C
             <SpellLink spell={TALENTS.BURNING_RUSH_TALENT} icon /> or mitigate incoming damage with{' '}
             <SpellLink spell={SPELLS.UNENDING_RESOLVE} icon />/
             <SpellLink spell={TALENTS.DARK_PACT_TALENT} icon />.<br />
+            You can use 3 <SpellLink spell={SPELLS.DEMONIC_HEALTHSTONE} icon /> if you have{' '}
+            <SpellLink spell={TALENTS.PACT_OF_GLUTTONY_TALENT} icon /> talented.
+            <br />
             While you shouldn't cast these defensives on cooldown, be aware of them and use them
             whenever effective. Not using them at all indicates you might not be aware of them or
             not using them optimally.
@@ -90,6 +93,9 @@ const AfflictionWarlockChecklist = ({ combatant, castEfficiency, thresholds }: C
           <AbilityRequirement spell={TALENTS.DARK_PACT_TALENT.id} />
         )}
         <AbilityRequirement spell={SPELLS.UNENDING_RESOLVE.id} />
+        {combatant.hasTalent(TALENTS.PACT_OF_GLUTTONY_TALENT) && (
+          <AbilityRequirement spell={SPELLS.DEMONIC_HEALTHSTONE.id} />
+        )}
       </Rule>
       <Rule
         name="Always be casting"

--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Sharrq, Zeboot, Meldris, ToppleTheNun, Jonfanz, Mae, dodse, Arlie, Putr
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 10, 1), <>Add support for <SpellLink spell={SPELLS.DEMONIC_HEALTHSTONE} /> </>, Gazh),
   change(date(2024, 9, 28), <>Add support for <SpellLink spell={TALENTS_WARLOCK.MARK_OF_FHARG_TALENT}/> & <SpellLink spell={TALENTS_WARLOCK.MARK_OF_SHATUG_TALENT}/></>, Gazh),
   change(date(2024, 9, 26), "Add support for Hero Talents", Gazh),
   change(date(2024, 5, 31), <>Fixed <SpellLink spell={TALENTS_WARLOCK.POWER_SIPHON_TALENT}/> statistic</>, Zyer),

--- a/src/analysis/retail/warlock/demonology/CONFIG.tsx
+++ b/src/analysis/retail/warlock/demonology/CONFIG.tsx
@@ -1,17 +1,17 @@
-import { Zyer } from 'CONTRIBUTORS';
+import { Zyer, Gazh } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
 
-// import CHANGELOG from './CHANGELOG';
+import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Zyer],
+  contributors: [Zyer, Gazh],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '10.2.7',
-  supportLevel: SupportLevel.MaintainedFull,
+  patchCompatibility: '11.0.2',
+  supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -72,18 +72,18 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/myndpGBw3k7rjVDf/4-Mythic+Smolderon+-+Kill+(7:01)/Yumiblood/standard',
+  exampleReport: "/report/hY6vg1LxqzmR94XG/126-Heroic+Broodtwister+Ovi'nax+-+Kill+(6:24)/Meurthe/",
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.DEMONOLOGY_WARLOCK,
   // The contents of your changelog.
-  // changelog: CHANGELOG,
+  changelog: CHANGELOG,
   // The CombatLogParser class for your spec.
-  // parser: () =>
-  //   import('./CombatLogParser' /* webpackChunkName: "DemonologyWarlock" */).then(
-  //     (exports) => exports.default,
-  //   ),
+  parser: () =>
+    import('./CombatLogParser' /* webpackChunkName: "DemonologyWarlock" */).then(
+      (exports) => exports.default,
+    ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: import.meta.url,
 };

--- a/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 1), <>Add support for <SpellLink spell={SPELLS.DEMONIC_HEALTHSTONE} /> </>, Gazh),
   change(date(2024, 9, 26), "Add support for Hero Talents", Gazh),
   change(date(2023, 7, 8), 'Update CDR on Dark Pact and Unending Resolve', Arlie),
   change(date(2023, 7, 8), 'Update SpellLink usage.', ToppleTheNun),

--- a/src/analysis/retail/warlock/destruction/CONFIG.tsx
+++ b/src/analysis/retail/warlock/destruction/CONFIG.tsx
@@ -1,16 +1,17 @@
+import { Gazh } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 
-// import CHANGELOG from './CHANGELOG';
+import CHANGELOG from './CHANGELOG';
 import { SupportLevel } from 'parser/Config';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [],
+  contributors: [Gazh],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: null,
-  supportLevel: SupportLevel.Unmaintained,
+  patchCompatibility: '11.0.2',
+  supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -39,18 +40,18 @@ export default {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/TGzmk4bXDZJndpj7/6-Heroic+Opulence+-+Kill+(8:12)/3-Lunaira',
+  exampleReport: '/report/9dvKWtRTxa4Ab3Yj/8-Heroic+The+Silken+Court+-+Kill+(6:30)/Trundle',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.DESTRUCTION_WARLOCK,
   // The contents of your changelog.
-  // changelog: CHANGELOG,
+  changelog: CHANGELOG,
   // The CombatLogParser class for your spec.
-  // parser: () =>
-  //   import('./CombatLogParser' /* webpackChunkName: "DestructionWarlock" */).then(
-  //     (exports) => exports.default,
-  //   ),
+  parser: () =>
+    import('./CombatLogParser' /* webpackChunkName: "DestructionWarlock" */).then(
+      (exports) => exports.default,
+    ),
   // The path to the current directory (relative form project root). This is used for generating a GitHub link directly to your spec's code.
   path: import.meta.url,
 };

--- a/src/analysis/retail/warlock/destruction/modules/features/Checklist/Component.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/features/Checklist/Component.tsx
@@ -110,6 +110,9 @@ const DestructionWarlockChecklist = ({
             <SpellLink spell={TALENTS.BURNING_RUSH_TALENT} icon /> or mitigate incoming damage with{' '}
             <SpellLink spell={SPELLS.UNENDING_RESOLVE} icon />/
             <SpellLink spell={TALENTS.DARK_PACT_TALENT} icon />.<br />
+            You can use 3 <SpellLink spell={SPELLS.DEMONIC_HEALTHSTONE} icon /> if you have{' '}
+            <SpellLink spell={TALENTS.PACT_OF_GLUTTONY_TALENT} icon /> talented.
+            <br />
             While you shouldn't cast these defensives on cooldown, be aware of them and use them
             whenever effective. Not using them at all indicates you might not be aware of them or
             not using them optimally.
@@ -120,6 +123,9 @@ const DestructionWarlockChecklist = ({
           <AbilityRequirement spell={TALENTS.DARK_PACT_TALENT.id} />
         )}
         <AbilityRequirement spell={SPELLS.UNENDING_RESOLVE.id} />
+        {combatant.hasTalent(TALENTS.PACT_OF_GLUTTONY_TALENT) && (
+          <AbilityRequirement spell={SPELLS.DEMONIC_HEALTHSTONE.id} />
+        )}
       </Rule>
       <Rule
         name="Always be casting"

--- a/src/common/SPELLS/others.ts
+++ b/src/common/SPELLS/others.ts
@@ -318,6 +318,11 @@ const spells = {
     name: 'Healthstone',
     icon: 'warlock_-healthstone',
   },
+  DEMONIC_HEALTHSTONE: {
+    id: 452930,
+    name: 'Demonic Healthstone',
+    icon: 'warlock_-bloodstone',
+  },
   ANCIENT_REJUVENATION_POTION: {
     id: 188018,
     name: 'Ancient Rejuvenation Potion',

--- a/src/common/TALENTS/warlock.ts
+++ b/src/common/TALENTS/warlock.ts
@@ -1150,7 +1150,7 @@ const talents = {
   PACT_OF_GLUTTONY_TALENT: {
     id: 386689,
     name: 'Pact of Gluttony',
-    icon: 'warlock__bloodstone',
+    icon: 'warlock_-bloodstone',
     maxRanks: 1,
     entryIds: [91434],
     definitionIds: [{ id: 96436, specId: 267 }],

--- a/src/parser/retail/modules/items/Healthstone.ts
+++ b/src/parser/retail/modules/items/Healthstone.ts
@@ -4,6 +4,7 @@ import Events, { Class, DeathEvent } from 'parser/core/Events';
 import Combatants from 'parser/shared/modules/Combatants';
 
 import Potion from './Potion';
+import { TALENTS_WARLOCK } from 'common/TALENTS';
 
 const ONE_HOUR_MS = 3600000; // one hour
 const COOLDOWN_MS = 60000; // one minute
@@ -19,7 +20,7 @@ class Healthstone extends Potion {
 
   protected combatants!: Combatants;
 
-  static spells = [SPELLS.HEALTHSTONE.id];
+  static spells = [SPELLS.HEALTHSTONE.id, SPELLS.DEMONIC_HEALTHSTONE.id];
   static recommendedEfficiency = 0;
   static extraAbilityInfo = {
     isDefensive: true,
@@ -32,6 +33,9 @@ class Healthstone extends Potion {
     super(options);
     this.active = this.hasWarlock(options.combatants as Combatants);
     this.addEventListener(Events.death.to(SELECTED_PLAYER), this.onDeath);
+    this.maxCasts = this.selectedCombatant.hasTalent(TALENTS_WARLOCK.PACT_OF_GLUTTONY_TALENT)
+      ? 3
+      : 1;
   }
 
   protected hasWarlock(combatants: Combatants) {


### PR DESCRIPTION
### Description

Re-enabled demonology and destruction spec : partial maintain, 
a bit of work still needed but we can re-enabled it, all hero talents are here, demonic healthstone and many more.
all this stuff was already merged #7083 #7092 and this one

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

test report for Demonic Healthstone.

- Test report URL: `/report/9dvKWtRTxa4Ab3Yj/8-Heroic+The+Silken+Court+-+Kill+(6:30)/Trundle/standard/statistics`
- Screenshot(s):

![image](https://github.com/user-attachments/assets/617aff14-71d2-4e1e-b41d-c7e59b9113b7)
![image](https://github.com/user-attachments/assets/67e96dd5-74bf-49c0-b9b1-6907e0280c36)

in character page before i change the icon name : 
![image](https://github.com/user-attachments/assets/d320b925-1622-4a83-9b94-4221255d818b)
now
![image](https://github.com/user-attachments/assets/9e59b5df-2919-491e-842e-11ff38824c2f)

![image](https://github.com/user-attachments/assets/b988211b-d7f6-4635-9237-5c921410028e)




