### PR TITLE
[Evoker] Fix an issue with MajorDefensive module when recieving Renewing Blaze externally

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/evoker';
 
 export default [
+  change(date(2024, 10, 4), <>Fix an issue with external <SpellLink spell={TALENTS.RENEWING_BLAZE_TALENT}/> for MajorDefensive module</>, Vollmer),
   change(date(2024, 10, 4), <>Fix some edgecases for <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> module</>, Vollmer),
   change(date(2024, 9, 16), "Update Buff Helper note gen for Frame Glows WA", Vollmer),
   change(date(2024, 9, 10), "Update Ability Filters for Helper Modules for TWW S1", Vollmer),

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_EVOKER } from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2024, 10, 4), <>Fix an issue with external <SpellLink spell={TALENTS_EVOKER.RENEWING_BLAZE_TALENT}/> for MajorDefensive module</>, Vollmer),
   change(date(2024, 9, 10), "Update various Modules & Guide Sections for TWW S1", Vollmer),
   change(date(2024, 9, 6), <>Implement <SpellLink spell={TALENTS_EVOKER.WINGLEADER_TALENT}/> module</>, Vollmer),
   change(date(2024, 9, 6), <>Update MajorDefensive module for <SpellLink spell={TALENTS_EVOKER.LIFECINDERS_TALENT}/> and <SpellLink spell={TALENTS_EVOKER.HARDENED_SCALES_TALENT}/></>, Vollmer), 

--- a/src/analysis/retail/evoker/shared/modules/normalizers/DefensiveNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/DefensiveNormalizer.ts
@@ -37,6 +37,13 @@ class DefensiveNormalizer extends EventsNormalizer {
         continue;
       }
 
+      // Only normalize our own events
+      // Flameshaper Evokers can apply Renewing Blaze to us, and we don't analyze those
+      if (event.sourceID !== this.selectedCombatant.id) {
+        fixedEvents.push(event);
+        continue;
+      }
+
       const spellId = event.ability.guid;
       const castLink = DEFS_TO_NORMALIZE.get(spellId);
       if (!castLink) {


### PR DESCRIPTION
### Description

Fixes an issue with normalization that would remove unintended events, causing issues with the `MajorDefensive` module.
Now only normalizes events sourced from the player.

### Testing

- Test report URL: `/report/PhfkJCmn83tTDa1c/18-Heroic+The+Silken+Court+-+Wipe+3+(9:18)/Shadywoker/standard/about`

