### PR TITLE
fix talent error that is spamming sentry + remove redux state from sentry upload

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 12), <>Prevent requesting spell data for unknown spell ids.</>, emallson),
   change(date(2024, 10, 7), <>Add the ability of <ItemLink id={ITEMS.TREACHEROUS_TRANSMITTER.id}/> to the spellbook when equipped.</>, Vetyst),
   change(date(2024, 10, 5), 'Fix viewing the character tab for certain regions.', Vetyst),
   change(date(2024, 10, 4), 'Added Earthen food buffs to consumable check.', emallson),

--- a/src/interface/report/Results/PlayerInfoTalent.tsx
+++ b/src/interface/report/Results/PlayerInfoTalent.tsx
@@ -14,16 +14,13 @@ const PlayerInfoTalent = ({ talentEntry }: Props) => {
   const talent = getTalentFromEntry(talentEntry);
   if (!talent) {
     return (
-      <>
+      <div className="talent-info-row">
         <div className="talent-icon">
           <Icon icon={FALLBACK_ICON} style={{ width: '2em', height: '2em' }} />
         </div>
-        <div className="talent-name">
-          <SpellLink spell={talentEntry.spellID} icon={false}>
-            Unknown talent: {talentEntry.spellID}
-          </SpellLink>
-        </div>
-      </>
+        <div className="talent-name">Unknown Talent {talentEntry.id}</div>
+        <div className="talent-level">{talentEntry.rank}</div>
+      </div>
     );
   }
 

--- a/src/interface/report/Results/PlayerInfoTalents.tsx
+++ b/src/interface/report/Results/PlayerInfoTalents.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const PlayerInfoTalents = ({ talents }: Props) => {
-  if (talents.every((talent) => talent.spellID === 0)) {
+  if (talents.length === 0 || talents.every((talent) => talent.id === 0)) {
     return (
       <div className="player-details-talents">
         <h3>

--- a/src/interface/useSpellInfo.ts
+++ b/src/interface/useSpellInfo.ts
@@ -10,19 +10,19 @@ import { maybeGetTalentOrSpell } from 'common/maybeGetTalentOrSpell';
 
 const fetcher = (...args: Parameters<typeof fetch>) => fetch(...args).then((res) => res.json());
 
-const useSpellInfo = (spell: number | Spell) => {
+const useSpellInfo = (spell: number | Spell | undefined) => {
   const { expansion } = useExpansionContext();
-  const spellId = getSpellId(spell);
+  const spellId = spell ? getSpellId(spell) : null;
   const argumentAsSpell =
-    typeof spell === 'number' ? maybeGetTalentOrSpell(spellId, expansion) : spell;
+    typeof spell === 'number' ? maybeGetTalentOrSpell(spell, expansion) : spell;
 
-  const { data, error } = useSWR<Spell>(makeApiUrl(`spell/${spellId}`), {
+  const { data, error } = useSWR<Spell>(spellId ? makeApiUrl(`spell/${spellId}`) : null, {
     fetcher,
     isPaused: () => argumentAsSpell !== undefined,
   });
 
   useEffect(() => {
-    if (data) {
+    if (spellId && data) {
       SPELLS[spellId] = data;
     }
   }, [data, spellId]);

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -1097,10 +1097,7 @@ export interface Soulbind {
 export interface TalentEntry {
   id: number;
   nodeID: number;
-  spellID: number;
   rank: number;
-  icon?: string;
-  spellType?: number;
 }
 
 export interface CombatantInfoEvent extends Event<EventType.CombatantInfo> {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,4 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
-import { createReduxEnhancer as sentryCreateReduxEnhancer } from '@sentry/react';
 import internetExplorerReducer from 'interface/reducers/internetExplorer';
 import userReducer from 'interface/reducers/user';
 import combatantsReducer from 'interface/reducers/combatants';
@@ -10,7 +9,6 @@ import openModalsReducer from 'interface/reducers/openModals';
 import charactersByIdReducer from 'interface/reducers/charactersById';
 import reportCodesIgnoredPreviousPatchWarningReducer from 'interface/reducers/reportCodesIgnoredPreviousPatchWarning';
 import tooltipsReducer from 'interface/reducers/tooltips';
-import { isPresent } from 'common/typeGuards';
 
 import { reducer as navigationReducer } from './interface/reducers/navigation';
 
@@ -35,9 +33,6 @@ const rootReducer = combineReducers({
 
 export const store = configureStore({
   reducer: rootReducer,
-  enhancers: [import.meta.env.VITE_SENTRY_DSN ? sentryCreateReduxEnhancer({}) : null].filter(
-    isPresent,
-  ),
 });
 
 // Infer the `RootState` and `AppDispatch` types from the store itself


### PR DESCRIPTION
Discussed in #maintainers. We have a lot of errors from outdated (?) talent data. When there was no matching entry, we were sending a request for `/spell/undefined` to the backend, which did not send back a valid response (since the endpoint is expecting a number).

This prevents sending the bad requests both in the talent layer and in the `useSpellInfo`.