### PR TITLE
[Mistweaver] Removed Guidance todo from Vivify cast breakdown

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date (2024, 12, 16), <>Got rid of TODO in <SpellLink spell={SPELLS.VIVIFY}/> cast performance breakdown.</>, Vohrr),
   change(date (2024, 11, 6), <>Fixed some missed <SpellLink spell={TALENTS_MONK.RUSHING_WIND_KICK_TALENT}/> checks in Celestial Conduit modules.</>, Vohrr),
   change(date (2024, 10, 31), <>Rewrote <SpellLink spell={TALENTS_MONK.MIST_WRAP_TALENT}/> for accuracy and to include value gained from <SpellLink spell={TALENTS_MONK.MENDING_PROLIFERATION_TALENT}/>. Updated several other modules to filter out healing that is not affected by healing increases.</>, Vohrr),
   change(date (2024, 10, 29), <>Added <SpellLink spell={TALENTS_MONK.RUSHING_WIND_KICK_TALENT}/> to the Talent Healing Breakdown</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
@@ -209,7 +209,7 @@ class Vivify extends Analyzer {
             <small>
               Blue is a perfect cast - high rem count and low overheal. Green is a good cast - high
               rem count and moderate overheal OR moderate rem count and low overheal. Yellow is an
-              ok cast - at least 5 rems and low overheal. Mouseover to see details about each cast.
+              ok cast - at least 5 rems or low overheal. Mouseover to see details about each cast.
             </small>
             <PerformanceBoxRow values={this.castEntries} />
           </div>
@@ -341,7 +341,6 @@ class Vivify extends Analyzer {
     const percentOverheal = overhealPerCast / (healingPerCast + overhealPerCast);
 
     let value = QualitativePerformance.Fail;
-    //TODO: update this for TWW rem averages (pool of mists / heart of the jade serpent)
     const rmConst =
       this.selectedCombatant.getTalentRank(TALENTS_MONK.RISING_MIST_TALENT) * RM_AVG_REM_DIFF;
     if (rems >= 8 + rmConst && percentOverheal <= 0.6) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Vivify.tsx
@@ -94,7 +94,6 @@ class Vivify extends Analyzer {
     return this.cleaveHits / this.casts || 0;
   }
 
-  //TODO: update for pool of mists / heart of the jade serpent
   get estimatedAverageReMs() {
     if (this.risingMistActive) {
       this.expectedAverageReMs = BASE_AVERAGE_REMS * 2;
@@ -207,7 +206,11 @@ class Vivify extends Analyzer {
             <strong>
               <SpellLink spell={SPELLS.VIVIFY} /> casts
             </strong>{' '}
-            <small> GUIDANCE COMING SOON. Mouseover to see details about each cast.</small>
+            <small>
+              Blue is a perfect cast - high rem count and low overheal. Green is a good cast - high
+              rem count and moderate overheal OR moderate rem count and low overheal. Yellow is an
+              ok cast - at least 5 rems and low overheal. Mouseover to see details about each cast.
+            </small>
             <PerformanceBoxRow values={this.castEntries} />
           </div>
           <div style={styleObj}>
@@ -347,7 +350,7 @@ class Vivify extends Analyzer {
       value = QualitativePerformance.Good;
     } else if (rems >= 4 + rmConst && percentOverheal <= 0.7) {
       value = QualitativePerformance.Good;
-    } else if (fullOverhealHits <= 3 + rmConst || percentOverheal <= 0.3) {
+    } else if (fullOverhealHits <= 2 + rmConst || percentOverheal <= 0.3) {
       value = QualitativePerformance.Ok;
     }
 


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/79734c80-35fc-40b6-87eb-ac0794a5e44e)

After
![image](https://github.com/user-attachments/assets/81c896eb-1464-4cd2-b996-6617bd0b7acb)
