### PR TITLE
[Arcane Mage] 11.0.5 Update

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -5,6 +5,8 @@ import { change, date } from 'common/changelog';
 import { Sharrq, Sref } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2024, 11, 23), <>Fixed an issue that was preventing the Cast Delay from showing if <SpellLink spell={TALENTS.ARCANE_MISSILES_TALENT} /> ended at the exact same timestamp as the next cast (0 Delay).</>, Sharrq),
+  change(date(2024, 11, 23), <>Updated <SpellLink spell={TALENTS.ARCANE_MISSILES_TALENT} /> guide wording.</>, Sharrq),
   change(date(2024, 11, 23), <>Updated <SpellLink spell={SPELLS.ARCANE_BARRAGE} /> for 11.0.5.</>, Sharrq),
   change(date(2024, 10, 22), <>Updated the Warning banner to reflect the current status of Arcane's analysis. Fixed a typo in the guide.</>, Sharrq),
   change(date(2024, 10, 9), <>Adjusted <SpellLink spell={TALENTS.TOUCH_OF_THE_MAGI_TALENT} /> to account for <SpellLink spell={SPELLS.BURDEN_OF_POWER_BUFF} />, <SpellLink spell={SPELLS.GLORIOUS_INCANDESCENCE_BUFF} />, and <SpellLink spell={SPELLS.INTUITION_BUFF} /> when evaluating <SpellLink spell={SPELLS.ARCANE_CHARGE} />s.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { change, date } from 'common/changelog';
 import { Sharrq, Sref } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2024, 11, 23), <>Updated Spec Support to 11.0.5 and updated Warning.</>, Sharrq),
   change(date(2024, 11, 23), <>Fixed an issue that was preventing the Cast Delay from showing if <SpellLink spell={TALENTS.ARCANE_MISSILES_TALENT} /> ended at the exact same timestamp as the next cast (0 Delay).</>, Sharrq),
   change(date(2024, 11, 23), <>Updated <SpellLink spell={TALENTS.ARCANE_MISSILES_TALENT} /> guide wording.</>, Sharrq),
   change(date(2024, 11, 23), <>Updated <SpellLink spell={SPELLS.ARCANE_BARRAGE} /> for 11.0.5.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { change, date } from 'common/changelog';
 import { Sharrq, Sref } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2024, 11, 23), <>Updated <SpellLink spell={SPELLS.ARCANE_BARRAGE} /> for 11.0.5.</>, Sharrq),
   change(date(2024, 10, 22), <>Updated the Warning banner to reflect the current status of Arcane's analysis. Fixed a typo in the guide.</>, Sharrq),
   change(date(2024, 10, 9), <>Adjusted <SpellLink spell={TALENTS.TOUCH_OF_THE_MAGI_TALENT} /> to account for <SpellLink spell={SPELLS.BURDEN_OF_POWER_BUFF} />, <SpellLink spell={SPELLS.GLORIOUS_INCANDESCENCE_BUFF} />, and <SpellLink spell={SPELLS.INTUITION_BUFF} /> when evaluating <SpellLink spell={SPELLS.ARCANE_CHARGE} />s.</>, Sharrq),
   change(date(2024, 10, 9), <>Fixed an issue that caused <SpellLink spell={TALENTS.ARCANE_MISSILES_TALENT} /> to sometimes incorrectly claim the player had <SpellLink spell={SPELLS.NETHER_PRECISION_BUFF} /> due to incorrect event ordering in the log.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CONFIG.tsx
+++ b/src/analysis/retail/mage/arcane/CONFIG.tsx
@@ -11,7 +11,7 @@ const config: Config = {
   contributors: [Sharrq, Sref],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '11.0.2',
+  patchCompatibility: '11.0.5',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
@@ -50,15 +50,15 @@ const config: Config = {
       frontmatterType: 'guide',
       notes: (
         <AlertWarning>
-          This has not been updated for 11.0.5. Once APL stuff gets resolved following the last
-          minute Arcane nerfs, I will get this updated. If you have questions about this, ping me in
-          the Altered Time Mage Discord <code>@Sharrq</code>
+          This is now updated for 11.0.5. If you notice any issues or if something is missing, ping
+          me in the Altered Time Mage Discord <code>@Sharrq</code>
         </AlertWarning>
       ),
     },
   },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/x3ZYqgMm6VPHXkyc/2-Mythic+Eranog+-+Kill+(2:49)/Bthread/standard',
+  exampleReport:
+    '/report/YG9R3NkhwmBDv871/28-Heroic+Sikran,+Captain+of+the+Sureki+-+Kill+(3:37)/Coeus/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/mage/arcane/SPELLS.ts
+++ b/src/analysis/retail/mage/arcane/SPELLS.ts
@@ -132,6 +132,11 @@ const spells = {
     name: 'Intuition',
     icon: 'spell_shadow_brainwash',
   },
+  AETHERVISION_BUFF: {
+    id: 467634,
+    name: 'Aethervision',
+    icon: 'sha_ability_rogue_bloodyeye_nightborne',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/analysis/retail/mage/arcane/core/ArcaneMissiles.tsx
+++ b/src/analysis/retail/mage/arcane/core/ArcaneMissiles.tsx
@@ -34,7 +34,6 @@ export default class ArcaneMissiles extends Analyzer {
     const clearcasting = this.selectedCombatant.getBuff(SPELLS.CLEARCASTING_ARCANE.id);
 
     this.missileCasts.push({
-      ordinal: this.missileCasts.length + 1,
       cast: event,
       ticks: damageTicks.length,
       aetherAttunement: this.selectedCombatant.hasBuff(SPELLS.AETHER_ATTUNEMENT_PROC_BUFF.id),
@@ -63,14 +62,17 @@ export default class ArcaneMissiles extends Analyzer {
           SPELLS.ARCANE_BLAST,
           SPELLS.ARCANE_BARRAGE,
           SPELLS.ARCANE_EXPLOSION,
+          TALENTS.ARCANE_SURGE_TALENT,
         ],
-        startTimestamp: cast.channel?.timestamp,
+        startTimestamp: m.channelEnd,
         count: 1,
       })[0];
-      if (m.channelEnd && nextCast && nextCast.channel?.beginChannel.timestamp) {
+      if (m.channelEnd && nextCast && nextCast.channel) {
         m.channelEndDelay = nextCast.channel.beginChannel.timestamp - m.channelEnd;
+        m.nextCast = nextCast;
       } else if (m.channelEnd && nextCast) {
         m.channelEndDelay = nextCast.timestamp - m.channelEnd;
+        m.nextCast = nextCast;
       }
     });
   }
@@ -101,7 +103,6 @@ export default class ArcaneMissiles extends Analyzer {
 }
 
 export interface ArcaneMissilesCast {
-  ordinal: number;
   cast: CastEvent;
   ticks: number;
   aetherAttunement: boolean;
@@ -113,4 +114,5 @@ export interface ArcaneMissilesCast {
   channelEnd?: number;
   gcdEnd?: number;
   channelEndDelay?: number;
+  nextCast?: CastEvent;
 }

--- a/src/analysis/retail/mage/arcane/guide/ArcaneMissiles.tsx
+++ b/src/analysis/retail/mage/arcane/guide/ArcaneMissiles.tsx
@@ -116,10 +116,10 @@ class ArcaneMissilesGuide extends Analyzer {
         });
       }
 
-      if (am.channelEndDelay) {
+      if (am.channelEndDelay !== undefined && am.nextCast) {
         tooltipItems.push({
           perf: this.channelDelayUtil(am.channelEndDelay),
-          detail: `Delay Until Next Cast (${formatDurationMillisMinSec(am.channelEndDelay, 3)}s)`,
+          detail: `${formatDurationMillisMinSec(am.channelEndDelay, 3)} Delay Until Next Cast (${am.nextCast.ability.name})`,
         });
       } else {
         tooltipItems.push({ perf: QualitativePerformance.Fail, detail: 'Next Cast Not Found' });
@@ -155,21 +155,20 @@ class ArcaneMissilesGuide extends Analyzer {
     const explanation = (
       <>
         <div>
-          <b>{arcaneMissiles}</b> primarily is your {clearcasting} spender but also increases damage
-          via procs such as {netherPrecision}, {aetherAttunement}, and {highVoltage}. Refer to these
-          guidelines to take advantage of these procs without conflicting with your other procs and
-          buffs.
+          <b>{arcaneMissiles}</b> is your {clearcasting} spender and increases damage via procs such
+          as {netherPrecision}, {aetherAttunement}, and {highVoltage}. The below guidelines take
+          advantage of these procs without conflicting with other procs and buffs.
           <ul>
             <li>
-              If capped on {clearcasting} charges, cast {arcaneMissiles} immediately, regardless of
-              any of the below items, to avoid munching procs (gaining a charge when capped).
+              Cast {arcaneMissiles} immediately if capped on {clearcasting} charges, ignoring any of
+              the below items, to avoid munching procs (gaining a charge while capped).
             </li>
             <li>
               Do not cast {arcaneMissiles} if you have {netherPrecision}.
             </li>
             <li>
-              If you have {aetherAttunement} fully channel {arcaneMissiles}. If you don't, then you
-              can optionally cancel your channel immediately after the GCD ends.
+              If you don't have {aetherAttunement}, you can optionally clip your {arcaneMissiles}{' '}
+              cast once the GCD ends for a small damage boost.
             </li>
           </ul>
         </div>


### PR DESCRIPTION
- Updated Arcane Barrage and Arcane Missiles for 11.0.5
- Fixed an issue that caused the Arcane Missiles Next Cast Delay to not show in the tooltip if the delay was 0 (missiles ended at the exact same timestamp as the next cast)
- Updated spec support to 11.0.5 MaintainedFull
- Updated the default report for the Specs page
- Updated the warning banner to mention that arcane has been updated to 11.0.5