### PR TITLE
[Augmentation] Fix some edgecases for Breath of Eons module

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/evoker';
 
 export default [
+  change(date(2024, 10, 4), <>Fix some edgecases for <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> module</>, Vollmer),
   change(date(2024, 9, 16), "Update Buff Helper note gen for Frame Glows WA", Vollmer),
   change(date(2024, 9, 10), "Update Ability Filters for Helper Modules for TWW S1", Vollmer),
   change(date(2024, 9, 6), <>Implement <SpellLink spell={TALENTS.WINGLEADER_TALENT}/> module</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/modules/breahtofeons/BreathOfEonsRotational.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/breahtofeons/BreathOfEonsRotational.tsx
@@ -8,6 +8,7 @@ import Events, {
   EmpowerEndEvent,
   EventType,
   GetRelatedEvents,
+  HasRelatedEvent,
   RemoveBuffEvent,
   RemoveDebuffEvent,
   UpdateSpellUsableEvent,
@@ -15,6 +16,7 @@ import Events, {
 } from 'parser/core/Events';
 import {
   BREATH_EBON_APPLY_LINK,
+  BREATH_OF_EONS_DEBUFF_LINK,
   EBON_MIGHT_BUFF_LINKS,
   ebonIsFromBreath,
   getBreathOfEonsBuffEvents,
@@ -443,7 +445,9 @@ class BreathOfEonsRotational extends Analyzer {
       this.currentBreathWindow.start = event.timestamp;
     }
 
-    this.activeDebuffs = this.activeDebuffs + 1;
+    if (HasRelatedEvent(event, BREATH_OF_EONS_DEBUFF_LINK)) {
+      this.activeDebuffs = this.activeDebuffs + 1;
+    }
 
     this.currentPerformanceBreathWindow.temporalWoundsCounter.push({
       timestamp: event.timestamp,

--- a/src/analysis/retail/evoker/augmentation/modules/breahtofeons/BreathOfEonsRotational.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/breahtofeons/BreathOfEonsRotational.tsx
@@ -24,7 +24,7 @@ import {
   getBreathOfEonsDebuffApplyEvents,
 } from '../normalizers/CastLinkNormalizer';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
-import Spell from 'common/SPELLS/dragonflight/potions';
+import Potions from 'common/SPELLS/thewarwithin/potions';
 import BreathOfEonsSection from './BreathOfEonsSection';
 import spells from 'common/SPELLS/dragonflight/trinkets';
 import trinkets from 'common/ITEMS/dragonflight/trinkets';
@@ -139,7 +139,7 @@ class BreathOfEonsRotational extends Analyzer {
     spells.MIRROR_OF_FRACTURED_TOMORROWS,
   ];
 
-  trackedPotions = [Spell.ELEMENTAL_POTION_OF_ULTIMATE_POWER, Spell.ELEMENTAL_POTION_OF_POWER];
+  trackedPotions = [Potions.TEMPERED_POTION];
 
   foundTrinket = this.selectedCombatant.hasTrinket(trinkets.IRIDEUS_FRAGMENT.id)
     ? spells.IRIDEUS_FRAGMENT.id
@@ -262,7 +262,7 @@ class BreathOfEonsRotational extends Analyzer {
       }
     });
 
-    let potionReady = this.spellUsable.isAvailable(Spell.ELEMENTAL_POTION_OF_POWER.id) ? 1 : 0;
+    let potionReady = this.spellUsable.isAvailable(Potions.TEMPERED_POTION.id) ? 1 : 0;
     let potionUsed = 0;
     // Check if Potion was used pre-breath
     this.trackedPotions.forEach((potion) => {

--- a/src/analysis/retail/evoker/augmentation/modules/breahtofeons/BreathOfEonsRotational.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/breahtofeons/BreathOfEonsRotational.tsx
@@ -527,7 +527,7 @@ class BreathOfEonsRotational extends Analyzer {
           0,
         );
 
-        perfWindow.ebonMightDroppedDuration = droppedUptime;
+        perfWindow.ebonMightDroppedDuration += droppedUptime;
       }
 
       breathWindow.breathPerformance = perfWindow;

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
@@ -152,6 +152,26 @@ const EVENT_LINKS: EventLink[] = [
     anyTarget: false,
     forwardBufferMs: BREATH_OF_EONS_DAMAGE_BUFFER,
   },
+  /**
+   * So this is *slightly* cursed, but basically fixes an issue with mobs sharing HP eg. Silken Court.
+   * Essentially will just apply links backwards if no link is already present.
+   * example log:
+   * https://www.warcraftlogs.com/reports/zCvY2PKpHtd6MqAW#fight=4&type=auras&pins=0%24Separate%24%23244F4B%24damage%240%240.0.0.Any%24184027896.0.0.Evoker%24true%240.0.0.Any%24false%24409632&hostility=1&spells=debuffs&target=217&ability=409560&view=events&start=4819003&end=4837682
+   */
+  {
+    linkRelation: BREATH_OF_EONS_DAMAGE_LINK,
+    reverseLinkRelation: BREATH_OF_EONS_DAMAGE_LINK,
+    linkingEventId: SPELLS.BREATH_OF_EONS_DAMAGE.id,
+    linkingEventType: EventType.Damage,
+    referencedEventId: SPELLS.TEMPORAL_WOUND_DEBUFF.id,
+    referencedEventType: EventType.RemoveDebuff,
+    anyTarget: true,
+    maximumLinks: 1,
+    backwardBufferMs: BREATH_OF_EONS_DAMAGE_BUFFER,
+    additionalCondition(linkingEvent, _referencedEvent) {
+      return !HasRelatedEvent(linkingEvent, BREATH_OF_EONS_DAMAGE_LINK);
+    },
+  },
   {
     linkRelation: BREATH_OF_EONS_DEBUFF_LINK,
     reverseLinkRelation: BREATH_OF_EONS_DEBUFF_LINK,

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
@@ -38,6 +38,7 @@ export const EBON_MIGHT_APPLY_REMOVE_LINK = 'ebonMightApplyRemoveLink';
 export const BREATH_OF_EONS_CAST_DEBUFF_APPLY_LINK = 'breathOfEonsCastDebuffApplyLink';
 export const BREATH_OF_EONS_CAST_BUFF_LINK = 'breathOfEonsCastBuffLink';
 export const BREATH_OF_EONS_DAMAGE_LINK = 'breathOfEonsDamageLink';
+export const BREATH_OF_EONS_DEBUFF_LINK = 'breathOfEonsDebuffLink';
 
 const ERUPTION_CAST_DAM_LINK = 'eruptionCastDamLink';
 const ERUPTION_CHITIN_LINK = 'eruptionChitinLink';
@@ -57,6 +58,7 @@ const BREATH_EBON_BUFFER = 250;
 const EBON_MIGHT_BUFFER = 150;
 const BREATH_OF_EONS_DEBUFF_APPLY_BUFFER = 8000;
 const BREATH_OF_EONS_BUFF_BUFFER = 8000;
+const BREATH_OF_EONS_DEBUFF_BUFFER = 14000;
 const BREATH_OF_EONS_DAMAGE_BUFFER = 100;
 const PUPIL_OF_ALEXSTRASZA_BUFFER = 1000;
 const UPHEAVAL_DAMAGE_BUFFER = 800;
@@ -149,6 +151,17 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventType: EventType.Damage,
     anyTarget: false,
     forwardBufferMs: BREATH_OF_EONS_DAMAGE_BUFFER,
+  },
+  {
+    linkRelation: BREATH_OF_EONS_DEBUFF_LINK,
+    reverseLinkRelation: BREATH_OF_EONS_DEBUFF_LINK,
+    linkingEventId: SPELLS.TEMPORAL_WOUND_DEBUFF.id,
+    linkingEventType: EventType.ApplyDebuff,
+    referencedEventId: SPELLS.TEMPORAL_WOUND_DEBUFF.id,
+    referencedEventType: EventType.RemoveDebuff,
+    anyTarget: false,
+    maximumLinks: 1,
+    forwardBufferMs: BREATH_OF_EONS_DEBUFF_BUFFER,
   },
   {
     linkRelation: PUPIL_OF_ALEXSTRASZA_LINK,


### PR DESCRIPTION
### Description

Fixed a few edgecases for the `Breath of Eons` module.

1. Account for missing `removedebuff` events.
2. Account for mobs sharing HP

Also updated potion ID to use TWW ones. And tweaked the dropped `Ebon Might` uptime calc a bit.

### Testing

- Test report URL: 

`/report/RFGPY7JAz6WTyZwB/46-Mythic+Broodtwister+Ovi'nax+-+Wipe+29+(6:51)/Lunrawr/standard/overview`
![image](https://github.com/user-attachments/assets/fbf191e6-9f33-4551-ab55-e0838f92f944)
![image](https://github.com/user-attachments/assets/380e05ad-7ed2-481c-93a6-554458f623c3)

`/report/PhfkJCmn83tTDa1c/22-Heroic+The+Silken+Court+-+Wipe+6+(8:42)/Shadywoker/standard`
![image](https://github.com/user-attachments/assets/4571dd06-cb14-4540-b125-b90d1dc4c6af)
![image](https://github.com/user-attachments/assets/605acadc-9fdf-48ee-9cf4-6cac7e51ca4f)
