### PR TITLE
[Arcane Mage] Updated Warning

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { change, date } from 'common/changelog';
 import { Sharrq, Sref } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2024, 10, 22), <>Updated the Warning banner to reflect the current status of Arcane's analysis. Fixed a typo in the guide.</>, Sharrq),
   change(date(2024, 10, 9), <>Adjusted <SpellLink spell={TALENTS.TOUCH_OF_THE_MAGI_TALENT} /> to account for <SpellLink spell={SPELLS.BURDEN_OF_POWER_BUFF} />, <SpellLink spell={SPELLS.GLORIOUS_INCANDESCENCE_BUFF} />, and <SpellLink spell={SPELLS.INTUITION_BUFF} /> when evaluating <SpellLink spell={SPELLS.ARCANE_CHARGE} />s.</>, Sharrq),
   change(date(2024, 10, 9), <>Fixed an issue that caused <SpellLink spell={TALENTS.ARCANE_MISSILES_TALENT} /> to sometimes incorrectly claim the player had <SpellLink spell={SPELLS.NETHER_PRECISION_BUFF} /> due to incorrect event ordering in the log.</>, Sharrq),
   change(date(2024, 10, 9), <>Updated <SpellLink spell={TALENTS.ARCANE_SURGE_TALENT} /> to no longer complain about Mana % or <SpellLink spell={SPELLS.ARCANE_CHARGE} />s for the Opener.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CONFIG.tsx
+++ b/src/analysis/retail/mage/arcane/CONFIG.tsx
@@ -50,8 +50,9 @@ const config: Config = {
       frontmatterType: 'guide',
       notes: (
         <AlertWarning>
-          This has been updated for the latest Arcane Mage changes. If something is missing or
-          incorrect, please ping me (<code>@Sharrq</code>) in the Mage Discord and let me know.
+          This has not been updated for 11.0.5. Once APL stuff gets resolved following the last
+          minute Arcane nerfs, I will get this updated. If you have questions about this, ping me in
+          the Altered Time Mage Discord <code>@Sharrq</code>
         </AlertWarning>
       ),
     },

--- a/src/analysis/retail/mage/arcane/Guide.tsx
+++ b/src/analysis/retail/mage/arcane/Guide.tsx
@@ -30,7 +30,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           <SpellLink spell={SPELLS.CLEARCASTING_BUFF} /> procs. While some encounters have forced
           downtime, which WoWAnalyzer does not account for, anything you can do to minimize your
           downtime will help your damage. Additionally, to better contextualize your downtime, we
-          recommend comparing your downtime to another Fire Mage that did better than you on the
+          recommend comparing your downtime to another Arcane Mage that did better than you on the
           same encounter with roughly the same kill time. If you have less downtime than them, then
           maybe there is something you can do to improve.
         </>


### PR DESCRIPTION
I was working on the 11.0.5 updates, and then Blizzard decided to do some last minute changes which potentially will change the rotation for Sunfury. I am going to wait for the Mage Discord to finish their testing and APL updates before I update this for 11.0.5

I also fixed a typo in the guide that referred to Fire Mage instead of Arcane.