### PR TITLE
Druid Balance - fixed an issue where Celestial Alignment wouldn't show in Cooldowns Tab when Orbital Strike is chosen

### DIFF
--- a/src/analysis/retail/druid/balance/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/balance/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2024, 11, 18), <>Fixed an issue where <SpellLink spell={TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT} /> wouldn't show in cooldowns tab when <SpellLink spell={TALENTS_DRUID.ORBITAL_STRIKE_TALENT} /> talent is chosen.</>, Sref),
   change(date(2024, 10, 26), <>Update underlying talent data for 11.0.5. Fixed cooldown display with <SpellLink spell={TALENTS_DRUID.WHIRLING_STARS_TALENT} />. Added support for <SpellLink spell={TALENTS_DRUID.LUNAR_CALLING_TALENT} /> in Guide text. Fixed an issue where Mushroom cooldown graph would be shown when player takes <SpellLink spell={TALENTS_DRUID.SUNSEEKER_MUSHROOM_TALENT} />. </>, Sref),
   change(date(2024, 10, 1), <>Updated cooldown graph / tracking to handle <SpellLink spell={TALENTS_DRUID.CONTROL_OF_THE_DREAM_TALENT} /></>, Sref),
   change(date(2024, 8, 17), <>Marked updated for 11.0.2 and updated the spec's 'About' page.</>, Sref),

--- a/src/analysis/retail/druid/balance/modules/Abilities.tsx
+++ b/src/analysis/retail/druid/balance/modules/Abilities.tsx
@@ -76,7 +76,7 @@ class Abilities extends CoreAbilities {
       // Cooldowns
       {
         spell: cdSpell(combatant).id,
-        buffSpellId: SPELLS.INCARNATION_CHOSEN_OF_ELUNE.id,
+        buffSpellId: cdSpell(combatant).id,
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: cdCooldown(combatant),
         enabled: combatant.hasTalent(TALENTS_DRUID.INCARNATION_CHOSEN_OF_ELUNE_TALENT),
@@ -90,7 +90,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: cdSpell(combatant).id,
-        buffSpellId: SPELLS.CELESTIAL_ALIGNMENT.id,
+        buffSpellId: cdSpell(combatant).id,
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: cdCooldown(combatant),
         enabled:

--- a/src/analysis/retail/druid/balance/modules/features/CooldownThroughputTracker.tsx
+++ b/src/analysis/retail/druid/balance/modules/features/CooldownThroughputTracker.tsx
@@ -17,6 +17,16 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
       summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
       branch: GameBranch.Retail,
     },
+    {
+      spell: SPELLS.INCARNATION_ORBITAL_STRIKE.id,
+      summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
+      branch: GameBranch.Retail,
+    },
+    {
+      spell: SPELLS.CELESTIAL_ALIGNMENT_ORBITAL_STRIKE.id,
+      summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
+      branch: GameBranch.Retail,
+    },
   ];
 }
 


### PR DESCRIPTION
### Description

Orbital Strike changes the cast ID for CA/Incarn, just needed to add them to the list in CooldownThroughputTracker

### Testing
- Test report URL: `/report/RWYPQ4cDky3Jjr8K/7-Mythic+The+Silken+Court+-+Kill+(8:09)/Bozlaay/standard/cooldowns`
