### PR TITLE
frost_mage: fix typo in comet storm cast info

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -147,8 +147,8 @@ export const Sref: Contributor = {
   avatar: avatar('sref-avatar.jpg'),
 };
 
-export const Soulmerlin: Contributor = {
-  nickname: 'Soulmerlin',
+export const Soulhealer95: Contributor = {
+  nickname: 'Soul',
   github: 'Soulhealer95',
   mains: [
     {
@@ -171,10 +171,6 @@ export const enragednuke: Contributor = {
 export const Skamer: Contributor = {
   nickname: 'Skamer',
   github: 'Skamer',
-};
-export const Soulhealer95: Contributor = {
-  nickname: 'Soulhealer',
-  github: 'Soulhealer95',
 };
 export const Salarissia: Contributor = {
   nickname: 'Salarissia',

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -146,6 +146,19 @@ export const Sref: Contributor = {
   discord: 'Sref#1337',
   avatar: avatar('sref-avatar.jpg'),
 };
+
+export const Soulmerlin: Contributor = {
+  nickname: 'Soulmerlin',
+  github: 'Soulhealer95',
+  mains: [
+    {
+      name: 'Soulmerlin',
+      spec: SPECS.FROST_MAGE,
+      link: 'https://www.warcraftlogs.com/character/us/sargeras/soulmerlin',
+    },
+  ],
+};
+
 export const Iskalla: Contributor = {
   nickname: 'Iskalla',
   github: 'Iskalla',

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -1,11 +1,11 @@
 import { change, date } from 'common/changelog';
 import { SpellLink } from 'interface';
-import { Sharrq, Earosselot } from 'CONTRIBUTORS';
+import { Sharrq, Earosselot, Soulhealer95 } from 'CONTRIBUTORS';
 import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore
 export default [
-  change(date(2024, 11, 22), <>Fixed a typo in the comet storm hit description</>, Soulmerlin),
+  change(date(2024, 11, 22), <>Fixed a typo in the comet storm hit description</>, Soulhealer95),
   change(date(2024, 10, 18), <>Apls: Updated for Spell Slinger and added for Frostfire for patch 11.0.5</>, Earosselot),
   change(date(2024, 10, 17), <>Fixed Frostfire Bolt on Winters Chill module for Frostfire.</>, Earosselot),
   change(date(2024, 9, 18), <>Updated the Warning Banner explaining the current state of Frost Mage.</>, Sharrq),

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore
 export default [
+  change(date(2024, 11, 22), <>Fixed a typo in the comet storm hit description</>, Soulhealer95),
   change(date(2024, 10, 18), <>Apls: Updated for Spell Slinger and added for Frostfire for patch 11.0.5</>, Earosselot),
   change(date(2024, 10, 17), <>Fixed Frostfire Bolt on Winters Chill module for Frostfire.</>, Earosselot),
   change(date(2024, 9, 18), <>Updated the Warning Banner explaining the current state of Frost Mage.</>, Sharrq),

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore
 export default [
-  change(date(2024, 11, 22), <>Fixed a typo in the comet storm hit description</>, Soulhealer95),
+  change(date(2024, 11, 22), <>Fixed a typo in the comet storm hit description</>, Soulmerlin),
   change(date(2024, 10, 18), <>Apls: Updated for Spell Slinger and added for Frostfire for patch 11.0.5</>, Earosselot),
   change(date(2024, 10, 17), <>Fixed Frostfire Bolt on Winters Chill module for Frostfire.</>, Earosselot),
   change(date(2024, 9, 18), <>Updated the Warning Banner explaining the current state of Frost Mage.</>, Sharrq),

--- a/src/analysis/retail/mage/frost/talents/CometStorm.tsx
+++ b/src/analysis/retail/mage/frost/talents/CometStorm.tsx
@@ -60,7 +60,7 @@ class CometStorm extends Analyzer {
     this.cometStorm.push(cometStormDetails);
 
     let performance = QualitativePerformance.Fail;
-    const count = `${cometStormDetails.shatteredHits} shattered hits / ${cometStormDetails.enemiesHit.length} enemies hitted`;
+    const count = `${cometStormDetails.shatteredHits} shattered hits / ${cometStormDetails.enemiesHit.length} enemies hit`;
     if (enemies.length === 1) {
       if (cometStormDetails.shatteredHits >= 7) {
         performance = QualitativePerformance.Perfect;


### PR DESCRIPTION
very simple grammatical fix from hitted to hit.

### Description

<!-- A brief description of the changes made with this pull request.-->

### Testing
Tested on a local instance.
<!-- How can the reviewer test your changes (if applicable)? -->
check any of the frost mages and the comet storm segment
- Test report URL: `https://www.warcraftlogs.com/reports/pm4BdZry981QRJgV`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/9e28bb8d-60a9-47f0-a51c-9f1188b3b156)
