### PR TITLE
update report URL parsing to handle new WCL URL format

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -40,7 +40,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2024, 12, 7), 'Added support for new style of WCL URLs.', emallson),
+  change(date(2024, 12, 11), 'Added support for new style of WCL URLs.', emallson),
   change(date(2024, 11, 13), <>Updated common hunter spells and talents with script</>, Yellot),
   change(date(2024, 11, 10), <>Added <ItemLink id={ITEMS.SKARDYNS_GRACE.id}/></>, Yellot),
   change(date(2024, 11, 9),  <>Added <ItemLink id={ITEMS.MAD_QUEENS_MANDATE.id}/> and <ItemLink id={ITEMS.OVINAXS_MERCURIAL_EGG.id}/></>, Yellot),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -40,6 +40,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 12, 7), 'Added support for new style of WCL URLs.', emallson),
   change(date(2024, 11, 13), <>Updated common hunter spells and talents with script</>, Yellot),
   change(date(2024, 11, 10), <>Added <ItemLink id={ITEMS.SKARDYNS_GRACE.id}/></>, Yellot),
   change(date(2024, 11, 9),  <>Added <ItemLink id={ITEMS.MAD_QUEENS_MANDATE.id}/> and <ItemLink id={ITEMS.OVINAXS_MERCURIAL_EGG.id}/></>, Yellot),

--- a/src/interface/ReportSelector.test.jsx
+++ b/src/interface/ReportSelector.test.jsx
@@ -23,30 +23,6 @@ describe('ReportSelector', () => {
       'a:AB1CDEf2G3HIjk4L',
     );
   });
-  test('getCode accepts relative url', () => {
-    expect(getReportCode('reports/AB1CDEf2G3HIjk4L')).toBe('AB1CDEf2G3HIjk4L');
-    expect(getReportCode('reports/AB1CDEf2G3HIjk4L/')).toBe('AB1CDEf2G3HIjk4L');
-  });
-  test('getCode accepts anonymous relative url', () => {
-    expect(getReportCode('reports/a:AB1CDEf2G3HIjk4L')).toBe('a:AB1CDEf2G3HIjk4L');
-    expect(getReportCode('reports/a:AB1CDEf2G3HIjk4L/')).toBe('a:AB1CDEf2G3HIjk4L');
-  });
-  test('getCode accepts report code with hashtag', () => {
-    expect(getReportCode('AB1CDEf2G3HIjk4L#fight=6&type=healing&source=10')).toBe(
-      'AB1CDEf2G3HIjk4L',
-    );
-    expect(getReportCode('AB1CDEf2G3HIjk4L/#fight=6&type=healing&source=10')).toBe(
-      'AB1CDEf2G3HIjk4L',
-    );
-  });
-  test('getCode accepts anonymous report code with hashtag', () => {
-    expect(getReportCode('a:AB1CDEf2G3HIjk4L#fight=6&type=healing&source=10')).toBe(
-      'a:AB1CDEf2G3HIjk4L',
-    );
-    expect(getReportCode('a:AB1CDEf2G3HIjk4L/#fight=6&type=healing&source=10')).toBe(
-      'a:AB1CDEf2G3HIjk4L',
-    );
-  });
   test('getCode accepts full url with hashtag', () => {
     expect(
       getReportCode(
@@ -116,46 +92,48 @@ describe('ReportSelector', () => {
       getReportCode(
         'https://www.warcraftlogs.com/reports/AB1CDEf2G3HIjk4#fight=6&type=healing&source=10',
       ),
-    ).toBe(null);
+    ).toBe(undefined);
     expect(
       getReportCode(
         'https://www.warcraftlogs.com/reports/AB1CDEf2G3HIjk-4#fight=6&type=healing&source=10',
       ),
-    ).toBe(null);
+    ).toBe(undefined);
     expect(
       getReportCode(
         'https://www.warcraftlogs.com/reports/AB1CDEf2G3HIjk4AA#fight=6&type=healing&source=10',
       ),
-    ).toBe(null);
+    ).toBe(undefined);
     expect(
       getReportCode('https://www.warcraftlogs.com/reports/#fight=6&type=healing&source=10'),
-    ).toBe(null);
-    expect(getReportCode('https://www.warcraftlogs.com/')).toBe(null);
-    expect(getReportCode('https://www.warcraftlogs.com/reports/<report code>')).toBe(null);
+    ).toBe(undefined);
+    expect(getReportCode('https://www.warcraftlogs.com/')).toBe(undefined);
+    expect(getReportCode('https://www.warcraftlogs.com/reports/<report code>')).toBe(undefined);
   });
   test('getCode does not accept malformed anonymous report codes', () => {
     // Anonymous report URLs
-    expect(getReportCode('https://www.warcraftlogs.com/reports/a:AB1CDEf2G3HIjk4')).toBe(null);
-    expect(getReportCode('https://www.warcraftlogs.com/reports/a:AB1CDEf2G3HIjk4LL')).toBe(null);
+    expect(getReportCode('https://www.warcraftlogs.com/reports/a:AB1CDEf2G3HIjk4')).toBe(undefined);
+    expect(getReportCode('https://www.warcraftlogs.com/reports/a:AB1CDEf2G3HIjk4LL')).toBe(
+      undefined,
+    );
     expect(
       getReportCode(
         'https://www.warcraftlogs.com/reports/a:AB1CDEf2G3HIjk4#fight=6&type=healing&source=10',
       ),
-    ).toBe(null);
+    ).toBe(undefined);
     expect(
       getReportCode(
         'https://www.warcraftlogs.com/reports/a:AB1CDEf2G3HIjk-4#fight=6&type=healing&source=10',
       ),
-    ).toBe(null);
+    ).toBe(undefined);
     expect(
       getReportCode(
         'https://www.warcraftlogs.com/reports/a:AB1CDEf2G3HIjk4AA#fight=6&type=healing&source=10',
       ),
-    ).toBe(null);
+    ).toBe(undefined);
     expect(
       getReportCode('https://www.warcraftlogs.com/reports/a:#fight=6&type=healing&source=10'),
-    ).toBe(null);
-    expect(getReportCode('https://www.warcraftlogs.com/')).toBe(null);
-    expect(getReportCode('https://www.warcraftlogs.com/reports/<report code>')).toBe(null);
+    ).toBe(undefined);
+    expect(getReportCode('https://www.warcraftlogs.com/')).toBe(undefined);
+    expect(getReportCode('https://www.warcraftlogs.com/reports/<report code>')).toBe(undefined);
   });
 });


### PR DESCRIPTION
WCL changed the urls to use query params (?fight=whatever) instead of hash params (#fight=whatever) and this broke our parser.

the new one handles both old and new style, as well as bare report codes. as part of this, i removed some tests (and support for) a few super uncommon code types (e.g. bare code with hash) since that makes parsing way harder for no real reason.

