### PR TITLE
fix(TTW): Resolve rare instance of duplicated events.

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 6), 'Resolved a rare instance of duplicated events', Vetyst),
   change(date(2024, 10, 5), 'Fix viewing the character tab for certain regions.', Vetyst),
   change(date(2024, 10, 4), 'Added Earthen food buffs to consumable check.', emallson),
   change(date(2024, 10, 4), <>Added simple statistics for <ItemLink id={ITEMS.SPYMASTERS_WEB.id}/>.</>, Vetyst),

--- a/src/interface/report/hooks/useEvents.ts
+++ b/src/interface/report/hooks/useEvents.ts
@@ -46,8 +46,14 @@ const useEvents = ({
       }
     };
 
+    const filterEventsToFight = (events: AnyEvent[], fightId: number): AnyEvent[] => {
+      return events.filter((event: AnyEvent) => {
+        return event.fight === fightId;
+      });
+    };
+
     (async () => {
-      const events = await load(fight.start_time);
+      const events = filterEventsToFight(await load(fight.start_time), fight.id);
       setEvents(events);
     })();
 

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -371,8 +371,8 @@ export type AnyEvent<T extends EventType = EventType> = T extends keyof MappedEv
 export interface Event<T extends string> {
   /** Event type string */
   type: T;
-  /** The fight id */
-  fight: number;
+  /** The fight id, This not present for WoWA fabricated events */
+  fight?: number;
   /** Timestamp in milliseconds */
   timestamp: number;
   /** True iff the event happened before the pull. Added by WoWA */
@@ -720,7 +720,6 @@ export interface ExtraAttacksEvent extends Event<EventType.ExtraAttacks> {
   targetID: number;
   targetIsFriendly: boolean;
   targetMarker?: number;
-  fight: number;
   extraAttacks: number;
 }
 
@@ -1012,7 +1011,6 @@ export interface CreateEvent extends Event<EventType.Create> {
 export interface SpellstealEvent extends Event<EventType.Spellsteal> {
   ability: Ability;
   extraAbility: Ability;
-  fight: number;
   isBuff: boolean;
   sourceID: number;
   sourceIsFriendly: boolean;

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -371,6 +371,8 @@ export type AnyEvent<T extends EventType = EventType> = T extends keyof MappedEv
 export interface Event<T extends string> {
   /** Event type string */
   type: T;
+  /** The fight id */
+  fight: number;
   /** Timestamp in milliseconds */
   timestamp: number;
   /** True iff the event happened before the pull. Added by WoWA */


### PR DESCRIPTION
Noticed an error being throw for Void Torrent talent of the shadow priest through sentry. Upon investigation it seemed that all of the events were duplicated as you can see in the log here;

* /report/hKXnp4AcNJjzC7VP/9-Heroic+The+Bloodbound+Horror+-+Kill+(4:09)/Popispectre/standard/events

I notived that the events were being downloaded from the WCL Api. Investigating this it seemed that the fight was logged/uploaded twice within with the same timestamps. To fix this issue i decided to filter down to the events of the selected fight only.

The effects are quite noticable for the Statistics overview;

Before:
![image](https://github.com/user-attachments/assets/813999e2-10bb-4ffd-8f69-b30e9e48c5bf)
![image](https://github.com/user-attachments/assets/2e960cd0-6fee-49ca-91d2-4c64b4212c52)





After:
![image](https://github.com/user-attachments/assets/3fd822ec-b49e-46ab-b960-4dd15ccdeb16)
![image](https://github.com/user-attachments/assets/d1caa714-078a-4848-b2f6-27105a564303)
