### PR TITLE
[Warrior] [Arms] Revamp Arms APL for The War Within

### DIFF
--- a/src/analysis/retail/warrior/arms/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/arms/CHANGELOG.tsx
@@ -1,9 +1,10 @@
-import { manu310891, nullDozzer } from 'CONTRIBUTORS';
+import { manu310891, Nevdok, nullDozzer } from 'CONTRIBUTORS';
 import TALENTS from 'common/TALENTS/warrior';
 import { change, date } from 'common/changelog';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 1, 6), 'Update years-old Arms theorycrafting and APL logic', Nevdok),
   change(date(2024, 10, 14), <>Add <SpellLink spell={TALENTS.INTERVENE_TALENT} /> to spellbook. Cooldown adjustments when specced into <SpellLink spell={TALENTS.HONED_REFLEXES_TALENT} />.</>, nullDozzer),
   change(date(2024, 9, 18), 'Fix various rage bugs! Fix bladestorm not being tracked.', nullDozzer),
   change(date(2024, 9, 7), 'Greatly improved tracking of rage generation and sources of rage. Visualized by showing a graph of Rage in the Rage usage tab.', nullDozzer),

--- a/src/analysis/retail/warrior/arms/modules/checklist/Component.tsx
+++ b/src/analysis/retail/warrior/arms/modules/checklist/Component.tsx
@@ -25,7 +25,6 @@ const ArmsWarriorChecklist = ({
       {...props}
     />
   );
-
   return (
     <Checklist>
       <AplRule
@@ -33,12 +32,19 @@ const ArmsWarriorChecklist = ({
         checkResults={checkResults}
         castEfficiency={castEfficiency}
         name="Rotation Efficiency"
-        cooldowns={[SPELLS.COLOSSUS_SMASH, TALENTS.WARBREAKER_TALENT, TALENTS.AVATAR_SHARED_TALENT]}
+        cooldowns={[
+          SPELLS.COLOSSUS_SMASH,
+          TALENTS.WARBREAKER_TALENT,
+          TALENTS.AVATAR_SHARED_TALENT,
+          TALENTS.THUNDEROUS_ROAR_TALENT,
+          SPELLS.BLADESTORM,
+        ]}
         description={
           <div style={{ color: 'white' }}>
             Warrior has a simple rotation. That does not mean the class is trivial to play. Small
             mistakes will compound themselves and result in a large final DPS loss. Use the graphic
             below to see if you are making small rotational mistakes.
+            <br />
             <strong> NOTE:</strong> The priority list below does not include{' '}
             <SpellLink spell={TALENTS.REND_ARMS_TALENT} icon />
             <br />

--- a/src/analysis/retail/warrior/arms/modules/checklist/Module.tsx
+++ b/src/analysis/retail/warrior/arms/modules/checklist/Module.tsx
@@ -11,6 +11,7 @@ import MortalStrike from '../core/Execute/MortalStrike';
 import SweepingStrikes from '../core/SweepingStrikes';
 import AlwaysBeCasting from '../features/AlwaysBeCasting';
 import Component from './Component';
+import TALENTS from 'common/TALENTS/warrior';
 
 class Checklist extends BaseChecklist {
   static dependencies = {
@@ -37,9 +38,12 @@ class Checklist extends BaseChecklist {
 
   render() {
     const checkResults = aplCheck(this.owner.eventHistory, this.owner.info);
+    const executeThreshold = this.owner.info.combatant.hasTalent(TALENTS.MASSACRE_SPEC_TALENT)
+      ? 0.35
+      : 0.2;
     return (
       <Component
-        apl={apl}
+        apl={apl(executeThreshold)}
         checkResults={checkResults}
         combatant={this.combatants.selected}
         castEfficiency={this.castEfficiency}

--- a/src/analysis/retail/warrior/arms/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/warrior/arms/modules/core/AplCheck.tsx
@@ -1,69 +1,257 @@
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warrior';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import SpellLink from 'interface/SpellLink';
 import { suggestion } from 'parser/core/Analyzer';
-import aplCheck, { build } from 'parser/shared/metrics/apl';
+import { AnyEvent } from 'parser/core/Events';
+import aplCheck, { Apl, build, CheckResult, PlayerInfo } from 'parser/shared/metrics/apl';
 import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import * as cnd from 'parser/shared/metrics/apl/conditions';
 
-export const apl = build([
-  //2 Overpower Charges
-  {
-    spell: SPELLS.OVERPOWER,
-    condition: cnd.spellCharges(SPELLS.OVERPOWER, { atLeast: 2, atMost: 2 }),
-  },
-  //Mortal Strike Conditions:
-  // Execute: Deep Wounds < 1 GCD || Enduring Blow || (2 Overpower Stacks && 2 Exploiter Stacks) || Battlelord Buff
-  // Non-Execute: Enduring BLow || 2 Overpower Stacks || Battlelord
-  {
-    spell: SPELLS.MORTAL_STRIKE,
-    condition: cnd.hasTalent(TALENTS.BATTLELORD_TALENT),
-  },
-  {
-    spell: SPELLS.MORTAL_STRIKE,
-    condition: cnd.and(
-      cnd.buffStacks(SPELLS.OVERPOWER, { atLeast: 2 }),
-      cnd.buffStacks(TALENTS.EXECUTIONERS_PRECISION_TALENT, { atLeast: 2 }),
-      cnd.inExecute(),
-    ),
-  },
-  {
-    spell: SPELLS.MORTAL_STRIKE,
-    condition: cnd.and(cnd.buffStacks(SPELLS.OVERPOWER, { atLeast: 2 }), cnd.not(cnd.inExecute())),
-  },
-  // Execute /w Sudden Death
-  { spell: SPELLS.EXECUTE, condition: cnd.buffPresent(SPELLS.SUDDEN_DEATH_ARMS_TALENT_BUFF) },
-  // Skull Splitter No Execute: <55 rage and no sudden death
-  {
-    spell: TALENTS.SKULLSPLITTER_TALENT,
-    condition: cnd.and(
-      cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 55 }),
-      cnd.not(cnd.inExecute()),
-    ),
-  },
-  // Skull Splitter Execute: <45 rage
-  {
-    spell: TALENTS.SKULLSPLITTER_TALENT,
-    condition: cnd.and(cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 45 }), cnd.inExecute()),
-  },
-  SPELLS.OVERPOWER,
-  SPELLS.MORTAL_STRIKE,
-  { spell: SPELLS.WHIRLWIND, condition: cnd.hasTalent(TALENTS.FERVOR_OF_BATTLE_TALENT) },
-  { spell: SPELLS.EXECUTE, condition: cnd.inExecute() },
-  //not fervor + (rage > 50 / cs debuff / not eb lego)
-  // this might be a bit much
-  //SPELLS.SLAM,
-  { spell: SPELLS.SLAM, condition: cnd.not(cnd.hasTalent(TALENTS.FERVOR_OF_BATTLE_TALENT)) },
-  /* {
-    spell: SPELLS.SLAM,
-    condition: cnd.and(
-      cnd.hasNoTalent(SPELLS.FERVOR_OF_BATTLE_TALENT),
-      cnd.or(cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 50 }), cnd.hasNoLegendary(SPELLS.ENDURING_BLOW)),
-    ),
-  }, */
-]);
+const JUGGERNAUT_DURATION = 12000;
 
-export const check = aplCheck(apl);
+// tmy https://www.warcraftlogs.com/reports/Lna7ANqKFbBWkD2Q?fight=20&type=casts&source=376
+// bris https://www.warcraftlogs.com/reports/1R9TkvMF7HLPpVdm?fight=19&type=damage-done&source=43
+// nezy (opp) https://www.warcraftlogs.com/reports/y9gBTjamNH84vGMZ?fight=26&type=damage-done&source=2
+
+const notBladestorming = cnd.not(cnd.buffPresent(SPELLS.BLADESTORM)); // don't get mad about the MS procs from Unhinged
+
+export const apl = (executeThreshold: number): Apl => {
+  const executeUsable = cnd.or(
+    cnd.buffPresent(SPELLS.SUDDEN_DEATH_ARMS_TALENT_BUFF),
+    cnd.and(
+      cnd.inExecute(executeThreshold),
+      cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 200 }),
+    ),
+  );
+
+  return build([
+    // Exe with 3x MFE, 2x SD, refresh Jugg
+    {
+      spell: SPELLS.EXECUTE_GLYPHED,
+      condition: cnd.and(
+        executeUsable,
+        notBladestorming,
+        cnd.or(
+          cnd.debuffStacks(SPELLS.MARKED_FOR_EXECUTION, { atLeast: 3, atMost: 3 }),
+          cnd.buffStacks(SPELLS.SUDDEN_DEATH_ARMS_TALENT_BUFF, { atLeast: 2, atMost: 2 }),
+          cnd.buffRemaining(SPELLS.JUGGERNAUT, JUGGERNAUT_DURATION, { atMost: 3000 }),
+        ),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.EXECUTE_GLYPHED} /> when any of the following conditions are
+          met:
+          <ul>
+            <li>
+              Your target has 3 stacks of <SpellLink spell={SPELLS.MARKED_FOR_EXECUTION} />
+            </li>
+            <li>
+              You have 2 stacks of <SpellLink spell={SPELLS.SUDDEN_DEATH_ARMS_TALENT_BUFF} />
+            </li>
+            <li>
+              Your <SpellLink spell={SPELLS.JUGGERNAUT} /> is about to expire
+            </li>
+          </ul>
+        </>
+      ),
+    },
+
+    // SkS inside execute
+    {
+      spell: TALENTS.SKULLSPLITTER_TALENT,
+      condition: cnd.optionalRule(
+        cnd.and(
+          cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 850 }), // rage is logged 10x higher than the player's "real" value
+          cnd.inExecute(executeThreshold),
+          notBladestorming,
+        ),
+      ),
+      description: (
+        <>
+          (Optional) Cast <SpellLink spell={TALENTS.SKULLSPLITTER_TALENT} /> while below 85 rage and
+          in execute range. You can gamble on getting enough rage from other sources, but on average
+          it's best to avoid that.
+        </>
+      ),
+    },
+
+    // MS inside execute
+    {
+      spell: SPELLS.MORTAL_STRIKE,
+      condition: cnd.and(
+        cnd.debuffStacks(SPELLS.EXECUTIONERS_PRECISION_DEBUFF, { atLeast: 2 }),
+        cnd.buffStacks(SPELLS.LETHAL_BLOWS_BUFF, { atLeast: 1 }),
+        cnd.inExecute(executeThreshold),
+        notBladestorming,
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.MORTAL_STRIKE} /> while in execute range with 2 stacks of{' '}
+          <SpellLink spell={SPELLS.EXECUTIONERS_PRECISION_DEBUFF} /> and{' '}
+          <SpellLink spell={SPELLS.LETHAL_BLOWS_BUFF} /> (Nerub-ar Palace tier set buff)
+        </>
+      ),
+    },
+
+    // OP inside execute with Opp
+    {
+      spell: SPELLS.OVERPOWER,
+      condition: cnd.and(
+        cnd.buffPresent(SPELLS.OPPORTUNIST),
+        cnd.buffStacks(TALENTS.OVERPOWER_TALENT, { atMost: 1 }), // Martial Prowess buff
+        cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 800 }),
+        cnd.inExecute(executeThreshold),
+        notBladestorming,
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.OVERPOWER} /> while in execute range with the following
+          conditions:
+          <ul>
+            <li>
+              You have the <SpellLink spell={SPELLS.OPPORTUNIST} /> buff
+            </li>
+            <li>You are below 80 rage</li>
+            <li>
+              You have fewer than 2 stacks of{' '}
+              <SpellLink spell={TALENTS.OVERPOWER_TALENT}> Martial Prowess</SpellLink>{' '}
+            </li>
+          </ul>
+        </>
+      ),
+    },
+
+    // OP inside execute with FF
+    {
+      spell: SPELLS.OVERPOWER,
+      condition: cnd.and(
+        cnd.hasTalent(TALENTS.FIERCE_FOLLOWTHROUGH_TALENT),
+        cnd.buffStacks(TALENTS.OVERPOWER_TALENT, { atMost: 1 }), // Martial Prowess buff
+        cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 400 }),
+        cnd.inExecute(executeThreshold),
+        notBladestorming,
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.OVERPOWER} /> while in execute range with the following
+          conditions:
+          <ul>
+            <li>You are below 40 rage</li>
+            <li>
+              You have fewer than 2 stacks of{' '}
+              <SpellLink spell={TALENTS.OVERPOWER_TALENT}> Martial Prowess</SpellLink>{' '}
+            </li>
+          </ul>
+        </>
+      ),
+    },
+
+    // Exe in execute
+    {
+      spell: SPELLS.EXECUTE_GLYPHED,
+      condition: cnd.and(executeUsable, cnd.inExecute(executeThreshold), notBladestorming),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.EXECUTE_GLYPHED} /> while in execute range
+        </>
+      ),
+    },
+
+    // OP with FF outside execute
+    {
+      spell: SPELLS.OVERPOWER,
+      condition: cnd.and(
+        cnd.hasTalent(TALENTS.FIERCE_FOLLOWTHROUGH_TALENT),
+        cnd.spellCharges(SPELLS.OVERPOWER, { atLeast: 2 }),
+        notBladestorming,
+        cnd.not(cnd.inExecute(executeThreshold)),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.OVERPOWER} /> when you have 2 charges available
+        </>
+      ),
+    },
+
+    // OP with Opp outside execute
+    {
+      spell: SPELLS.OVERPOWER,
+      condition: cnd.and(
+        cnd.buffPresent(SPELLS.OPPORTUNIST),
+        notBladestorming,
+        cnd.not(cnd.inExecute(executeThreshold)),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.OVERPOWER} /> when you have the{' '}
+          <SpellLink spell={SPELLS.OPPORTUNIST} /> buff
+        </>
+      ),
+    },
+
+    // MS outside execute
+    {
+      spell: SPELLS.MORTAL_STRIKE,
+      condition: cnd.not(cnd.inExecute(executeThreshold)),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.MORTAL_STRIKE} /> while outside execute range
+        </>
+      ),
+    },
+
+    // SkS outside execute
+    {
+      spell: TALENTS.SKULLSPLITTER_TALENT,
+      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold)), notBladestorming),
+      description: (
+        <>
+          Cast <SpellLink spell={TALENTS.SKULLSPLITTER_TALENT} /> while outside execute range
+        </>
+      ),
+    },
+
+    // filler execute
+    {
+      spell: SPELLS.EXECUTE_GLYPHED,
+      condition: cnd.and(executeUsable, cnd.not(cnd.inExecute(executeThreshold)), notBladestorming),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.EXECUTE_GLYPHED} />
+        </>
+      ),
+    },
+
+    // OP
+    {
+      spell: SPELLS.OVERPOWER,
+      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold)), notBladestorming),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.OVERPOWER} />
+        </>
+      ),
+    },
+
+    // Slam
+    {
+      spell: SPELLS.SLAM,
+      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold)), notBladestorming),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.SLAM} />
+        </>
+      ),
+    },
+  ]);
+};
+
+export const check = (events: AnyEvent[], info: PlayerInfo): CheckResult => {
+  const executeThreshold = info.combatant.hasTalent(TALENTS.MASSACRE_SPEC_TALENT) ? 0.35 : 0.2;
+  const check = aplCheck(apl(executeThreshold));
+  return check(events, info);
+};
 
 export default suggestion((events, info) => {
   const { violations } = check(events, info);

--- a/src/analysis/retail/warrior/arms/modules/core/Bladestorm.tsx
+++ b/src/analysis/retail/warrior/arms/modules/core/Bladestorm.tsx
@@ -2,10 +2,9 @@ import { defineMessage } from '@lingui/macro';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warrior';
-import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
-import Events, { EndChannelEvent, CastEvent, DamageEvent } from 'parser/core/Events';
+import Events, { CastEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 
 import SpellUsable from '../features/SpellUsable';
@@ -18,10 +17,8 @@ interface CurrentCast {
   text: string | null;
 }
 
-const RAGE_STARVED_AMOUNT = 50;
-const AVATAR_FORGIVENESS = 4000; // Milliseconds
-const WARBREAKER_FOREGIVENESS = 4000;
-const SWEEPING_STRIKES_FORGIVENESS = 2000;
+const AVATAR_FORGIVENESS = 5000; // Milliseconds
+const WARBREAKER_FORGIVENESS = 5000;
 
 class Bladestorm extends Analyzer {
   static dependencies = {
@@ -48,16 +45,6 @@ class Bladestorm extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.BLADESTORM),
       this._onBladestormCast,
     );
-
-    this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.BLADESTORM_DAMAGE),
-      this._onBladestormDamage,
-    );
-
-    this.addEventListener(
-      Events.EndChannel.by(SELECTED_PLAYER).spell(SPELLS.BLADESTORM),
-      this._onBladestormEnd,
-    );
   }
 
   get suggestionThresholds() {
@@ -65,8 +52,8 @@ class Bladestorm extends Analyzer {
       actual: this.badCasts / this.totalCasts,
       isGreaterThan: {
         minor: 0,
-        average: 0.2,
-        major: 0.5,
+        average: 0.1,
+        major: 0.3,
       },
       style: ThresholdStyle.PERCENTAGE,
     };
@@ -81,91 +68,18 @@ class Bladestorm extends Analyzer {
       enemiesHit: [],
       text: null,
     };
-  }
 
-  _onBladestormDamage(event: DamageEvent) {
-    const enemy = `${event.targetID} ${event.targetInstance || 0}`;
-
-    if (!this.currentCast.enemiesHit.includes(enemy)) {
-      this.currentCast.enemiesHit.push(enemy);
-    }
-  }
-
-  _onBladestormEnd(event: EndChannelEvent) {
     this.wasValidBladestorm();
   }
 
   wasValidBladestorm() {
-    if (this.currentCast.enemiesHit.length > 1) {
-      this.checkMultiTargetRequirements();
-    } else {
-      this.checkSingleTargetRequirements();
-    }
-  }
-
-  checkSingleTargetRequirements() {
-    if (!this.currentCast.event) {
-      return;
-    }
-
-    // Bladestorm should only be used when rage starved
-    const rage =
-      this.currentCast.event.classResources &&
-      this.currentCast.event.classResources.find((e) => e.type === RESOURCE_TYPES.RAGE.id);
-    if (rage && rage.amount > RAGE_STARVED_AMOUNT) {
-      this.badCasts += 1;
-      addInefficientCastReason(
-        this.currentCast.event,
-        'Bladestorm was used while you still had rage to use on higher priority abilities during a single target situation',
-      );
-    }
-  }
-
-  checkMultiTargetRequirements() {
     if (this.currentCast.event === null) {
       return;
     }
 
     let badCast = false;
-
-    // Bladestorm shouldn't overlap with Sweeping Strikes
-    const sweepingStrikesBuff = this.selectedCombatant.getBuff(
-      SPELLS.SWEEPING_STRIKES.id,
-      this.currentCast.event.timestamp,
-    );
-    if (sweepingStrikesBuff && sweepingStrikesBuff.end) {
-      badCast =
-        sweepingStrikesBuff.end - this.currentCast.event.timestamp < SWEEPING_STRIKES_FORGIVENESS;
-    }
-
-    if (badCast && !this.currentCast.text) {
-      this.currentCast.text =
-        'Since Bladestorm does not benefit from Sweeping Strikes, you should not have both up at the same time during mutli-target situations.';
-    }
-
-    // Bladestorm should be aligned with Warbreaker
-    badCast =
-      badCast ||
-      (this.selectedCombatant.hasTalent(TALENTS.WARBREAKER_TALENT) &&
-        this.spellUsable.isAvailable(TALENTS.WARBREAKER_TALENT.id)) ||
-      this.spellUsable.cooldownRemaining(TALENTS.WARBREAKER_TALENT.id) < WARBREAKER_FOREGIVENESS;
-
-    if (badCast && !this.currentCast.text) {
-      this.currentCast.text =
-        'Bladestorm was used while you had Warbreaker available or about to become available in a multi-target situation.';
-    }
-
-    // Bladestorm should be aligned with Avatar
-    badCast =
-      badCast ||
-      (this.selectedCombatant.hasTalent(TALENTS.AVATAR_SHARED_TALENT) &&
-        this.spellUsable.isAvailable(TALENTS.AVATAR_SHARED_TALENT.id)) ||
-      this.spellUsable.cooldownRemaining(TALENTS.AVATAR_SHARED_TALENT.id) < AVATAR_FORGIVENESS;
-
-    if (badCast && !this.currentCast.text) {
-      this.currentCast.text =
-        'Bladestorm was used while you had Avatar available or about to become available in a multi-target situation.';
-    }
+    badCast = this.checkColossusSmashAvailable();
+    badCast = badCast || this.checkAvatarAvailable();
 
     if (badCast) {
       this.badCasts += 1;
@@ -173,15 +87,39 @@ class Bladestorm extends Analyzer {
     }
   }
 
+  checkColossusSmashAvailable(): boolean {
+    const warbreakerTalented = this.selectedCombatant.hasTalent(TALENTS.WARBREAKER_TALENT);
+    const remainingCooldown = warbreakerTalented
+      ? this.spellUsable.cooldownRemaining(TALENTS.WARBREAKER_TALENT.id)
+      : this.spellUsable.cooldownRemaining(SPELLS.COLOSSUS_SMASH.id);
+
+    const aligned = remainingCooldown < WARBREAKER_FORGIVENESS;
+    if (aligned && !this.currentCast.text) {
+      this.currentCast.text =
+        'Bladestorm was used while you had Colossus Smash/Warbreaker available or about to become available.';
+    }
+    return aligned;
+  }
+
+  checkAvatarAvailable(): boolean {
+    const remainingCooldown = this.spellUsable.cooldownRemaining(SPELLS.AVATAR_SHARED.id);
+
+    const aligned = remainingCooldown < AVATAR_FORGIVENESS;
+    if (aligned && !this.currentCast.text) {
+      this.currentCast.text =
+        'Bladestorm was used while you had Avatar available or about to become available.';
+    }
+    return aligned;
+  }
+
   suggestions(when: When) {
     when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
       suggest(
         <>
-          Do not cast <SpellLink spell={SPELLS.BLADESTORM} /> when you have rage to spend during
-          single target fights. In multi-target situations, Bladestorm should not overlap with{' '}
-          <SpellLink spell={SPELLS.SWEEPING_STRIKES} /> and you should try to align Bladestorm with
-          cooldowns such as <SpellLink spell={TALENTS.AVATAR_SHARED_TALENT} /> and{' '}
-          <SpellLink spell={TALENTS.WARBREAKER_TALENT} />
+          It is worth delaying your <SpellLink spell={SPELLS.BLADESTORM} /> for up to 5 seconds to
+          align with cooldowns such as <SpellLink spell={TALENTS.AVATAR_SHARED_TALENT} /> and{' '}
+          <SpellLink spell={SPELLS.COLOSSUS_SMASH} />, but it otherwise should be used as often as
+          possible.
         </>,
       )
         .icon(SPELLS.BLADESTORM.icon)

--- a/src/analysis/retail/warrior/arms/modules/features/CooldownThroughputTracker.tsx
+++ b/src/analysis/retail/warrior/arms/modules/features/CooldownThroughputTracker.tsx
@@ -29,7 +29,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
     },
     {
       spell: TALENTS.COLOSSUS_SMASH_TALENT.id,
-      duration: 10,
+      duration: 13, // blunt instruments talent
       summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
     },
   ];

--- a/src/analysis/retail/warrior/arms/modules/features/RageDetails.tsx
+++ b/src/analysis/retail/warrior/arms/modules/features/RageDetails.tsx
@@ -4,13 +4,16 @@ import { formatPercentage } from 'common/format';
 import { NumberThreshold, ThresholdStyle, When } from 'parser/core/ParseResults';
 
 class RageDetails extends WarriorRageDetails {
+  // Arms doesn't really care about wasting rage
+  // except kind of during execute
+  // but that's handled by the Skullsplitter and OP APL rules
   get efficiencySuggestionThresholds(): NumberThreshold {
     return {
       actual: 1 - this.wastedPercent,
       isLessThan: {
-        minor: 0.95,
-        average: 0.9,
-        major: 0.85,
+        minor: 0.75,
+        average: 0.7,
+        major: 0.65,
       },
       style: ThresholdStyle.PERCENTAGE,
     };
@@ -20,9 +23,9 @@ class RageDetails extends WarriorRageDetails {
     return {
       actual: this.wastedPercent,
       isGreaterThan: {
-        minor: 0.05,
-        average: 0.1,
-        major: 0.15,
+        minor: 0.25,
+        average: 0.3,
+        major: 0.35,
       },
       style: ThresholdStyle.PERCENTAGE,
     };

--- a/src/common/SPELLS/warrior.ts
+++ b/src/common/SPELLS/warrior.ts
@@ -379,10 +379,30 @@ const spells = {
   },
 
   // Arm Talents
+  EXECUTIONERS_PRECISION_DEBUFF: {
+    id: 386633, // ID for the debuff is different from the talent
+    name: "Executioner's Precision",
+    icon: 'inv_sword_48',
+  },
+  FIERCE_FOLLOWTHROUGH_BUFF: {
+    id: 458689,
+    name: 'Fierce Followthrough',
+    icon: 'spell_deathknight_butcher2',
+  },
   IN_FOR_THE_KILL_TALENT_BUFF: {
     id: 248622,
     name: 'In For The Kill',
     icon: 'ability_blackhand_marked4death',
+  },
+  JUGGERNAUT: {
+    id: 383290,
+    name: 'Juggernaut',
+    icon: 'warrior_talent_icon_skirmisher',
+  },
+  OPPORTUNIST: {
+    id: 456120,
+    name: 'Opportunist',
+    icon: 'ability_warrior_weaponmastery',
   },
   SUDDEN_DEATH_ARMS_TALENT_BUFF: {
     id: 52437,
@@ -653,6 +673,11 @@ const spells = {
     id: 410219,
     name: 'Earthen Smash',
     icon: 'inv_misc_head_dragon_red',
+  },
+  LETHAL_BLOWS_BUFF: {
+    id: 455485,
+    name: 'Lethal Blows',
+    icon: 'spell_warrior_sharpenblade',
   },
 
   //Fatality talent is split into 3 IDs, the talent (703), and these two.

--- a/src/parser/shared/metrics/apl/conditions/debuffStacks.tsx
+++ b/src/parser/shared/metrics/apl/conditions/debuffStacks.tsx
@@ -38,7 +38,7 @@ export default function debuffStacks(spell: Spell, range: Range): Condition<numb
       state >= (range.atLeast || 0) && (range.atMost === undefined || state <= range.atMost),
     describe: (tense) => (
       <>
-        enemie {tenseAlt(tense, 'have', 'had')} {formatRange(range)}{' '}
+        enemies {tenseAlt(tense, 'have', 'had')} {formatRange(range)}{' '}
         <SpellLink spell={spell.id} icon /> stacks
       </>
     ),

--- a/src/parser/shared/metrics/apl/conditions/hasResource.tsx
+++ b/src/parser/shared/metrics/apl/conditions/hasResource.tsx
@@ -8,9 +8,12 @@ import { Range, formatRange } from './index';
 const castResource = (resource: Resource, event: AplTriggerEvent): ClassResources | undefined =>
   event.classResources?.find(({ type }) => type === resource.id);
 
-const rangeSatisfied = (actualAmount: number, range: Range): boolean =>
-  actualAmount >= (range.atLeast || 0) &&
-  (range.atMost === undefined || actualAmount <= range.atMost);
+const rangeSatisfied = (actualAmount: number, range: Range): boolean => {
+  return (
+    actualAmount >= (range.atLeast || 0) &&
+    (range.atMost === undefined || actualAmount <= range.atMost)
+  );
+};
 
 // NOTE: this doesn't explicitly model natural regen (mana, energy, focus) but
 // when the classResources are present it does use those as the main source of

--- a/src/parser/shared/modules/features/Checklist/Requirement.tsx
+++ b/src/parser/shared/modules/features/Checklist/Requirement.tsx
@@ -80,7 +80,7 @@ class Requirement extends React.PureComponent<Props> {
         <div className="flex">
           <div className="flex-main">{name}</div>
           {tooltip && (
-            <div className="flex-sub" style={{ marginLeft: 10 }}>
+            <div className="flex-sub content-middle" style={{ marginLeft: 10 }}>
               <Tooltip content={tooltip}>
                 <div>
                   <InformationIcon />


### PR DESCRIPTION
### Description

The Arms Warrior APL hasn't been updated in many years, leading to it providing recommendations that are no longer in line with guides and the sim APL. This PR primarily aims to update the AplCheck to match the [current sim APL](https://github.com/simulationcraft/simc/blob/thewarwithin/profiles/TWW1/TWW1_Warrior_Arms.simc), as well as some tweaks to logic around Bladestorm.

Note that many top logs intentionally play "incorrectly" to gamble on buff refreshes and rage refunds - these changes aim to replicate the sim APL's recommendations for average cases, not high-roll gambling cases.

### Testing


- Test report URL: `/report/1R9TkvMF7HLPpVdm/19/43`, `/report/Lna7ANqKFbBWkD2Q/20/376`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/b34aa0e5-6ebd-49b9-a593-66a0cc428bdd)
![image](https://github.com/user-attachments/assets/d8a95912-127e-4fd3-baae-a868e34c316b)

![image](https://github.com/user-attachments/assets/983d7119-7519-4b27-9151-17c99f120ca9)
![image](https://github.com/user-attachments/assets/4f7c1b95-918a-483b-ad5b-571a6e80d6fd)
