### PR TITLE
feat(warrior/protection): Added TWW1 2P Season 1 tier set effect.

### DIFF
--- a/src/analysis/retail/warrior/protection/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/protection/CHANGELOG.tsx
@@ -6,5 +6,5 @@ import { SpellLink } from 'interface';
 // prettier-ignore
 export default [
   change(date(2024, 10, 28), <>Added The War Within Season 1 2-pieces tier set effect <SpellLink spell={SPELLS.EXPERT_STRATEGIST_BUFF}/> as <SpellLink spell={SPELLS.SHIELD_SLAM} /> reset tracker.</>, Rzial),
-  change(date(2022, 3, 16), 'Initial Update for The War Within.', Rzial),
+  change(date(2024, 10, 24), 'Initial Update for The War Within.', Rzial),
 ];

--- a/src/analysis/retail/warrior/protection/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/protection/CHANGELOG.tsx
@@ -1,7 +1,10 @@
 import { change, date } from 'common/changelog';
+import SPELLS from 'common/SPELLS';
 import { Rzial } from 'CONTRIBUTORS';
+import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 28), <>Added The War Within Season 1 2-pieces tier set effect <SpellLink spell={SPELLS.EXPERT_STRATEGIST_BUFF}/> as <SpellLink spell={SPELLS.SHIELD_SLAM} /> reset tracker.</>, Rzial),
   change(date(2022, 3, 16), 'Initial Update for The War Within.', Rzial),
 ];

--- a/src/analysis/retail/warrior/protection/CombatLogParser.ts
+++ b/src/analysis/retail/warrior/protection/CombatLogParser.ts
@@ -32,6 +32,7 @@ import SpellReflection from '../shared/modules/talents/SpellReflection';
 import ImpendingVictory from '../shared/modules/talents/ImpendingVictory';
 import RavagerHitCheck from './modules/spells/RavagerHitCheck';
 import RageGenerationNormalizer from './normalizers/RageGenerationNormalizer';
+import WarWithin2PS1TierSet from './modules/items/WarWithin2PS1TierSet';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -77,7 +78,7 @@ class CombatLogParser extends CoreCombatLogParser {
     ravagerHitCheck: RavagerHitCheck,
 
     // Tier
-    // TODO
+    WarWithin2PS1TierSet,
   };
 }
 

--- a/src/analysis/retail/warrior/protection/modules/items/WarWithin2PS1TierSet.tsx
+++ b/src/analysis/retail/warrior/protection/modules/items/WarWithin2PS1TierSet.tsx
@@ -1,0 +1,31 @@
+import SPELLS from 'common/SPELLS';
+import talents from 'common/TALENTS/warrior';
+import { TIERS } from 'game/TIERS';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+
+export default class WarWithin2PS1TierSet extends Analyzer.withDependencies({
+  spellUsable: SpellUsable,
+}) {
+  constructor(options: Options) {
+    super(options);
+    this.active =
+      this.selectedCombatant.hasTalent(talents.STRATEGIST_TALENT) &&
+      this.selectedCombatant.has2PieceByTier(TIERS.TWW1);
+
+    this.addEventListener(
+      Events.applybuff.spell(SPELLS.EXPERT_STRATEGIST_BUFF),
+      this.resetShieldSlam,
+    );
+
+    this.addEventListener(
+      Events.refreshbuff.spell(SPELLS.EXPERT_STRATEGIST_BUFF),
+      this.resetShieldSlam,
+    );
+  }
+
+  private resetShieldSlam(): void {
+    this.deps.spellUsable.endCooldown(SPELLS.SHIELD_SLAM.id);
+  }
+}

--- a/src/common/SPELLS/warrior.ts
+++ b/src/common/SPELLS/warrior.ts
@@ -654,6 +654,13 @@ const spells = {
     icon: 'ability_criticalstrike',
   },
 
+  // T31 2p buff
+  EXPERT_STRATEGIST_BUFF: {
+    id: 455499,
+    name: 'Expert Strategist',
+    icon: 'ability_warrior_vigilance',
+  },
+
   // Talent in here so SpellLink doesn't return Unknown
   IMPENETRABLE_WALL_TALENT: {
     id: 384072,


### PR DESCRIPTION
### Description

Shield Slam skill events are processed way better if we use the 2P set buff as complementary element for resets.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: /report/9qDCZjkbJc3PGABV/49-Mythic+Ulgrax+the+Devourer+-+Kill+(6:40)/Сарлет/standard/debug
- Screenshot(s):
![image](https://github.com/user-attachments/assets/9fcf8ef9-d527-42ed-91db-893dad1c674a)

