### PR TITLE
feature(TWW): Treacherous Transmitter trinket

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 7), <>Add the ability of <ItemLink id={ITEMS.TREACHEROUS_TRANSMITTER.id}/> to the spellbook when equipped.</>, Vetyst),
   change(date(2024, 10, 5), 'Fix viewing the character tab for certain regions.', Vetyst),
   change(date(2024, 10, 4), 'Added Earthen food buffs to consumable check.', emallson),
   change(date(2024, 10, 4), <>Added simple statistics for <ItemLink id={ITEMS.SPYMASTERS_WEB.id}/>.</>, Vetyst),

--- a/src/common/ITEMS/thewarwithin/trinkets.ts
+++ b/src/common/ITEMS/thewarwithin/trinkets.ts
@@ -16,6 +16,11 @@ const trinkets = {
     name: "Spymaster's Web",
     icon: 'inv_11_0_raid_spymastersweb_purple',
   },
+  TREACHEROUS_TRANSMITTER: {
+    id: 221023,
+    name: 'Treacherous Transmitter',
+    icon: 'inv_etherealraid_communicator_color1',
+  },
 } satisfies Record<string, Item>;
 
 export default trinkets;

--- a/src/common/SPELLS/thewarwithin/trinkets.ts
+++ b/src/common/SPELLS/thewarwithin/trinkets.ts
@@ -18,6 +18,12 @@ const spells = {
     name: "Spymaster's Report",
     icon: 'inv_nerubianspiderling2_black',
   },
+  // Treacherous Transmitter
+  CRYPTIC_INSTRUCTIONS: {
+    id: 449946,
+    name: 'Cryptic Instructions',
+    icon: 'inv_etherealraid_communicator_color1',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -111,6 +111,7 @@ import {
   StormridersFury,
 } from 'parser/retail/modules/items/thewarwithin';
 import CritRacial from 'parser/shared/modules/racials/CritRacial';
+import TreacherousTransmitter from 'parser/retail/modules/items/thewarwithin/trinkets/TreacherousTransmitter';
 
 // This prints to console anything that the DI has to do
 const debugDependencyInjection = false;
@@ -220,6 +221,7 @@ class CombatLogParser {
     authorityOfTheDepths: AuthorityOfTheDepths,
     signetOfThePriory: SignetOfThePriory,
     spymastersWeb: SpymastersWeb,
+    treacherousTransmitter: TreacherousTransmitter,
 
     // Embellishments
     darkmoonSigilAscension: DarkmoonSigilAscension,

--- a/src/parser/retail/modules/items/thewarwithin/trinkets/TreacherousTransmitter.ts
+++ b/src/parser/retail/modules/items/thewarwithin/trinkets/TreacherousTransmitter.ts
@@ -1,0 +1,28 @@
+import ITEMS from 'common/ITEMS/thewarwithin/trinkets';
+import SPELLS from 'common/SPELLS/thewarwithin/trinkets';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+import Abilities from 'parser/core/modules/Abilities';
+
+export default class TreacherousTransmitter extends Analyzer.withDependencies({
+  abilities: Abilities,
+}) {
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.TREACHEROUS_TRANSMITTER.id);
+    if (!this.active) {
+      return;
+    }
+
+    this.deps.abilities.add({
+      spell: SPELLS.CRYPTIC_INSTRUCTIONS.id,
+      category: SPELL_CATEGORY.COOLDOWNS,
+      cooldown: 90,
+      castEfficiency: {
+        suggestion: true,
+        recommendedEfficiency: 0.9,
+      },
+    });
+  }
+}


### PR DESCRIPTION
Simply add the Treacherous Transmitter trinket's ability to the spellbook when it is equipped by the character.

A log that uses this trinket:
* /report/VNBv3HX9dLxb1YMc/7-Normal+The+Bloodbound+Horror+-+Kill+(1:59)/Elenoray/standard/overview