### PR TITLE
feat(annotation-debugger): Added header for annotation rows and fixed minor rendering issues

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -20,6 +20,7 @@ import {
   nullDozzer,
   Pilsung,
   Putro,
+  Rzial,
   Seriousnes,
   Sref,
   Taevis,
@@ -38,6 +39,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 10, 28), `Updated annotation list rendering for the annotation debugger`, Rzial),
   change(date(2024, 10, 14), `Fixed some technical issues with rendering of lists`, nullDozzer),
   change(date(2024, 10, 12), `Fixed an issue with the effective healing/damage patch causing the per-second damage and healing graphs to be incorrect and causing some by-ability healing and damage numbers to be too low`, Sref),
   change(date(2024, 10, 12), <>Prevent requesting spell data for unknown spell ids.</>, emallson),

--- a/src/interface/DebugAnnotationsTab.tsx
+++ b/src/interface/DebugAnnotationsTab.tsx
@@ -40,14 +40,19 @@ function ModuleDebugAnnotations({ module, annotations }: ModuleAnnotations) {
       <DotContainer>
         {intoRows(annotations, parser.fight.start_time).map((row, index) => (
           <Row key={index}>
-            {row.map((props, index) => (
-              <AnnotationDot
-                {...props}
-                key={index}
-                onClick={() => setSelected((current) => (current === props ? null : props))}
-                selected={selected === props}
-              />
-            ))}
+            <RowTimestamp>
+              {`${index}:00`} - {row.length} events
+            </RowTimestamp>
+            <RowContent>
+              {row.map((props, index) => (
+                <AnnotationDot
+                  {...props}
+                  key={index}
+                  onClick={() => setSelected((current) => (current === props ? null : props))}
+                  selected={selected === props}
+                />
+              ))}
+            </RowContent>
           </Row>
         ))}
       </DotContainer>
@@ -192,15 +197,33 @@ const Dot = styled('div')<{ color: string; selected?: boolean }>`
 
 const DotContainer = styled.div`
   display: flex;
+  margin-top: 0.5em;
   flex-direction: column;
-  gap: 2px;
+  flex-wrap: wrap;
 
-  font-size: 75%;
+  gap: 4px;
+
+  // Originally 70% (10.5px)
+  // This aims to have a pixel perfect value so Dots doesn't get deformed
+  // by navigator rendering interpolations.
+  font-size: 71.4288%;
 `;
 
 const Row = styled.div`
+  border-left: 1px solid #eee;
+  padding-left: 4px;
+`;
+
+const RowTimestamp = styled.div`
+  display: inline-block;
+  margin-bottom: 2px;
+`;
+
+const RowContent = styled.div`
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
+
   gap: 2px;
 `;
 


### PR DESCRIPTION
### Description

Added header info for each row in the annotation debugger which includes the minute related to the row and the number of events in each row.

Also fixed two main minor issues:
- Non-integer font-size for annotations making the dots deformed depending on browser and screen parameters. Having an integer value will reduce the chances of this happening.
- Rows with a lot of events were causing dot stretching and in extreme cases broken rendering

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/XrA3BxZH2FdWRQm9/15-Mythic+Sikran,+Captain+of+the+Sureki+-+Kill+(4:24)/Adian/standard/debug`
- Screenshot(s):
<img src="https://github.com/user-attachments/assets/1395dfd8-0203-41a3-b7ef-d6216fda435f" width="600">
<img src="https://github.com/user-attachments/assets/5bfc73c0-187d-4c22-ba25-5397a2fbc0fa" width="600">
