### PR TITLE
[Augmentation] Fix nil issue with Breath of Eons module when a buff target has missing combatant info

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/evoker';
 
 export default [
+  change(date(2024, 11, 18), <>Fix issue with <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> module when buff targets don't have proper combatant info</>, Vollmer),
   change(date(2024, 10, 24), <>Fix event issues with <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> & MajorDefensives modules</>, Vollmer),
   change(date(2024, 10, 4), <>Fix an issue with external <SpellLink spell={TALENTS.RENEWING_BLAZE_TALENT}/> for MajorDefensive module</>, Vollmer),
   change(date(2024, 10, 4), <>Fix some edgecases for <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> module</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/modules/breahtofeons/BreathOfEonsRotational.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/breahtofeons/BreathOfEonsRotational.tsx
@@ -281,6 +281,11 @@ class BreathOfEonsRotational extends Analyzer {
         GetRelatedEvents(relatedEvent, EBON_MIGHT_BUFF_LINKS).forEach((ebonMightEvent) => {
           if (ebonMightEvent.type === EventType.ApplyBuff) {
             const buffTarget = this.combatants.players[ebonMightEvent.targetID];
+
+            if (!buffTarget) {
+              return;
+            }
+
             currentBuffedTargets.set(buffTarget.name, buffTarget);
           }
         });


### PR DESCRIPTION
### Description
Fixes a nil issue when a buff target doesn't have proper combatant info. 

The problem is most likely deeper rooted in parsing of the individual combatant (Resto shaman in this example), since the log file seems to be un-corrupted, at least on first glance.

### Testing

- Test report URL: `/report/nAxBm6HXgL34hfkz/1-Mythic++Mists+of+Tirna+Scithe+-+Kill+(29:18)/Valyrawr/standard/overview`
