### PR TITLE
Add linting to avoid missing keys, and fix all existing problems regarding missing keys

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -241,6 +241,17 @@ module.exports = {
 
     // "only" filter for tests are commonly used during development and rarely desired in git (use .skip instead)
     'no-only-tests/no-only-tests': 'error',
+
+    // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
+    // Ensure that the key attribute is always used in a list of elements.
+    'react/jsx-key': [
+      'error',
+      {
+        checkFragmentShorthand: true,
+        checkKeyMustBeforeSpread: true,
+        warnOnDuplicates: true,
+      },
+    ],
   },
   overrides: [
     // Disable some rules for .js files to not have to update all old files in one go

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 14), `Fixed some technical issues with rendering of lists`, nullDozzer),
   change(date(2024, 10, 12), `Fixed an issue with the effective healing/damage patch causing the per-second damage and healing graphs to be incorrect and causing some by-ability healing and damage numbers to be too low`, Sref),
   change(date(2024, 10, 12), <>Prevent requesting spell data for unknown spell ids.</>, emallson),
   change(date(2024, 10, 7), <>Add the ability of <ItemLink id={ITEMS.TREACHEROUS_TRANSMITTER.id}/> to the spellbook when equipped.</>, Vetyst),

--- a/src/analysis/retail/druid/restoration/modules/spells/Swiftmend.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Swiftmend.tsx
@@ -16,6 +16,7 @@ import { TALENTS_DRUID } from 'common/TALENTS';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
 import { calculateHealTargetHealthPercent } from 'parser/core/EventCalculateLib';
+import { Fragment } from 'react';
 import { formatPercentage } from 'common/format';
 import { abilityToSpell } from 'common/abilityToSpell';
 import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
@@ -129,9 +130,9 @@ class Swiftmend extends Analyzer {
             extended{' '}
             <strong>
               {extendedHotIds.map((id, index) => (
-                <>
+                <Fragment key={id}>
                   <SpellLink key={id} spell={id} />{' '}
-                </>
+                </Fragment>
               ))}
             </strong>
           </>

--- a/src/analysis/retail/druid/shared/spells/ControlOfTheDream.tsx
+++ b/src/analysis/retail/druid/shared/spells/ControlOfTheDream.tsx
@@ -5,6 +5,7 @@ import Events, { UpdateSpellUsableEvent, UpdateSpellUsableType } from 'parser/co
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import Abilities from 'parser/core/modules/Abilities';
 import Statistic from 'parser/ui/Statistic';
+import { Fragment } from 'react';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -98,11 +99,11 @@ export default class ControlOfTheDream extends Analyzer.withDependencies({
         <BoringSpellValueText spell={TALENTS_DRUID.CONTROL_OF_THE_DREAM_TALENT}>
           <>
             {this.cdrSpellInfos.map((cdrInfo, spellId) => (
-              <>
+              <Fragment key={spellId}>
                 <SpellIcon spell={spellId} /> {(cdrInfo.totalEffectiveCdr / 1_000).toFixed(0)}s{' '}
                 <small>eff. CDR</small> / {cdrInfo.earlyCasts} <small>early casts</small>
                 <br />
-              </>
+              </Fragment>
             ))}
           </>
         </BoringSpellValueText>

--- a/src/analysis/retail/evoker/devastation/modules/guide/DragonRageWindows.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DragonRageWindows.tsx
@@ -4,7 +4,7 @@ import Casts, { isApplicableEvent } from 'interface/report/Results/Timeline/Cast
 import EmbeddedTimelineContainer, {
   SpellTimeline,
 } from 'interface/report/Results/Timeline/EmbeddedTimeline';
-import { useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import { RageWindowCounter } from '../abilities/DragonRage';
 import { AnyEvent } from 'parser/core/Events';
 import { Info } from 'parser/core/metric';
@@ -37,11 +37,11 @@ export function DragonRageWindowSection({
         windowDurations.push(duration);
 
         if (relevantEvents.length === 0) {
-          return <>No events in this window.</>;
+          return 'No events in this window';
         }
 
         return (
-          <>
+          <Fragment key={`${window.start}_${window.end}`}>
             {window.fightEndDuringDR && <>Fight ended during Dragonrage.</>}
             <ExplanationAndDataSubSection
               explanationPercent={30}
@@ -63,7 +63,7 @@ export function DragonRageWindowSection({
                 </div>
               }
             />
-          </>
+          </Fragment>
         );
       }),
     [rageWindows, windowDurations, events, info],

--- a/src/analysis/retail/priest/discipline/modules/features/AtonementHealingBreakdown.tsx
+++ b/src/analysis/retail/priest/discipline/modules/features/AtonementHealingBreakdown.tsx
@@ -50,34 +50,32 @@ const AtonementHealingBreakdown = ({
               const reason = getReason(spellId);
 
               return (
-                <>
-                  <tr key={ability.guid}>
-                    <td style={{ width: '30%' }}>
-                      <SpellLink spell={abilityToSpell(ability)} icon={false}>
-                        <Icon icon={ability.abilityIcon} /> {ability.name}
-                      </SpellLink>
-                      {reason && <> ({reason})</>}
-                    </td>
-                    <td style={{ paddingRight: 5, textAlign: 'right', whiteSpace: 'nowrap' }}>
-                      {formatPercentage(healing.effective / currentTotal)} %
-                    </td>
-                    <td style={{ width: '70%' }}>
-                      {/* TODO: Color the bar based on the damage type, physical = yellow, chaos = gradient, etc. idk */}
-                      <div
-                        className="performance-bar"
-                        style={{ width: `${(healing.effective / highestHealing) * 100}%` }}
-                      />
-                    </td>
-                    <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
-                      <TooltipElement content={`Total: ${formatNumber(healing.effective)}`}>
-                        {formatNumber((healing.effective / fightDuration) * 1000)} HPS
-                      </TooltipElement>
-                    </td>
-                    <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
-                      {formatPercentage(healing.overheal / healing.raw)} %
-                    </td>
-                  </tr>
-                </>
+                <tr key={ability.guid}>
+                  <td style={{ width: '30%' }}>
+                    <SpellLink spell={abilityToSpell(ability)} icon={false}>
+                      <Icon icon={ability.abilityIcon} /> {ability.name}
+                    </SpellLink>
+                    {reason && <> ({reason})</>}
+                  </td>
+                  <td style={{ paddingRight: 5, textAlign: 'right', whiteSpace: 'nowrap' }}>
+                    {formatPercentage(healing.effective / currentTotal)} %
+                  </td>
+                  <td style={{ width: '70%' }}>
+                    {/* TODO: Color the bar based on the damage type, physical = yellow, chaos = gradient, etc. idk */}
+                    <div
+                      className="performance-bar"
+                      style={{ width: `${(healing.effective / highestHealing) * 100}%` }}
+                    />
+                  </td>
+                  <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
+                    <TooltipElement content={`Total: ${formatNumber(healing.effective)}`}>
+                      {formatNumber((healing.effective / fightDuration) * 1000)} HPS
+                    </TooltipElement>
+                  </td>
+                  <td style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
+                    {formatPercentage(healing.overheal / healing.raw)} %
+                  </td>
+                </tr>
               );
             })}
       </tbody>

--- a/src/analysis/retail/rogue/subtlety/modules/core/GeneratorFollowingVanish.tsx
+++ b/src/analysis/retail/rogue/subtlety/modules/core/GeneratorFollowingVanish.tsx
@@ -70,15 +70,13 @@ class GeneratorFollowingVanish extends Analyzer {
 
   statistic(): React.ReactNode {
     const tableEntries: React.ReactNode[] = this.badFollowingVanishCasts.map((castPair, idx) => (
-      <>
-        <tr key={idx}>
-          <td>{this.owner.formatTimestamp(castPair[0].timestamp)}</td>
-          <td>
-            <SpellIcon spell={abilityToSpell(castPair[1].ability)} />
-          </td>
-          <td>{this.owner.formatTimestamp(castPair[1].timestamp)}</td>
-        </tr>
-      </>
+      <tr key={idx}>
+        <td>{this.owner.formatTimestamp(castPair[0].timestamp)}</td>
+        <td>
+          <SpellIcon spell={abilityToSpell(castPair[1].ability)} />
+        </td>
+        <td>{this.owner.formatTimestamp(castPair[1].timestamp)}</td>
+      </tr>
     ));
     return (
       <>

--- a/src/analysis/retail/shaman/elemental/modules/hero/farseer/CallOfTheAncestors.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/hero/farseer/CallOfTheAncestors.tsx
@@ -342,22 +342,20 @@ class CallOfTheAncestors extends MajorCooldown<CallAncestor> {
           <ul>
             {[...ancestorSpells].map(([id, spells], index) => {
               return (
-                <>
-                  <div>
-                    <li key={`ancestor-${id}`}>
-                      <span>Ancestor {index + 1}</span>
-                      <ul>
-                        {[...spells.entries()].map(([spellId, damage]) => {
-                          return (
-                            <li key={`ancestor-${id}-${spellId}`}>
-                              <SpellLink spell={spellId} />: {formatNumber(damage)}
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    </li>
-                  </div>
-                </>
+                <div key={`ancestor-${id}`}>
+                  <li>
+                    <span>Ancestor {index + 1}</span>
+                    <ul>
+                      {[...spells.entries()].map(([spellId, damage]) => {
+                        return (
+                          <li key={`ancestor-${id}-${spellId}`}>
+                            <SpellLink spell={spellId} />: {formatNumber(damage)}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </li>
+                </div>
               );
             })}
           </ul>

--- a/src/analysis/retail/shaman/enhancement/modules/talents/ElementalBlastGuide.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/ElementalBlastGuide.tsx
@@ -234,11 +234,9 @@ class ElementalBlastGuide extends MajorCooldown<ElementalBlastCastDetails> {
               const count = cast.elementalSpiritsActive[spellId];
               const spell = maybeGetTalentOrSpell(spellId)!;
               return (
-                <>
-                  <li key={spellId}>
-                    <strong>{count}</strong> <SpellLink spell={spell} />
-                  </li>
-                </>
+                <li key={spellId}>
+                  <strong>{count}</strong> <SpellLink spell={spell} />
+                </li>
               );
             })}
         </ul>

--- a/src/analysis/retail/shaman/enhancement/modules/talents/LegacyOfTheFrostWitch.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/LegacyOfTheFrostWitch.tsx
@@ -161,12 +161,10 @@ class LegacyOfTheFrostWitch extends Analyzer {
         {typedKeys(this.buffedSpells).map((spellId) => {
           const spell = maybeGetSpell(spellId)!;
           return (
-            <>
-              <li key={spell?.id}>
-                <SpellLink spell={spell} /> -{' '}
-                <strong>{formatNumber(this.buffedSpells[spell.id])}</strong>
-              </li>
-            </>
+            <li key={spellId}>
+              <SpellLink spell={spell} /> -{' '}
+              <strong>{formatNumber(this.buffedSpells[spell.id])}</strong>
+            </li>
           );
         })}
       </>

--- a/src/analysis/retail/warrior/arms/modules/talents/AngerManagement.tsx
+++ b/src/analysis/retail/warrior/arms/modules/talents/AngerManagement.tsx
@@ -7,6 +7,7 @@ import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
+import { Fragment } from 'react';
 
 /**
  * Every 20 Rage you spend reduces the remaining cooldown on Colossus Smash and Bladestorm by 1 sec.
@@ -45,11 +46,11 @@ class AngerManagement extends Analyzer {
 
   get tooltip() {
     return this.cooldownsAffected.map((id) => (
-      <>
+      <Fragment key={id}>
         {SPELLS[id].name}: {formatDuration(this.effectiveReduction.get(id) || 0)} reduction (
         {formatDuration(this.wastedReduction.get(id) || 0)} wasted)
         <br />
-      </>
+      </Fragment>
     ));
   }
 

--- a/src/parser/classic/modules/items/FoodChecker.tsx
+++ b/src/parser/classic/modules/items/FoodChecker.tsx
@@ -5,6 +5,7 @@ import SUGGESTION_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 import { When, ThresholdStyle } from 'parser/core/ParseResults';
 import { ItemLink } from 'interface';
 import BaseFoodChecker from 'parser/shared/modules/items/FoodChecker';
+import { Fragment } from 'react';
 import items from 'common/ITEMS/classic/cooking';
 
 const BAKED_ROCKFISH = items.BAKED_ROCKFISH.id; // https://www.wowhead.com/cata/item=62661
@@ -104,10 +105,10 @@ const RecommendedFoodList = ({ spellId }: { spellId: number }) => {
   return (
     <>
       {foodInfo.recommendedFood.map((higherFoodId: number, index: number) => (
-        <>
+        <Fragment key={higherFoodId}>
           <ItemLink id={higherFoodId} key={index} />
           &nbsp;
-        </>
+        </Fragment>
       ))}
     </>
   );
@@ -118,12 +119,12 @@ const DebugText = () => {
     <>
       {Object.keys(FOOD_MAPPINGS).map((spellId: string, index: number) => {
         return (
-          <>
+          <Fragment key={spellId}>
             <hr />
             <ItemLink id={FOOD_MAPPINGS[Number(spellId)].itemId} key={index} />
             <br />
             <RecommendedFoodList spellId={Number(spellId)} />
-          </>
+          </Fragment>
         );
       })}
     </>

--- a/src/parser/retail/modules/items/thewarwithin/embellishments/DarkmoonSigilAscension.tsx
+++ b/src/parser/retail/modules/items/thewarwithin/embellishments/DarkmoonSigilAscension.tsx
@@ -169,11 +169,7 @@ class DarkmoonSigilAscension extends EmbellishmentAnalyzer.withDependencies({
         const buff = BUFFS[Number(spellId)];
         const entry = aggregatedStats.get(buff.stat);
         if (!entry) {
-          return (
-            <>
-              <p key={spellId}>Didn't proc</p>
-            </>
-          );
+          return <p key={spellId}>Didn't proc</p>;
         }
 
         const StatIcon = getIcon(buff.stat);

--- a/src/parser/retail/modules/items/thewarwithin/embellishments/DarkmoonSigilAscension.tsx
+++ b/src/parser/retail/modules/items/thewarwithin/embellishments/DarkmoonSigilAscension.tsx
@@ -165,57 +165,45 @@ class DarkmoonSigilAscension extends EmbellishmentAnalyzer.withDependencies({
     );
 
     return {
-      tooltip: (
-        <>
-          {Object.keys(BUFFS).map((spellId) => {
-            const buff = BUFFS[Number(spellId)];
-            const entry = aggregatedStats.get(buff.stat);
-            if (!entry) {
-              return (
-                <>
-                  <p key={spellId}>Didn't proc</p>
-                </>
-              );
-            }
+      tooltip: Object.keys(BUFFS).map((spellId) => {
+        const buff = BUFFS[Number(spellId)];
+        const entry = aggregatedStats.get(buff.stat);
+        if (!entry) {
+          return (
+            <>
+              <p key={spellId}>Didn't proc</p>
+            </>
+          );
+        }
 
-            const StatIcon = getIcon(buff.stat);
-            const statName = getName(buff.stat)!.toLowerCase();
-            const uptimePercentage = entry.duration / this.owner.fightDuration;
-            const totalAmount = Math.round(entry.total / entry.procs);
+        const StatIcon = getIcon(buff.stat);
+        const statName = getName(buff.stat)!.toLowerCase();
+        const uptimePercentage = entry.duration / this.owner.fightDuration;
+        const totalAmount = Math.round(entry.total / entry.procs);
 
-            return (
-              <>
-                <p key={spellId}>
-                  The <SpellLink spell={buff.spell} /> {statName} buff gave <StatIcon />{' '}
-                  <b>{totalAmount}</b> {statName}, and had a total uptime of{' '}
-                  <b>{formatDuration(entry.duration)}</b>, {formatPercentage(uptimePercentage, 1)}%
-                  of the fight.
-                </p>
-              </>
-            );
-          })}
-        </>
-      ),
-      content: (
-        <>
-          {averageStats.map((entry) => {
-            const stat = entry.stat as STAT;
-            const StatIcon = getIcon(stat);
-            const statName = getName(stat);
-            const uptimePercentage = entry.duration / this.owner.fightDuration;
-            const totalAmount = Math.round(entry.total / entry.procs);
-            const calculatedAverage = Math.round(totalAmount * uptimePercentage);
+        return (
+          <p key={spellId}>
+            The <SpellLink spell={buff.spell} /> {statName} buff gave <StatIcon />{' '}
+            <b>{totalAmount}</b> {statName}, and had a total uptime of{' '}
+            <b>{formatDuration(entry.duration)}</b>, {formatPercentage(uptimePercentage, 1)}% of the
+            fight.
+          </p>
+        );
+      }),
+      content: averageStats.map((entry) => {
+        const stat = entry.stat as STAT;
+        const StatIcon = getIcon(stat);
+        const statName = getName(stat);
+        const uptimePercentage = entry.duration / this.owner.fightDuration;
+        const totalAmount = Math.round(entry.total / entry.procs);
+        const calculatedAverage = Math.round(totalAmount * uptimePercentage);
 
-            return (
-              <>
-                <p key={stat}>
-                  <StatIcon /> {calculatedAverage} <small>{statName} over time</small>
-                </p>
-              </>
-            );
-          })}
-        </>
-      ),
+        return (
+          <p key={stat}>
+            <StatIcon /> {calculatedAverage} <small>{statName} over time</small>
+          </p>
+        );
+      }),
     };
   }
 }

--- a/src/parser/shared/metrics/apl/annotate.tsx
+++ b/src/parser/shared/metrics/apl/annotate.tsx
@@ -2,6 +2,7 @@ import { SpellLink } from 'interface';
 
 import type { Tense, CheckResult, InternalRule, Violation } from './index';
 import { addInefficientCastReason } from 'parser/core/EventMetaLib';
+import { Fragment } from 'react';
 
 export function ConditionDescription({
   tense,
@@ -37,10 +38,10 @@ function InefficientCastAnnotation({ violation }: { violation: Violation }) {
   return (
     <>
       {violation.expectedCast.map((spell, index) => (
-        <>
+        <Fragment key={spell.id}>
           {index > 0 ? ' and ' : ''}
-          <SpellLink key={spell.id} spell={spell.id} />
-        </>
+          <SpellLink spell={spell.id} />
+        </Fragment>
       ))}{' '}
       {violation.expectedCast.length > 1 ? 'were' : 'was'} available and higher priority
       <ConditionDescription rule={violation.rule} />.


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->

So with #7056 I noticed that the Ascension module was throwing errors because of missing keys in lists of elements. 

I just wanted to fix that since it's been a while now, but then I felt there must be a more permanent solution to this, so I looked into eslint and see if there was any configuration to catch it. 

The crux seems to be that if you use "fragment shorthand" `<>Hello</<`, the lintrule does not by default show it as an error, weirdly... Changed most of them to use `<Fragment>`, and just remove some redundant fragments as well.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/...`
- Screenshot(s):
