### PR TITLE
Hide Circle of Healing analysis if not talented

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -1892,13 +1892,13 @@ export const Llanas: Contributor = {
 };
 export const xizbow: Contributor = {
   nickname: 'xizbow',
-  discord: 'xizbow#1856',
+  discord: 'xizbow',
   github: 'xizbow1',
   mains: [
     {
-      name: 'Greggoros',
-      spec: SPECS.HOLY_PALADIN,
-      link: 'https://worldofwarcraft.com/en-us/character/us/wyrmrest-accord/Greggoros',
+      name: 'Gregskull',
+      spec: SPECS.HOLY_PRIEST,
+      link: 'https://www.warcraftlogs.com/character/us/zuljin/gregskull',
     },
   ],
 };

--- a/src/analysis/retail/priest/holy/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/holy/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import TALENTS, { TALENTS_PRIEST } from 'common/TALENTS/priest';
-import { Arlie, Hana, Litena, Liavre, Squided, ToppleTheNun, Trevor, Saeldur } from 'CONTRIBUTORS';
+import { Arlie, Hana, Litena, Liavre, Squided, ToppleTheNun, Trevor, Saeldur, xizbow} from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2024, 10, 7), <>Properly hide Circle of Healing analysis if it isn't talented.</>, xizbow),
   change(date(2024, 9, 21), <>Changed tooltips, added crisis management, and added prismatic echoes </>, Liavre),
   change(date(2024, 9, 16), <>Implemented TWW S1 4pc </>, Liavre),
   change(date(2024, 9, 11), <>Split Divine Hymn/GS into proper attributions, fixed mana costs,

--- a/src/analysis/retail/priest/holy/Guide.tsx
+++ b/src/analysis/retail/priest/holy/Guide.tsx
@@ -22,7 +22,8 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         {modules.Lightweaver.guideSubsection}
         {modules.prayerOfHealing.guideSubsection}
         {modules.prayerOfMending.guideSubsection}
-        {modules.circleOfHealing.guideSubsection}
+        {info.combatant.hasTalent(TALENTS_PRIEST.CIRCLE_OF_HEALING_TALENT) &&
+          modules.circleOfHealing.guideSubsection}
         {modules.DivineStar.guideSubsectionHoly}
         {modules.Halo.guideSubsectionHoly}
       </Section>

--- a/src/analysis/retail/priest/holy/modules/spells/CircleOfHealing.tsx
+++ b/src/analysis/retail/priest/holy/modules/spells/CircleOfHealing.tsx
@@ -25,10 +25,7 @@ class CircleOfHealing extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    if (!this.selectedCombatant.hasTalent(TALENTS.CIRCLE_OF_HEALING_TALENT)) {
-      this.active = false;
-      return;
-    }
+    this.active = this.selectedCombatant.hasTalent(TALENTS.CIRCLE_OF_HEALING_TALENT);
 
     this.orisonActive = this.selectedCombatant.hasTalent(TALENTS.ORISON_TALENT);
 

--- a/src/analysis/retail/priest/holy/modules/spells/CircleOfHealing.tsx
+++ b/src/analysis/retail/priest/holy/modules/spells/CircleOfHealing.tsx
@@ -25,7 +25,10 @@ class CircleOfHealing extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.active = this.selectedCombatant.hasTalent(TALENTS.CIRCLE_OF_HEALING_TALENT);
+    if (!this.selectedCombatant.hasTalent(TALENTS.CIRCLE_OF_HEALING_TALENT)) {
+      this.active = false;
+      return;
+    }
 
     this.orisonActive = this.selectedCombatant.hasTalent(TALENTS.ORISON_TALENT);
 
@@ -82,6 +85,9 @@ class CircleOfHealing extends Analyzer {
   }
 
   get guideSubsection(): JSX.Element {
+    if (!this.selectedCombatant.hasTalent(TALENTS.CIRCLE_OF_HEALING_TALENT)) {
+      return <></>;
+    }
     const explanation = (
       <p>
         <b>

--- a/src/analysis/retail/priest/holy/modules/spells/CircleOfHealing.tsx
+++ b/src/analysis/retail/priest/holy/modules/spells/CircleOfHealing.tsx
@@ -82,9 +82,6 @@ class CircleOfHealing extends Analyzer {
   }
 
   get guideSubsection(): JSX.Element {
-    if (!this.selectedCombatant.hasTalent(TALENTS.CIRCLE_OF_HEALING_TALENT)) {
-      return <></>;
-    }
     const explanation = (
       <p>
         <b>


### PR DESCRIPTION
### Description

Circle of Healing analysis in the Overview section was showing regardless of whether or not it was talented.

### Testing

- Test report URL: `https://www.warcraftlogs.com/reports/FPh2BbcpaCYfKLXw#fight=12&type=summary&source=7`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/55ea90a0-595c-4219-b9a4-98390d5280fa)
![image](https://github.com/user-attachments/assets/7c15a3b3-5c5e-4ce7-a143-90ef3311ef8b)

