### PR TITLE
Add Aspect of Harmony guide for MW

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date (2024, 10, 13), <>Add <SpellLink spell={TALENTS_MONK.ASPECT_OF_HARMONY_TALENT}/> guide section</>, Trevor),
   change(date (2024, 10, 12), <>Added an average healing per cast metric to the <SpellLink spell={TALENTS_MONK.REVIVAL_TALENT}/> healing breakdown statistic.</>, Vohrr),
   change(date (2024, 10, 12), <>Fix an issue with <SpellLink spell={TALENTS_MONK.UPLIFTED_SPIRITS_TALENT}/> and updated to include additional <SpellLink spell={SPELLS.GUSTS_OF_MISTS}/> healing.</>, Vohrr),
   change(date (2024, 10, 6), <>Fix a crash in <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT}/> while it was active when fight ended.</>, Vetyst),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -93,6 +93,7 @@ import CelestialConduitNormalizer from '../shared/hero/ConduitOfTheCelestials/no
 import CelestialConduit from '../shared/hero/ConduitOfTheCelestials/talents/CelestialConduit';
 import StrengthOfTheBlackOx from './modules/heroTalents/StrengthOfTheBlackOx';
 import Coalesence from '../shared/hero/MasterOfHarmony/talents/Coalesence';
+import AspectOfHarmony from './modules/heroTalents/AspectOfHarmony';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -211,6 +212,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Hero Talents
     strengthOfTheBlackOx: StrengthOfTheBlackOx,
+    aspectOfHarmony: AspectOfHarmony,
   };
   static guide = Guide;
 }

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -35,6 +35,8 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         {info.combatant.hasTalent(TALENTS_MONK.SHEILUNS_GIFT_TALENT) && (
           <SheilunsGraph modules={modules} events={events} info={info} />
         )}
+        {info.combatant.hasTalent(TALENTS_MONK.ASPECT_OF_HARMONY_TALENT) &&
+          modules.aspectOfHarmony.guideSubsection}
         <RemGraphSubsection modules={modules} events={events} info={info} />
       </Section>
       <Section title="Healing Cooldowns">

--- a/src/analysis/retail/monk/mistweaver/modules/heroTalents/AspectOfHarmony.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/heroTalents/AspectOfHarmony.tsx
@@ -36,7 +36,8 @@ class AspectOfHarmony extends AspectOfHarmonyBaseAnalyzer {
       actual: pctRaid,
       isGreaterThanOrEqual: targetPerfRange,
     });
-    const pctOverheal = info.totalHealing / (info.totalHealing + info.overhealing);
+    const pctOverheal =
+      info.overhealing > 0 ? info.overhealing / (info.totalHealing + info.overhealing) : 0;
     const overhealPerf = evaluateQualitativePerformanceByThreshold({
       actual: pctOverheal,
       isLessThanOrEqual: overhealingPerfRange,

--- a/src/analysis/retail/monk/mistweaver/modules/heroTalents/AspectOfHarmony.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/heroTalents/AspectOfHarmony.tsx
@@ -1,0 +1,98 @@
+import AspectOfHarmonyBaseAnalyzer, {
+  CastInfo,
+} from 'analysis/retail/monk/shared/hero/MasterOfHarmony/talents/AspectOfHarmonyBase';
+import { formatPercentage } from 'common/format';
+import { TALENTS_MONK } from 'common/TALENTS';
+import { PerformanceMark } from 'interface/guide';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import SpellLink from 'interface/SpellLink';
+import {
+  evaluateQualitativePerformanceByThreshold,
+  getAveragePerf,
+  QualitativePerformanceThresholdRange,
+} from 'parser/ui/QualitativePerformance';
+import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
+
+const targetPerfRange: QualitativePerformanceThresholdRange = {
+  perfect: 1,
+  good: 0.9,
+  ok: 0.8,
+  fail: 0.7,
+};
+
+// maybe be more strict in the future once better logs emerge
+const overhealingPerfRange: QualitativePerformanceThresholdRange = {
+  good: 0.6,
+  ok: 0.7,
+  fail: 1,
+};
+
+class AspectOfHarmony extends AspectOfHarmonyBaseAnalyzer {
+  getEntryFromCast(info: CastInfo): BoxRowEntry {
+    const pctRaid = info.numBuffs / this.combatants.playerCount;
+    const targetPerf = evaluateQualitativePerformanceByThreshold({
+      actual: pctRaid,
+      isGreaterThanOrEqual: targetPerfRange,
+    });
+    const pctOverheal = info.totalHealing / (info.totalHealing + info.overhealing);
+    const overhealPerf = evaluateQualitativePerformanceByThreshold({
+      actual: pctOverheal,
+      isLessThanOrEqual: overhealingPerfRange,
+    });
+    const value = getAveragePerf([targetPerf, overhealPerf]);
+    const tooltip = (
+      <>
+        <div>
+          # of HoTs: {info.numBuffs} <PerformanceMark perf={targetPerf} />
+        </div>
+        <div>
+          Overhealing: {formatPercentage(pctOverheal)}% <PerformanceMark perf={overhealPerf} />
+        </div>
+      </>
+    );
+    return { value, tooltip };
+  }
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS_MONK.ASPECT_OF_HARMONY_TALENT} />
+        </b>{' '}
+        consumes stored vitality by healing allies after you use{' '}
+        <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> equal to 40% of the heal that
+        consumed it. It is extremely important to try to apply the HoT to as many allies as
+        possible, which is most easily achieved by using{' '}
+        <SpellLink spell={TALENTS_MONK.CHI_BURST_SHARED_TALENT} /> on the raid due to its ability to
+        hit an uncapped amount of targets while not consuming all stored vitality.
+      </p>
+    );
+    const styleObj = {
+      fontSize: 20,
+    };
+    const styleObjInner = {
+      fontSize: 15,
+    };
+    const entries = this.castEntries.map((castInfo: CastInfo) => {
+      return this.getEntryFromCast(castInfo);
+    });
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink spell={TALENTS_MONK.ASPECT_OF_HARMONY_TALENT} /> utilization
+          </strong>
+          <PerformanceBoxRow values={entries} />
+          <div style={styleObj}>
+            <b>{this.avgHots.toFixed(1)}</b> <small style={styleObjInner}>average HoTs</small>
+          </div>
+        </RoundedPanel>
+      </div>
+    );
+    return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
+  }
+}
+
+export default AspectOfHarmony;

--- a/src/analysis/retail/monk/mistweaver/modules/heroTalents/AspectOfHarmony.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/heroTalents/AspectOfHarmony.tsx
@@ -45,6 +45,7 @@ class AspectOfHarmony extends AspectOfHarmonyBaseAnalyzer {
     const value = getAveragePerf([targetPerf, overhealPerf]);
     const tooltip = (
       <>
+        <div>@ {this.owner.formatTimestamp(info.startTime)}</div>
         <div>
           # of HoTs: {info.numBuffs} <PerformanceMark perf={targetPerf} />
         </div>

--- a/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/AspectOfHarmony.tsx
+++ b/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/AspectOfHarmony.tsx
@@ -1,0 +1,87 @@
+import SPELLS from 'common/SPELLS';
+import { TALENTS_MONK } from 'common/TALENTS';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import {
+  ApplyBuffEvent,
+  ApplyDebuffEvent,
+  DamageEvent,
+  EventType,
+  HealEvent,
+} from 'parser/core/Events';
+
+interface CastInfo {
+  totalDamage: number;
+  overkill: number;
+  totalHealing: number;
+  overhealing: number;
+  numBuffs: number;
+  numDebuffs: number;
+  startTime: number;
+}
+
+class MasterOfHarmonyBaseAnalyzer extends Analyzer {
+  castEntries: CastInfo[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.ASPECT_OF_HARMONY_TALENT);
+  }
+
+  initEntry(
+    event: ApplyBuffEvent | ApplyDebuffEvent | HealEvent | DamageEvent,
+  ): CastInfo | undefined {
+    // normal init case is for aspect buff apply or for catching pre-pull TFT/CB
+    if (event.ability.guid === SPELLS.ASPECT_OF_HARMONY_BUFF.id || !this.castEntries.length) {
+      this.castEntries.push({
+        totalDamage: 0,
+        overkill: 0,
+        totalHealing: 0,
+        overhealing: 0,
+        numBuffs: 0,
+        numDebuffs: 0,
+        startTime: event.timestamp,
+      });
+    }
+    return this.castEntries.at(-1);
+  }
+
+  onPeriodicApply(event: ApplyBuffEvent | ApplyDebuffEvent) {
+    const entry = this.initEntry(event);
+    if (entry) {
+      if (event.type === EventType.ApplyBuff) {
+        entry.numBuffs += 1;
+      } else {
+        entry.numDebuffs += 1;
+      }
+    }
+  }
+
+  onHeal(event: HealEvent) {
+    // coalesence doesn't buff Aspect HOT
+    if (event.ability.guid === SPELLS.ASPECT_OF_HARMONY_HOT.id) {
+      return;
+    }
+    const entry = this.initEntry(event);
+    if (entry) {
+      entry.totalHealing += event.amount;
+      entry.overhealing += event.overheal || 0;
+    }
+  }
+
+  onDmg(event: DamageEvent) {
+    if (event.ability.guid === SPELLS.ASPECT_OF_HARMONY_DOT.id) {
+      return;
+    }
+    const entry = this.initEntry(event);
+    if (entry) {
+      entry.totalDamage += event.amount;
+      entry.overkill += event.overkill || 0;
+    }
+  }
+
+  getCastEntries(): CastInfo[] {
+    return this.castEntries;
+  }
+}
+
+export default MasterOfHarmonyBaseAnalyzer;

--- a/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/AspectOfHarmonyBase.tsx
+++ b/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/AspectOfHarmonyBase.tsx
@@ -84,10 +84,11 @@ class AspectOfHarmonyBaseAnalyzer extends Analyzer {
 
   onHeal(event: HealEvent) {
     // coalesence doesn't buff Aspect HOT
-    if (
-      event.ability.guid === SPELLS.ASPECT_OF_HARMONY_HOT.id ||
-      !this.combatants.getEntity(event)
-    ) {
+    if (event.ability.guid === SPELLS.ASPECT_OF_HARMONY_HOT.id) {
+      return;
+    }
+    const entity = this.combatants.getEntity(event);
+    if (!entity || !entity.hasBuff(SPELLS.ASPECT_OF_HARMONY_BUFF.id)) {
       return;
     }
     const entry = this.initEntry(event);

--- a/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/AspectOfHarmonyBase.tsx
+++ b/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/AspectOfHarmonyBase.tsx
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
-import Analyzer, { Options } from 'parser/core/Analyzer';
-import {
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
   ApplyBuffEvent,
   ApplyDebuffEvent,
   DamageEvent,
@@ -19,12 +19,22 @@ interface CastInfo {
   startTime: number;
 }
 
-class MasterOfHarmonyBaseAnalyzer extends Analyzer {
+class AspectOfHarmonyBaseAnalyzer extends Analyzer {
   castEntries: CastInfo[] = [];
 
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.ASPECT_OF_HARMONY_TALENT);
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.ASPECT_OF_HARMONY_HOT),
+      this.onPeriodicApply,
+    );
+    this.addEventListener(
+      Events.applydebuff.by(SELECTED_PLAYER).spell(SPELLS.ASPECT_OF_HARMONY_DOT),
+      this.onPeriodicApply,
+    );
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDmg);
   }
 
   initEntry(
@@ -84,4 +94,4 @@ class MasterOfHarmonyBaseAnalyzer extends Analyzer {
   }
 }
 
-export default MasterOfHarmonyBaseAnalyzer;
+export default AspectOfHarmonyBaseAnalyzer;

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -973,6 +973,11 @@ const spells = {
     name: 'Aspect of Harmony',
     icon: 'inv_enchanting_wod_essence2',
   },
+  ASPECT_OF_HARMONY_BUFF: {
+    id: 450711,
+    name: 'Aspect of Harmony',
+    icon: 'ability_evoker_essenceburst3',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/parser/ui/QualitativePerformance.ts
+++ b/src/parser/ui/QualitativePerformance.ts
@@ -86,7 +86,7 @@ export function evaluateQualitativePerformanceByThreshold(
   return new QualitativePerformanceAssertion(threshold)._getPerformance();
 }
 
-type QualitativePerformanceThresholdRange = {
+export type QualitativePerformanceThresholdRange = {
   fail?: number;
   ok?: number;
   good?: number;


### PR DESCRIPTION
### Description

- Adds base analyzer class that can be used for both mw/brm
- Adds guide section for Aspect of Harmony for mw

Overhealing check might be a bit strict atm, open to changing thresholds or removing it

### Testing
![image](https://github.com/user-attachments/assets/d4f944c7-3579-47cd-9709-17d99240b209)
![image](https://github.com/user-attachments/assets/1a7a589c-020f-4f02-87d1-ad4c37aacdfe)

