### PR TITLE
Fixed an issue where HealingDone and DamageDone weren't properly tallying values

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 12), `Fixed an issue with the effective healing/damage patch causing the per-second damage and healing graphs to be incorrect and causing some by-ability healing and damage numbers to be too low`, Sref),
   change(date(2024, 10, 12), <>Prevent requesting spell data for unknown spell ids.</>, emallson),
   change(date(2024, 10, 7), <>Add the ability of <ItemLink id={ITEMS.TREACHEROUS_TRANSMITTER.id}/> to the spellbook when equipped.</>, Vetyst),
   change(date(2024, 10, 5), 'Fix viewing the character tab for certain regions.', Vetyst),

--- a/src/parser/shared/modules/throughput/DamageDone.tsx
+++ b/src/parser/shared/modules/throughput/DamageDone.tsx
@@ -45,8 +45,10 @@ class DamageDone extends Analyzer {
       this._total = this._total.addEvent(event);
 
       const secondsIntoFight = Math.floor((event.timestamp - this.owner.fight.start_time) / 1000);
-      this.bySecond[secondsIntoFight] =
-        this.bySecond[secondsIntoFight] || DamageValue.fromEvent(event);
+      if (!this.bySecond[secondsIntoFight]) {
+        this.bySecond[secondsIntoFight] = DamageValue.empty();
+      }
+      this.bySecond[secondsIntoFight] = this.bySecond[secondsIntoFight].addEvent(event);
     }
   }
   onByPlayerPetDamage(event: DamageEvent) {

--- a/src/parser/shared/modules/throughput/HealingDone.tsx
+++ b/src/parser/shared/modules/throughput/HealingDone.tsx
@@ -65,25 +65,24 @@ class HealingDone extends Analyzer {
     absorbed = 0,
     overheal = 0,
   ) {
-    this._total = this._total.addValues({ regular: amount, absorbed, overheal });
+    const healVal: HealingValue = HealingValue.fromValues({
+      regular: amount,
+      absorbed,
+      overheal,
+    });
+    this._total = this._total.add(healVal);
 
     const spellId = event.ability.guid;
-    this._byAbility[spellId] =
-      this._byAbility[spellId] ||
-      HealingValue.fromValues({
-        regular: amount,
-        absorbed,
-        overheal,
-      });
+    if (!this._byAbility[spellId]) {
+      this._byAbility[spellId] = HealingValue.empty();
+    }
+    this._byAbility[spellId] = this._byAbility[spellId].add(healVal);
 
     const secondsIntoFight = Math.floor((event.timestamp - this.owner.fight.start_time) / 1000);
-    this.bySecond[secondsIntoFight] =
-      this.bySecond[secondsIntoFight] ||
-      HealingValue.fromValues({
-        regular: amount,
-        absorbed,
-        overheal,
-      });
+    if (!this.bySecond[secondsIntoFight]) {
+      this.bySecond[secondsIntoFight] = HealingValue.empty();
+    }
+    this.bySecond[secondsIntoFight] = this.bySecond[secondsIntoFight].add(healVal);
   }
   _addHealingByAbsorb(
     event: AbsorbedEvent | RemoveBuffEvent,


### PR DESCRIPTION
`DamageDone` and `HealingDone` weren't doing using the add function properly with bySecond and byAbility.

### Testing

- Test report URL: `/report/zyKqnbr2J7fYkHp6/74-Mythic+Rasha'nan+-+Kill+(5:56)/Vohrr/standard/statistics`
See diff in UpliftedSpirits numbers and also in DamageDone and HealingDone mini graphs
