### PR TITLE
Add Coalesence module

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date (2024, 10, 6), <>Add <SpellLink spell={TALENTS_MONK.COALESCENCE_TALENT}/> statistic</>, Trevor),
   change(date (2024, 9, 28), <>Fix crash in <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT}/> when it failed to hit any allies.</>, Trevor),
   change(date (2024, 9, 24), <>Fix <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT}/> event linking</>, Trevor),
   change(date (2024, 9, 24), <>Fix another crash condition</>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -92,6 +92,7 @@ import ConduitOfTheCelestialsEventLinks from '../shared/hero/ConduitOfTheCelesti
 import CelestialConduitNormalizer from '../shared/hero/ConduitOfTheCelestials/normalizers/CelestialConduitNormalizer';
 import CelestialConduit from '../shared/hero/ConduitOfTheCelestials/talents/CelestialConduit';
 import StrengthOfTheBlackOx from './modules/heroTalents/StrengthOfTheBlackOx';
+import Coalesence from '../shared/hero/MasterOfHarmony/talents/Coalesence';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -191,12 +192,14 @@ class CombatLogParser extends CoreCombatLogParser {
     chiHarmony: ChiHarmony,
     poolOfMists: PoolOfMists,
 
-    //Hero Talents
-    //Conduit
+    // Hero Talents
+    // Conduit
     celestialConduit: CelestialConduit,
     heartOfTheJadeSerpent: HeartOfTheJadeSerpent,
     restoreBalance: RestoreBalance,
     apl: AplCheck,
+    // Harmony
+    coalesence: Coalesence,
 
     // Borrowed Power
     t32TierSet: T32TierSet,

--- a/src/analysis/retail/monk/shared/hero/MasterOfHarmony/constants.ts
+++ b/src/analysis/retail/monk/shared/hero/MasterOfHarmony/constants.ts
@@ -1,1 +1,1 @@
-export const COALESENCE_INCREASE = 0.3;
+export const COALESENCE_INCREASE = 0.2;

--- a/src/analysis/retail/monk/shared/hero/MasterOfHarmony/constants.ts
+++ b/src/analysis/retail/monk/shared/hero/MasterOfHarmony/constants.ts
@@ -1,0 +1,1 @@
+export const COALESENCE_INCREASE = 0.3;

--- a/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/Coalesence.tsx
+++ b/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/Coalesence.tsx
@@ -33,6 +33,9 @@ class Coalesence extends Analyzer {
   }
 
   private onHeal(event: HealEvent) {
+    if (event.ability.guid === SPELLS.ASPECT_OF_HARMONY_HOT.id) {
+      return;
+    }
     const target = this.combatants.getEntity(event);
     if (
       !target ||
@@ -50,6 +53,9 @@ class Coalesence extends Analyzer {
   }
 
   private onDamage(event: DamageEvent) {
+    if (event.ability.guid === SPELLS.ASPECT_OF_HARMONY_DOT.id) {
+      return;
+    }
     const target = this.enemies.getEntity(event);
     if (
       !target ||

--- a/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/Coalesence.tsx
+++ b/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/Coalesence.tsx
@@ -1,0 +1,89 @@
+import { CAST_BUFFER_MS } from 'analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants';
+import SPELLS from 'common/SPELLS';
+import { TALENTS_MONK } from 'common/TALENTS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { calculateEffectiveDamage, calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
+import Events, { DamageEvent, HealEvent } from 'parser/core/Events';
+import Combatants from 'parser/shared/modules/Combatants';
+import { COALESENCE_INCREASE } from '../constants';
+import Enemies from 'parser/shared/modules/Enemies';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+
+class Coalesence extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    enemies: Enemies,
+  };
+  protected combatants!: Combatants;
+  protected enemies!: Enemies;
+  totalDmg: number = 0;
+  totalHealing: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.COALESCENCE_TALENT);
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
+  }
+
+  private onHeal(event: HealEvent) {
+    const target = this.combatants.getEntity(event);
+    if (
+      !target ||
+      !target.hasBuff(
+        SPELLS.ASPECT_OF_HARMONY_HOT,
+        event.timestamp,
+        CAST_BUFFER_MS,
+        0,
+        this.selectedCombatant.player.id,
+      )
+    ) {
+      return;
+    }
+    this.totalHealing += calculateEffectiveHealing(event, COALESENCE_INCREASE);
+  }
+
+  private onDamage(event: DamageEvent) {
+    const target = this.enemies.getEntity(event);
+    if (
+      !target ||
+      !target.hasBuff(
+        SPELLS.ASPECT_OF_HARMONY_DOT,
+        event.timestamp,
+        CAST_BUFFER_MS,
+        0,
+        this.selectedCombatant.player.id,
+      )
+    ) {
+      return;
+    }
+    this.totalDmg += calculateEffectiveDamage(event, COALESENCE_INCREASE);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(9)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.HERO_TALENTS}
+      >
+        <TalentSpellText talent={TALENTS_MONK.COALESCENCE_TALENT}>
+          <div>
+            <ItemHealingDone amount={this.totalHealing} />
+          </div>
+          <div>
+            <ItemDamageDone amount={this.totalDmg} />
+          </div>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default Coalesence;

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -963,6 +963,16 @@ const spells = {
     name: 'Flow of Battle',
     icon: 'ability_monk_energizingwine.jpg',
   },
+  ASPECT_OF_HARMONY_DOT: {
+    id: 450763,
+    name: 'Aspect of Harmony',
+    icon: 'inv-enchant-essencenethersmall',
+  },
+  ASPECT_OF_HARMONY_HOT: {
+    id: 450769,
+    name: 'Aspect of Harmony',
+    icon: 'inv_enchanting_wod_essence2',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;


### PR DESCRIPTION
### Description

Adds Coalesence module with numbers for tuesday tuning. This talent might not work on live, so probably won't land it until patch goes live.

![image](https://github.com/user-attachments/assets/110214c7-b88d-4309-af2e-39bd966e0c0c)


