### PR TITLE
[Evoker] Update CastLinks to account for extra combatlog delays introduced in 11.0.5

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/evoker';
 
 export default [
+  change(date(2024, 10, 24), <>Fix event issues with <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> & MajorDefensives modules</>, Vollmer),
   change(date(2024, 10, 4), <>Fix an issue with external <SpellLink spell={TALENTS.RENEWING_BLAZE_TALENT}/> for MajorDefensive module</>, Vollmer),
   change(date(2024, 10, 4), <>Fix some edgecases for <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> module</>, Vollmer),
   change(date(2024, 9, 16), "Update Buff Helper note gen for Frame Glows WA", Vollmer),

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
@@ -63,6 +63,10 @@ const BREATH_OF_EONS_DAMAGE_BUFFER = 300;
 const PUPIL_OF_ALEXSTRASZA_BUFFER = 1000;
 const UPHEAVAL_DAMAGE_BUFFER = 800;
 
+// In 11.0.5 Blizzard introduces a potential 1ms delay
+// https://www.warcraftlogs.com/reports/L48YR6WBjaXtTkMd/#fight=57&type=auras&pins=0%24Separate%24%23244F4B%24casts%240%240.0.0.Any%24176484645.0.0.Evoker%24true%240.0.0.Any%24false%24363916&target=8&ability=395152&start=10450757&end=10509380&view=events
+const EBON_MIGHT_APPLY_REMOVE_BUFFER = 1;
+
 // Tier
 // No clue why but this gets very weirdly staggered/delayed
 const TREMBLING_EARTH_BUFFER = 500;
@@ -119,6 +123,8 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventId: SPELLS.EBON_MIGHT_BUFF_EXTERNAL.id,
     referencedEventType: [EventType.RemoveBuff],
     anyTarget: false,
+    forwardBufferMs: EBON_MIGHT_APPLY_REMOVE_BUFFER,
+    backwardBufferMs: EBON_MIGHT_APPLY_REMOVE_BUFFER,
   },
   {
     linkRelation: BREATH_OF_EONS_CAST_DEBUFF_APPLY_LINK,

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
@@ -59,7 +59,7 @@ const EBON_MIGHT_BUFFER = 150;
 const BREATH_OF_EONS_DEBUFF_APPLY_BUFFER = 8000;
 const BREATH_OF_EONS_BUFF_BUFFER = 8000;
 const BREATH_OF_EONS_DEBUFF_BUFFER = 14000;
-const BREATH_OF_EONS_DAMAGE_BUFFER = 100;
+const BREATH_OF_EONS_DAMAGE_BUFFER = 300;
 const PUPIL_OF_ALEXSTRASZA_BUFFER = 1000;
 const UPHEAVAL_DAMAGE_BUFFER = 800;
 
@@ -150,6 +150,7 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventId: SPELLS.BREATH_OF_EONS_DAMAGE.id,
     referencedEventType: EventType.Damage,
     anyTarget: false,
+    backwardBufferMs: BREATH_OF_EONS_DAMAGE_BUFFER, // in 11.0.5 the damage events can now come before the removedebuff
     forwardBufferMs: BREATH_OF_EONS_DAMAGE_BUFFER,
   },
   /**

--- a/src/analysis/retail/evoker/shared/modules/normalizers/DefensiveCastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/DefensiveCastLinkNormalizer.ts
@@ -9,7 +9,7 @@ export const RENEWING_BLAZE = 'renewingBlaze'; // links cast to buff apply
 export const RENEWING_BLAZE_HEAL = 'renewingBlazeHeal'; // links heal buff and healing
 const TWIN_GUARDIAN_PARTNER = 'twinGuardianPartner'; // links external and personal buffs
 
-const CAST_BUFFER = 25;
+const CAST_BUFFER = 50;
 /** Heal buff can get applied immediately on use, and keeps getting refreshed on damage until
  * main acc buff runs out, so we set this high to make sure we catch all. */
 const RENEWING_BLAZE_DURATION = 25_000;


### PR DESCRIPTION
### Description

Updates CastLinks for `Ebon Might`, `Breath of Eons` and `Defensives` to account for 11.0.5 combatlog changes.

Defensives such as `Obsidian Scales` can now have their applybuff be delayed further.

Breath of Eons damage events can now not only be very delayed, but even happen before the debuff is removed!

### Testing

- Test report URL: `/report/L48YR6WBjaXtTkMd/57-Mythic+Nexus-Princess+Ky'veza+-+Kill+(6:22)/Rawrzemq/standard/overview`
