### PR TITLE
Fix crashes in Surging Totem & Ascendance analysis

### DIFF
--- a/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
@@ -1,12 +1,11 @@
 import { change, date } from 'common/changelog';
 import TALENTS from 'common/TALENTS/shaman';
-import {
-  Seriousnes,
-} from 'CONTRIBUTORS';
+import { emallson, Seriousnes } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 1, 6), <>Fix crash in <SpellLink spell={TALENTS.ASCENDANCE_ELEMENTAL_TALENT} /> analysis when <SpellLink spell={TALENTS.DEEPLY_ROOTED_ELEMENTS_TALENT} /> is used and <SpellLink spell={TALENTS.ASCENDANCE_ELEMENTAL_TALENT} /> is not cast.</>, emallson),
   change(date(2024, 11, 17), <>Initial support for 11.0.5</>, Seriousnes),
   change(date(2024, 9, 28), <>Fixed <SpellLink spell={TALENTS.SURGE_OF_POWER_TALENT} /> statistic incorrectly showing as <SpellLink spell={TALENTS.MASTER_OF_THE_ELEMENTS_ELEMENTAL_TALENT} /></>, Seriousnes),
   change(date(2024, 9, 28), <>Updating <SpellLink spell={TALENTS.STORMKEEPER_TALENT} /> analysis</>, Seriousnes),

--- a/src/analysis/retail/shaman/elemental/modules/talents/Ascendance.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/talents/Ascendance.tsx
@@ -132,6 +132,8 @@ class Ascendance extends MajorCooldown<AscendanceCooldownCast> {
     this.addEventListener(Events.any.by(SELECTED_PLAYER), this.onCast);
 
     if (this.selectedCombatant.hasTalent(TALENTS.DEEPLY_ROOTED_ELEMENTS_TALENT)) {
+      // initialize the ascendance proc counter in case the player cast a proc-eligible spell before casting ascendance
+      this.castsBeforeAscendanceProc.push({ count: 0 });
       this.addEventListener(
         Events.cast
           .by(SELECTED_PLAYER)

--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -1,20 +1,14 @@
-import { SpellLink } from 'interface'
+import { SpellLink } from 'interface';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
-import SPELLS from 'common/SPELLS'
+import SPELLS from 'common/SPELLS';
 import { change, date } from 'common/changelog';
 import { SHAMAN_TWW1_ID } from 'common/ITEMS/dragonflight';
 import ItemSetLink from 'interface/ItemSetLink';
-import {
-  Seriousnes,
-  Ypp,
-  Texleretour,
-  Vetyst,
-  PandaGoesBaa,
-} from 'CONTRIBUTORS';
-
+import { Seriousnes, Ypp, Texleretour, Vetyst, PandaGoesBaa, emallson } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2025, 1, 6), <>Fix crash in <SpellLink spell={TALENTS_SHAMAN.SURGING_TOTEM_TALENT} /> analysis when cast pre-pull.</>, emallson),
   change(date(2024, 10, 12), <>Fixed cooldowns for totems, <SpellLink spell={TALENTS_SHAMAN.TOTEMIC_RECALL_TALENT}/>, and <SpellLink spell={TALENTS_SHAMAN.ASCENDANCE_RESTORATION_TALENT}/> not properly accounting for cooldown reduction talents like <SpellLink spell={TALENTS_SHAMAN.FIRST_ASCENDANT_TALENT}/>.</>, PandaGoesBaa),
   change(date(2024, 10, 6), <>Fix another pre-pull error with <SpellLink spell={TALENTS_SHAMAN.SURGING_TOTEM_TALENT}/>.</>, Vetyst),
   change(date(2024, 9, 26), <>Fixed <SpellLink spell={TALENTS_SHAMAN.SURGING_TOTEM_TALENT}/> when used on pre-pull.</>, Vetyst),

--- a/src/analysis/retail/shaman/restoration/modules/talents/totemic/SurgingTotem.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/totemic/SurgingTotem.tsx
@@ -189,6 +189,15 @@ class SurgingTotem extends Analyzer {
       this.whirlingMotesExpired[spellId] += 1;
     } else {
       this.whirlingMotesConsumed[spellId] += 1;
+      if (this.SurgingTotemCasts.length === 0) {
+        // it is possible to have one of the buffs pre-pull. make up a cast at 0 if that occurred
+        this.SurgingTotemCasts.push({
+          timestamp: 0,
+          WhirlingAir: 0,
+          WhirlingEarth: 0,
+          WhirlingWater: 0,
+        });
+      }
       switch (event.ability.guid) {
         case SPELLS.WHIRLING_AIR.id: {
           this.SurgingTotemCasts[this.SurgingTotemCasts.length - 1].WhirlingAir = 1;


### PR DESCRIPTION
### Description

reported in discord.

- Ascendance (@Seriousnes): https://www.warcraftlogs.com/reports/AndLvgWprm73JNMK?fight=last&type=casts&source=75&ability=114050 note that the player basically never casts the spell
- Surging Totems (@danny-janse): couple reports, but easy to see here: https://www.warcraftlogs.com/reports/ZfNXvxwmznpPF63Y?type=summary&source=15&fight=12&view=events `Ctrl-F` Whirling. They lose the buff without casting Surging Totem because they cast it pre-pull. Ultimately, this should get pre-pull normalization to properly reflect cooldown. However, for the moment this stops the crash.
