### PR TITLE
[Warrior] [Fury] Revamp Fury modules for The War Within

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2565,3 +2565,8 @@ export const Kivlov: Contributor = {
     },
   ],
 };
+
+export const Nevdok: Contributor = {
+  nickname: 'Nevdok',
+  github: 'GeoffreyBalshaw',
+};

--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -1,7 +1,8 @@
-import { nullDozzer } from 'CONTRIBUTORS';
+import { Nevdok, nullDozzer } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2024, 12, 17), 'Update years-old Fury theorycrafting and APL logic', Nevdok),
   change(date(2024, 10, 13), 'Many improvements to cooldown and haste tracking.', nullDozzer),
   change(date(2024, 9, 18), 'Fix various rage bugs! Add some missing spells to spellbook.', nullDozzer),
   change(date(2024, 9, 7), 'Greatly improved tracking of rage generation and sources of rage. Visualized by showing a graph of Rage in the Rage usage tab.', nullDozzer),

--- a/src/analysis/retail/warrior/fury/CombatLogParser.ts
+++ b/src/analysis/retail/warrior/fury/CombatLogParser.ts
@@ -22,6 +22,9 @@ import Checklist from './modules/features/checklist/Module';
 import ColdSteelHotBloodNormalizer from './modules/normalizers/ColdSteelHotBlood';
 import EnrageBeforeBloodthirst from './modules/normalizers/EnrageBeforeBloodthirst';
 import EnrageRefreshNormalizer from './modules/normalizers/EnrageRefresh';
+import CrushingBlow from './modules/spells/CrushingBlow';
+import Bloodbath from './modules/spells/Bloodbath';
+import SlayerExecute from './modules/spells/SlayerExecute';
 import MissedRampage from './modules/spells/MissedRampage';
 import Recklessness from './modules/spells/Recklessness';
 import WhirlWind from './modules/spells/Whirlwind';
@@ -63,6 +66,9 @@ class CombatLogParser extends CoreCombatLogParser {
 
     enrageUptime: Enrage,
 
+    crushingBlow: CrushingBlow,
+    bloodbath: Bloodbath,
+    slayerExecute: SlayerExecute,
     missedRampage: MissedRampage,
     recklessness: Recklessness,
 

--- a/src/analysis/retail/warrior/fury/modules/core/RageDetails.tsx
+++ b/src/analysis/retail/warrior/fury/modules/core/RageDetails.tsx
@@ -2,30 +2,60 @@ import { defineMessage } from '@lingui/macro';
 import WarriorRageDetails from 'analysis/retail/warrior/shared/modules/core/RageDetails';
 import { formatPercentage } from 'common/format';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import { TALENTS_WARRIOR } from 'common/TALENTS';
 
 class RageDetails extends WarriorRageDetails {
+  hasRecklessAbandon: boolean = this.selectedCombatant.hasTalent(
+    TALENTS_WARRIOR.RECKLESS_ABANDON_TALENT,
+  );
+
   get efficiencySuggestionThresholds() {
-    return {
-      actual: 1 - this.wastedPercent,
-      isLessThan: {
-        minor: 0.95,
-        average: 0.9,
-        major: 0.85,
-      },
-      style: ThresholdStyle.PERCENTAGE,
-    };
+    // Reckless Abandon cares much less about wasting rage than Anger Management does
+    if (this.hasRecklessAbandon) {
+      return {
+        actual: this.wastedPercent,
+        isGreaterThan: {
+          minor: 0.75,
+          average: 0.7,
+          major: 0.65,
+        },
+        style: ThresholdStyle.PERCENTAGE,
+      };
+    } else {
+      return {
+        actual: 1 - this.wastedPercent,
+        isLessThan: {
+          minor: 0.95,
+          average: 0.9,
+          major: 0.85,
+        },
+        style: ThresholdStyle.PERCENTAGE,
+      };
+    }
   }
 
   get suggestionThresholds() {
-    return {
-      actual: this.wastedPercent,
-      isGreaterThan: {
-        minor: 0.05,
-        average: 0.1,
-        major: 0.15,
-      },
-      style: ThresholdStyle.PERCENTAGE,
-    };
+    if (this.hasRecklessAbandon) {
+      return {
+        actual: this.wastedPercent,
+        isGreaterThan: {
+          minor: 0.25,
+          average: 0.3,
+          major: 0.35,
+        },
+        style: ThresholdStyle.PERCENTAGE,
+      };
+    } else {
+      return {
+        actual: this.wastedPercent,
+        isGreaterThan: {
+          minor: 0.05,
+          average: 0.1,
+          major: 0.15,
+        },
+        style: ThresholdStyle.PERCENTAGE,
+      };
+    }
   }
 
   suggestions(when: When) {

--- a/src/analysis/retail/warrior/fury/modules/features/checklist/Component.tsx
+++ b/src/analysis/retail/warrior/fury/modules/features/checklist/Component.tsx
@@ -1,7 +1,5 @@
 import SPELLS from 'common/SPELLS';
-import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { SpellLink } from 'interface';
-import { ResourceLink } from 'interface';
 import PreparationRule from 'parser/retail/modules/features/Checklist/PreparationRule';
 import Checklist from 'parser/shared/modules/features/Checklist';
 import {
@@ -46,8 +44,7 @@ const FuryWarriorChecklist = ({ combatant, castEfficiency, thresholds }: Checkli
           <>
             Using <SpellLink spell={SPELLS.RAMPAGE} /> is an important part of the Fury rotation. If
             you aren't Enraged, <SpellLink spell={SPELLS.RAMPAGE} /> should be used as soon as you
-            have enough rage. Also, use <SpellLink spell={SPELLS.RAMPAGE} /> if you would reach
-            maximum rage otherwise.
+            have enough rage.
           </>
         }
       >
@@ -79,18 +76,6 @@ const FuryWarriorChecklist = ({ combatant, castEfficiency, thresholds }: Checkli
         }
       >
         <Requirement name="Downtime" thresholds={thresholds.downtimeSuggestionThresholds} />
-      </Rule>
-      <Rule
-        name="Don't get too angry"
-        description={
-          <>
-            Minimizing your wasted <ResourceLink id={RESOURCE_TYPES.RAGE.id} /> should be top
-            priority as a Fury Warrior, so be sure to use <SpellLink spell={SPELLS.RAMPAGE} /> to
-            avoid this.
-          </>
-        }
-      >
-        <Requirement name="Lost Rage" thresholds={thresholds.rageDetails} />
       </Rule>
 
       <PreparationRule thresholds={thresholds} />

--- a/src/analysis/retail/warrior/fury/modules/features/checklist/Module.tsx
+++ b/src/analysis/retail/warrior/fury/modules/features/checklist/Module.tsx
@@ -5,6 +5,9 @@ import Combatants from 'parser/shared/modules/Combatants';
 import BaseChecklist from 'parser/shared/modules/features/Checklist/Module';
 
 import RageDetails from '../../core/RageDetails';
+import CrushingBlow from '../../spells/CrushingBlow';
+import Bloodbath from '../../spells/Bloodbath';
+import SlayerExecute from '../../spells/SlayerExecute';
 import MissedRampage from '../../spells/MissedRampage';
 import WhirlWind from '../../spells/Whirlwind';
 import AlwaysBeCasting from '../AlwaysBeCasting';
@@ -21,6 +24,9 @@ class Checklist extends BaseChecklist {
     missedRampage: MissedRampage,
     preparationRuleAnalyzer: PreparationRuleAnalyzer,
     whirlWind: WhirlWind,
+    crushingBlow: CrushingBlow,
+    bloodbath: Bloodbath,
+    slayerExecute: SlayerExecute,
   };
 
   // Core
@@ -31,6 +37,9 @@ class Checklist extends BaseChecklist {
 
   // Spells
   protected whirlWind!: WhirlWind;
+  protected crushingBlow!: CrushingBlow;
+  protected bloodbath!: Bloodbath;
+  protected slayerExecute!: SlayerExecute;
 
   // Resources
   protected rageDetails!: RageDetails;
@@ -47,6 +56,9 @@ class Checklist extends BaseChecklist {
           downtimeSuggestionThresholds: this.alwaysBeCasting.downtimeSuggestionThresholds,
           missedRampage: this.missedRampage.suggestionThresholds,
           whirlWind: this.whirlWind.suggestionThresholds,
+          crushingBlow: this.crushingBlow.suggestionThresholds,
+          bloodbath: this.bloodbath.suggestionThresholds,
+          slayerExecute: this.slayerExecute.suggestionThresholds,
         }}
       />
     );

--- a/src/analysis/retail/warrior/fury/modules/spells/Bloodbath.tsx
+++ b/src/analysis/retail/warrior/fury/modules/spells/Bloodbath.tsx
@@ -1,0 +1,93 @@
+import { defineMessage } from '@lingui/macro';
+import SPELLS from 'common/SPELLS';
+import talents, { TALENTS_WARRIOR } from 'common/TALENTS/warrior';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+
+/*  Example log:
+ *  https://www.warcraftlogs.com/reports/vM8zdCPFhZkxfW3y?fight=45&type=casts&source=13
+ */
+
+const VICIOUS_CONTEMPT_EXECUTE_RANGE = 0.35;
+// Track how many times Rampage was used before using the charge of Bloodbath it provides
+class Bloodbath extends Analyzer {
+  missedBloodbaths: number = 0;
+  unenragedCount: number = 0;
+  inViciousContemptRange: boolean = false;
+  hasViciousContemptTalented: boolean = false;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(talents.RECKLESS_ABANDON_TALENT);
+    this.hasViciousContemptTalented = this.selectedCombatant.hasTalent(
+      TALENTS_WARRIOR.VICIOUS_CONTEMPT_TALENT,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.RAMPAGE),
+      this.onRampageCast,
+    );
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLOODBATH), this.onDamage);
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.missedBloodbaths,
+      isGreaterThan: {
+        minor: 0,
+        average: 4,
+        major: 8,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  onDamage(event: DamageEvent) {
+    if (event.hitPoints && event.maxHitPoints) {
+      if (event.hitPoints / event.maxHitPoints < VICIOUS_CONTEMPT_EXECUTE_RANGE) {
+        this.inViciousContemptRange = true;
+      }
+    }
+  }
+
+  onRampageCast() {
+    if (this.selectedCombatant.hasBuff(SPELLS.BLOODBATH_BUFF)) {
+      const bloodcrazeStacks = this.selectedCombatant.getBuffStacks(SPELLS.BLOODCRAZE.id);
+
+      // Technically the sim APL adds a check for <= 115 rage here as well (as of 11.0.7)
+      // But even published guides (wowhead, maxroll) don't reflect that for simplicity
+      // It's a ~0.2% dps gain
+      if (
+        (this.inViciousContemptRange && this.hasViciousContemptTalented) ||
+        bloodcrazeStacks >= 3
+      ) {
+        this.missedBloodbaths += 1;
+      }
+    }
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          There were {actual} times you used <SpellLink spell={SPELLS.RAMPAGE} /> before using your
+          charge of <SpellLink spell={SPELLS.BLOODBATH} />. <SpellLink spell={SPELLS.BLOODBATH} />{' '}
+          is one of your highest damage abilities, and should be used every time it is available, as
+          long as you are already enraged. Refer to Wowhead or Maxroll guides for a full description
+          of when to best use <SpellLink spell={SPELLS.BLOODBATH} /> .
+        </>,
+      )
+        .icon(SPELLS.BLOODBATH.icon)
+        .actual(
+          defineMessage({
+            id: 'warrior.fury.suggestions.bloodbath.missed',
+            message: `${actual} missed Bloodbaths.`,
+          }),
+        )
+        .recommended(`${recommended} is recommended.`),
+    );
+  }
+}
+
+export default Bloodbath;

--- a/src/analysis/retail/warrior/fury/modules/spells/CrushingBlow.tsx
+++ b/src/analysis/retail/warrior/fury/modules/spells/CrushingBlow.tsx
@@ -1,0 +1,67 @@
+import { defineMessage } from '@lingui/macro';
+import SPELLS from 'common/SPELLS';
+import talents from 'common/TALENTS/warrior';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events from 'parser/core/Events';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+
+/*  Example log:
+ *  https://www.warcraftlogs.com/reports/vM8zdCPFhZkxfW3y?fight=45&type=casts&source=13
+ */
+
+// Track how many times Rampage was used before using the charge of Crushing Blow it provides
+class CrushingBlow extends Analyzer {
+  cbBuffRefreshCount: number = 0;
+  unenragedCount: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(talents.RECKLESS_ABANDON_TALENT);
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.RAMPAGE),
+      this.onRampageCast,
+    );
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.cbBuffRefreshCount,
+      isGreaterThan: {
+        minor: 0,
+        average: 4,
+        major: 8,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  onRampageCast() {
+    if (this.selectedCombatant.hasBuff(SPELLS.CRUSHING_BLOW_BUFF)) {
+      this.cbBuffRefreshCount += 1;
+    }
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          There were {actual} times you used <SpellLink spell={SPELLS.RAMPAGE} /> before using your
+          charge of <SpellLink spell={SPELLS.CRUSHING_BLOW} />.{' '}
+          <SpellLink spell={SPELLS.CRUSHING_BLOW} /> is your highest damage ability, and should be
+          used every time it is available, as long as you are already enraged.
+        </>,
+      )
+        .icon(SPELLS.CRUSHING_BLOW.icon)
+        .actual(
+          defineMessage({
+            id: 'warrior.fury.suggestions.crushingblows.missed',
+            message: `${actual} missed Crushing Blows.`,
+          }),
+        )
+        .recommended(`${recommended} is recommended.`),
+    );
+  }
+}
+
+export default CrushingBlow;

--- a/src/analysis/retail/warrior/fury/modules/spells/SlayerExecute.tsx
+++ b/src/analysis/retail/warrior/fury/modules/spells/SlayerExecute.tsx
@@ -1,0 +1,193 @@
+import { defineMessage } from '@lingui/macro';
+import SPELLS from 'common/SPELLS';
+import talents from 'common/TALENTS/warrior';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  ApplyBuffEvent,
+  ApplyDebuffEvent,
+  ApplyDebuffStackEvent,
+  CastEvent,
+  EventType,
+  RefreshBuffEvent,
+  RemoveBuffStackEvent,
+  RemoveDebuffEvent,
+  RemoveDebuffStackEvent,
+} from 'parser/core/Events';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import { currentStacks } from 'parser/shared/modules/helpers/Stacks';
+import SpellUsable from '../features/SpellUsable';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+
+/*  Example log:
+ *  https://www.warcraftlogs.com/reports/vM8zdCPFhZkxfW3y?fight=45&type=casts&source=13
+ *  https://www.warcraftlogs.com/reports/bzfPd1NBxRa9hG7n?fight=17&type=casts&source=15
+ */
+const ASHEN_JUGGERNAUT_DURATION = 15000;
+const SUDDEN_DEATH_DURATION = 12000;
+const BUFF_REFRESH_BUFFER = 6000;
+const RAMPAGE_RAGE_COST = 80;
+const MAX_MARKED_FOR_EXECUTION_STACKS = 3;
+// Track how many times Execute was used prematurely relative to its respective buff/debuffs
+
+class SlayerExecute extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+  protected spellUsable!: SpellUsable;
+
+  overusedExecutes: number = 0;
+  markedForExecutionStacks: number = 0;
+  hasAshenJuggernaut: boolean = false;
+  ashenJuggernautExpirationTimestamp: number = 0;
+  suddenDeathExpirationTimestamp: number = 0;
+  lastSuddenDeathRemoveBuffStackTimestamp: number = 0;
+  ramWasAvailable: boolean = false; //rampage
+  rbWasAvailable: boolean = false; //raging blow
+  ajCount: number = 0;
+  sdCount: number = 0;
+  mfeCount: number = 0;
+  availCount: number = 0;
+  rawCount: number = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(talents.SLAYERS_DOMINANCE_TALENT);
+    this.hasAshenJuggernaut = this.selectedCombatant.hasTalent(talents.ASHEN_JUGGERNAUT_TALENT);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.EXECUTE_FURY), this.onCast);
+
+    this.addEventListener(
+      Events.applydebuff.by(SELECTED_PLAYER).spell(SPELLS.MARKED_FOR_EXECUTION),
+      this.onMarkedForExecutionStackChange,
+    );
+    this.addEventListener(
+      Events.applydebuffstack.by(SELECTED_PLAYER).spell(SPELLS.MARKED_FOR_EXECUTION),
+      this.onMarkedForExecutionStackChange,
+    );
+    this.addEventListener(
+      Events.removedebuff.by(SELECTED_PLAYER).spell(SPELLS.MARKED_FOR_EXECUTION),
+      this.onMarkedForExecutionStackChange,
+    );
+    this.addEventListener(
+      Events.removedebuffstack.by(SELECTED_PLAYER).spell(SPELLS.MARKED_FOR_EXECUTION),
+      this.onMarkedForExecutionStackChange,
+    );
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_DEATH_FURY_TALENT_BUFF),
+      this.onSuddenDeathStackChange,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_DEATH_FURY_TALENT_BUFF),
+      this.onSuddenDeathStackChange,
+    );
+    this.addEventListener(
+      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_DEATH_FURY_TALENT_BUFF),
+      this.updateRemoveBuffStack,
+    );
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.overusedExecutes,
+      isGreaterThan: {
+        minor: 0,
+        average: 5,
+        major: 12,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  onMarkedForExecutionStackChange(
+    event: ApplyDebuffEvent | ApplyDebuffStackEvent | RemoveDebuffStackEvent | RemoveDebuffEvent,
+  ) {
+    this.markedForExecutionStacks = currentStacks(event);
+  }
+
+  updateRemoveBuffStack(event: RemoveBuffStackEvent) {
+    this.lastSuddenDeathRemoveBuffStackTimestamp = event.timestamp;
+  }
+
+  onSuddenDeathStackChange(event: ApplyBuffEvent | RefreshBuffEvent) {
+    // 2->1 stacks triggers refresh buff event, but doesn't extend duration
+    // so ignore those
+    // but we still want to listen to refreshbuff because
+    // 2->2 stacks triggers a refresh event and extends duration
+    if (
+      event.type === EventType.RefreshBuff &&
+      event.timestamp - this.lastSuddenDeathRemoveBuffStackTimestamp < 100
+    ) {
+      return;
+    }
+    this.suddenDeathExpirationTimestamp = event.timestamp + SUDDEN_DEATH_DURATION;
+  }
+
+  onCast(event: CastEvent) {
+    let usedForAshenJuggernaut = false;
+    let usedForSuddenDeath = false;
+    let usedForMarkedForExecution = false;
+
+    if (this.ashenJuggernautExpirationTimestamp - event.timestamp < BUFF_REFRESH_BUFFER) {
+      usedForAshenJuggernaut = true;
+    }
+    // Assume new AJ duration on cast of Execute
+    // which is true unless the execute is parried
+    this.ashenJuggernautExpirationTimestamp = event.timestamp + ASHEN_JUGGERNAUT_DURATION;
+
+    if (
+      this.suddenDeathExpirationTimestamp - event.timestamp < BUFF_REFRESH_BUFFER ||
+      this.selectedCombatant.getBuffStacks(SPELLS.SUDDEN_DEATH_FURY_TALENT_BUFF) === 2
+    ) {
+      usedForSuddenDeath = true;
+    }
+
+    if (this.markedForExecutionStacks === MAX_MARKED_FOR_EXECUTION_STACKS) {
+      usedForMarkedForExecution = true;
+    }
+
+    let rage = 0;
+    const rageResource = event.classResources?.find(
+      (resource) => resource.type === RESOURCE_TYPES.RAGE.id,
+    );
+    if (!rageResource) {
+      return;
+    } else {
+      rage = rageResource.amount / 10;
+    }
+    this.ramWasAvailable = rage > RAMPAGE_RAGE_COST;
+    this.rbWasAvailable = this.spellUsable.isAvailable(SPELLS.RAGING_BLOW.id);
+
+    if (
+      !usedForAshenJuggernaut &&
+      !usedForSuddenDeath &&
+      !usedForMarkedForExecution &&
+      (this.rbWasAvailable || this.ramWasAvailable)
+    ) {
+      this.overusedExecutes += 1;
+    }
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          You cast execute prematurely {actual} times. Execute has powerful buffs and debuffs
+          associated with it, but does relatively little damage on its own. Refer to Wowhead or
+          Maxroll guides for a full description of when to best use{' '}
+          <SpellLink spell={SPELLS.EXECUTE_FURY} />
+        </>,
+      )
+        .icon(SPELLS.EXECUTE_FURY.icon)
+        .actual(
+          defineMessage({
+            id: 'warrior.fury.suggestions.slayerExecute.missed',
+            message: `${actual} premature Executes.`,
+          }),
+        )
+        .recommended(`${recommended} is recommended.`),
+    );
+  }
+}
+
+export default SlayerExecute;

--- a/src/common/SPELLS/warrior.ts
+++ b/src/common/SPELLS/warrior.ts
@@ -495,9 +495,19 @@ const spells = {
     name: 'Crushing Blow',
     icon: 'ability_hunter_swiftstrike',
   },
+  CRUSHING_BLOW_BUFF: {
+    id: 396752,
+    name: 'Crushing Blow',
+    icon: 'ability_hunter_swiftstrike',
+  },
   // spell replacement for bloodthirst when using reckless abondon
   BLOODBATH: {
     id: 335096,
+    name: 'Bloodbath',
+    icon: 'ability_warrior_bloodbath',
+  },
+  BLOODBATH_BUFF: {
+    id: 461288,
     name: 'Bloodbath',
     icon: 'ability_warrior_bloodbath',
   },
@@ -525,6 +535,21 @@ const spells = {
     id: 335082,
     name: 'Frenzy',
     icon: 'ability_rogue_bloodyeye',
+  },
+  BLOODCRAZE: {
+    id: 393951,
+    name: 'Bloodcraze',
+    icon: 'ability_creature_cursed_02',
+  },
+  MARKED_FOR_EXECUTION: {
+    id: 445584,
+    name: 'Marked For Execution',
+    icon: 'ability_blackhand_marked4death',
+  },
+  ASHEN_JUGGERNAUT: {
+    id: 392537,
+    name: 'Ashen Juggernaut',
+    icon: 'warrior_talent_icon_skirmisher',
   },
 
   // Protection:


### PR DESCRIPTION
### Description

Warrior hasn't been updated with major talent and theorycrafting updates in a few years. In particular, the current iteration of WoWAnalyzer places a very high priority on effectively using Rampage and avoiding wasted Rage, which is no longer a very high priority for Fury in most cases. 

This PR updates some existing modules, mostly to account for Rampage's relatively lower priority, as well as adding a few new modules to account for common errors in the most common Fury raid spec

### Testing

- Test report URL: `/report/vM8zdCPFhZkxfW3y/45/13`, `/report/bzfPd1NBxRa9hG7n/17/15`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/2254ffb4-d428-43cf-bd95-36aee8d1ff81)
