### PR TITLE
[Mistweaver] Improve accuracy of Mistwrap module

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date (2024, 10, 31), <>Rewrote <SpellLink spell={TALENTS_MONK.MIST_WRAP_TALENT}/> for accuracy and to include value gained from <SpellLink spell={TALENTS_MONK.MENDING_PROLIFERATION_TALENT}/>. Updated several other modules to filter out healing that is not affected by healing increases.</>, Vohrr),
   change(date (2024, 10, 29), <>Added <SpellLink spell={TALENTS_MONK.RUSHING_WIND_KICK_TALENT}/> to the Talent Healing Breakdown</>, Vohrr),
   change(date (2024, 10, 28), <>Updated <SpellLink spell={TALENTS_MONK.RUSHING_WIND_KICK_TALENT}/> for October 29 buffs.</>, Vohrr),
   change(date (2024, 10, 24), <>Added analysis for <SpellLink spell={TALENTS_MONK.RUSHING_WIND_KICK_TALENT}/>.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -86,6 +86,7 @@ export const DANCING_MIST_CHANCE = 0.08;
 export const RAPID_DIFFUSION_DURATION = 3000; // per rank
 export const RISING_MIST_EXTENSION = 4000;
 export const ENVELOPING_MIST_INCREASE = 0.3;
+export const ENVELOPING_BREATH_INCREASE = 0.1;
 export const MISTWRAP_INCREASE = 0.1;
 export const YULON_REDUCTION = 0.5;
 export const ANCIENT_ARTS_LEG_SWEEP = 5;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MistWrap.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MistWrap.tsx
@@ -12,18 +12,24 @@ import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
-import { ENVELOPING_MIST_INCREASE, MISTWRAP_INCREASE } from '../../constants';
+import {
+  ABILITIES_AFFECTED_BY_HEALING_INCREASES,
+  ENVELOPING_BREATH_INCREASE,
+  ENVELOPING_MIST_INCREASE,
+  MISTWRAP_INCREASE,
+} from '../../constants';
 import HotTrackerMW from '../core/HotTrackerMW';
+import { Tracker } from 'parser/shared/modules/HotTracker';
 
 const ENVELOPING_BASE_DURATION = 6000;
 
 class MistWrap extends Analyzer {
-  hotInfo: Map<string, HotInfo> = new Map<string, HotInfo>();
-
   effectiveHealing: number = 0;
   overHealing: number = 0;
   envMistHealingBoost: number = 0;
   envBreathHealingBoost: number = 0;
+  mendingProliferationBoost: number = 0;
+  mendingProliferationActive: boolean = false;
 
   static dependencies = {
     hotTracker: HotTrackerMW,
@@ -38,6 +44,9 @@ class MistWrap extends Analyzer {
     if (!this.active) {
       return;
     }
+    this.mendingProliferationActive = this.selectedCombatant.hasTalent(
+      TALENTS_MONK.MENDING_PROLIFERATION_TALENT,
+    );
     this.addEventListener(
       Events.heal
         .by(SELECTED_PLAYER)
@@ -60,10 +69,7 @@ class MistWrap extends Analyzer {
         this.effectiveHealing += event.amount + (event.absorbed || 0);
         this.overHealing += event.overheal || 0;
       } else {
-        let totalExtension = 0;
-        Object.keys(hot.extensions).forEach((idx, index) => {
-          totalExtension += hot.extensions[index].amount;
-        });
+        const totalExtension = hot.extensions.reduce((sum, cur) => sum + cur.amount, 0);
         if (hot.start + ENVELOPING_BASE_DURATION + totalExtension < event.timestamp) {
           this.effectiveHealing += event.amount + (event.absorbed || 0);
           this.overHealing += event.overheal || 0;
@@ -73,20 +79,40 @@ class MistWrap extends Analyzer {
   }
 
   genericHeal(event: HealEvent) {
-    const targetId = event.targetID;
     const spellId = event.ability.guid;
-    if (
-      !this.hotTracker.hots[targetId] ||
-      !this.hotTracker.hots[targetId][SPELLS.ENVELOPING_BREATH_HEAL.id] ||
-      !this.hotTracker.hots[targetId][TALENTS_MONK.ENVELOPING_MIST_TALENT.id]
-    ) {
+
+    if (!ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(event.ability.guid)) {
       return;
     }
 
-    const envMistHot = this.hotTracker.hots[targetId][TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
-    const envBreathHot = this.hotTracker.hots[targetId][SPELLS.ENVELOPING_BREATH_HEAL.id];
-    //handle envelop mist bonus healing
-    if (envMistHot && spellId !== TALENTS_MONK.ENVELOPING_MIST_TALENT.id) {
+    //enveloping mist is only increased by enveloping breath
+    if (spellId === TALENTS_MONK.ENVELOPING_MIST_TALENT.id) {
+      this.calculateEnvelopingBreath(event);
+      return;
+    }
+
+    //enveloping breath is not increased by itself
+    if (spellId === SPELLS.ENVELOPING_BREATH_HEAL.id) {
+      this.calculateEnvelopingMist(event);
+      this.calculateMendingProliferation(event);
+      return;
+    }
+
+    this.calculateEnvelopingBreath(event);
+    this.calculateEnvelopingMist(event);
+    this.calculateMendingProliferation(event);
+  }
+
+  private calculateEnvelopingBreath(event: HealEvent) {
+    const envBreathHot = this.getHot(event, SPELLS.ENVELOPING_BREATH_HEAL.id);
+    if (envBreathHot && envBreathHot.start + ENVELOPING_BASE_DURATION < event.timestamp) {
+      this.envBreathHealingBoost += calculateEffectiveHealing(event, ENVELOPING_BREATH_INCREASE);
+    }
+  }
+
+  private calculateEnvelopingMist(event: HealEvent) {
+    const envMistHot = this.getHot(event, TALENTS_MONK.ENVELOPING_MIST_TALENT.id);
+    if (envMistHot) {
       //check for extensions
       if (envMistHot.extensions?.length === 0) {
         //bonus healing is 40% from additional time or 10% from additional healing based on timestamp
@@ -96,29 +122,47 @@ class MistWrap extends Analyzer {
             : calculateEffectiveHealing(event, MISTWRAP_INCREASE);
       } else {
         //get total extensions and apply bonus healing
-        let totalExtension = 0;
-        Object.keys(envMistHot.extensions).forEach((idx, index) => {
-          totalExtension += envMistHot.extensions[index].amount;
-        });
-        //bonus healing is 40% from additional time or 10% from additional healing based on timestamp
-        this.envMistHealingBoost +=
-          envMistHot.start + ENVELOPING_BASE_DURATION + totalExtension < event.timestamp
-            ? calculateEffectiveHealing(event, ENVELOPING_MIST_INCREASE + MISTWRAP_INCREASE)
-            : calculateEffectiveHealing(event, MISTWRAP_INCREASE);
+        //This whole block is a necessary bandaid because misty peaks procs silently extend the duration
+        //and reset the extension cap on existing enveloping mist without a refresh event
+        const totalExtension = envMistHot.extensions.reduce((sum, cur) => sum + cur.amount, 0);
+        const totalDuration = event.timestamp - envMistHot.start;
+
+        if (totalDuration > Number(envMistHot.maxDuration)) {
+          this.envMistHealingBoost += calculateEffectiveHealing(event, MISTWRAP_INCREASE);
+        } else {
+          this.envMistHealingBoost +=
+            envMistHot.start + ENVELOPING_BASE_DURATION + totalExtension < event.timestamp
+              ? calculateEffectiveHealing(event, ENVELOPING_MIST_INCREASE + MISTWRAP_INCREASE)
+              : calculateEffectiveHealing(event, MISTWRAP_INCREASE);
+        }
       }
-    }
-    //handle envelop breath bonus healing
-    if (
-      envBreathHot &&
-      envBreathHot.start + ENVELOPING_BASE_DURATION < event.timestamp &&
-      spellId !== SPELLS.ENVELOPING_BREATH_HEAL.id
-    ) {
-      this.envBreathHealingBoost += calculateEffectiveHealing(event, MISTWRAP_INCREASE);
     }
   }
 
+  private calculateMendingProliferation(event: HealEvent) {
+    const combatant = this.combatants.getEntity(event);
+    const hasMendingProliferation =
+      combatant && combatant.hasBuff(SPELLS.MENDING_PROLIFERATION_BUFF.id);
+
+    //mending proliferation gets the additiona 10% bonus as well, this bonus stacks with the regular env bonus
+    if (hasMendingProliferation) {
+      this.mendingProliferationBoost += calculateEffectiveHealing(event, MISTWRAP_INCREASE);
+    }
+  }
+
+  private getHot(event: HealEvent, spellId: number): Tracker | undefined {
+    return this.hotTracker.hots[event.targetID]
+      ? this.hotTracker.hots[event.targetID][spellId] || undefined
+      : undefined;
+  }
+
   get totalHealing() {
-    return this.envBreathHealingBoost + this.envMistHealingBoost + this.effectiveHealing;
+    return (
+      this.envBreathHealingBoost +
+      this.envMistHealingBoost +
+      this.mendingProliferationBoost +
+      this.effectiveHealing
+    );
   }
 
   subStatistic() {
@@ -140,9 +184,9 @@ class MistWrap extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            Effective Healing: {formatNumber(this.effectiveHealing)}
+            Effective HoT Healing: {formatNumber(this.effectiveHealing)}
             <br />
-            Overhealing: {formatNumber(this.overHealing)}
+            HoT Overhealing: {formatNumber(this.overHealing)}
             <br />
             Bonus Healing from extra <SpellLink
               spell={SPELLS.ENVELOPING_BREATH_HEAL}
@@ -150,6 +194,14 @@ class MistWrap extends Analyzer {
             <br />
             Bonus Healing from extra <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT} />{' '}
             duration: {formatNumber(this.envMistHealingBoost)}
+            {this.mendingProliferationActive && (
+              <>
+                <br />
+                Bonus Healing from <SpellLink
+                  spell={TALENTS_MONK.MENDING_PROLIFERATION_TALENT}
+                /> : {formatNumber(this.mendingProliferationBoost)}
+              </>
+            )}
           </>
         }
       >
@@ -162,9 +214,3 @@ class MistWrap extends Analyzer {
 }
 
 export default MistWrap;
-
-type HotInfo = {
-  applyTimeStamp: number;
-  playerAppliedTo: string;
-  spellId: number;
-};

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MistWrap.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MistWrap.tsx
@@ -144,7 +144,7 @@ class MistWrap extends Analyzer {
     const hasMendingProliferation =
       combatant && combatant.hasBuff(SPELLS.MENDING_PROLIFERATION_BUFF.id);
 
-    //mending proliferation gets the additiona 10% bonus as well, this bonus stacks with the regular env bonus
+    //mending proliferation gets the additional 10% bonus as well, this bonus stacks with the regular env bonus
     if (hasMendingProliferation) {
       this.mendingProliferationBoost += calculateEffectiveHealing(event, MISTWRAP_INCREASE);
     }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/MistyPeaks.tsx
@@ -13,6 +13,11 @@ import TalentSpellText from 'parser/ui/TalentSpellText';
 import SpellLink from 'interface/SpellLink';
 import Combatants from 'parser/shared/modules/Combatants';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
+import {
+  ABILITIES_AFFECTED_BY_HEALING_INCREASES,
+  ENVELOPING_MIST_INCREASE,
+  MISTWRAP_INCREASE,
+} from '../../constants';
 
 const UNAFFECTED_SPELLS = [TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
 
@@ -43,8 +48,8 @@ class MistyPeaks extends Analyzer {
       return;
     }
     this.envmHealingIncrease = this.selectedCombatant.hasTalent(TALENTS_MONK.MIST_WRAP_TALENT)
-      ? 0.4
-      : 0.3;
+      ? ENVELOPING_MIST_INCREASE + MISTWRAP_INCREASE
+      : ENVELOPING_MIST_INCREASE;
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell([TALENTS_MONK.ENVELOPING_MIST_TALENT]),
       this.handleEnvApply,
@@ -88,6 +93,7 @@ class MistyPeaks extends Analyzer {
     const spellId = event.ability.guid;
     if (
       UNAFFECTED_SPELLS.includes(spellId) ||
+      !ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(spellId) ||
       !this.hotTracker.hots[targetId] ||
       !this.hotTracker.hots[targetId][TALENTS_MONK.ENVELOPING_MIST_TALENT.id]
     ) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ShaohaosLessons.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ShaohaosLessons.tsx
@@ -28,6 +28,7 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import Spell from 'common/SPELLS/Spell';
+import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from '../../constants';
 
 const DESPAIR_CRIT_INCREASE = 0.3;
 const DOUBT_INCREASE = 0.4;
@@ -127,7 +128,10 @@ class ShaohaosLessons extends Analyzer {
   }
 
   handleHealDoubt(event: HealEvent) {
-    if (!this.selectedCombatant.hasBuff(SPELLS.LESSON_OF_DOUBT_BUFF.id)) {
+    if (
+      !ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(event.ability.guid) ||
+      !this.selectedCombatant.hasBuff(SPELLS.LESSON_OF_DOUBT_BUFF.id)
+    ) {
       return;
     }
     const targetPlayerHealthPercent = (event.hitPoints - event.amount) / event.maxHitPoints;

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -1,4 +1,3 @@
-import SPELLS from 'common/SPELLS';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import { Options } from 'parser/core/Module';
 import { TALENTS_MONK } from 'common/TALENTS';
@@ -30,7 +29,6 @@ import {
   REVIVAL_GOM,
   VIVIFY,
   SHEILUNS_GIFT,
-  CALMING_COALESCENCE,
   MANA_TEA_CHANNEL,
   MANA_TEA_CAST_LINK,
   MT_BUFF_REMOVAL,
@@ -87,19 +85,6 @@ const EVENT_LINKS: EventLink[] = [
     },
     maximumLinks(c) {
       return c.hasTalent(TALENTS_MONK.LEGACY_OF_WISDOM_TALENT) ? 5 : 3;
-    },
-  },
-  {
-    linkRelation: CALMING_COALESCENCE,
-    linkingEventId: [SPELLS.CALMING_COALESCENCE_BUFF.id],
-    linkingEventType: [EventType.RemoveBuff],
-    referencedEventId: [TALENTS_MONK.LIFE_COCOON_TALENT.id],
-    referencedEventType: [EventType.Cast],
-    backwardBufferMs: CAST_BUFFER_MS,
-    forwardBufferMs: CAST_BUFFER_MS,
-    anyTarget: true,
-    isActive(c) {
-      return c.hasTalent(TALENTS_MONK.CALMING_COALESCENCE_TALENT);
     },
   },
 ];
@@ -276,10 +261,6 @@ export function isFromCraneStyleBok(event: HealEvent) {
 
 export function isFromCraneStyleSCK(event: HealEvent) {
   return HasRelatedEvent(event, CRANE_STYLE_SCK);
-}
-
-export function isFromLifeCocoon(event: RemoveBuffEvent) {
-  return HasRelatedEvent(event, CALMING_COALESCENCE);
 }
 
 export function getSheilunsGiftHits(event: CastEvent): HealEvent[] {

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants.ts
@@ -54,6 +54,5 @@ export const MANA_TEA_YULONS_WHISPER = 'MTYulonsWhisper';
 export const STRENGTH_OF_THE_BLACK_OX = 'SotBO';
 
 // Misc
-export const CALMING_COALESCENCE = 'Calming Coalescence';
 export const CAST_BUFFER_MS = 100;
 export const CHI_WAVE_RSK = 'ChiWaveRSK';


### PR DESCRIPTION
### Description

Mistwrap was not accurately tracking healing contributions from the additional healing increase it provides.

- Added filtering out of healing from spells that aren't affected by it
- Added tracking for the additional 10% increased healing to the mending proliferation buff when talented
- Reworked the extension check logic that was over-attributing in some cases due to TWW's the new behavior of misty peaks -- will work on fixing this properly within the hottracker in a different PR
- Updated a few other modules that were not filtering out healing from spells that aren't affected by healing increases

### Screenshots
Before
![image](https://github.com/user-attachments/assets/ace1d66c-137c-4253-89c3-7ebd8655bbc9)

After
![image](https://github.com/user-attachments/assets/6ddd4c0f-3e3a-4b29-9d7a-95a02989f087)


Log: `/report/q9QbCGn3c1wLYAmx/28-Mythic+Rasha'nan+-+Kill+(4:56)/Vohrr/standard/statistics`
