### PR TITLE
update text for blackout combo section to reflect actual BoF behavior

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 13), <>Updated text for <SpellLink spell={talents.BLACKOUT_COMBO_TALENT} /> section.</>, emallson),
   change(date(2024, 8, 31), <>Updated <SpellLink spell={talents.ANVIL__STAVE_TALENT} /> implementation to better fit TWW behavior.</>, emallson),
   change(date(2024, 8, 31), <>Added <SpellLink spell={talents.ENDLESS_DRAUGHT_TALENT} /> support</>, emallson),
   change(date(2024, 8, 31), <>Added basic <SpellLink spell={talents.MANTRA_OF_PURITY_TALENT} /> support</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/spells/BlackoutCombo/BlackoutComboSection.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/BlackoutCombo/BlackoutComboSection.tsx
@@ -92,25 +92,25 @@ export default function BlackoutComboSection(): JSX.Element | null {
             <li>
               <div>
                 <strong>
-                  <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} />: On Multi-Target.
+                  <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} />: Sometimes.
                 </strong>
               </div>
               <div>
-                The 50% damage boost is very good, as is the extra 5% DR. This is generally the
-                default combo on trash in Mythic+.
+                The main value of comboing <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} /> is in
+                the bonus 5% damage reduction. The damage bonus only applies to a single target.{' '}
+                <em>However,</em> the extra damage reduction will be removed the next time you
+                re-apply <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} />.
               </div>
             </li>
             <li>
               <div>
                 <strong>
-                  <SpellLink spell={talents.KEG_SMASH_TALENT} />: Often.
+                  <SpellLink spell={talents.KEG_SMASH_TALENT} />: Sometimes.
                 </strong>
               </div>
               <div>
-                Purely defensive, but not bad. You can combo more often than you can use{' '}
-                <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} />, so this is often used in
-                multi-target settings where <SpellLink spell={SPELLS.TIGER_PALM} /> is less
-                valuable.
+                Purely defensive, but not bad. This is often used incidentally multi-target settings
+                where <SpellLink spell={SPELLS.TIGER_PALM} /> is less valuable.
               </div>
             </li>
             <li>


### PR DESCRIPTION
the damage bonus for BoF apparently only hits a single target. The DR behavior was known but was secondary to the damage bonus...except the damage bonus is broken.