### PR TITLE
Fury cap revised for FS VDH

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2529,3 +2529,9 @@ export const PandaGoesBaa: Contributor = {
     },
   ],
 };
+
+export const Quaarkz: Contributor = {
+  nickname: 'Quaarkz',
+  github: 'Quaarkz',
+  discord: 'Quaarkz',
+};

--- a/src/analysis/retail/demonhunter/shared/constants.ts
+++ b/src/analysis/retail/demonhunter/shared/constants.ts
@@ -7,6 +7,8 @@ export const SHATTERED_RESTORATION_SCALING = [0, 5, 10];
 
 export const UNRESTRAINED_FURY_SCALING = [0, 10, 20];
 
+export const UNTETHERED_FURY_SCALING = [0, 50];
+
 export const ERRATIC_FELHEART_SCALING = [0, 0.1, 0.2];
 
 export const PITCH_BLACK_SCALING = [0, 120];

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
-import { ToppleTheNun } from 'CONTRIBUTORS';
+import { Quaarkz, ToppleTheNun } from 'CONTRIBUTORS';
 import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 17), 'Untethered Fury talent taken into consideration for Fracture analysis.', Quaarkz),
   change(date(2024, 9, 23), <>Improve handling of <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} /> in preparation for Demonsurge.</>, ToppleTheNun),
   change(date(2024, 9, 3), 'Add Aldrachi Reaver and Fel-scarred abilities to the spellbook.', ToppleTheNun),
   change(date(2024, 9, 3), 'Remove support for DF S3/S4 tier set.', ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/Fracture.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/Fracture.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 import Events, { CastEvent } from 'parser/core/Events';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { UNRESTRAINED_FURY_SCALING } from 'analysis/retail/demonhunter/shared';
+import { UNTETHERED_FURY_SCALING } from 'analysis/retail/demonhunter/shared';
 import { TIERS } from 'game/TIERS';
 import {
   ChecklistUsageInfo,
@@ -65,17 +66,21 @@ export default class Fracture extends Analyzer {
       BASE_FURY +
       UNRESTRAINED_FURY_SCALING[
         this.selectedCombatant.getTalentRank(TALENTS.UNRESTRAINED_FURY_TALENT)
-      ];
+      ] +
+      UNTETHERED_FURY_SCALING[this.selectedCombatant.getTalentRank(TALENTS.UNTETHERED_FURY_TALENT)];
+
     this.inMetaFuryLimit =
       getMetaInitialFuryLimit(hasT292Pc) +
       UNRESTRAINED_FURY_SCALING[
         this.selectedCombatant.getTalentRank(TALENTS.UNRESTRAINED_FURY_TALENT)
-      ];
+      ] +
+      UNTETHERED_FURY_SCALING[this.selectedCombatant.getTalentRank(TALENTS.UNTETHERED_FURY_TALENT)];
     this.notMetaFuryLimit =
       getNonMetaInitialFuryLimit(hasT292Pc) +
       UNRESTRAINED_FURY_SCALING[
         this.selectedCombatant.getTalentRank(TALENTS.UNRESTRAINED_FURY_TALENT)
-      ];
+      ] +
+      UNTETHERED_FURY_SCALING[this.selectedCombatant.getTalentRank(TALENTS.UNTETHERED_FURY_TALENT)];
 
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS.FRACTURE_TALENT),


### PR DESCRIPTION
Untethered talent from Fel Scarred taken into consideration for the fracture analysis.

Pretty simple changes, define the two states of the talent, export it and sum to the max fury if its talented, same as how Unrestrained Fury works.

### Testing
Tested with logs from both FS and AR and it had the expected results

- Screenshot(s):
![image](https://github.com/user-attachments/assets/e918182b-60dd-4452-bf3a-0a91538b189d)
![image](https://github.com/user-attachments/assets/012fa265-e72d-4711-9c05-4083f360b070)

@ToppleTheNun I hope this is fine :)