### PR TITLE
[Arcane Mage] Additional Fixes

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -5,6 +5,9 @@ import { change, date } from 'common/changelog';
 import { Sharrq, Sref } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2024, 10, 9), <>Adjusted <SpellLink spell={TALENTS.TOUCH_OF_THE_MAGI_TALENT} /> to account for <SpellLink spell={SPELLS.BURDEN_OF_POWER_BUFF} />, <SpellLink spell={SPELLS.GLORIOUS_INCANDESCENCE_BUFF} />, and <SpellLink spell={SPELLS.INTUITION_BUFF} /> when evaluating <SpellLink spell={SPELLS.ARCANE_CHARGE} />s.</>, Sharrq),
+  change(date(2024, 10, 9), <>Fixed an issue that caused <SpellLink spell={TALENTS.ARCANE_MISSILES_TALENT} /> to sometimes incorrectly claim the player had <SpellLink spell={SPELLS.NETHER_PRECISION_BUFF} /> due to incorrect event ordering in the log.</>, Sharrq),
+  change(date(2024, 10, 9), <>Updated <SpellLink spell={TALENTS.ARCANE_SURGE_TALENT} /> to no longer complain about Mana % or <SpellLink spell={SPELLS.ARCANE_CHARGE} />s for the Opener.</>, Sharrq),
   change(date(2024, 10, 5), <>Now showing a message in the <SpellLink spell={SPELLS.ARCANE_ORB} /> section to indicate if they did not cast the spell at all.</>, Sharrq),
   change(date(2024, 10, 5), <>Fixed a bug that would crash Arcane Mage logs in dungeons such as Siege of Boralis and Mists of Tirna Scithe.</>, Sharrq),
   change(date(2024, 10, 5), <>Fixed an issue that was causing <SpellLink spell={SPELLS.ARCANE_CHARGE} /> to be miscounted, or not counted at all in some cases.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CombatLogParser.ts
+++ b/src/analysis/retail/mage/arcane/CombatLogParser.ts
@@ -60,11 +60,13 @@ import ArcaneTempo from './talents/ArcaneTempo';
 //Normalizers
 import ArcaneChargesNormalizer from './normalizers/ArcaneCharges';
 import ArcaneSurgeNormalizer from './normalizers/ArcaneSurge';
+import NetherPrecisionNormalizer from './normalizers/NetherPrecision';
 import CastLinkNormalizer from './normalizers/CastLinkNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     //Normalizers
+    netherPrecisionNormalizer: NetherPrecisionNormalizer,
     arcaneChargesNormalizer: ArcaneChargesNormalizer,
     arcaneSurgeNormalizer: ArcaneSurgeNormalizer,
     castLinkNormalizer: CastLinkNormalizer,

--- a/src/analysis/retail/mage/arcane/guide/TouchOfTheMagi.tsx
+++ b/src/analysis/retail/mage/arcane/guide/TouchOfTheMagi.tsx
@@ -16,6 +16,8 @@ import CooldownExpandable, {
   CooldownExpandableItem,
 } from 'interface/guide/components/CooldownExpandable';
 
+const MAX_ARCANE_CHARGES = 4;
+
 class TouchOfTheMagiGuide extends Analyzer {
   static dependencies = {
     touchOfTheMagi: TouchOfTheMagi,
@@ -47,14 +49,19 @@ class TouchOfTheMagiGuide extends Analyzer {
     const checklistItems: CooldownExpandableItem[] = [];
 
     const noCharges = cast.charges === 0;
+    const maxCharges = cast.charges === MAX_ARCANE_CHARGES;
     checklistItems.push({
       label: (
         <>
           <SpellLink spell={SPELLS.ARCANE_CHARGE} />s Before Touch
         </>
       ),
-      result: <PassFailCheckmark pass={noCharges} />,
-      details: <>{cast.charges}</>,
+      result: <PassFailCheckmark pass={noCharges || (maxCharges && cast.refundBuff)} />,
+      details: (
+        <>
+          {cast.charges} {cast.refundBuff ? '(Refund)' : ''}
+        </>
+      ),
     });
 
     const activeTime = cast.activeTime;
@@ -69,7 +76,9 @@ class TouchOfTheMagiGuide extends Analyzer {
     });
 
     const overallPerf =
-      noCharges && activeTime ? QualitativePerformance.Good : QualitativePerformance.Fail;
+      (noCharges || (maxCharges && cast.refundBuff)) && activeTime
+        ? QualitativePerformance.Good
+        : QualitativePerformance.Fail;
 
     return (
       <CooldownExpandable
@@ -92,15 +101,17 @@ class TouchOfTheMagiGuide extends Analyzer {
     const arcaneBlast = <SpellLink spell={SPELLS.ARCANE_BLAST} />;
     const arcaneSurge = <SpellLink spell={TALENTS.ARCANE_SURGE_TALENT} />;
     const presenceOfMind = <SpellLink spell={TALENTS.PRESENCE_OF_MIND_TALENT} />;
+    const burdenOfPower = <SpellLink spell={TALENTS.BURDEN_OF_POWER_TALENT} />;
+    const gloriousIncandescence = <SpellLink spell={TALENTS.GLORIOUS_INCANDESCENCE_TALENT} />;
+    const intuition = <SpellLink spell={SPELLS.INTUITION_BUFF} />;
     const touchOfTheMagiIcon = <SpellIcon spell={TALENTS.TOUCH_OF_THE_MAGI_TALENT} />;
 
     const explanation = (
       <>
         <div>
-          <b>{touchOfTheMagi}</b> is a short duration debuff and is available for each burn phase,
-          accumulating 20% of your damage. When the debuff expires it explodes dealing the
-          accumulated damage to the target and reduced damage to nearby enemies. To maximize your
-          burst, refer to the below:
+          <b>{touchOfTheMagi}</b> is a short debuff available for each burn phase and grants you 4{' '}
+          {arcaneCharge}s and accumulates 20% of your damage for the duration. When the debuff
+          expires it explodes dealing damage to the target and reduced damage to nearby targets.
         </div>
         <div>
           <ul>
@@ -109,8 +120,12 @@ class TouchOfTheMagiGuide extends Analyzer {
               until the debuff expires.
             </li>
             <li>
-              {touchOfTheMagi} gives you 4 {arcaneCharge}s, so spend them with {arcaneBarrage} and
-              cast {touchOfTheMagi} while {arcaneBarrage} is in the air.
+              Spend your {arcaneCharge}s with {arcaneBarrage} and then cast {touchOfTheMagi} while{' '}
+              {arcaneBarrage}
+              is in the air for some extra damage. cast
+              {touchOfTheMagi} while {arcaneBarrage} is in the air. This should be done even if your
+              charges will be refunded anyway via {burdenOfPower}, {gloriousIncandescence}, or{' '}
+              {intuition}.
             </li>
             <li>
               Major Burn Phase: Ensure you have {siphonStorm} and {netherPrecision}. Your cast

--- a/src/analysis/retail/mage/arcane/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/arcane/normalizers/CastLinkNormalizer.ts
@@ -23,6 +23,7 @@ const BUFF_REMOVE = 'BuffRemove';
 const DEBUFF_APPLY = 'DebuffApply';
 const DEBUFF_REMOVE = 'DebuffRemove';
 const ENERGIZE = 'Energize';
+const REFUND_CHARGE_BUFF = 'RefundBuff';
 
 const EVENT_LINKS: EventLink[] = [
   {
@@ -150,6 +151,22 @@ const EVENT_LINKS: EventLink[] = [
     anyTarget: true,
     forwardBufferMs: CAST_BUFFER_MS,
     backwardBufferMs: CAST_BUFFER_MS,
+  },
+  {
+    reverseLinkRelation: DEBUFF_APPLY,
+    linkingEventId: SPELLS.TOUCH_OF_THE_MAGI_DEBUFF.id,
+    linkingEventType: EventType.ApplyDebuff,
+    linkRelation: REFUND_CHARGE_BUFF,
+    referencedEventId: [
+      SPELLS.BURDEN_OF_POWER_BUFF.id,
+      SPELLS.INTUITION_BUFF.id,
+      SPELLS.GLORIOUS_INCANDESCENCE_BUFF.id,
+    ],
+    referencedEventType: EventType.RemoveBuff,
+    maximumLinks: 1,
+    anyTarget: true,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: 500,
   },
   {
     reverseLinkRelation: DEBUFF_APPLY,

--- a/src/analysis/retail/mage/arcane/normalizers/NetherPrecision.ts
+++ b/src/analysis/retail/mage/arcane/normalizers/NetherPrecision.ts
@@ -1,0 +1,25 @@
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/mage';
+import EventOrderNormalizer, { EventOrder } from 'parser/core/EventOrderNormalizer';
+import { EventType } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+
+const EVENT_ORDERS: EventOrder[] = [
+  {
+    beforeEventId: SPELLS.NETHER_PRECISION_BUFF.id,
+    beforeEventType: EventType.RemoveBuff,
+    afterEventId: TALENTS.ARCANE_MISSILES_TALENT.id,
+    afterEventType: EventType.Cast,
+    bufferMs: 50,
+    anyTarget: true,
+    updateTimestamp: true,
+  },
+];
+
+class NetherPrecision extends EventOrderNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_ORDERS);
+  }
+}
+
+export default NetherPrecision;

--- a/src/analysis/retail/mage/arcane/talents/TouchOfTheMagi.tsx
+++ b/src/analysis/retail/mage/arcane/talents/TouchOfTheMagi.tsx
@@ -7,6 +7,7 @@ import Events, {
   RemoveDebuffEvent,
   GetRelatedEvent,
   GetRelatedEvents,
+  RemoveBuffEvent,
 } from 'parser/core/Events';
 import { ThresholdStyle } from 'parser/core/ParseResults';
 import ArcaneChargeTracker from '../core/ArcaneChargeTracker';
@@ -45,6 +46,7 @@ export default class TouchOfTheMagi extends Analyzer {
     const ordinal = this.touchCasts.length + 1;
     const removeDebuff: RemoveDebuffEvent | undefined = GetRelatedEvent(event, 'DebuffRemove');
     const damageEvents: DamageEvent[] = GetRelatedEvents(event, 'SpellDamage');
+    const refundBuff: RemoveBuffEvent | undefined = GetRelatedEvent(event, 'RefundBuff');
     let damage = 0;
     damageEvents.forEach((d) => (damage += d.amount + (d.absorb || 0)));
 
@@ -53,6 +55,7 @@ export default class TouchOfTheMagi extends Analyzer {
       applied: event.timestamp,
       removed: removeDebuff?.timestamp || this.owner.fight.end_time,
       charges: this.chargeTracker.current,
+      refundBuff: refundBuff ? true : false,
       damage: damageEvents || [],
       totalDamage: damage,
     });
@@ -103,6 +106,7 @@ export interface TouchOfTheMagiCast {
   applied: number;
   removed: number;
   charges: number;
+  refundBuff: boolean;
   activeTime?: number;
   damage: DamageEvent[];
   totalDamage: number;


### PR DESCRIPTION
- Removed the mana check from Arcane Surge
- Adjusted Arcane Surge to not complain about Arcane Charges in the opener
- Adjusted Touch of the Magi to check for Burden of Power, Glorious Incandescence, and Intuition when evaluating Arcane Charges
- Fixed an issue where the Nether Precision Remove Buff was sometimes happening after the next Arcane Missiles cast, causing it to get flagged for having Nether Precision active during Missiles