### PR TITLE
[Augmentation] Update Molten Embers multipliers & add guide section

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/evoker';
 
 export default [
+  change(date(2024, 11, 26), <>Update multipliers for <SpellLink spell={TALENTS.MOLTEN_EMBERS_TALENT} /> module & add guide section</>, Vollmer),
   change(date(2024, 11, 18), <>Fix issue with <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> module when buff targets don't have proper combatant info</>, Vollmer),
   change(date(2024, 10, 24), <>Fix event issues with <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> & MajorDefensives modules</>, Vollmer),
   change(date(2024, 10, 4), <>Fix an issue with external <SpellLink spell={TALENTS.RENEWING_BLAZE_TALENT}/> for MajorDefensive module</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/constants.tsx
+++ b/src/analysis/retail/evoker/augmentation/constants.tsx
@@ -28,7 +28,8 @@ export const TECTONIC_LOCUS_MULTIPLIER = 0.5;
 export const VOLCANISM_ESSENCE_REDUCTION = 1;
 export const ANACHRONISM_ESSENCE_CHANCE = 0.35;
 export const SYMBIOTIC_HEALING_INCREASE = 0.03;
-export const MOLTEN_EMBERS_MULTIPLIER = 0.2;
+export const MOLTEN_EMBERS_MULTIPLIER = [0.1, 0.13, 0.2, 0.4];
+export const MOLTEN_EMBERS_MULTIPLIER_NO_BLAST_FURNACE = [0.12, 0.17, 0.3, 1.2];
 
 // Breath of Eons multiplier
 export const BREATH_OF_EONS_MULTIPLIER = 0.1;

--- a/src/analysis/retail/evoker/augmentation/modules/guide/CoreRotation.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/guide/CoreRotation.tsx
@@ -57,6 +57,8 @@ export function CoreRotationSection({ modules, events, info }: GuideProps<typeof
       {modules.sandsOfTime.guideSubsection()}
 
       {modules.shiftingSands.guideSubsection()}
+
+      {modules.moltenEmbers.guideSubsection()}
     </Section>
   );
 }

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MoltenEmbers.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MoltenEmbers.tsx
@@ -139,7 +139,6 @@ class MoltenEmbers extends Analyzer {
 
   private finalize() {
     // finalize performances
-    console.log(this.upheavalCasts);
     this.uses = this.upheavalCasts.map((upheavalCast) => this.upheavalUsage(upheavalCast));
   }
 

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MoltenEmbers.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MoltenEmbers.tsx
@@ -63,7 +63,7 @@ class MoltenEmbers extends Analyzer {
   moltenEmbersDamageSources: DamageSources = {};
 
   hasFontOfMagic = false;
-  perfectMoltenEmbersRank = 3;
+  perfectFireBreathRank = 3;
 
   moltenEmbersAmplifiers = MOLTEN_EMBERS_MULTIPLIER_NO_BLAST_FURNACE;
 
@@ -95,7 +95,7 @@ class MoltenEmbers extends Analyzer {
       TALENTS.FONT_OF_MAGIC_AUGMENTATION_TALENT,
     );
     if (this.hasFontOfMagic) {
-      this.perfectMoltenEmbersRank = 4;
+      this.perfectFireBreathRank = 4;
     }
 
     if (this.selectedCombatant.hasTalent(TALENTS.BLAST_FURNACE_TALENT)) {
@@ -184,7 +184,7 @@ class MoltenEmbers extends Analyzer {
         <SpellLink spell={SPELLS.FIRE_BREATH} /> upranked
       </div>
     );
-    if (this.perfectMoltenEmbersRank === upheavalCast.fireBreathRank) {
+    if (this.perfectFireBreathRank === upheavalCast.fireBreathRank) {
       return {
         performance: QualitativePerformance.Perfect,
         summary: summary,
@@ -204,7 +204,7 @@ class MoltenEmbers extends Analyzer {
         <div>
           <SpellLink spell={SPELLS.FIRE_BREATH} /> cast at rank {upheavalCast.fireBreathRank}. You
           should try to uprank <SpellLink spell={SPELLS.FIRE_BREATH} /> as high as possible (
-          {this.perfectMoltenEmbersRank}).
+          {this.perfectFireBreathRank}).
         </div>
       ),
     };

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MoltenEmbers.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MoltenEmbers.tsx
@@ -11,7 +11,10 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
-import { MOLTEN_EMBERS_MULTIPLIER } from '../../constants';
+import {
+  MOLTEN_EMBERS_MULTIPLIER,
+  MOLTEN_EMBERS_MULTIPLIER_NO_BLAST_FURNACE,
+} from '../../constants';
 import { BLACK_DAMAGE_SPELLS } from 'analysis/retail/evoker/shared/constants';
 import Enemies from 'parser/shared/modules/Enemies';
 import { Talent } from 'common/TALENTS/types';
@@ -62,6 +65,8 @@ class MoltenEmbers extends Analyzer {
   hasFontOfMagic = false;
   perfectMoltenEmbersRank = 3;
 
+  moltenEmbersAmplifiers = MOLTEN_EMBERS_MULTIPLIER_NO_BLAST_FURNACE;
+
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.MOLTEN_EMBERS_TALENT);
@@ -92,6 +97,10 @@ class MoltenEmbers extends Analyzer {
     if (this.hasFontOfMagic) {
       this.perfectMoltenEmbersRank = 4;
     }
+
+    if (this.selectedCombatant.hasTalent(TALENTS.BLAST_FURNACE_TALENT)) {
+      this.moltenEmbersAmplifiers = MOLTEN_EMBERS_MULTIPLIER;
+    }
   }
 
   onDamage(event: DamageEvent) {
@@ -101,7 +110,10 @@ class MoltenEmbers extends Analyzer {
       return;
     }
 
-    const effAmount = calculateEffectiveDamage(event, MOLTEN_EMBERS_MULTIPLIER);
+    const effAmount = calculateEffectiveDamage(
+      event,
+      this.moltenEmbersAmplifiers[this.previousFireBreathRank - 1],
+    );
 
     this.moltenEmbersDamageSources[event.ability.guid].amount += effAmount;
     this.totalMoltenEmbersDamage += effAmount;

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MoltenEmbers.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MoltenEmbers.tsx
@@ -181,7 +181,7 @@ class MoltenEmbers extends Analyzer {
   private getFireBreathRankPerformance(upheavalCast: UpheavalCast) {
     const summary = (
       <div>
-        Upranked <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT
+        <SpellLink spell={SPELLS.FIRE_BREATH} /> upranked
       </div>
     );
     if (this.perfectMoltenEmbersRank === upheavalCast.fireBreathRank) {
@@ -190,8 +190,8 @@ class MoltenEmbers extends Analyzer {
         summary: summary,
         details: (
           <div>
-            <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT active at max rank (
-            {upheavalCast.fireBreathRank}). Good job!
+            <SpellLink spell={SPELLS.FIRE_BREATH} /> cast at max rank ({upheavalCast.fireBreathRank}
+            ). Good job!
           </div>
         ),
       };
@@ -202,8 +202,8 @@ class MoltenEmbers extends Analyzer {
       summary: summary,
       details: (
         <div>
-          <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT active at rank {upheavalCast.fireBreathRank}.
-          You should try to uprank <SpellLink spell={SPELLS.FIRE_BREATH} /> as high as possible (
+          <SpellLink spell={SPELLS.FIRE_BREATH} /> cast at rank {upheavalCast.fireBreathRank}. You
+          should try to uprank <SpellLink spell={SPELLS.FIRE_BREATH} /> as high as possible (
           {this.perfectMoltenEmbersRank}).
         </div>
       ),

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MoltenEmbers.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MoltenEmbers.tsx
@@ -4,7 +4,7 @@ import { formatNumber } from 'common/format';
 
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
-import Events, { DamageEvent } from 'parser/core/Events';
+import Events, { DamageEvent, EmpowerEndEvent, GetRelatedEvents } from 'parser/core/Events';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 
 import Statistic from 'parser/ui/Statistic';
@@ -17,6 +17,12 @@ import Enemies from 'parser/shared/modules/Enemies';
 import { Talent } from 'common/TALENTS/types';
 import Spell from 'common/SPELLS/Spell';
 import DonutChart from 'parser/ui/DonutChart';
+import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
+import { UPHEAVAL_CAST_DAM_LINK } from '../normalizers/CastLinkNormalizer';
+import SpellLink from 'interface/SpellLink';
+import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import ContextualSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
 
 type DamageSources = {
   [key: number]: { amount: number; spell: Spell | Talent };
@@ -31,8 +37,14 @@ const COLORS = [
   'rgb(255, 206, 86)',
 ];
 
+type UpheavalCast = {
+  event: EmpowerEndEvent;
+  fireBreathActive: boolean;
+  fireBreathRank: number;
+};
+
 /**
- * Fire Breath causes enemies to take 20% increased damage from your Black spells.
+ * Fire Breath causes enemies to take up to 40% increased damage from your Black spells, increased based on its empower level.
  */
 class MoltenEmbers extends Analyzer {
   static dependencies = {
@@ -40,8 +52,15 @@ class MoltenEmbers extends Analyzer {
   };
   protected enemies!: Enemies;
 
+  private uses: SpellUse[] = [];
+  private upheavalCasts: UpheavalCast[] = [];
+
+  previousFireBreathRank = 0;
   totalMoltenEmbersDamage: number = 0;
   moltenEmbersDamageSources: DamageSources = {};
+
+  hasFontOfMagic = false;
+  perfectMoltenEmbersRank = 3;
 
   constructor(options: Options) {
     super(options);
@@ -52,8 +71,26 @@ class MoltenEmbers extends Analyzer {
       this.onDamage,
     );
 
+    this.addEventListener(
+      Events.empowerEnd.by(SELECTED_PLAYER).spell([TALENTS.UPHEAVAL_TALENT, SPELLS.UPHEAVAL_FONT]),
+      this.onUpheavalCast,
+    );
+    this.addEventListener(
+      Events.empowerEnd.by(SELECTED_PLAYER).spell([SPELLS.FIRE_BREATH, SPELLS.FIRE_BREATH_FONT]),
+      this.onFireBreathCast,
+    );
+
+    this.addEventListener(Events.fightend, this.finalize);
+
     for (const spell of BLACK_DAMAGE_SPELLS) {
       this.moltenEmbersDamageSources[spell.id] = { amount: 0, spell };
+    }
+
+    this.hasFontOfMagic = this.selectedCombatant.hasTalent(
+      TALENTS.FONT_OF_MAGIC_AUGMENTATION_TALENT,
+    );
+    if (this.hasFontOfMagic) {
+      this.perfectMoltenEmbersRank = 4;
     }
   }
 
@@ -68,6 +105,157 @@ class MoltenEmbers extends Analyzer {
 
     this.moltenEmbersDamageSources[event.ability.guid].amount += effAmount;
     this.totalMoltenEmbersDamage += effAmount;
+  }
+
+  onFireBreathCast(event: EmpowerEndEvent) {
+    this.previousFireBreathRank = event.empowermentLevel;
+  }
+
+  onUpheavalCast(event: EmpowerEndEvent) {
+    const damageEvents = GetRelatedEvents(event, UPHEAVAL_CAST_DAM_LINK);
+    const fireBreathActive = damageEvents.some((e) => {
+      const enemy = this.enemies.getEntity(e);
+      return enemy && enemy.getBuff(SPELLS.FIRE_BREATH_DOT.id);
+    });
+
+    this.upheavalCasts.push({
+      event,
+      fireBreathActive,
+      fireBreathRank: this.previousFireBreathRank,
+    });
+  }
+
+  private finalize() {
+    // finalize performances
+    console.log(this.upheavalCasts);
+    this.uses = this.upheavalCasts.map((upheavalCast) => this.upheavalUsage(upheavalCast));
+  }
+
+  private upheavalUsage(upheavalCast: UpheavalCast): SpellUse {
+    const fireBreathActivePerformance = this.getFireBreathActivePerformance(upheavalCast);
+
+    const checklistItems: ChecklistUsageInfo[] = [
+      {
+        check: 'upheaval-molten-embers-dot-active',
+        timestamp: upheavalCast.event.timestamp,
+        ...fireBreathActivePerformance,
+      },
+    ];
+
+    if (fireBreathActivePerformance.performance === QualitativePerformance.Perfect) {
+      const fireBreathRankPerformance = this.getFireBreathRankPerformance(upheavalCast);
+      checklistItems.push({
+        check: 'upheaval-molten-embers-dot-rank',
+        timestamp: upheavalCast.event.timestamp,
+        ...fireBreathRankPerformance,
+      });
+    }
+
+    const actualPerformance = combineQualitativePerformances(
+      checklistItems.map((item) => item.performance),
+    );
+
+    return {
+      event: upheavalCast.event,
+      performance: actualPerformance,
+      checklistItems,
+      performanceExplanation:
+        actualPerformance !== QualitativePerformance.Fail
+          ? `${actualPerformance} Usage`
+          : 'Bad Usage',
+    };
+  }
+
+  private getFireBreathRankPerformance(upheavalCast: UpheavalCast) {
+    const summary = (
+      <div>
+        Upranked <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT
+      </div>
+    );
+    if (this.perfectMoltenEmbersRank === upheavalCast.fireBreathRank) {
+      return {
+        performance: QualitativePerformance.Perfect,
+        summary: summary,
+        details: (
+          <div>
+            <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT active at max rank (
+            {upheavalCast.fireBreathRank}). Good job!
+          </div>
+        ),
+      };
+    }
+
+    return {
+      performance: QualitativePerformance.Good,
+      summary: summary,
+      details: (
+        <div>
+          <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT active at rank {upheavalCast.fireBreathRank}.
+          You should try to uprank <SpellLink spell={SPELLS.FIRE_BREATH} /> as high as possible (
+          {this.perfectMoltenEmbersRank}).
+        </div>
+      ),
+    };
+  }
+
+  private getFireBreathActivePerformance(upheavalCast: UpheavalCast) {
+    const summary = (
+      <div>
+        <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT active
+      </div>
+    );
+    if (upheavalCast.fireBreathActive) {
+      return {
+        performance: QualitativePerformance.Perfect,
+        summary: summary,
+        details: (
+          <div>
+            <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT active. Good job!
+          </div>
+        ),
+      };
+    }
+
+    return {
+      performance: QualitativePerformance.Fail,
+      summary: summary,
+      details: (
+        <div>
+          <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT wasn't active. You should try to line up{' '}
+          <SpellLink spell={SPELLS.UPHEAVAL} /> with <SpellLink spell={SPELLS.FIRE_BREATH} />.
+        </div>
+      ),
+    };
+  }
+
+  guideSubsection(): JSX.Element | null {
+    if (!this.active) {
+      return null;
+    }
+
+    const explanation = (
+      <section>
+        <strong>
+          <SpellLink spell={TALENTS.MOLTEN_EMBERS_TALENT} />
+        </strong>{' '}
+        amplifies the damage of your Black Spells eg. <SpellLink spell={SPELLS.UPHEAVAL} />, based
+        on the rank of <SpellLink spell={SPELLS.FIRE_BREATH} /> that is active on the target.
+        Ideally you should try to line up both these empowers, whilst making sure to use{' '}
+        <SpellLink spell={SPELLS.FIRE_BREATH} /> at as high rank as possible.
+      </section>
+    );
+
+    return (
+      <ContextualSpellUsageSubSection
+        title="Molten Embers"
+        explanation={explanation}
+        uses={this.uses}
+        castBreakdownSmallText={
+          <> - These boxes represent each cast, colored by how good the usage was.</>
+        }
+        abovePerformanceDetails={<div style={{ marginBottom: 10 }}></div>}
+      />
+    );
   }
 
   statistic() {


### PR DESCRIPTION
### Description

Updated the multipliers to account for the recent talent changes.

Also added a requested guide section for evaluating `Upheaval` casts with regards to `Fire Breath` upranking.

### Testing

- Test report URL: `/report/6rHRPk9cqTj8Vdmx/3-Mythic++Ara-Kara,+City+of+Echoes+-+Kill+(26:20)/Jisoodc/standard/overview`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/7d98d3c1-9ddd-4030-a637-c54c2711aebe)
![image](https://github.com/user-attachments/assets/1ea342f0-5e10-4c9d-b3a6-657cfda8a647)
![image](https://github.com/user-attachments/assets/5615bd21-baa1-422d-8d3b-a0db9da530cc)
![image](https://github.com/user-attachments/assets/e2071634-9804-46b8-96da-34d428ecbe07)
![image](https://github.com/user-attachments/assets/6f98f530-2fbc-4dff-86ab-84b8cc85b9fd)
![image](https://github.com/user-attachments/assets/4b338a20-b273-417e-aa99-3440f88cfd23)

