### PR TITLE
Improve Active Time estimation for Arms Warrior in Cataclysm

### DIFF
--- a/src/analysis/classic/warrior/arms/CHANGELOG.tsx
+++ b/src/analysis/classic/warrior/arms/CHANGELOG.tsx
@@ -3,6 +3,8 @@ import { emallson } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2024, 11, 2), 'Added compensation for unavoidable rotational downtime to Active Time estimation', emallson),
+  change(date(2024, 11, 2), 'Adjust GCDs for Arms Warrior to ignore Haste', emallson),
   change(date(2024, 8, 8), 'Adjust active time section of the Arms Warrior guide', emallson),
   change(date(2024, 8, 4), 'Added foundational support for Arms Warrior', emallson),
 ];

--- a/src/analysis/classic/warrior/arms/Guide.tsx
+++ b/src/analysis/classic/warrior/arms/Guide.tsx
@@ -7,7 +7,6 @@ import { FoundationHighlight as HL } from 'interface/guide/foundation/shared';
 import Explanation from 'interface/guide/components/Explanation';
 import ResourceLink from 'interface/ResourceLink';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
-import { TooltipElement } from 'interface/Tooltip';
 import PerformanceStrong from 'interface/PerformanceStrong';
 import { formatPercentage } from 'common/format';
 import AlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
@@ -46,12 +45,8 @@ function ArmsDowntimeSection() {
         </Para>
         <Para>
           In Cataclysm, Arms Warrior does not have enough abilities or{' '}
-          <ResourceLink id={RESOURCE_TYPES.RAGE.id} /> to fill every GCD. This means that you will
-          have lower{' '}
-          <TooltipElement content={<>The percentage of time spent using spells and abilities.</>}>
-            Active Time
-          </TooltipElement>{' '}
-          than other specs.
+          <ResourceLink id={RESOURCE_TYPES.RAGE.id} /> to fill every GCD. GCDs that are empty
+          because no abilities are usable are also counted as Active Time.
         </Para>
         <Para>
           With practice, you can keep active <em>and</em> pick the right spells for each moment, but
@@ -75,7 +70,7 @@ function ArmsDowntimeSection() {
       <Para>
         As a general guideline,{' '}
         <HL>
-          you should have <strong>70%+</strong> active time during normal phases of a boss fight.
+          you should have <strong>80%+</strong> active time during normal phases of a boss fight.
         </HL>{' '}
         Exceptional players will often hit <em>nearly 100%</em> during these periods.
       </Para>

--- a/src/analysis/classic/warrior/arms/modules/features/Abilities.ts
+++ b/src/analysis/classic/warrior/arms/modules/features/Abilities.ts
@@ -10,7 +10,7 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.REND.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        gcd: { base: 1500 },
+        gcd: { static: 1500 },
       },
       {
         spell: SPELLS.HEROIC_STRIKE.id,
@@ -28,24 +28,24 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.MORTAL_STRIKE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        gcd: { base: 1500 },
+        gcd: { static: 1500 },
         cooldown: 4.5,
       },
       {
         spell: SPELLS.SLAM.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        gcd: { base: 1500 },
+        gcd: { static: 1500 },
       },
       {
         spell: SPELLS.COLOSSUS_SMASH.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        gcd: { base: 1500 },
+        gcd: { static: 1500 },
         cooldown: 20,
       },
       {
         spell: SPELLS.WHIRLWIND.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
-        gcd: { base: 1500 },
+        gcd: { static: 1500 },
       },
       // Execute and Overpower are handled in separate modules
       // Rotational AOE

--- a/src/analysis/classic/warrior/arms/modules/features/AlwaysBeCasting.ts
+++ b/src/analysis/classic/warrior/arms/modules/features/AlwaysBeCasting.ts
@@ -1,7 +1,29 @@
+import CLASSIC_SPELLS from 'common/SPELLS/classic';
 import { ThresholdStyle, type NumberThreshold } from 'parser/core/ParseResults';
+import { AplChecker, build } from 'parser/shared/metrics/apl';
 import CoreAlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import * as cnd from 'parser/shared/metrics/apl/conditions';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { Options } from 'parser/core/Analyzer';
+import Events, { AnyEvent, FightEndEvent } from 'parser/core/Events';
 
-export default class AlwaysBeCasting extends CoreAlwaysBeCasting {
+export default class AlwaysBeCasting extends CoreAlwaysBeCasting.withDependencies({
+  spellUsable: SpellUsable,
+}) {
+  private aplChecker;
+
+  private lastUptimeStart?: number;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.aplChecker = new AplChecker(apl, this.owner.info);
+
+    this.addEventListener(Events.any, this.processAplDowntime);
+    this.addEventListener(Events.fightend, this.finalize);
+  }
+
   get downtimeSuggestionThresholds(): NumberThreshold {
     return {
       actual: this.downtimePercentage,
@@ -13,4 +35,60 @@ export default class AlwaysBeCasting extends CoreAlwaysBeCasting {
       style: ThresholdStyle.PERCENTAGE,
     };
   }
+
+  private processAplDowntime(event: AnyEvent) {
+    // the idea here is that we add "uptime" from the point where the APL says "don't cast anything" to the next point where the APL says "cast something"
+    const expectedCast = this.aplChecker.expectedCast();
+
+    this.aplChecker.processEvent(event);
+
+    if (expectedCast && this.lastUptimeStart && event.timestamp >= this.owner.fight.start_time) {
+      // apl: "cast something"
+      if (this.lastUptimeStart !== event.timestamp) {
+        this.addNewUptime(this.lastUptimeStart, event.timestamp, false, 'Arms APL-based downtime');
+      }
+      this.lastUptimeStart = undefined;
+    } else if (!expectedCast && !this.lastUptimeStart) {
+      // apl: "don't cast anything"
+      this.lastUptimeStart = event.timestamp;
+    }
+  }
+
+  private finalize(event: FightEndEvent) {
+    if (this.lastUptimeStart) {
+      this.addNewUptime(
+        this.lastUptimeStart,
+        event.timestamp,
+        false,
+        'Arms APL-based downtime (finalizer)',
+      );
+    }
+  }
 }
+
+const apl = build([
+  {
+    spell: CLASSIC_SPELLS.REND,
+    condition: cnd.debuffMissing(CLASSIC_SPELLS.REND_DEBUFF),
+  },
+  {
+    spell: CLASSIC_SPELLS.COLOSSUS_SMASH,
+    condition: cnd.debuffMissing(CLASSIC_SPELLS.COLOSSUS_SMASH),
+  },
+  CLASSIC_SPELLS.MORTAL_STRIKE,
+  {
+    spell: CLASSIC_SPELLS.EXECUTE,
+    condition: cnd.inExecute(),
+  },
+  {
+    spell: CLASSIC_SPELLS.OVERPOWER,
+    condition: cnd.buffPresent(CLASSIC_SPELLS.TASTE_FOR_BLOOD),
+  },
+  {
+    spell: CLASSIC_SPELLS.HEROIC_STRIKE,
+    condition: cnd.or(
+      cnd.buffPresent(CLASSIC_SPELLS.BATTLE_TRANCE),
+      cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 }, 0),
+    ),
+  },
+]);

--- a/src/analysis/classic/warrior/shared/Execute.tsx
+++ b/src/analysis/classic/warrior/shared/Execute.tsx
@@ -17,7 +17,7 @@ export default class Execute extends ExecuteHelper.withDependencies({ abilities:
     this.deps.abilities.add({
       spell: SPELLS.EXECUTE.id,
       category: SPELL_CATEGORY.ROTATIONAL,
-      gcd: { base: 1500 },
+      gcd: { static: 1500 },
     });
   }
 }

--- a/src/analysis/classic/warrior/shared/Overpower.tsx
+++ b/src/analysis/classic/warrior/shared/Overpower.tsx
@@ -20,7 +20,7 @@ export default class Overpower extends ExecuteHelper.withDependencies({ abilitie
     this.deps.abilities.add({
       spell: SPELLS.OVERPOWER.id,
       category: SPELL_CATEGORY.ROTATIONAL,
-      gcd: { base: 1500 },
+      gcd: { static: 1500 },
       castEfficiency: {
         suggestion: false,
         maxCasts: () => this.maxCasts,

--- a/src/common/SPELLS/classic/warrior.ts
+++ b/src/common/SPELLS/classic/warrior.ts
@@ -118,7 +118,7 @@ const spells = {
   BATTLE_TRANCE: {
     id: 12964,
     name: 'Battle Trance',
-    icon: 'inv_helmet_06',
+    icon: 'inv_helmet_06.jpg',
   },
   PUMMEL: {
     id: 6552,

--- a/src/common/SPELLS/classic/warrior.ts
+++ b/src/common/SPELLS/classic/warrior.ts
@@ -115,6 +115,11 @@ const spells = {
     name: 'Taste for Blood',
     icon: 'ability_rogue_hungerforblood.jpg.jpg',
   },
+  BATTLE_TRANCE: {
+    id: 12964,
+    name: 'Battle Trance',
+    icon: 'inv_helmet_06',
+  },
   PUMMEL: {
     id: 6552,
     name: 'Pummel',
@@ -127,6 +132,11 @@ const spells = {
   },
   REND: {
     id: 772,
+    name: 'Rend',
+    icon: 'ability_gouge.jpg',
+  },
+  REND_DEBUFF: {
+    id: 94009,
     name: 'Rend',
     icon: 'ability_gouge.jpg',
   },

--- a/src/parser/shared/metrics/apl/index.ts
+++ b/src/parser/shared/metrics/apl/index.ts
@@ -506,7 +506,7 @@ export class AplChecker {
 
     this.assertLookaheadCompat();
 
-    this.lastTimestamp = info.combatant.owner.fight.start_time;
+    this.lastTimestamp = info.combatant?.owner.fight.start_time ?? -1;
     this.lastSeenHostileTargetID = -1;
 
     // rules for spells that aren't known are automatically ignored

--- a/src/parser/shared/metrics/apl/index.ts
+++ b/src/parser/shared/metrics/apl/index.ts
@@ -4,6 +4,7 @@ import {
   BeginChannelEvent,
   CastEvent,
   EventType,
+  HasTarget,
   UpdateSpellUsableEvent,
   UpdateSpellUsableType,
 } from 'parser/core/Events';
@@ -273,11 +274,11 @@ export const spells = (rule: InternalRule): Spell[] =>
   rule.spell.type === TargetType.SpellList ? rule.spell.target : [rule.spell.target];
 
 export function lookaheadSlice(
-  events: AnyEvent[],
+  events: AnyEvent[] | undefined,
   startIx: number,
   duration: number | undefined,
 ): AnyEvent[] {
-  if (!duration) {
+  if (!events || !duration) {
     return [];
   }
 
@@ -305,11 +306,11 @@ function ruleApplies(
   rule: InternalRule,
   abilities: Set<number>,
   result: CheckState,
-  events: AnyEvent[],
+  event: AnyEvent,
+  events: AnyEvent[] | undefined,
   eventIndex: number,
   requireCooldownAvailable: boolean = false,
 ): Spell[] | false {
-  const event = events[eventIndex];
   if (event.type !== EventType.Cast && event.type !== EventType.BeginChannel) {
     console.error('attempted to apply APL rule to non-cast event, ignoring', event);
     return false;
@@ -334,6 +335,12 @@ function ruleApplies(
       console.warn(
         `APL: Spell was cast but we thought it was out of range: ${spell.id} (${spell.name})`,
         event,
+      );
+    }
+
+    if (!events && rule.condition?.lookahead) {
+      throw new Error(
+        'attempted to use lookahead rule without full event list. lookahead rules are deprecated. please switch to using EventLinkNormalizer',
       );
     }
 
@@ -371,7 +378,8 @@ function applicableRule(
   apl: Apl,
   abilities: Set<number>,
   result: CheckState,
-  events: AnyEvent[],
+  event: AnyEvent,
+  events: AnyEvent[] | undefined,
   eventIndex: number,
   requireCooldownAvailable: boolean = false,
 ): ApplicableRule | undefined {
@@ -380,6 +388,7 @@ function applicableRule(
       rule,
       abilities,
       result,
+      event,
       events,
       eventIndex,
       requireCooldownAvailable,
@@ -472,6 +481,195 @@ function updateCheckState(result: CheckState, apl: Apl, event: AnyEvent): CheckS
   return result;
 }
 
+/**
+ * The main driver for an APL's state. Individual events are processed via `processEvent`. Most consumers will use `getResult()` after processing all events to retrieve a summary of successes / violations.
+ *
+ * This class is currently in an in-between state where it is usable with *most* APLs within an Analyzer, but some APL features (notably: lookaheads) are not supported.
+ */
+export class AplChecker {
+  private apl: Apl;
+  private info: PlayerInfo;
+  private abilities;
+  private applicableSpells;
+
+  private state: CheckState;
+  private events?: AnyEvent[];
+
+  private lastSeenHostileTargetID: number;
+  private lastSeenHostileTargetInstance: number | undefined = undefined;
+  private lastTimestamp: number;
+
+  constructor(apl: Apl, info: PlayerInfo, events?: AnyEvent[]) {
+    this.apl = apl;
+    this.info = info;
+    this.events = events;
+
+    this.assertLookaheadCompat();
+
+    this.lastTimestamp = info.combatant.owner.fight.start_time;
+    this.lastSeenHostileTargetID = -1;
+
+    // rules for spells that aren't known are automatically ignored
+    const { abilities, applicableSpells } = knownSpells(apl, info);
+    this.abilities = abilities;
+    this.applicableSpells = applicableSpells;
+
+    this.state = {
+      successes: [],
+      violations: [],
+      abilityState: {},
+      conditionState: initState(apl, info),
+      locationState: initLocationState(info),
+    };
+  }
+
+  /**
+   * Assert that either we can process lookaheads, or there are no lookaheads.
+   * Lookaheads are (unofficially?) deprecated in favor of EventLinkNormalizer.
+   */
+  private assertLookaheadCompat() {
+    if (!this.apl.conditions) {
+      return; // no conditions = no lookahead conditions
+    }
+
+    if (this.events) {
+      return; // events present = we can do lookaheads
+    }
+
+    for (const condition of this.apl.conditions) {
+      if (condition.lookahead) {
+        throw new Error(
+          `Unable to process lookahead condition ${condition.key}, no events present`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Retrieve the summary of results from checking the APL against events.
+   */
+  getResult(): CheckResult {
+    return this.state;
+  }
+
+  /**
+   * Process the event list that was passed to the constructor. If no event list was passed to the constructor, does nothing.
+   */
+  processAll(): void {
+    if (!this.events) {
+      return;
+    }
+    for (let i = 0; i < this.events.length; i += 1) {
+      this.processEvent(this.events[i], i);
+    }
+  }
+
+  /**
+   * Process a single event, returning the outcome.
+   */
+  processEvent(event: AnyEvent, eventIndex?: number): Success | Violation | undefined {
+    const [nextState, outcome] = this.processEventInternal(this.state, event, eventIndex ?? -1);
+    this.state = nextState;
+
+    if (HasTarget(event) && !event.targetIsFriendly && event.targetID) {
+      this.lastSeenHostileTargetID = event.targetID;
+      this.lastSeenHostileTargetInstance = event.targetInstance;
+    }
+
+    this.lastTimestamp = event.timestamp;
+
+    return outcome;
+  }
+
+  /**
+   * Get the expected cast in the current state, or undefined if no rules apply.
+   *
+   * This works by fabricating a dummy cast event for ability in the bottom-most rule and then checking what the expected cast *actually* is.
+   *
+   * This does not update the state of the checker---it is a pure function of the inputs and the current state.
+   *
+   * By default, the last seen hostile target is used. If you want to handle casts against specific targets, supply the `targetID` and `targetInstance` parameters.
+   */
+  expectedCast(targetID?: number, targetInstance?: number): Spell[] | undefined {
+    const bottomSpells = spells(this.apl.rules.at(-1)!);
+
+    const dummyEvent: CastEvent = {
+      type: EventType.Cast,
+      timestamp: this.lastTimestamp,
+      sourceID: this.info.playerId,
+      sourceIsFriendly: true,
+      targetID: targetID ?? this.lastSeenHostileTargetID,
+      targetInstance: targetInstance ?? this.lastSeenHostileTargetInstance,
+      targetIsFriendly: false,
+      ability: {
+        guid: bottomSpells[0].id,
+        name: '',
+        type: 0,
+        abilityIcon: '',
+      },
+    };
+
+    const rule = applicableRule(this.apl, this.abilities, this.state, dummyEvent, undefined, -1);
+    return rule?.availableSpells;
+  }
+
+  private processEventInternal(
+    result: CheckState,
+    event: AnyEvent,
+    eventIndex: number,
+  ): [CheckState, Success | Violation | undefined] {
+    let outcome: Success | Violation | undefined = undefined;
+    if (aplProcessesEvent(event, result, this.applicableSpells, this.info.playerId)) {
+      const applicable = applicableRule(
+        this.apl,
+        this.abilities,
+        result,
+        event,
+        this.events,
+        eventIndex,
+      );
+      if (applicable) {
+        const { rule, availableSpells } = applicable;
+
+        if (
+          spells(rule).every(
+            (spell) =>
+              result.abilityState[spell.id] !== undefined &&
+              !result.abilityState[spell.id].isAvailable,
+          ) &&
+          import.meta.env.DEV
+        ) {
+          console.warn(
+            'inconsistent ability state in APL checker:',
+            spells(rule).map((spell) => result.abilityState[spell.id]),
+            rule,
+            event,
+          );
+        }
+        if (spells(rule).some((spell) => spell.id === event.ability.guid)) {
+          // the player cast the correct spell
+          outcome = { rule, actualCast: event, kind: ResultKind.Success };
+          result.successes.push(outcome);
+        } else if (
+          this.info.combatant === undefined ||
+          event.timestamp >= this.info.combatant.owner.fight.start_time
+        ) {
+          // condition prevents punishing precast spells
+          outcome = {
+            kind: ResultKind.Violation,
+            rule,
+            expectedCast: availableSpells,
+            actualCast: event,
+          };
+          result.violations.push(outcome);
+        }
+      }
+    }
+
+    return [updateCheckState(result, this.apl, event), outcome];
+  }
+}
+
 const aplCheck = (apl: Apl) =>
   metric<[PlayerInfo], CheckResult>((events, info) => {
     // sort event history. this is a workaround for event dispatch happening
@@ -499,59 +697,10 @@ const aplCheck = (apl: Apl) =>
       }
     });
 
-    // rules for spells that aren't known are automatically ignored
-    const { abilities, applicableSpells } = knownSpells(apl, info);
+    const checker = new AplChecker(apl, info, events);
+    checker.processAll();
 
-    return events.reduce<CheckState>(
-      (result, event, eventIndex) => {
-        if (aplProcessesEvent(event, result, applicableSpells, info.playerId)) {
-          const applicable = applicableRule(apl, abilities, result, events, eventIndex);
-          if (applicable) {
-            const { rule, availableSpells } = applicable;
-
-            if (
-              spells(rule).every(
-                (spell) =>
-                  result.abilityState[spell.id] !== undefined &&
-                  !result.abilityState[spell.id].isAvailable,
-              ) &&
-              import.meta.env.DEV
-            ) {
-              console.warn(
-                'inconsistent ability state in APL checker:',
-                spells(rule).map((spell) => result.abilityState[spell.id]),
-                rule,
-                event,
-              );
-            }
-            if (spells(rule).some((spell) => spell.id === event.ability.guid)) {
-              // the player cast the correct spell
-              result.successes.push({ rule, actualCast: event, kind: ResultKind.Success });
-            } else if (
-              info.combatant === undefined ||
-              event.timestamp >= info.combatant.owner.fight.start_time
-            ) {
-              // condition prevents punishing precast spells
-              result.violations.push({
-                kind: ResultKind.Violation,
-                rule,
-                expectedCast: availableSpells,
-                actualCast: event,
-              });
-            }
-          }
-        }
-
-        return updateCheckState(result, apl, event);
-      },
-      {
-        successes: [],
-        violations: [],
-        abilityState: {},
-        conditionState: initState(apl, info),
-        locationState: initLocationState(info),
-      },
-    );
+    return checker.getResult();
   });
 
 export default aplCheck;

--- a/src/parser/shared/modules/AlwaysBeCasting.tsx
+++ b/src/parser/shared/modules/AlwaysBeCasting.tsx
@@ -100,7 +100,7 @@ class AlwaysBeCasting extends Analyzer {
   }
 
   /** Validates and logs inputs, then adds to activeTimeEdges list */
-  private addNewUptime(start: number, end: number, isHealingAbility: boolean, reason: string) {
+  protected addNewUptime(start: number, end: number, isHealingAbility: boolean, reason: string) {
     DEBUG &&
       console.log(
         `Active Time: adding from ${reason}: ${this.owner.formatTimestamp(start, 3)} to ${this.owner.formatTimestamp(end, 3)}${isHealingAbility ? ' (heal)' : ''}`,


### PR DESCRIPTION
### Description

In Cata, Arms is a *Downtime Spec.* There are not enough abilities or resources to fill every GCD, so some are unavoidably left empty.

Currently, the Guide explicitly calls this out and reduces the Active Time targets to compensate (based on, honestly, rough guesswork). This PR adjusts the Active Time calculation to count the unavoidable downtime as "uptime", the same way that other sources of unavoidable downtime (like GCDs, or casting) are counted.

To do that, it uses an APL to track what the expected cast is at each event. If there is no expected cast, then we treat it as downtime. (The method to do this might be too magical / have bad defaults and need adjusting).

In the process, I started refactoring some of the APL code to allow using APLs as checkers within Analyzers.

Additionally, I did some archaeology on Haste & the GCD in Classic, and I've become pretty confident that **haste does not impact the melee GCD.** As a result, I changed the Arms GCDs to be static at 1.5 seconds.

Specifically, classic has 3 types of haste: Melee, Ranged, and Spell. In patch 2.4, Spell Haste was changed to impact the GCD. Melee/Ranged haste were not. The wiki indicates that this was the status quo until WoD prepatch, which unified all 3 varieties of haste into a single "Haste" stat. Prior to this, melee abilities would not benefit from Spell Haste. 

### Testing

*Sample Report*

`/report/zHX3VMN6YAPRFTKg/32-Heroic+Chimaeron+-+Kill+(3:12)/Dolbob/standard`

Before
![image](https://github.com/user-attachments/assets/2ad169cc-01db-43bf-97e4-819c68ecdd63)

After
![image](https://github.com/user-attachments/assets/61a76d9d-0d6b-4a4a-9e09-96beba9ce308)

*Ahlaundoh (Current R1)*

`/report/8ZndcNyGkjTmMxYB/29-Heroic+Chimaeron+-+Kill+(2:56)/25-Ahlaundoh/standard`

Before
![image](https://github.com/user-attachments/assets/37fad7de-0430-4995-835b-f55b6e35a16a)

After
![image](https://github.com/user-attachments/assets/290bca24-e6bc-4b92-9aa2-53906557e2d6)

*Random Recent Log*

`/report/BDzNRdqAba9M6cCP/10-Heroic+Chimaeron+-+Kill+(3:45)/돌진후저세상/standard`

Before
![image](https://github.com/user-attachments/assets/25240b1a-6fd2-4ea2-88f7-8b6f18954272)


After
![image](https://github.com/user-attachments/assets/71ee4a9f-02ec-4939-8388-2d5b748780cd)

worth noting that on each of these logs, all of the GCDs still pass:
![image](https://github.com/user-attachments/assets/95109859-2fbd-497b-a0e3-bbd689941880)
