### PR TITLE
[Warrior] [Arms] Add Colossus APL and support Demolish

### DIFF
--- a/src/analysis/retail/warrior/arms/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/arms/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { change, date } from 'common/changelog';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 1, 9), 'Add support for Colossus hero spec', Nevdok),
   change(date(2025, 1, 6), 'Update years-old Arms theorycrafting and APL logic', Nevdok),
   change(date(2024, 10, 14), <>Add <SpellLink spell={TALENTS.INTERVENE_TALENT} /> to spellbook. Cooldown adjustments when specced into <SpellLink spell={TALENTS.HONED_REFLEXES_TALENT} />.</>, nullDozzer),
   change(date(2024, 9, 18), 'Fix various rage bugs! Fix bladestorm not being tracked.', nullDozzer),

--- a/src/analysis/retail/warrior/arms/CombatLogParser.tsx
+++ b/src/analysis/retail/warrior/arms/CombatLogParser.tsx
@@ -49,6 +49,9 @@ import SpellReflection from '../shared/modules/talents/SpellReflection';
 import FatalMark from './modules/talents/FatalMark';
 import SkullsplitterDotNormalizer from './normalizers/SkullsplitterExpiredDots';
 import BlademastersTormentNormalizer from './modules/talents/BlademastersTorment';
+import UnhingedMortalStrikeNormalizer from './normalizers/UnhingedMortalStrikeNormalizer';
+import Demolish from './modules/talents/Demolish';
+import DemolishNormalizer from './normalizers/DemolishNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -66,6 +69,8 @@ class CombatLogParser extends CoreCombatLogParser {
     improvedExecuteNormalizer: ImprovedExecuteNormalizer,
     skullsplitterDotNormalizer: SkullsplitterDotNormalizer,
     blademaastersTormetNormalizer: BlademastersTormentNormalizer,
+    unhingedMortalStrikeNormalizer: UnhingedMortalStrikeNormalizer,
+    demolishNormalizer: DemolishNormalizer,
 
     // WarriorCore
     abilities: Abilities,
@@ -117,6 +122,7 @@ class CombatLogParser extends CoreCombatLogParser {
     fatalMark: FatalMark,
     ChampionsSpear: ChampionsSpear,
     ChampionsMight: ChampionsMight,
+    demolish: Demolish,
 
     // Debuggers
     rageCountDebugger: RageCountDebugger,

--- a/src/analysis/retail/warrior/arms/modules/Abilities.ts
+++ b/src/analysis/retail/warrior/arms/modules/Abilities.ts
@@ -80,6 +80,19 @@ class Abilities extends CoreAbilities {
         },
         enabled: !false,
       },
+      {
+        spell: TALENTS.DEMOLISH_TALENT.id,
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: 45,
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.9,
+        },
+        enabled: combatant.hasTalent(TALENTS.DEMOLISH_TALENT),
+      },
       // Rotational AOE
       {
         spell: TALENTS.WARBREAKER_TALENT.id,

--- a/src/analysis/retail/warrior/arms/modules/checklist/Component.tsx
+++ b/src/analysis/retail/warrior/arms/modules/checklist/Component.tsx
@@ -38,6 +38,7 @@ const ArmsWarriorChecklist = ({
           TALENTS.AVATAR_SHARED_TALENT,
           TALENTS.THUNDEROUS_ROAR_TALENT,
           SPELLS.BLADESTORM,
+          SPELLS.DEMOLISH,
         ]}
         description={
           <div style={{ color: 'white' }}>

--- a/src/analysis/retail/warrior/arms/modules/checklist/Module.tsx
+++ b/src/analysis/retail/warrior/arms/modules/checklist/Module.tsx
@@ -11,7 +11,7 @@ import MortalStrike from '../core/Execute/MortalStrike';
 import SweepingStrikes from '../core/SweepingStrikes';
 import AlwaysBeCasting from '../features/AlwaysBeCasting';
 import Component from './Component';
-import TALENTS from 'common/TALENTS/warrior';
+import Demolish from '../talents/Demolish';
 
 class Checklist extends BaseChecklist {
   static dependencies = {
@@ -25,6 +25,7 @@ class Checklist extends BaseChecklist {
     mortalStrike: MortalStrike,
     sweepingStrikes: SweepingStrikes,
     bladestorm: Bladestorm,
+    demolish: Demolish,
   };
   protected combatants!: Combatants;
   protected castEfficiency!: CastEfficiency;
@@ -35,15 +36,13 @@ class Checklist extends BaseChecklist {
   protected mortalStrike!: MortalStrike;
   protected sweepingStrikes!: SweepingStrikes;
   protected bladestorm!: Bladestorm;
+  protected demolish!: Demolish;
 
   render() {
     const checkResults = aplCheck(this.owner.eventHistory, this.owner.info);
-    const executeThreshold = this.owner.info.combatant.hasTalent(TALENTS.MASSACRE_SPEC_TALENT)
-      ? 0.35
-      : 0.2;
     return (
       <Component
-        apl={apl(executeThreshold)}
+        apl={apl(this.owner.info)}
         checkResults={checkResults}
         combatant={this.combatants.selected}
         castEfficiency={this.castEfficiency}
@@ -56,6 +55,7 @@ class Checklist extends BaseChecklist {
           mortalStrikeUsage: this.mortalStrike.mortalStrikeUsageThresholds,
           badSweepingStrikes: this.sweepingStrikes.suggestionThresholds,
           badBladestorms: this.bladestorm.suggestionThresholds,
+          badDemolishes: this.demolish.suggestionThresholds,
         }}
       />
     );

--- a/src/analysis/retail/warrior/arms/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/warrior/arms/modules/core/AplCheck.tsx
@@ -1,22 +1,34 @@
 import SPELLS from 'common/SPELLS';
+import Spell from 'common/SPELLS/Spell';
 import TALENTS from 'common/TALENTS/warrior';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import SpellLink from 'interface/SpellLink';
 import { suggestion } from 'parser/core/Analyzer';
 import { AnyEvent } from 'parser/core/Events';
-import aplCheck, { Apl, build, CheckResult, PlayerInfo } from 'parser/shared/metrics/apl';
+import aplCheck, {
+  Apl,
+  build,
+  CheckResult,
+  Condition,
+  PlayerInfo,
+} from 'parser/shared/metrics/apl';
 import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import * as cnd from 'parser/shared/metrics/apl/conditions';
 
 const JUGGERNAUT_DURATION = 12000;
+export const MASSACRE_EXECUTE_THRESHOLD = 0.35;
+export const DEFAULT_EXECUTE_THRESHOLD = 0.2;
 
 // tmy https://www.warcraftlogs.com/reports/Lna7ANqKFbBWkD2Q?fight=20&type=casts&source=376
 // bris https://www.warcraftlogs.com/reports/1R9TkvMF7HLPpVdm?fight=19&type=damage-done&source=43
 // nezy (opp) https://www.warcraftlogs.com/reports/y9gBTjamNH84vGMZ?fight=26&type=damage-done&source=2
+// walhe (col) https://www.warcraftlogs.com/reports/Ft8NByGLZ64AMX2f?fight=14&type=summary&source=12
+// pravum (col, wb, no massacre) https://www.warcraftlogs.com/reports/WTgD24mMz6wYaBL1?fight=5&type=summary&source=138
 
-const notBladestorming = cnd.not(cnd.buffPresent(SPELLS.BLADESTORM)); // don't get mad about the MS procs from Unhinged
-
-export const apl = (executeThreshold: number): Apl => {
+export const apl = (info: PlayerInfo): Apl => {
+  const executeThreshold = info.combatant.hasTalent(TALENTS.MASSACRE_SPEC_TALENT)
+    ? MASSACRE_EXECUTE_THRESHOLD
+    : DEFAULT_EXECUTE_THRESHOLD;
   const executeUsable = cnd.or(
     cnd.buffPresent(SPELLS.SUDDEN_DEATH_ARMS_TALENT_BUFF),
     cnd.and(
@@ -24,14 +36,26 @@ export const apl = (executeThreshold: number): Apl => {
       cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 200 }),
     ),
   );
+  const executeSpell = info.combatant.hasTalent(TALENTS.MASSACRE_SPEC_TALENT)
+    ? SPELLS.EXECUTE_GLYPHED
+    : SPELLS.EXECUTE;
 
+  return info.combatant.hasTalent(TALENTS.SLAYERS_DOMINANCE_TALENT)
+    ? buildSlayerApl(executeThreshold, executeUsable, executeSpell)
+    : buildColossusApl(executeThreshold, executeUsable, executeSpell);
+};
+
+export const buildSlayerApl = (
+  executeThreshold: number,
+  executeUsable: Condition<any>,
+  executeSpell: Spell,
+): Apl => {
   return build([
     // Exe with 3x MFE, 2x SD, refresh Jugg
     {
-      spell: SPELLS.EXECUTE_GLYPHED,
+      spell: executeSpell,
       condition: cnd.and(
         executeUsable,
-        notBladestorming,
         cnd.or(
           cnd.debuffStacks(SPELLS.MARKED_FOR_EXECUTION, { atLeast: 3, atMost: 3 }),
           cnd.buffStacks(SPELLS.SUDDEN_DEATH_ARMS_TALENT_BUFF, { atLeast: 2, atMost: 2 }),
@@ -40,8 +64,7 @@ export const apl = (executeThreshold: number): Apl => {
       ),
       description: (
         <>
-          Cast <SpellLink spell={SPELLS.EXECUTE_GLYPHED} /> when any of the following conditions are
-          met:
+          Cast <SpellLink spell={executeSpell} /> when any of the following conditions are met:
           <ul>
             <li>
               Your target has 3 stacks of <SpellLink spell={SPELLS.MARKED_FOR_EXECUTION} />
@@ -64,7 +87,6 @@ export const apl = (executeThreshold: number): Apl => {
         cnd.and(
           cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 850 }), // rage is logged 10x higher than the player's "real" value
           cnd.inExecute(executeThreshold),
-          notBladestorming,
         ),
       ),
       description: (
@@ -83,7 +105,6 @@ export const apl = (executeThreshold: number): Apl => {
         cnd.debuffStacks(SPELLS.EXECUTIONERS_PRECISION_DEBUFF, { atLeast: 2 }),
         cnd.buffStacks(SPELLS.LETHAL_BLOWS_BUFF, { atLeast: 1 }),
         cnd.inExecute(executeThreshold),
-        notBladestorming,
       ),
       description: (
         <>
@@ -102,7 +123,6 @@ export const apl = (executeThreshold: number): Apl => {
         cnd.buffStacks(TALENTS.OVERPOWER_TALENT, { atMost: 1 }), // Martial Prowess buff
         cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 800 }),
         cnd.inExecute(executeThreshold),
-        notBladestorming,
       ),
       description: (
         <>
@@ -130,7 +150,6 @@ export const apl = (executeThreshold: number): Apl => {
         cnd.buffStacks(TALENTS.OVERPOWER_TALENT, { atMost: 1 }), // Martial Prowess buff
         cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 400 }),
         cnd.inExecute(executeThreshold),
-        notBladestorming,
       ),
       description: (
         <>
@@ -149,11 +168,11 @@ export const apl = (executeThreshold: number): Apl => {
 
     // Exe in execute
     {
-      spell: SPELLS.EXECUTE_GLYPHED,
-      condition: cnd.and(executeUsable, cnd.inExecute(executeThreshold), notBladestorming),
+      spell: executeSpell,
+      condition: cnd.and(executeUsable, cnd.inExecute(executeThreshold)),
       description: (
         <>
-          Cast <SpellLink spell={SPELLS.EXECUTE_GLYPHED} /> while in execute range
+          Cast <SpellLink spell={executeSpell} /> while in execute range
         </>
       ),
     },
@@ -164,7 +183,6 @@ export const apl = (executeThreshold: number): Apl => {
       condition: cnd.and(
         cnd.hasTalent(TALENTS.FIERCE_FOLLOWTHROUGH_TALENT),
         cnd.spellCharges(SPELLS.OVERPOWER, { atLeast: 2 }),
-        notBladestorming,
         cnd.not(cnd.inExecute(executeThreshold)),
       ),
       description: (
@@ -179,7 +197,6 @@ export const apl = (executeThreshold: number): Apl => {
       spell: SPELLS.OVERPOWER,
       condition: cnd.and(
         cnd.buffPresent(SPELLS.OPPORTUNIST),
-        notBladestorming,
         cnd.not(cnd.inExecute(executeThreshold)),
       ),
       description: (
@@ -204,7 +221,7 @@ export const apl = (executeThreshold: number): Apl => {
     // SkS outside execute
     {
       spell: TALENTS.SKULLSPLITTER_TALENT,
-      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold)), notBladestorming),
+      condition: cnd.not(cnd.inExecute(executeThreshold)),
       description: (
         <>
           Cast <SpellLink spell={TALENTS.SKULLSPLITTER_TALENT} /> while outside execute range
@@ -214,11 +231,11 @@ export const apl = (executeThreshold: number): Apl => {
 
     // filler execute
     {
-      spell: SPELLS.EXECUTE_GLYPHED,
-      condition: cnd.and(executeUsable, cnd.not(cnd.inExecute(executeThreshold)), notBladestorming),
+      spell: executeSpell,
+      condition: cnd.and(executeUsable, cnd.not(cnd.inExecute(executeThreshold))),
       description: (
         <>
-          Cast <SpellLink spell={SPELLS.EXECUTE_GLYPHED} />
+          Cast <SpellLink spell={executeSpell} />
         </>
       ),
     },
@@ -226,7 +243,7 @@ export const apl = (executeThreshold: number): Apl => {
     // OP
     {
       spell: SPELLS.OVERPOWER,
-      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold)), notBladestorming),
+      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold))),
       description: (
         <>
           Cast <SpellLink spell={SPELLS.OVERPOWER} />
@@ -237,7 +254,211 @@ export const apl = (executeThreshold: number): Apl => {
     // Slam
     {
       spell: SPELLS.SLAM,
-      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold)), notBladestorming),
+      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold))),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.SLAM} />
+        </>
+      ),
+    },
+  ]);
+};
+
+export const buildColossusApl = (
+  executeThreshold: number,
+  executeUsable: Condition<any>,
+  executeSpell: Spell,
+): Apl => {
+  return build([
+    // SkS in exe below 85
+    {
+      spell: TALENTS.SKULLSPLITTER_TALENT,
+      condition: cnd.optionalRule(
+        cnd.and(
+          cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 850 }), // rage is logged 10x higher than the player's "real" value
+          cnd.inExecute(executeThreshold),
+        ),
+      ),
+      description: (
+        <>
+          (Optional) Cast <SpellLink spell={TALENTS.SKULLSPLITTER_TALENT} /> while below 85 rage and
+          in execute range. You can gamble on getting enough rage from other sources, but on average
+          it's best to avoid that.
+        </>
+      ),
+    },
+
+    // MS in exe with 2xEP 2xLB (no battlelord)
+    {
+      spell: SPELLS.MORTAL_STRIKE,
+      condition: cnd.and(
+        cnd.debuffStacks(SPELLS.EXECUTIONERS_PRECISION_DEBUFF, { atLeast: 2 }),
+        cnd.buffStacks(SPELLS.LETHAL_BLOWS_BUFF, { atLeast: 2 }),
+        cnd.inExecute(executeThreshold),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.MORTAL_STRIKE} /> while in execute range with 2 stacks of{' '}
+          <SpellLink spell={SPELLS.EXECUTIONERS_PRECISION_DEBUFF} /> and{' '}
+          <SpellLink spell={SPELLS.LETHAL_BLOWS_BUFF} />
+        </>
+      ),
+    },
+
+    // MS in exe with 2xEP (battlelord)
+    {
+      spell: SPELLS.MORTAL_STRIKE,
+      condition: cnd.and(
+        cnd.debuffStacks(SPELLS.EXECUTIONERS_PRECISION_DEBUFF, { atLeast: 2 }),
+        cnd.hasTalent(TALENTS.BATTLELORD_TALENT),
+        cnd.inExecute(executeThreshold),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.MORTAL_STRIKE} /> while in execute range with 2 stacks of{' '}
+          <SpellLink spell={SPELLS.EXECUTIONERS_PRECISION_DEBUFF} />
+        </>
+      ),
+    },
+
+    // OP in exe with BL, 2 charges, <90 rage
+    {
+      spell: SPELLS.OVERPOWER,
+      condition: cnd.and(
+        cnd.hasTalent(TALENTS.BATTLELORD_TALENT),
+        cnd.spellCharges(SPELLS.OVERPOWER, { atLeast: 2 }),
+        cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 900 }),
+        cnd.inExecute(executeThreshold),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.OVERPOWER} /> in execute range when you have 2 charges
+          available and are below 90 rage
+        </>
+      ),
+    },
+
+    // exe in exe with 40 rage and EP
+    {
+      spell: executeSpell,
+      condition: cnd.and(
+        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 400 }),
+        cnd.hasTalent(TALENTS.EXECUTIONERS_PRECISION_TALENT),
+        cnd.inExecute(executeThreshold),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={executeSpell} /> while above 40 rage in execute range
+        </>
+      ),
+    },
+
+    // SkS (in exe)
+    {
+      spell: TALENTS.SKULLSPLITTER_TALENT,
+      condition: cnd.inExecute(executeThreshold),
+      description: (
+        <>
+          Cast <SpellLink spell={TALENTS.SKULLSPLITTER_TALENT} /> in execute range
+        </>
+      ),
+    },
+
+    // OP (in exe)
+    {
+      spell: SPELLS.OVERPOWER,
+      condition: cnd.inExecute(executeThreshold),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.OVERPOWER} /> in execute range
+        </>
+      ),
+    },
+
+    // exe in exe
+    {
+      spell: executeSpell,
+      condition: cnd.and(executeUsable, cnd.inExecute(executeThreshold)),
+      description: (
+        <>
+          Cast <SpellLink spell={executeSpell} /> in execute range
+        </>
+      ),
+    },
+
+    // MS in exe
+    {
+      spell: SPELLS.MORTAL_STRIKE,
+      condition: cnd.inExecute(executeThreshold),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.MORTAL_STRIKE} /> in execute range
+        </>
+      ),
+    },
+
+    // MS no exe
+    {
+      spell: SPELLS.MORTAL_STRIKE,
+      condition: cnd.not(cnd.inExecute(executeThreshold)),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.MORTAL_STRIKE} />
+        </>
+      ),
+    },
+
+    // SkS no exe
+    {
+      spell: TALENTS.SKULLSPLITTER_TALENT,
+      condition: cnd.not(cnd.inExecute(executeThreshold)),
+      description: (
+        <>
+          Cast <SpellLink spell={TALENTS.SKULLSPLITTER_TALENT} />
+        </>
+      ),
+    },
+
+    // 2op no exe
+    {
+      spell: SPELLS.OVERPOWER,
+      condition: cnd.and(
+        cnd.spellCharges(SPELLS.OVERPOWER, { atLeast: 2 }),
+        cnd.not(cnd.inExecute(executeThreshold)),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.OVERPOWER} /> with 2 charges available
+        </>
+      ),
+    },
+
+    // exe no exe
+    {
+      spell: executeSpell,
+      condition: cnd.and(executeUsable, cnd.not(cnd.inExecute(executeThreshold))),
+      description: (
+        <>
+          Cast <SpellLink spell={executeSpell} />
+        </>
+      ),
+    },
+
+    // OP no exe
+    {
+      spell: SPELLS.OVERPOWER,
+      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold))),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.OVERPOWER} />
+        </>
+      ),
+    },
+
+    // slam
+    {
+      spell: SPELLS.SLAM,
+      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold))),
       description: (
         <>
           Cast <SpellLink spell={SPELLS.SLAM} />
@@ -248,8 +469,7 @@ export const apl = (executeThreshold: number): Apl => {
 };
 
 export const check = (events: AnyEvent[], info: PlayerInfo): CheckResult => {
-  const executeThreshold = info.combatant.hasTalent(TALENTS.MASSACRE_SPEC_TALENT) ? 0.35 : 0.2;
-  const check = aplCheck(apl(executeThreshold));
+  const check = aplCheck(apl(info));
   return check(events, info);
 };
 

--- a/src/analysis/retail/warrior/arms/modules/talents/Demolish.tsx
+++ b/src/analysis/retail/warrior/arms/modules/talents/Demolish.tsx
@@ -1,0 +1,132 @@
+import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
+import TALENTS from 'common/TALENTS/warrior';
+import SPELLS from 'common/SPELLS/warrior';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import Events, {
+  CastEvent,
+  DamageEvent,
+  GetRelatedEvent,
+  RefreshBuffEvent,
+} from 'parser/core/Events';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import { addInefficientCastReason } from 'parser/core/EventMetaLib';
+import { DEMOLISH_DAMAGE_CAST } from '../../normalizers/DemolishNormalizer';
+import SpellLink from 'interface/SpellLink';
+import { defineMessage } from '@lingui/macro';
+import { DEFAULT_EXECUTE_THRESHOLD, MASSACRE_EXECUTE_THRESHOLD } from '../core/AplCheck';
+
+const COLOSSAL_MIGHT_MAX_STACKS = 10;
+const COLOSSAL_MIGHT_CD_REDUCTION = 2000; // ms
+
+class Demolish extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+
+  badDemolishes: number = 0;
+  executeThreshold: number = 0;
+  inExecuteRange: boolean = false;
+  colossusSmashDebuffActive: boolean = false;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.DEMOLISH_TALENT);
+    this.executeThreshold = this.selectedCombatant.hasTalent(TALENTS.MASSACRE_SPEC_TALENT)
+      ? MASSACRE_EXECUTE_THRESHOLD
+      : DEFAULT_EXECUTE_THRESHOLD;
+
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.COLOSSAL_MIGHT),
+      this.colossalMightRefresh,
+    );
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.DEMOLISH_DAMAGE),
+      this.onDemolishCast,
+    );
+
+    this.addEventListener(
+      Events.applydebuff.by(SELECTED_PLAYER).spell(SPELLS.COLOSSUS_SMASH_DEBUFF),
+      this.colossusSmashApplied,
+    );
+
+    this.addEventListener(
+      Events.removedebuff.by(SELECTED_PLAYER).spell(SPELLS.COLOSSUS_SMASH_DEBUFF),
+      this.colossusSmashRemoved,
+    );
+  }
+
+  // buff listener -> reduce demolish cd
+  colossalMightRefresh(event: RefreshBuffEvent) {
+    const stacks = this.selectedCombatant.getBuffStacks(SPELLS.COLOSSAL_MIGHT);
+
+    // when colossal might is refreshed at max stacks, reduce demolish cd by 2 seconds
+    if (stacks === COLOSSAL_MIGHT_MAX_STACKS) {
+      this.spellUsable.reduceCooldown(SPELLS.DEMOLISH.id, COLOSSAL_MIGHT_CD_REDUCTION);
+    }
+  }
+
+  colossusSmashApplied() {
+    this.colossusSmashDebuffActive = true;
+  }
+
+  colossusSmashRemoved() {
+    this.colossusSmashDebuffActive = false;
+  }
+
+  // in execute -> wait for CS first
+  onDemolishCast(event: DamageEvent) {
+    if (event.hitPoints && event.maxHitPoints) {
+      if (event.hitPoints / event.maxHitPoints < this.executeThreshold) {
+        this.inExecuteRange = true;
+      }
+    }
+
+    const demolishCastEvent: CastEvent | undefined = GetRelatedEvent(event, DEMOLISH_DAMAGE_CAST);
+
+    if (this.inExecuteRange && !this.colossusSmashDebuffActive) {
+      this.badDemolishes += 1;
+      if (demolishCastEvent) {
+        addInefficientCastReason(
+          demolishCastEvent,
+          'Demolish was used within execute range without the Colossus Smash debuff',
+        );
+      }
+    }
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.badDemolishes,
+      isGreaterThan: {
+        minor: 0,
+        average: 0,
+        major: 1,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          There were {actual} times you used <SpellLink spell={SPELLS.DEMOLISH} /> in execute range
+          without the <SpellLink spell={SPELLS.COLOSSUS_SMASH} /> debuff active.
+        </>,
+      )
+        .icon(SPELLS.DEMOLISH.icon)
+        .actual(
+          defineMessage({
+            id: 'warrior.arms.suggestions.demolish.colossussmash',
+            message: `${actual} Demolishes used in execute range without the Colossus Smash debuff`,
+          }),
+        )
+        .recommended(`${recommended} is recommended.`),
+    );
+  }
+}
+
+export default Demolish;

--- a/src/analysis/retail/warrior/arms/normalizers/DemolishNormalizer.tsx
+++ b/src/analysis/retail/warrior/arms/normalizers/DemolishNormalizer.tsx
@@ -1,0 +1,28 @@
+import SPELLS from 'common/SPELLS';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { EventType } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+
+export const DEMOLISH_DAMAGE_CAST = 'Demolish-Damage-Cast';
+const DEMOLISH_DURATION = 2000; // base 2s channel, hasted but shouldn't affect buffer window
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: DEMOLISH_DAMAGE_CAST,
+    linkingEventId: SPELLS.DEMOLISH_DAMAGE.id,
+    linkingEventType: EventType.Damage,
+    referencedEventId: SPELLS.DEMOLISH.id,
+    referencedEventType: EventType.Cast,
+    forwardBufferMs: DEMOLISH_DURATION,
+    backwardBufferMs: DEMOLISH_DURATION,
+    anyTarget: true,
+  },
+];
+
+class DemolishNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export default DemolishNormalizer;

--- a/src/analysis/retail/warrior/arms/normalizers/UnhingedMortalStrikeNormalizer.tsx
+++ b/src/analysis/retail/warrior/arms/normalizers/UnhingedMortalStrikeNormalizer.tsx
@@ -1,0 +1,57 @@
+import SPELLS from 'common/SPELLS';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { AnyEvent, CastEvent, EventType, GetRelatedEvents } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+
+const UNHINGED_MORTAL_STRIKE = 'Unhinged-Mortal-Strike';
+const RAVAGER_DAMAGE_BUFFER_MS = 5; // triggered MS *should* be at the exact same timestamp, but give some wiggle room
+const BLADESTORM_DAMAGE_BUFFER_MS = 100; // mortal strike cast is anywhere from ~5-100ms before the bladestorm damage tick
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: UNHINGED_MORTAL_STRIKE,
+    linkingEventId: SPELLS.MORTAL_STRIKE.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.RAVAGER_DAMAGE.id,
+    referencedEventType: EventType.Damage,
+    forwardBufferMs: RAVAGER_DAMAGE_BUFFER_MS,
+    backwardBufferMs: RAVAGER_DAMAGE_BUFFER_MS,
+    anyTarget: true,
+  },
+  {
+    linkRelation: UNHINGED_MORTAL_STRIKE,
+    linkingEventId: SPELLS.MORTAL_STRIKE.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.BLADESTORM_DAMAGE.id,
+    referencedEventType: EventType.Damage,
+    forwardBufferMs: BLADESTORM_DAMAGE_BUFFER_MS,
+    backwardBufferMs: BLADESTORM_DAMAGE_BUFFER_MS,
+    anyTarget: true,
+  },
+];
+
+function isUnhingedMortalStrike(event: CastEvent): boolean {
+  return GetRelatedEvents(event, UNHINGED_MORTAL_STRIKE).length > 0;
+}
+
+class UnhingedMortalStrikeNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+
+  normalize(rawEvents: AnyEvent[]): AnyEvent[] {
+    const events = super.normalize(rawEvents);
+
+    events.forEach((event, index) => {
+      if (event.type === EventType.Cast && isUnhingedMortalStrike(event)) {
+        events.splice(index, 1); // remove original cast event
+        (event as AnyEvent).type = EventType.FreeCast;
+        event.__modified = true;
+        events.push(event); // add freecast event
+      }
+    });
+    return events;
+  }
+}
+
+export default UnhingedMortalStrikeNormalizer;

--- a/src/common/SPELLS/warrior.ts
+++ b/src/common/SPELLS/warrior.ts
@@ -321,6 +321,11 @@ const spells = {
     name: 'Bladestorm',
     icon: 'ability_warrior_bladestorm',
   },
+  COLOSSAL_MIGHT: {
+    id: 440989,
+    name: 'Colossal Might',
+    icon: 'ability_warrior_strengthofarms',
+  },
   COLOSSUS_SMASH: {
     id: 167105,
     name: 'Colossus Smash',
@@ -330,6 +335,16 @@ const spells = {
     id: 208086,
     name: 'Colossus Smash',
     icon: 'ability_warrior_colossussmash',
+  },
+  DEMOLISH: {
+    id: 436358,
+    name: 'Demolish',
+    icon: 'inv_ability_colossuswarrior_demolish',
+  },
+  DEMOLISH_DAMAGE: {
+    id: 440884,
+    name: 'Demolish',
+    icon: 'inv_ability_colossuswarrior_demolish',
   },
   DIE_BY_THE_SWORD: {
     id: 118038,


### PR DESCRIPTION
### Description

- Add APL support for Colossus
- Add support for Demolish (efficiency, cooldown reduction, aligning with Colossus Smash)
- Refactor Slayer APL added in https://github.com/WoWAnalyzer/WoWAnalyzer/pull/7214 with normalizer for handling Unhinged
- Make Execute spell objects variable depending on owner's talents

### Testing

- Test report URL: (Colossus) `/report/Ft8NByGLZ64AMX2f/14/12` and `/report/WTgD24mMz6wYaBL1/5/138`, (Slayer, APL regression testing) `/report/Lna7ANqKFbBWkD2Q/20/376` and `/report/1R9TkvMF7HLPpVdm/19/43`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/ca49672e-3b47-4962-9428-9f40b8234679)
![image](https://github.com/user-attachments/assets/40995d8d-5e02-4f70-a52a-94ad07115348)
![image](https://github.com/user-attachments/assets/d067bedc-0555-41bf-a7d0-f8ff3a5df13a)
![image](https://github.com/user-attachments/assets/4a356fc3-5fed-4f22-b666-f6a5d3a7d421)
