### PR TITLE
Druid Resto - Updated HarmoniusBlooming and Mastery module to account for talent now 1 point with the effect of the old 2 pointer

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2024, 11, 18), <>Fixed an issue where <SpellLink spell={TALENTS_DRUID.HARMONIOUS_BLOOMING_TALENT} /> was counted as only 1 mastery stack.</>, Sref),
   change(date(2024, 10, 27), <>Updated for 11.0.5, handling added / changed talents and added statistics module for <SpellLink spell={TALENTS_DRUID.RENEWING_SURGE_TALENT} />. Fixed an issue where a cast efficiency bar would show for <SpellLink spell={TALENTS_DRUID.TRANQUILITY_TALENT} /> and <SpellLink spell={TALENTS_DRUID.INNERVATE_TALENT} /> even when player didn't take the talents. Fixed an issue where Grove Guardian Swiftmend healing wasn't registering.</>, Sref),
   change(date(2024, 10, 1), <>Updated cooldown graph / tracking to handle <SpellLink spell={TALENTS_DRUID.CONTROL_OF_THE_DREAM_TALENT} /></>, Sref),
   change(date(2024, 9, 23), <>Added breakdown of HoT extensions to <SpellLink spell={TALENTS_DRUID.VERDANT_INFUSION_TALENT}/> statistic tooltip.</>, Sref),

--- a/src/analysis/retail/druid/restoration/constants.ts
+++ b/src/analysis/retail/druid/restoration/constants.ts
@@ -10,6 +10,9 @@ export const LIFEBLOOM_BUFFS: Spell[] = [
   SPELLS.LIFEBLOOM_UNDERGROWTH_HOT_HEAL,
 ];
 
+/** Additional mastery stacks granted by Harmonius Blooming talent */
+export const HARMONIUS_BLOOMING_EXTRA_STACKS = 2;
+
 export function lifebloomSpell(c: Combatant): Spell {
   return c.hasTalent(TALENTS_DRUID.UNDERGROWTH_TALENT)
     ? SPELLS.LIFEBLOOM_UNDERGROWTH_HOT_HEAL

--- a/src/analysis/retail/druid/restoration/modules/core/Mastery.ts
+++ b/src/analysis/retail/druid/restoration/modules/core/Mastery.ts
@@ -14,6 +14,7 @@ import {
   MASTERY_STACK_BUFF_IDS,
   TRIPLE_MASTERY_BENEFIT_IDS,
 } from 'analysis/retail/druid/restoration/constants';
+import { HB_EXTRA_STACKS } from 'analysis/retail/druid/restoration/modules/spells/HarmoniusBlooming';
 
 const DEBUG = false;
 
@@ -54,9 +55,9 @@ class Mastery extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.extraLbStacks = this.selectedCombatant.getTalentRank(
-      TALENTS_DRUID.HARMONIOUS_BLOOMING_TALENT,
-    );
+    this.extraLbStacks = this.selectedCombatant.hasTalent(TALENTS_DRUID.HARMONIOUS_BLOOMING_TALENT)
+      ? HB_EXTRA_STACKS
+      : 0;
     this.lbBuffId = this.selectedCombatant.hasTalent(TALENTS_DRUID.UNDERGROWTH_TALENT)
       ? SPELLS.LIFEBLOOM_UNDERGROWTH_HOT_HEAL.id
       : SPELLS.LIFEBLOOM_HOT_HEAL.id;

--- a/src/analysis/retail/druid/restoration/modules/core/Mastery.ts
+++ b/src/analysis/retail/druid/restoration/modules/core/Mastery.ts
@@ -11,10 +11,10 @@ import { TALENTS_DRUID } from 'common/TALENTS';
 import SPELLS from 'common/SPELLS';
 import {
   ABILITIES_AFFECTED_BY_HEALING_INCREASES,
+  HARMONIUS_BLOOMING_EXTRA_STACKS,
   MASTERY_STACK_BUFF_IDS,
   TRIPLE_MASTERY_BENEFIT_IDS,
 } from 'analysis/retail/druid/restoration/constants';
-import { HB_EXTRA_STACKS } from 'analysis/retail/druid/restoration/modules/spells/HarmoniusBlooming';
 
 const DEBUG = false;
 
@@ -56,7 +56,7 @@ class Mastery extends Analyzer {
     super(options);
 
     this.extraLbStacks = this.selectedCombatant.hasTalent(TALENTS_DRUID.HARMONIOUS_BLOOMING_TALENT)
-      ? HB_EXTRA_STACKS
+      ? HARMONIUS_BLOOMING_EXTRA_STACKS
       : 0;
     this.lbBuffId = this.selectedCombatant.hasTalent(TALENTS_DRUID.UNDERGROWTH_TALENT)
       ? SPELLS.LIFEBLOOM_UNDERGROWTH_HOT_HEAL.id

--- a/src/analysis/retail/druid/restoration/modules/spells/HarmoniusBlooming.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/HarmoniusBlooming.tsx
@@ -7,8 +7,7 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
-
-export const HB_EXTRA_STACKS = 2;
+import { HARMONIUS_BLOOMING_EXTRA_STACKS } from 'analysis/retail/druid/restoration/constants';
 
 /**
  *
@@ -39,7 +38,8 @@ class HarmoniusBlooming extends Analyzer {
     const totalMasteryHealing =
       this.mastery.getMasteryHealing(SPELLS.LIFEBLOOM_HOT_HEAL.id) +
       this.mastery.getMasteryHealing(SPELLS.LIFEBLOOM_UNDERGROWTH_HOT_HEAL.id);
-    const portionFromExtraStacks = HB_EXTRA_STACKS / (HB_EXTRA_STACKS + 1);
+    const portionFromExtraStacks =
+      HARMONIUS_BLOOMING_EXTRA_STACKS / (HARMONIUS_BLOOMING_EXTRA_STACKS + 1);
     return totalMasteryHealing * portionFromExtraStacks;
   }
 
@@ -51,8 +51,8 @@ class HarmoniusBlooming extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            This is the healing enabled by the extra {HB_EXTRA_STACKS} stacks of Mastery from
-            Harmonius Blooming.
+            This is the healing enabled by the extra {HARMONIUS_BLOOMING_EXTRA_STACKS} stacks of
+            Mastery from Harmonius Blooming.
           </>
         }
       >

--- a/src/analysis/retail/druid/restoration/modules/spells/HarmoniusBlooming.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/HarmoniusBlooming.tsx
@@ -8,11 +8,15 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 
+export const HB_EXTRA_STACKS = 2;
+
 /**
+ *
+ *
  * **Harmonius Blooming**
  * Spec Talent
  *
- * Lifebloom counts for (2 / 3) stacks of Mastery: Harmony
+ * Lifebloom counts for 3 stacks of Mastery: Harmony
  */
 class HarmoniusBlooming extends Analyzer {
   static dependencies = {
@@ -21,12 +25,9 @@ class HarmoniusBlooming extends Analyzer {
 
   protected mastery!: Mastery;
 
-  ranks: number;
-
   constructor(options: Options) {
     super(options);
-    this.ranks = this.selectedCombatant.getTalentRank(TALENTS_DRUID.HARMONIOUS_BLOOMING_TALENT);
-    this.active = this.ranks > 0;
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.HARMONIOUS_BLOOMING_TALENT);
   }
 
   /**
@@ -38,7 +39,7 @@ class HarmoniusBlooming extends Analyzer {
     const totalMasteryHealing =
       this.mastery.getMasteryHealing(SPELLS.LIFEBLOOM_HOT_HEAL.id) +
       this.mastery.getMasteryHealing(SPELLS.LIFEBLOOM_UNDERGROWTH_HOT_HEAL.id);
-    const portionFromExtraStacks = this.ranks / (this.ranks + 1);
+    const portionFromExtraStacks = HB_EXTRA_STACKS / (HB_EXTRA_STACKS + 1);
     return totalMasteryHealing * portionFromExtraStacks;
   }
 
@@ -50,8 +51,8 @@ class HarmoniusBlooming extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            This is the healing enabled by the extra {this.ranks}{' '}
-            {this.ranks > 1 ? 'stacks' : 'stack'} of Mastery from Harmonius Blooming.
+            This is the healing enabled by the extra {HB_EXTRA_STACKS} stacks of Mastery from
+            Harmonius Blooming.
           </>
         }
       >


### PR DESCRIPTION
### Description
With Harmonious Blooming changes, we now need to give "2 stacks per rank"

