### PR TITLE
[Devastation] Update Shattering Star & Eternity Surge when using TWW1 4pc

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_EVOKER } from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2024, 11, 18), <>Update <SpellLink spell={TALENTS_EVOKER.SHATTERING_STAR_TALENT}/> & <SpellLink spell={TALENTS_EVOKER.ETERNITY_SURGE_TALENT}/> cooldown when using TWW1 4pc</>, Vollmer),
   change(date(2024, 10, 4), <>Fix an issue with external <SpellLink spell={TALENTS_EVOKER.RENEWING_BLAZE_TALENT}/> for MajorDefensive module</>, Vollmer),
   change(date(2024, 9, 10), "Update various Modules & Guide Sections for TWW S1", Vollmer),
   change(date(2024, 9, 6), <>Implement <SpellLink spell={TALENTS_EVOKER.WINGLEADER_TALENT}/> module</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/modules/Abilities.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/Abilities.tsx
@@ -4,6 +4,7 @@ import { SpellbookAbility } from 'parser/core/modules/Ability';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 import SPELLS from 'common/SPELLS';
 import { BASE_EVOKER_RANGE, EMPOWER_BASE_GCD, EMPOWER_MINIMUM_GCD } from '../../shared';
+import { TIERS } from 'game/TIERS';
 
 class Abilities extends CoreAbilities {
   spellbook(): SpellbookAbility[] {
@@ -38,7 +39,9 @@ class Abilities extends CoreAbilities {
           ? SPELLS.ETERNITY_SURGE_FONT.id
           : SPELLS.ETERNITY_SURGE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: combatant.hasTalent(TALENTS.EVENT_HORIZON_TALENT) ? 27 : 30,
+        cooldown:
+          (combatant.hasTalent(TALENTS.EVENT_HORIZON_TALENT) ? 27 : 30) -
+          (combatant.has4PieceByTier(TIERS.TWW1) ? 4 : 0),
         gcd: {
           base: EMPOWER_BASE_GCD,
           minimum: EMPOWER_MINIMUM_GCD,
@@ -53,7 +56,7 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS.SHATTERING_STAR_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 20,
+        cooldown: 20 - (combatant.has4PieceByTier(TIERS.TWW1) ? 4 : 0),
         gcd: {
           base: 1500,
         },


### PR DESCRIPTION
### Description

Simply adds the 4 second CDR applied to both spells when 4pc is equipped.

### Testing

- Test report URL: `/report/t9TgMLD4AQmb73Py/39-Mythic+Queen+Ansurek+-+Wipe+28+(5:24)/Vollmerto/standard/overview`
