### PR TITLE
[Unholy DK] Correct GCD and Cooldown for AMS

### DIFF
--- a/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
@@ -1,6 +1,10 @@
 import { change, date } from 'common/changelog';
 import { Vetyst } from 'CONTRIBUTORS';
+import { SpellLink } from 'interface';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/deathknight';
 
 export default [
+  change(date(2024, 10, 7), <>Correct GCD and cooldown of <SpellLink spell={SPELLS.ANTI_MAGIC_SHELL.id} /> when paired with <SpellLink spell={TALENTS.ANTI_MAGIC_BARRIER_TALENT.id} /> and <SpellLink spell={TALENTS.UNYIELDING_WILL_TALENT.id} />.</>, Vetyst),
   change(date(2024, 10, 4), 'Enable Core Foundation of Unholy DK for TWW.', Vetyst),
 ];

--- a/src/analysis/retail/deathknight/unholy/modules/Abilities.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/Abilities.tsx
@@ -171,11 +171,11 @@ class Abilities extends CoreAbilities {
         spell: SPELLS.ANTI_MAGIC_SHELL.id,
         category: SPELL_CATEGORY.DEFENSIVE,
         cooldown:
-          80 -
-          Number(combatant.hasTalent(TALENTS.ANTI_MAGIC_BARRIER_TALENT)) * 20 -
+          60 -
+          Number(combatant.hasTalent(TALENTS.ANTI_MAGIC_BARRIER_TALENT)) * 20 +
           Number(combatant.hasTalent(TALENTS.UNYIELDING_WILL_TALENT)) * 20,
         gcd: {
-          base: 1500,
+          static: 0,
         },
       },
       {


### PR DESCRIPTION
Corrected the GCD and Cooldown for AMS was incorrect. Yes the CD is meant to increase with Unyielding Resolve.

Can be checked with log:
* /report/VNBv3HX9dLxb1YMc/7-Normal+The+Bloodbound+Horror+-+Kill+(1:59)/10-Elenoray/standard

Before:
<img width="846" alt="image" src="https://github.com/user-attachments/assets/c42967b7-92a9-44b6-a9ec-4e4b39f09949">


After:
<img width="942" alt="image" src="https://github.com/user-attachments/assets/4eb4f314-9428-41a6-89d5-e15f2bdfcacd">
