### PR TITLE
Initial Chronowarden support for Aug

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -1,9 +1,10 @@
 import { change, date } from 'common/changelog';
-import { Vollmer } from 'CONTRIBUTORS';
+import { Vollmer, KYZ } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/evoker';
 
 export default [
+  change(date(2024, 12, 22), <>Enable <SpellLink spell={TALENTS.CHRONO_FLAME_TALENT}/> and <SpellLink spell={TALENTS.THREADS_OF_FATE_TALENT}/> modules</>, KYZ),
   change(date(2024, 11, 26), <>Update multipliers for <SpellLink spell={TALENTS.MOLTEN_EMBERS_TALENT} /> module & add guide section</>, Vollmer),
   change(date(2024, 11, 18), <>Fix issue with <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> module when buff targets don't have proper combatant info</>, Vollmer),
   change(date(2024, 10, 24), <>Fix event issues with <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> & MajorDefensives modules</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/evoker';
 
 export default [
+  change(date(2024, 12, 22), <>Implement <SpellLink spell={TALENTS.REVERBERATIONS_TALENT}/> module</>, KYZ),
   change(date(2024, 12, 22), <>Enable <SpellLink spell={TALENTS.CHRONO_FLAME_TALENT}/> and <SpellLink spell={TALENTS.THREADS_OF_FATE_TALENT}/> modules</>, KYZ),
   change(date(2024, 11, 26), <>Update multipliers for <SpellLink spell={TALENTS.MOLTEN_EMBERS_TALENT} /> module & add guide section</>, Vollmer),
   change(date(2024, 11, 18), <>Fix issue with <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT} /> module when buff targets don't have proper combatant info</>, Vollmer),

--- a/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
@@ -65,9 +65,9 @@ import {
   UnrelentingSiege,
   Wingleader,
   Slipstream,
+  Chronoflame,
+  ThreadsOfFate,
 } from 'analysis/retail/evoker/shared';
-import Chronoflame from '../shared/modules/talents/hero/chronowarden/Chronoflame';
-import ThreadsOfFate from '../shared/modules/talents/hero/chronowarden/ThreadsOfFate';
 
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {

--- a/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
@@ -67,6 +67,7 @@ import {
   Slipstream,
   Chronoflame,
   ThreadsOfFate,
+  Reverberations,
 } from 'analysis/retail/evoker/shared';
 
 class CombatLogParser extends MainCombatLogParser {
@@ -138,6 +139,7 @@ class CombatLogParser extends MainCombatLogParser {
     slipstream: Slipstream,
     chronoflame: Chronoflame,
     threadsOfFate: ThreadsOfFate,
+    reverberations: Reverberations,
 
     // Features
     buffTrackerGraph: BuffTrackerGraph,

--- a/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
@@ -66,6 +66,8 @@ import {
   Wingleader,
   Slipstream,
 } from 'analysis/retail/evoker/shared';
+import Chronoflame from '../shared/modules/talents/hero/chronowarden/Chronoflame';
+import ThreadsOfFate from '../shared/modules/talents/hero/chronowarden/ThreadsOfFate';
 
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
@@ -134,6 +136,8 @@ class CombatLogParser extends MainCombatLogParser {
     unrelentingSiege: UnrelentingSiege,
     wingLeader: Wingleader,
     slipstream: Slipstream,
+    chronoflame: Chronoflame,
+    threadsOfFate: ThreadsOfFate,
 
     // Features
     buffTrackerGraph: BuffTrackerGraph,

--- a/src/analysis/retail/evoker/shared/index.ts
+++ b/src/analysis/retail/evoker/shared/index.ts
@@ -30,4 +30,5 @@ export { default as Wingleader } from './modules/talents/hero/scalecommander/Win
 export { default as Slipstream } from './modules/talents/hero/scalecommander/Slipstream';
 export { default as Chronoflame } from './modules/talents/hero/chronowarden/Chronoflame';
 export { default as ThreadsOfFate } from './modules/talents/hero/chronowarden/ThreadsOfFate';
+export { default as Reverberations } from './modules/talents/hero/chronowarden/Reverberations';
 export * from './constants';

--- a/src/analysis/retail/evoker/shared/index.ts
+++ b/src/analysis/retail/evoker/shared/index.ts
@@ -28,4 +28,6 @@ export { default as DivertedPower } from './modules/talents/hero/scalecommander/
 export { default as UnrelentingSiege } from './modules/talents/hero/scalecommander/UnrelentingSiege';
 export { default as Wingleader } from './modules/talents/hero/scalecommander/Wingleader';
 export { default as Slipstream } from './modules/talents/hero/scalecommander/Slipstream';
+export { default as Chronoflame } from './modules/talents/hero/chronowarden/Chronoflame';
+export { default as ThreadsOfFate } from './modules/talents/hero/chronowarden/ThreadsOfFate';
 export * from './constants';

--- a/src/analysis/retail/evoker/shared/modules/talents/hero/chronowarden/Reverberations.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/hero/chronowarden/Reverberations.tsx
@@ -1,15 +1,18 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { HealEvent } from 'parser/core/Events';
+import Events, { DamageEvent, HealEvent } from 'parser/core/Events';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import SPELLS from 'common/SPELLS';
+import SPECS from 'game/SPECS';
 
 class Reverberations extends Analyzer {
-  hotHealing: number = 0;
+  dotDamage = 0;
+  hotHealing = 0;
 
   constructor(options: Options) {
     super(options);
@@ -18,13 +21,27 @@ class Reverberations extends Analyzer {
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.SPIRITBLOOM_HOT),
       this.onSbHotHeal,
     );
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.UPHEAVAL_DOT),
+      this.onUhDotDamage,
+    );
   }
 
   onSbHotHeal(event: HealEvent) {
     this.hotHealing += event.amount;
   }
 
+  onUhDotDamage(event: DamageEvent) {
+    this.dotDamage += event.amount;
+  }
+
   statistic() {
+    const returnedItemDone =
+      this.selectedCombatant.spec === SPECS.PRESERVATION_EVOKER ? (
+        <ItemHealingDone amount={this.hotHealing} />
+      ) : (
+        <ItemDamageDone amount={this.dotDamage} />
+      );
     return (
       <Statistic
         position={STATISTIC_ORDER.CORE(5)}
@@ -32,9 +49,7 @@ class Reverberations extends Analyzer {
         category={STATISTIC_CATEGORY.HERO_TALENTS}
       >
         <TalentSpellText talent={TALENTS_EVOKER.REVERBERATIONS_TALENT}>
-          <div>
-            <ItemHealingDone amount={this.hotHealing} />
-          </div>
+          <div>{returnedItemDone}</div>
         </TalentSpellText>
       </Statistic>
     );

--- a/src/analysis/retail/evoker/shared/modules/talents/hero/scalecommander/MassDisintegrate.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/hero/scalecommander/MassDisintegrate.tsx
@@ -50,7 +50,7 @@ class MassDisintegrate extends Analyzer {
     super(options);
     this.active =
       this.selectedCombatant.hasTalent(TALENTS.MASS_DISINTEGRATE_TALENT) ||
-      this.selectedCombatant.hasTalent(TALENTS.ERUPTION_TALENT);
+      this.selectedCombatant.hasTalent(TALENTS.MASS_ERUPTION_TALENT);
     this.isDevastation = this.selectedCombatant.hasTalent(TALENTS.MASS_DISINTEGRATE_TALENT);
 
     this.addEventListener(

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -588,6 +588,11 @@ const spells = {
     name: 'Spiritbloom',
     icon: 'ability_evoker_spiritbloom2',
   },
+  UPHEAVAL_DOT: {
+    id: 431620,
+    name: 'Upheaval',
+    icon: 'ability_evoker_upheaval',
+  },
   CHRONO_FLAME_CAST: {
     id: 431443,
     name: 'Chronoflame',


### PR DESCRIPTION
### Description

- Enabled the Chrono Flame and Thread of Fate modules for Aug. (These already existed for Pres and require no changes to be used for Aug.)
- Adjusted the Reverberations module to also work for Aug.
- Fixed small error causing Mass Eruption module to load based on whether Eruption, rather than Mass Eruption, was talented.

### Testing

![ChronowardenAugInitial](https://github.com/user-attachments/assets/745658e0-a7de-43dd-90dc-5b7c6ba2a3ca)

[Log link](https://www.warcraftlogs.com/reports/dARpygajT62QLVPn?fight=15&source=52)