### PR TITLE
Maelstrom Weapon Buff Normalizer should start at 2nd event

### DIFF
--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 12, 9), <>Mythic+ fix for maelstrom normalizer</>, Seriousnes),
   change(date(2024, 11, 19), <>Fixing incorrect placement of <SpellLink spell={TALENTS.CRASH_LIGHTNING_TALENT}/> in APL.</>, Seriousnes),
   change(date(2024, 11, 13), <>Updating to 11.0.5</>, Seriousnes),
   change(date(2024, 10, 8), <>Fixing prepull casts of <SpellLink spell={TALENTS.FERAL_SPIRIT_TALENT} /> and non-zero starting <SpellLink spell={SPELLS.MAELSTROM_WEAPON_BUFF}/></>, Seriousnes),

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromRefreshBuffNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/MaelstromRefreshBuffNormalizer.tsx
@@ -16,6 +16,7 @@ class MaestromRefreshBuffNormalizer extends EventsNormalizer {
     for (let index = 0; index < events.length; index += 1) {
       const event = events[index];
       if (
+        index > 0 &&
         event.type === EventType.RefreshBuff &&
         event.ability.guid === SPELLS.MAELSTROM_WEAPON_BUFF.id
       ) {


### PR DESCRIPTION
### Description

Bug fix for https://discord.com/channels/316864121536512000/360770373454659585/1315370112265490433

### Testing

Test report loads without error

- Test report URL: `/report/Zt1r8hfVj3kgBqYW/7-Mythic++City+of+Threads+-+Kill+(33:50)/Fslbfsx/standard`
