### PR TITLE
[Resto Shaman[ Fix another pre-pull error with Surging Totem.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ temp
 # Extension files nobody cares about
 /.idea/markdown-navigator.xml
 /.idea/markdown-navigator/profiles_settings.xml
+# PhpStorm
+/.idea/php.xml
 # Visual Studio code
 /.vscode
 **.code-workspace

--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -14,6 +14,7 @@ import {
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 6), <>Fix another pre-pull error with <SpellLink spell={TALENTS_SHAMAN.SURGING_TOTEM_TALENT}/>.</>, Vetyst),
   change(date(2024, 9, 26), <>Fixed <SpellLink spell={TALENTS_SHAMAN.SURGING_TOTEM_TALENT}/> when used on pre-pull.</>, Vetyst),
   change(date(2024, 9, 15), <>Fixed <SpellLink spell={TALENTS_SHAMAN.DOWNPOUR_TALENT}/> and <SpellLink spell={TALENTS_SHAMAN.UNLEASH_LIFE_TALENT}/> interaction.</>, Ypp),
   change(date(2024, 8, 27), <>Updated <SpellLink spell={TALENTS_SHAMAN.ANCESTRAL_VIGOR_TALENT}/> for The War Within : one rank for the talent, for 10% max health increase. Updated Lives saved statistic, accounting for <SpellLink spell={TALENTS_SHAMAN.DOWNPOUR_TALENT}/>.</>, Ypp),

--- a/src/analysis/retail/shaman/restoration/constants.ts
+++ b/src/analysis/retail/shaman/restoration/constants.ts
@@ -21,6 +21,10 @@ export const DOWNPOUR = 'Downpour';
 export const HIGH_TIDE = 'HighTide';
 //event link ms settings
 export const CAST_BUFFER_MS = 100;
+// 50 was too low, 100 was too high
+// had no issues with 85ms
+export const SURGING_TOTEM_BUFFER_MS = 85;
+
 export const PWAVE_TRAVEL_MS = 1100;
 export const UNLEASH_LIFE_REMOVE_MS = 400;
 //healing increases
@@ -123,3 +127,10 @@ export const FLASH_FLOOD_CAST_SPEED_MODIFIER = 0.1; // per rank
 export const HEALING_RAIN_DURATION = 10000;
 export const RIPTIDE_BASE_DURATION = 18000;
 export const WAVESPEAKERS_BLESSING = 3000;
+export const SURGING_TOTEM_DURATION = 24000;
+
+export const WHIRLING_ELEMENTS_MOTES = [
+  SPELLS.WHIRLING_AIR,
+  SPELLS.WHIRLING_EARTH,
+  SPELLS.WHIRLING_WATER,
+];

--- a/src/analysis/retail/shaman/restoration/normalizers/SurgingTotemPrePullNormalizer.ts
+++ b/src/analysis/retail/shaman/restoration/normalizers/SurgingTotemPrePullNormalizer.ts
@@ -1,16 +1,15 @@
 import SPELLS from 'common/SPELLS/shaman';
-import { AnyEvent, CastEvent, EventType, SummonEvent } from 'parser/core/Events';
+import { AnyEvent, ApplyBuffEvent, CastEvent, EventType, SummonEvent } from 'parser/core/Events';
 import EventsNormalizer from 'parser/core/EventsNormalizer';
 import MAGIC_SCHOOLS from 'game/MAGIC_SCHOOLS';
 import Combatants from 'parser/shared/modules/Combatants';
-
-/**
- * We detect the totem based on the NPC id used in the death event.
- *
- * https://www.wowhead.com/npc=225409/surging-totem
- */
-const SURGING_TOTEM_NPC_ID = 225409;
-const SURGING_TOTEM_DURATION_MS = 24000;
+import {
+  SURGING_TOTEM_BUFFER_MS,
+  SURGING_TOTEM_DURATION,
+  WHIRLING_ELEMENTS_MOTES,
+} from 'analysis/retail/shaman/restoration/constants';
+import NPCS from 'common/NPCS/shaman';
+import Spell from 'common/SPELLS/Spell';
 
 class SurgingTotemPrePullNormalizer extends EventsNormalizer {
   static dependencies = {
@@ -22,7 +21,7 @@ class SurgingTotemPrePullNormalizer extends EventsNormalizer {
   normalize(events: AnyEvent[]) {
     // Find the Surging Totem based on NPC id from the current player's pet list.
     const targetNPC = this.owner.playerPets.find(
-      (npc: { guid: number | undefined }) => npc.guid === SURGING_TOTEM_NPC_ID,
+      (npc: { guid: number | undefined }) => npc.guid === NPCS.SURGING_TOTEM.id,
     );
 
     // Ensure the player has used Surging totem before going through the Pre Pull Normalizer.
@@ -39,24 +38,29 @@ class SurgingTotemPrePullNormalizer extends EventsNormalizer {
       }
 
       // Stop parsing events after the duration of the totem has elapsed.
-      if (event.timestamp > this.owner.fight.start_time + SURGING_TOTEM_DURATION_MS) {
+      if (
+        event.timestamp >
+        this.owner.fight.start_time + SURGING_TOTEM_DURATION + SURGING_TOTEM_BUFFER_MS
+      ) {
         break;
       }
 
       // Start time should be before the start of the fight.
-      const startTime =
+      const startTime: number =
         this.owner.fight.start_time -
-        (SURGING_TOTEM_DURATION_MS - (event.timestamp - this.owner.fight.start_time));
+        (SURGING_TOTEM_DURATION -
+          (event.timestamp - this.owner.fight.start_time - SURGING_TOTEM_BUFFER_MS));
 
-      // Fabricate a casts as they happen when a Surging Totem is placed.
-      const castHealingRainEvent: CastEvent = {
+      // Fabricate a events as they happen when a Surging Totem is cast in the correct sequence.
+      const summonSurgingTotemEvent: SummonEvent = {
         ability: {
-          guid: SPELLS.HEALING_RAIN_TOTEMIC.id,
-          name: SPELLS.HEALING_RAIN_TOTEMIC.name,
-          abilityIcon: SPELLS.HEALING_RAIN_TOTEMIC.icon,
+          guid: SPELLS.SURGING_TOTEM.id,
+          name: SPELLS.SURGING_TOTEM.name,
+          abilityIcon: SPELLS.SURGING_TOTEM.icon,
           type: MAGIC_SCHOOLS.ids.NATURE,
         },
-        type: EventType.Cast,
+        targetInstance: 2,
+        type: EventType.Summon,
         timestamp: startTime,
         sourceID: this.owner.playerId,
         sourceIsFriendly: true,
@@ -83,15 +87,14 @@ class SurgingTotemPrePullNormalizer extends EventsNormalizer {
         prepull: true,
       };
 
-      const summonSurgingTotemEvent: SummonEvent = {
+      const castHealingRainEvent: CastEvent = {
         ability: {
-          guid: SPELLS.SURGING_TOTEM.id,
-          name: SPELLS.SURGING_TOTEM.name,
-          abilityIcon: SPELLS.SURGING_TOTEM.icon,
+          guid: SPELLS.HEALING_RAIN_TOTEMIC.id,
+          name: SPELLS.HEALING_RAIN_TOTEMIC.name,
+          abilityIcon: SPELLS.HEALING_RAIN_TOTEMIC.icon,
           type: MAGIC_SCHOOLS.ids.NATURE,
         },
-        targetInstance: 2,
-        type: EventType.Summon,
+        type: EventType.Cast,
         timestamp: startTime,
         sourceID: this.owner.playerId,
         sourceIsFriendly: true,
@@ -101,9 +104,30 @@ class SurgingTotemPrePullNormalizer extends EventsNormalizer {
         prepull: true,
       };
 
-      events.splice(0, 0, castHealingRainEvent);
-      events.splice(0, 0, castSurgingTotemEvent);
       events.splice(0, 0, summonSurgingTotemEvent);
+      events.splice(0, 0, castSurgingTotemEvent);
+      events.splice(0, 0, castHealingRainEvent);
+
+      WHIRLING_ELEMENTS_MOTES.forEach((spell: Spell) => {
+        const applyBuffEvent: ApplyBuffEvent = {
+          ability: {
+            guid: spell.id,
+            name: spell.name,
+            abilityIcon: spell.icon,
+            type: MAGIC_SCHOOLS.ids.PHYSICAL,
+          },
+          type: EventType.ApplyBuff,
+          timestamp: startTime,
+          sourceID: this.owner.playerId,
+          sourceIsFriendly: true,
+          targetIsFriendly: true,
+          targetID: this.owner.playerId,
+          __fabricated: true,
+          prepull: true,
+        };
+
+        events.splice(0, 0, applyBuffEvent);
+      });
       break;
     }
 

--- a/src/common/NPCS/shaman.ts
+++ b/src/common/NPCS/shaman.ts
@@ -26,6 +26,11 @@ const npcs = {
     name: 'Ancestor',
     type: 'Pet',
   },
+  SURGING_TOTEM: {
+    id: 225409,
+    name: 'Surging Totem',
+    type: 'Pet',
+  },
 } satisfies Record<string, NPC>;
 
 export default npcs;


### PR DESCRIPTION
Noticed in the sentry logs that there was another error involving Surging Totem being cast on prepull that was not fixed with #7082 
* Implemented the same Surging Totem buffer for the normalizer.
* Implemented the Swirling Elements in the normalizer.
* Corrected the order in which the events happen within the normalizer.
* Made the Surging Totem module less confusing (Talking about the naming here)
* Cleaned up the normalizer slightly now that we have the NPC constant.

See log:
* https://wowanalyzer.com/report/3PvbpMfFDKtwy468/27-Mythic+Ulgrax+the+Devourer+-+Kill+(10:03)/Juserguser/standard/about
