### PR TITLE
attempt to remove user (ip) information before sending to sentry

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,6 +40,7 @@ if (import.meta.env.VITE_SENTRY_DSN) {
     allowUrls: ['wowanalyzer.com/assets/'],
 
     beforeSend(event) {
+      // this is *an attempt* to keep sentry from sending up user info that we don't want & don't need
       if (event.user) {
         delete event.user;
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,14 @@ if (import.meta.env.VITE_SENTRY_DSN) {
     environment: import.meta.env.VITE_ENVIRONMENT_NAME,
     allowUrls: ['wowanalyzer.com/assets/'],
 
+    beforeSend(event) {
+      if (event.user) {
+        delete event.user;
+      }
+
+      return event;
+    },
+
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     tracesSampleRate: 1.0,
@@ -48,6 +56,8 @@ if (import.meta.env.VITE_SENTRY_DSN) {
 
     ignoreErrors: [/TypeError: Failed to fetch/, /Failed to fetch/],
   });
+
+  Sentry.setUser(null);
 }
 
 render(<Root />, document.getElementById('app-mount'));


### PR DESCRIPTION
vetyst pointed out that sentry currently includes IP information. we don't have any need for this info, so this is an attempt to disable it.

ref:
- https://docs.sentry.io/platforms/javascript/guides/react/enriching-events/identify-user/
- https://docs.sentry.io/platforms/javascript/data-management/sensitive-data/#before-send-before-send-transaction

i need to test this with an actual sentry token to confirm nothing breaks, but also would not mind comment (esp from @Pewtro @kfinch)