### PR TITLE
[Frostfire Mage] fix frostfire bolt winters chill precast

### DIFF
--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 17), <>Fixed Frostfire Bolt on Winters Chill module for Frostfire.</>, Earosselot),
   change(date(2024, 9, 18), <>Updated the Warning Banner explaining the current state of Frost Mage.</>, Sharrq),
   change(date(2024, 8, 25), <>Added support for <SpellLink spell={TALENTS.SPELLFROST_TEACHINGS_TALENT} />.</>, Earosselot),
   change(date(2024, 8, 23), <>Adding APL for Spellslinger Frost.</>, Earosselot),

--- a/src/analysis/retail/mage/frost/SPELLS.ts
+++ b/src/analysis/retail/mage/frost/SPELLS.ts
@@ -137,6 +137,11 @@ const spells = {
     name: 'Spellfrost Teachings',
     icon: '70_inscription_vantus_rune_azure',
   },
+  FROSTFIRE_BOLT_DAMAGE: {
+    id: 468655,
+    name: 'Frostfire Bolt',
+    icon: 'inv_ability_frostfiremage_frostfirebolt',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/analysis/retail/mage/frost/core/WintersChill.tsx
+++ b/src/analysis/retail/mage/frost/core/WintersChill.tsx
@@ -48,6 +48,7 @@ class WintersChill extends Analyzer {
         .spell([
           SPELLS.FROSTBOLT_DAMAGE,
           SPELLS.GLACIAL_SPIKE_DAMAGE,
+          SPELLS.FROSTFIRE_BOLT_DAMAGE,
           SPELLS.ICE_LANCE_DAMAGE,
           TALENTS.RAY_OF_FROST_TALENT,
         ]),
@@ -88,6 +89,10 @@ class WintersChill extends Analyzer {
         d.apply.timestamp <= event.timestamp && d.remove && d.remove.timestamp >= event.timestamp,
     );
     if (wintersChillDebuff === -1) {
+      return;
+    }
+    const isTick = event.tick;
+    if (isTick !== undefined && isTick) {
       return;
     }
     this.wintersChill[wintersChillDebuff].damageEvents?.push(event);

--- a/src/analysis/retail/mage/frost/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/frost/normalizers/CastLinkNormalizer.ts
@@ -39,8 +39,6 @@ const EVENT_LINKS: EventLink[] = [
     backwardBufferMs: CAST_BUFFER_MS,
     additionalCondition: (linkingEvent, referencedEvent) => {
       const isTick = (referencedEvent as DamageEvent).tick;
-      console.log(isTick);
-      console.log(referencedEvent);
       return isTick === undefined || !isTick;
     },
   },

--- a/src/analysis/retail/mage/frost/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/frost/normalizers/CastLinkNormalizer.ts
@@ -30,6 +30,22 @@ const EVENT_LINKS: EventLink[] = [
   },
   {
     reverseLinkRelation: SPELL_CAST,
+    linkingEventId: TALENTS.FROSTFIRE_BOLT_TALENT.id,
+    linkingEventType: EventType.Cast,
+    linkRelation: SPELL_DAMAGE,
+    referencedEventId: SPELLS.FROSTFIRE_BOLT_DAMAGE.id,
+    referencedEventType: EventType.Damage,
+    forwardBufferMs: 3000,
+    backwardBufferMs: CAST_BUFFER_MS,
+    additionalCondition: (linkingEvent, referencedEvent) => {
+      const isTick = (referencedEvent as DamageEvent).tick;
+      console.log(isTick);
+      console.log(referencedEvent);
+      return isTick === undefined || !isTick;
+    },
+  },
+  {
+    reverseLinkRelation: SPELL_CAST,
     linkingEventId: TALENTS.GLACIAL_SPIKE_TALENT.id,
     linkingEventType: EventType.Cast,
     linkRelation: SPELL_DAMAGE,
@@ -149,7 +165,11 @@ const EVENT_LINKS: EventLink[] = [
     linkingEventId: SPELLS.WINTERS_CHILL.id,
     linkingEventType: EventType.ApplyDebuff,
     linkRelation: PRE_CAST,
-    referencedEventId: [SPELLS.FROSTBOLT.id, TALENTS.GLACIAL_SPIKE_TALENT.id],
+    referencedEventId: [
+      SPELLS.FROSTBOLT.id,
+      TALENTS.GLACIAL_SPIKE_TALENT.id,
+      TALENTS.FROSTFIRE_BOLT_TALENT.id,
+    ],
     referencedEventType: EventType.Cast,
     anyTarget: true,
     maximumLinks: 1,


### PR DESCRIPTION
### Description

The problem is described on [this](https://discord.com/channels/316864121536512000/376695647891488768/1296122730835349630) discord message.

### Testing

Now you can check that FFBolts are taking into account as precast.

- Test report URL: https://www.warcraftlogs.com/reports/B4xR72Dzrjnyp9gL/#fight=3&source=2 
- Screenshot(s):
![image](https://github.com/user-attachments/assets/82d3fde0-e9aa-4b10-9535-8ba967c2137c)
