### PR TITLE
[Warrior] [Fury] Add inefficient cast reasons for slayer fury

### DIFF
--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { Nevdok, nullDozzer } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2025, 1, 7), 'Add inefficient cast alerts to timeline', Nevdok),
   change(date(2024, 12, 17), 'Update years-old Fury theorycrafting and APL logic', Nevdok),
   change(date(2024, 10, 13), 'Many improvements to cooldown and haste tracking.', nullDozzer),
   change(date(2024, 9, 18), 'Fix various rage bugs! Add some missing spells to spellbook.', nullDozzer),

--- a/src/analysis/retail/warrior/fury/modules/spells/Bloodbath.tsx
+++ b/src/analysis/retail/warrior/fury/modules/spells/Bloodbath.tsx
@@ -3,7 +3,8 @@ import SPELLS from 'common/SPELLS';
 import talents, { TALENTS_WARRIOR } from 'common/TALENTS/warrior';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent } from 'parser/core/Events';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
+import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 
 /*  Example log:
@@ -51,7 +52,7 @@ class Bloodbath extends Analyzer {
     }
   }
 
-  onRampageCast() {
+  onRampageCast(event: CastEvent) {
     if (this.selectedCombatant.hasBuff(SPELLS.BLOODBATH_BUFF)) {
       const bloodcrazeStacks = this.selectedCombatant.getBuffStacks(SPELLS.BLOODCRAZE.id);
 
@@ -63,6 +64,7 @@ class Bloodbath extends Analyzer {
         bloodcrazeStacks >= 3
       ) {
         this.missedBloodbaths += 1;
+        addInefficientCastReason(event, 'Rampage was used before using Bloodbath');
       }
     }
   }

--- a/src/analysis/retail/warrior/fury/modules/spells/CrushingBlow.tsx
+++ b/src/analysis/retail/warrior/fury/modules/spells/CrushingBlow.tsx
@@ -3,7 +3,8 @@ import SPELLS from 'common/SPELLS';
 import talents from 'common/TALENTS/warrior';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events from 'parser/core/Events';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
+import Events, { CastEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 
 /*  Example log:
@@ -36,9 +37,10 @@ class CrushingBlow extends Analyzer {
     };
   }
 
-  onRampageCast() {
+  onRampageCast(event: CastEvent) {
     if (this.selectedCombatant.hasBuff(SPELLS.CRUSHING_BLOW_BUFF)) {
       this.cbBuffRefreshCount += 1;
+      addInefficientCastReason(event, 'Rampage was used before using Crushing Blow');
     }
   }
 

--- a/src/analysis/retail/warrior/fury/modules/spells/SlayerExecute.tsx
+++ b/src/analysis/retail/warrior/fury/modules/spells/SlayerExecute.tsx
@@ -18,6 +18,7 @@ import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import { currentStacks } from 'parser/shared/modules/helpers/Stacks';
 import SpellUsable from '../features/SpellUsable';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
 /*  Example log:
  *  https://www.warcraftlogs.com/reports/vM8zdCPFhZkxfW3y?fight=45&type=casts&source=13
@@ -165,6 +166,10 @@ class SlayerExecute extends Analyzer {
       (this.rbWasAvailable || this.ramWasAvailable)
     ) {
       this.overusedExecutes += 1;
+      addInefficientCastReason(
+        event,
+        'Execute was used without 3 stacks of Marked for Execution, or when neither Ashen Juggernaut or Sudden Death were near expiring',
+      );
     }
   }
 


### PR DESCRIPTION
### Description

Support for some common Fury rotational errors was added in https://github.com/WoWAnalyzer/WoWAnalyzer/pull/7205, but I wasn't aware at the time of the `addInefficientCastReason()` function to highlight the specific casts on the timeline view. This PR is just to add those ineffecient cast function calls into the checks for Crushing Blow, Bloodbath, and Execute (Slayer).

### Testing

- Test report URL: `/report/vM8zdCPFhZkxfW3y/45-Mythic+Nexus-Princess+Ky'veza+-+Kill+(6:22)/Sskeed/standard/timeline`, `/report/bzfPd1NBxRa9hG7n/17-Mythic+Nexus-Princess+Ky'veza+-+Kill+(6:01)/Bigbowwl/standard/timeline`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/f56be3aa-34cc-489c-804c-6864203e5933)
![image](https://github.com/user-attachments/assets/73a49d78-4672-4972-9be8-c09d705a64ae)
