### PR TITLE
Druid 11.0.5

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_DRUID } from 'common/TALENTS/druid';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2024, 10, 27), <>Updated patch compatibility to 11.0.5.</>, Sref),
   change(date(2024, 9, 13), <>Updated guide text to indicate finishes should always be used with 5 CPs. Fixed a typo in Rip cast breakdown.</>, Sref),
   change(date(2024, 8, 22), <><SpellLink spell={TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT}/> tracker should now correctly detect procced <SpellLink spell={TALENTS_DRUID.RAVAGE_TALENT}/> casts.</>, Sref),
   change(date(2024, 8, 22), <>Cleaner display of <SpellLink spell={SPELLS.RAKE}/>, <SpellLink spell={SPELLS.RIP}/>, <SpellLink spell={SPELLS.FEROCIOUS_BITE}/>, and <SpellLink spell={TALENTS_DRUID.SUDDEN_AMBUSH_TALENT}/> sections in Guide.</>, Sref),

--- a/src/analysis/retail/druid/feral/CONFIG.tsx
+++ b/src/analysis/retail/druid/feral/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Sref],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '11.0.2',
+  patchCompatibility: '11.0.5',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/druid/guardian/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/guardian/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2024, 10, 27), <>Updated patch compatibility to 11.0.5.</>, Sref),
   change(date(2024, 9, 23), <>Fixed an issue where active defensives weren't showing on the Timeline or Death Recap views. Added <SpellLink spell={TALENTS_DRUID.LUNAR_BEAM_TALENT} /> to the defensives list.</>, Sref),
   change(date(2024, 8, 17), <>Marked updated for 11.0.2 and updated the spec's 'About' page.</>, Sref),
   change(date(2024, 8, 14), <>Updated spells to account for 11.0.2 balance patch.</>, Sref),

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
-  change(date(2024, 10, 27), <>Updated for 11.0.5, handling added / changed talents and added statistics module for <SpellLink spell={TALENTS_DRUID.RENEWING_SURGE_TALENT} /></>, Sref),
+  change(date(2024, 10, 27), <>Updated for 11.0.5, handling added / changed talents and added statistics module for <SpellLink spell={TALENTS_DRUID.RENEWING_SURGE_TALENT} />. Fixed an issue where a cast efficiency bar would show for <SpellLink spell={TALENTS_DRUID.TRANQUILITY_TALENT} /> and <SpellLink spell={TALENTS_DRUID.INNERVATE_TALENT} /> even when player didn't take the talents.</>, Sref),
   change(date(2024, 10, 1), <>Updated cooldown graph / tracking to handle <SpellLink spell={TALENTS_DRUID.CONTROL_OF_THE_DREAM_TALENT} /></>, Sref),
   change(date(2024, 9, 23), <>Added breakdown of HoT extensions to <SpellLink spell={TALENTS_DRUID.VERDANT_INFUSION_TALENT}/> statistic tooltip.</>, Sref),
   change(date(2024, 9, 13), <>Removed mana saved attribution from <SpellLink spell={TALENTS_DRUID.INCARNATION_TREE_OF_LIFE_TALENT}/> tracking.</>, Sref),

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
-  change(date(2024, 10, 27), <>Updated for 11.0.5, handling added / changed talents and added statistics module for <SpellLink spell={TALENTS_DRUID.RENEWING_SURGE_TALENT} />. Fixed an issue where a cast efficiency bar would show for <SpellLink spell={TALENTS_DRUID.TRANQUILITY_TALENT} /> and <SpellLink spell={TALENTS_DRUID.INNERVATE_TALENT} /> even when player didn't take the talents.</>, Sref),
+  change(date(2024, 10, 27), <>Updated for 11.0.5, handling added / changed talents and added statistics module for <SpellLink spell={TALENTS_DRUID.RENEWING_SURGE_TALENT} />. Fixed an issue where a cast efficiency bar would show for <SpellLink spell={TALENTS_DRUID.TRANQUILITY_TALENT} /> and <SpellLink spell={TALENTS_DRUID.INNERVATE_TALENT} /> even when player didn't take the talents. Fixed an issue where Grove Guardian Swiftmend healing wasn't registering.</>, Sref),
   change(date(2024, 10, 1), <>Updated cooldown graph / tracking to handle <SpellLink spell={TALENTS_DRUID.CONTROL_OF_THE_DREAM_TALENT} /></>, Sref),
   change(date(2024, 9, 23), <>Added breakdown of HoT extensions to <SpellLink spell={TALENTS_DRUID.VERDANT_INFUSION_TALENT}/> statistic tooltip.</>, Sref),
   change(date(2024, 9, 13), <>Removed mana saved attribution from <SpellLink spell={TALENTS_DRUID.INCARNATION_TREE_OF_LIFE_TALENT}/> tracking.</>, Sref),

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2024, 10, 27), <>Updated for 11.0.5, handling added / changed talents and added statistics module for <SpellLink spell={TALENTS_DRUID.RENEWING_SURGE_TALENT} /></>, Sref),
   change(date(2024, 10, 1), <>Updated cooldown graph / tracking to handle <SpellLink spell={TALENTS_DRUID.CONTROL_OF_THE_DREAM_TALENT} /></>, Sref),
   change(date(2024, 9, 23), <>Added breakdown of HoT extensions to <SpellLink spell={TALENTS_DRUID.VERDANT_INFUSION_TALENT}/> statistic tooltip.</>, Sref),
   change(date(2024, 9, 13), <>Removed mana saved attribution from <SpellLink spell={TALENTS_DRUID.INCARNATION_TREE_OF_LIFE_TALENT}/> tracking.</>, Sref),

--- a/src/analysis/retail/druid/restoration/CONFIG.tsx
+++ b/src/analysis/retail/druid/restoration/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Sref],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '11.0.2',
+  patchCompatibility: '11.0.5',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/druid/restoration/CombatLogParser.ts
+++ b/src/analysis/retail/druid/restoration/CombatLogParser.ts
@@ -62,6 +62,7 @@ import CenariusGuidanceTol from 'analysis/retail/druid/restoration/modules/spell
 import ControlOfTheDream from 'analysis/retail/druid/shared/spells/ControlOfTheDream';
 import Germination from 'analysis/retail/druid/restoration/modules/spells/Germination';
 import ThrivingVegetation from 'analysis/retail/druid/restoration/modules/spells/ThrivingVegetation';
+import RenewingSurge from 'analysis/retail/druid/restoration/modules/spells/RenewingSurge';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -130,6 +131,7 @@ class CombatLogParser extends CoreCombatLogParser {
     controlOfTheDream: ControlOfTheDream,
     germination: Germination,
     thrivingVegetation: ThrivingVegetation,
+    renewingSurge: RenewingSurge,
 
     // Mana Tab
     manaTracker: ManaTracker,

--- a/src/analysis/retail/druid/restoration/Guide.tsx
+++ b/src/analysis/retail/druid/restoration/Guide.tsx
@@ -87,16 +87,20 @@ function CooldownGraphSubsection({ modules, events, info }: GuideProps<typeof Co
           useThresholds
         />
       )}
-      <CastEfficiencyBar
-        spellId={SPELLS.TRANQUILITY_CAST.id}
-        gapHighlightMode={GapHighlight.FullCooldown}
-        useThresholds
-      />
-      <CastEfficiencyBar
-        spellId={SPELLS.INNERVATE.id}
-        gapHighlightMode={GapHighlight.FullCooldown}
-        useThresholds
-      />
+      {info.combatant.hasTalent(TALENTS_DRUID.TRANQUILITY_TALENT) && (
+        <CastEfficiencyBar
+          spellId={SPELLS.TRANQUILITY_CAST.id}
+          gapHighlightMode={GapHighlight.FullCooldown}
+          useThresholds
+        />
+      )}
+      {info.combatant.hasTalent(TALENTS_DRUID.INNERVATE_TALENT) && (
+        <CastEfficiencyBar
+          spellId={SPELLS.INNERVATE.id}
+          gapHighlightMode={GapHighlight.FullCooldown}
+          useThresholds
+        />
+      )}
     </SubSection>
   );
 }
@@ -116,8 +120,10 @@ function CooldownBreakdownSubsection({
         modules.flourish.guideCastBreakdown}
       {info.combatant.hasTalent(TALENTS_DRUID.INCARNATION_TREE_OF_LIFE_TALENT) &&
         modules.treeOfLife.guideCastBreakdown}
-      {modules.tranquility.guideCastBreakdown}
-      {modules.innervate.guideCastBreakdown}
+      {info.combatant.hasTalent(TALENTS_DRUID.TRANQUILITY_TALENT) &&
+        modules.tranquility.guideCastBreakdown}
+      {info.combatant.hasTalent(TALENTS_DRUID.INNERVATE_TALENT) &&
+        modules.innervate.guideCastBreakdown}
     </SubSection>
   );
 }

--- a/src/analysis/retail/druid/restoration/modules/Abilities.tsx
+++ b/src/analysis/retail/druid/restoration/modules/Abilities.tsx
@@ -22,7 +22,7 @@ class Abilities extends CoreAbilities {
         spell: TALENTS_DRUID.CENARION_WARD_TALENT.id,
         enabled: combatant.hasTalent(TALENTS_DRUID.CENARION_WARD_TALENT),
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 30,
+        cooldown: combatant.hasTalent(TALENTS_DRUID.WILDWOOD_ROOTS_TALENT) ? 20 : 30,
         gcd: {
           base: 1500,
         },
@@ -155,6 +155,7 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: 60 - combatant.getTalentRank(TALENTS_DRUID.PASSING_SEASONS_TALENT) * 12,
         gcd: null,
+        charges: combatant.hasTalent(TALENTS_DRUID.TWINLEAF_TALENT) ? 2 : 1,
       },
       {
         spell: TALENTS_DRUID.OVERGROWTH_TALENT.id,

--- a/src/analysis/retail/druid/restoration/modules/core/hottracking/HotTrackerRestoDruid.tsx
+++ b/src/analysis/retail/druid/restoration/modules/core/hottracking/HotTrackerRestoDruid.tsx
@@ -146,7 +146,8 @@ class HotTrackerRestoDruid extends HotTracker {
       },
       {
         spell: SPELLS.CENARION_WARD_HEAL,
-        duration: 8000,
+        duration:
+          8000 + this.selectedCombatant.getTalentRank(TALENTS_DRUID.WILDWOOD_ROOTS_TALENT) * 2000,
         tickPeriod: 2000,
       },
       {

--- a/src/analysis/retail/druid/restoration/modules/spells/RenewingSurge.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/RenewingSurge.tsx
@@ -1,0 +1,95 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Module';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import Events, { CastEvent } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS';
+import { getDirectHeal } from 'analysis/retail/druid/restoration/normalizers/CastLinkNormalizer';
+import { calculateHealTargetHealthPercent } from 'parser/core/EventCalculateLib';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { SpellIcon, SpellLink } from 'interface';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { formatPercentage } from 'common/format';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+const MAX_CDR = 6_000; // 15 second cooldown * 40% CDR
+
+/**
+ * **Spring Blossoms**
+ * Spec Talent Tier 6
+ *
+ * The cooldown of Swiftmend is reduced by up to 40%, based on the current health of the target.
+ * Cooldown is reduced more when cast on a lower health target.
+ */
+export default class RenewingSurge extends Analyzer.withDependencies({ spellUsable: SpellUsable }) {
+  /** Total times Swiftmend cast */
+  totalCasts: number = 0;
+  /** Total CDR applied */
+  totalCdrMs: number = 0;
+  /** Total health percent of Swiftmend targets (divide by total casts for average target health) */
+  totalHealthPercent: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.RENEWING_SURGE_TALENT);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SWIFTMEND),
+      this.onSwiftmendCast,
+    );
+  }
+
+  onSwiftmendCast(event: CastEvent) {
+    this.totalCasts += 1;
+
+    let targetHealthPercent = undefined;
+    const swiftmendHeal = getDirectHeal(event);
+    if (swiftmendHeal) {
+      targetHealthPercent = calculateHealTargetHealthPercent(swiftmendHeal);
+      this.totalHealthPercent += targetHealthPercent;
+      const missingHealth = 1 - targetHealthPercent;
+      const cdr = MAX_CDR * missingHealth;
+      this.totalCdrMs += cdr;
+      this.deps.spellUsable.reduceCooldown(SPELLS.SWIFTMEND.id, cdr);
+    }
+  }
+
+  get cdrPerCastString(): string {
+    return this.totalCasts === 0
+      ? 'N/A'
+      : (this.totalCdrMs / this.totalCasts / 1000).toFixed(1) + 's';
+  }
+
+  get averageTargetHealthPercentString(): string {
+    return this.totalCasts === 0
+      ? 'N/A'
+      : formatPercentage(this.totalHealthPercent / this.totalCasts, 0) + '%';
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        size="flexible"
+        position={STATISTIC_ORDER.OPTIONAL(6)} // number based on talent row
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            <p>
+              This is the cooldown reduction per <SpellLink spell={SPELLS.SWIFTMEND} /> cast,
+              averaged over the entire encounter. The average health of your swiftmend targets was{' '}
+              <strong>{this.averageTargetHealthPercentString}</strong>.
+            </p>
+          </>
+        }
+      >
+        <TalentSpellText talent={TALENTS_DRUID.RENEWING_SURGE_TALENT}>
+          <>
+            <SpellIcon spell={SPELLS.SWIFTMEND} /> {this.cdrPerCastString}{' '}
+            <small>avg CDR per cast</small>
+          </>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -476,7 +476,7 @@ const spells = {
   },
   // 'Swiftmend' cast by Grove Guardians
   GROVE_GUARDIANS_SWIFTMEND: {
-    id: 422094,
+    id: 142421,
     name: 'Swiftmend',
     icon: 'inv_relics_idolofrejuvenation',
   },


### PR DESCRIPTION
### Description

Marked Resto, Feral, and Guardian updated for 11.0.5 (already did Balance in a previous patch)
* Feral - no needed changes
* Guardian - no needed changes
* Resto - updated data numbers for new talents, and added a statistic for the new Renewing Surge talent. Fixed a minor issue with cooldown bars showing for spells that weren't talented.

### Testing

- Test report URL: `/report/D9zqcHphKMFgCnYJ/2-Mythic++Ara-Kara,+City+of+Echoes+-+Wipe+1+(22:34)/Ayurveda/standard/overview`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/dc227c85-2db8-4832-bcb3-f585747ddbe6)
![renewing_surge_tooltip](https://github.com/user-attachments/assets/33e099e7-a556-47f9-b562-5babcf215a9e)

