### PR TITLE
[Discipline] Add Voidblast to a few talents

### DIFF
--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -1,7 +1,8 @@
 import { change, date } from 'common/changelog';
-import { Hana, fel1ne} from 'CONTRIBUTORS';
+import { Hana, fel1ne, Saeldur } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2024, 12, 3), <>Add void blast to words of the pious and void summoner.</>, Saeldur),
   change(date(2024, 10, 26), <>Fix atonement sources module.</>, fel1ne),
   change(date(2024, 9, 23), <>Add void blast to weal and woe</>, Hana),
   change(date(2024, 3, 9), <>The War Within Clean up.</>, Hana),

--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -2,7 +2,7 @@ import { change, date } from 'common/changelog';
 import { Hana, fel1ne, Saeldur } from 'CONTRIBUTORS';
 
 export default [
-  change(date(2024, 12, 3), <>Add void blast to words of the pious and void summoner.</>, Saeldur),
+  change(date(2024, 12, 3), <>Add Void Blast to Words of the Pious, Void Summoner and Train of Thought.</>, Saeldur),
   change(date(2024, 10, 26), <>Fix atonement sources module.</>, fel1ne),
   change(date(2024, 9, 23), <>Add void blast to weal and woe</>, Hana),
   change(date(2024, 3, 9), <>The War Within Clean up.</>, Hana),

--- a/src/analysis/retail/priest/discipline/modules/spells/ShadowCovenant/ShadowCovenant.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/ShadowCovenant/ShadowCovenant.tsx
@@ -155,7 +155,9 @@ class ShadowCovenant extends Analyzer {
             This value includes the healing from bonus atonement healing caused by the damage amped
             and bonus healing to spells which do shadow healing. This number represents the{' '}
             {this.selectedCombatant.hasTalent(TALENTS_PRIEST.MINDBENDER_DISCIPLINE_TALENT)
-              ? 10
+              ? this.selectedCombatant.hasTalent(TALENTS_PRIEST.VOIDWRAITH_TALENT)
+                ? 25
+                : 10
               : 25}
             % amp from <SpellLink spell={TALENTS_PRIEST.SHADOW_COVENANT_TALENT} />, and the extra
             10% amp from <SpellLink spell={TALENTS_PRIEST.TWILIGHT_CORRUPTION_TALENT} /> if it is

--- a/src/analysis/retail/priest/discipline/modules/spells/TrainOfThought.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/TrainOfThought.tsx
@@ -19,7 +19,9 @@ class TrainOfThought extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(TALENTS.TRAIN_OF_THOUGHT_TALENT);
 
     this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell([SPELLS.SMITE, SPELLS.SHADOW_SMITE]),
+      Events.cast
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.SMITE, SPELLS.SHADOW_SMITE, SPELLS.VOID_BLAST_DAMAGE_DISC]),
       this.onCdrCast,
     );
   }

--- a/src/analysis/retail/priest/discipline/modules/spells/VoidSummoner.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/VoidSummoner.tsx
@@ -36,6 +36,7 @@ class VoidSummoner extends Analyzer {
           SPELLS.MIND_BLAST,
           SPELLS.PENANCE_CAST,
           SPELLS.DARK_REPRIMAND_CAST,
+          SPELLS.VOID_BLAST_DAMAGE_DISC,
         ]),
       this.onCdrCast,
     );

--- a/src/analysis/retail/priest/discipline/modules/spells/WordsOfThePious.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/WordsOfThePious.tsx
@@ -12,6 +12,13 @@ import SPELLS from 'common/SPELLS';
 import { getDamageEvent } from '../../normalizers/AtonementTracker';
 
 const WORDS_OF_THE_PIOUS_INCREASE = 0.1;
+const WORDS_OF_THE_PIOUS_SPELLS = [
+  SPELLS.SMITE,
+  SPELLS.SHADOW_SMITE,
+  TALENTS_PRIEST.HOLY_NOVA_TALENT,
+  SPELLS.VOID_BLAST_DAMAGE_DISC,
+];
+const WORDS_OF_THE_PIOUS_SPELL_IDS = WORDS_OF_THE_PIOUS_SPELLS.map((spell) => spell.id);
 
 class WordsOfThePious extends Analyzer {
   healing = 0;
@@ -21,9 +28,7 @@ class WordsOfThePious extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_PRIEST.WORDS_OF_THE_PIOUS_TALENT);
     this.addEventListener(
-      Events.damage
-        .by(SELECTED_PLAYER)
-        .spell([SPELLS.SMITE, SPELLS.SHADOW_SMITE, TALENTS_PRIEST.HOLY_NOVA_TALENT]),
+      Events.damage.by(SELECTED_PLAYER).spell(WORDS_OF_THE_PIOUS_SPELLS),
       this.onDamage,
     );
     this.addEventListener(
@@ -49,13 +54,10 @@ class WordsOfThePious extends Analyzer {
       return;
     }
 
-    if (
-      damageEvent.ability.guid !== TALENTS_PRIEST.HOLY_NOVA_TALENT.id &&
-      damageEvent.ability.guid !== SPELLS.SMITE.id &&
-      damageEvent.ability.guid !== SPELLS.SHADOW_SMITE.id
-    ) {
+    if (!WORDS_OF_THE_PIOUS_SPELL_IDS.includes(damageEvent.ability.guid)) {
       return;
     }
+
     this.healing += calculateEffectiveHealing(event, WORDS_OF_THE_PIOUS_INCREASE);
   }
 


### PR DESCRIPTION
### Description
Couple of small short simple changes to improve module usability without large overhauls:
* Add Void Blast to Words of the Pious, Void Summoner and Train of Thought.
* Fix the Shadow Covenant tooltip with Voidwraith Talent

### Testing

- /reports/41vQLRznPtpFJcNC#fight=31&type=healing
