### PR TITLE
fix(TTW): Character Tab Regional Errors

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 5), 'Fix viewing the character tab for certain regions.', Vetyst),
   change(date(2024, 10, 4), 'Added Earthen food buffs to consumable check.', emallson),
   change(date(2024, 10, 4), <>Added simple statistics for <ItemLink id={ITEMS.SPYMASTERS_WEB.id}/>.</>, Vetyst),
   change(date(2024, 10, 3), 'Fixed rendering of the Header on the character log browser.', Vetyst),

--- a/src/interface/CharacterParses.tsx
+++ b/src/interface/CharacterParses.tsx
@@ -320,7 +320,9 @@ class CharacterParses extends Component<CharacterParsesProps, CharacterParsesSta
     }
 
     const data = await response.json();
-    const classImageUrl = classBackgroundImage(CLASS_NAMES[data.class].name, data.region);
+    const classImageUrl = data?.class
+      ? classBackgroundImage(CLASS_NAMES[data.class].name, data.region)
+      : null;
     const avatarUrl = data.thumbnail
       ? data.thumbnail.startsWith('https')
         ? data.thumbnail

--- a/src/interface/report/Results/PlayerInfo.tsx
+++ b/src/interface/report/Results/PlayerInfo.tsx
@@ -44,10 +44,13 @@ const PlayerInfo = ({ combatant }: Props) => {
   const gear: Item[] = _parseGear(combatant._combatantInfo.gear);
   const talents = combatant._combatantInfo.talentTree;
   const averageIlvl = getAverageItemLevel(gear);
-  const classBackground = classBackgroundImage(
-    CLASS_NAMES[combatant.characterProfile.class].name,
-    combatant.characterProfile?.region,
-  );
+  console.log(combatant.characterProfile);
+  const classBackground = combatant.characterProfile?.class
+    ? classBackgroundImage(
+        CLASS_NAMES[combatant.characterProfile?.class].name,
+        combatant.characterProfile?.region,
+      )
+    : undefined;
   const characterBackground = characterBackgroundImage(
     combatant.characterProfile?.thumbnail,
     combatant.characterProfile?.region,


### PR DESCRIPTION
Because of the changes i've done in #7105 to rendering the images fromthe armory, certain regions were unable to navigate to their character tab. This PR should fix that,.

Failing log:
* /report/ApLYwMzVq4ndFHCt/36-Heroic+Nexus-Princess+Ky'veza+-+Kill+(4:11)/%EC%A0%95%EC%8B%A0%EA%B1%B4%EA%B0%95%EB%B3%B5%EC%9B%90%EC%88%A0%EC%82%AC/standard/character

Working log:
* /report/gybDQKFTn8vRwWPZ/21-Mythic+Ulgrax+the+Devourer+-+Kill+(9:04)/Bléssindisc/standard/character