### PR TITLE
Improved frostfire apl and added a bit of support for boltspam raid b…

### DIFF
--- a/src/analysis/retail/mage/frost/Guide.tsx
+++ b/src/analysis/retail/mage/frost/Guide.tsx
@@ -51,6 +51,11 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
     </SubSection>
   );
 
+  const isBoltspamBuild =
+    info.combatant.hasTalent(TALENTS.DEEP_SHATTER_TALENT) &&
+    info.combatant.hasTalent(TALENTS.DEEP_SHATTER_TALENT) &&
+    info.combatant.hasTalent(TALENTS.SLICK_ICE_TALENT);
+
   return (
     <>
       <Section title="Core">
@@ -59,9 +64,15 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           {info.combatant.hasTalent(TALENTS.SPLINTERSTORM_TALENT) && (
             <AplSectionData checker={ssApl.spellslingerCheck} apl={ssApl.spellslingerApl} />
           )}
-          {info.combatant.hasTalent(TALENTS.FLASH_FREEZEBURN_TALENT) && (
-            <AplSectionData checker={ffApl.frostfireCheck} apl={ffApl.frostfireApl} />
-          )}
+          {info.combatant.hasTalent(TALENTS.FLASH_FREEZEBURN_TALENT) &&
+            (isBoltspamBuild ? (
+              <AplSectionData
+                checker={ffApl.boltspamFrostfireCheck}
+                apl={ffApl.boltspamFrostfireApl}
+              />
+            ) : (
+              <AplSectionData checker={ffApl.frostfireCheck} apl={ffApl.frostfireApl} />
+            ))}
         </SubSection>
         {alwaysBeCastingSubsection}
         {modules.wintersChill.guideSubsection}

--- a/src/analysis/retail/mage/frost/Guide.tsx
+++ b/src/analysis/retail/mage/frost/Guide.tsx
@@ -53,7 +53,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
 
   const isBoltspamBuild =
     info.combatant.hasTalent(TALENTS.DEEP_SHATTER_TALENT) &&
-    info.combatant.hasTalent(TALENTS.DEEP_SHATTER_TALENT) &&
+    info.combatant.hasTalent(TALENTS.DEATHS_CHILL_TALENT) &&
     info.combatant.hasTalent(TALENTS.SLICK_ICE_TALENT);
 
   return (

--- a/src/analysis/retail/mage/frost/apl/FrostfireAplCheck.tsx
+++ b/src/analysis/retail/mage/frost/apl/FrostfireAplCheck.tsx
@@ -6,7 +6,7 @@ import SpellLink from 'interface/SpellLink';
 import * as apl from './FrostAplCommons';
 
 const precastFrostfireBolt = cnd.lastSpellCast(TALENTS.FROSTFIRE_BOLT_TALENT);
-const excessFrost = cnd.buffPresent(TALENTS.EXCESS_FROST_TALENT);
+const excessFrost = cnd.buffPresent(SPELLS.EXCESS_FROST_BUFF);
 
 const flurryFfCondition = cnd.or(
   cnd.and(
@@ -35,7 +35,7 @@ const flurryFfDescription = (
 export const frostfireApl = build([
   {
     spell: TALENTS.GLACIAL_SPIKE_TALENT,
-    condition: cnd.and(apl.fiveIcicles, apl.canShatter),
+    condition: cnd.and(apl.fiveIcicles),
   },
   {
     spell: TALENTS.FLURRY_TALENT,
@@ -49,3 +49,27 @@ export const frostfireApl = build([
 ]);
 
 export const frostfireCheck = aplCheck(frostfireApl);
+
+export const boltspamFrostfireApl = build([
+  {
+    spell: TALENTS.GLACIAL_SPIKE_TALENT,
+    condition: cnd.and(apl.fiveIcicles),
+  },
+  {
+    spell: TALENTS.FLURRY_TALENT,
+    condition: cnd.and(
+      cnd.buffStacks(SPELLS.ICICLES_BUFF, { atMost: 4 }),
+      cnd.debuffMissing(SPELLS.WINTERS_CHILL),
+    ),
+  },
+  {
+    spell: TALENTS.ICE_LANCE_TALENT,
+    condition: cnd.and(
+      cnd.buffPresent(SPELLS.EXCESS_FIRE_BUFF),
+      cnd.buffMissing(SPELLS.BRAIN_FREEZE_BUFF),
+    ),
+  },
+  TALENTS.FROSTFIRE_BOLT_TALENT,
+]);
+
+export const boltspamFrostfireCheck = aplCheck(boltspamFrostfireApl);

--- a/src/analysis/retail/mage/shared/SPELLS.ts
+++ b/src/analysis/retail/mage/shared/SPELLS.ts
@@ -186,6 +186,11 @@ const spells = {
     name: 'Excess Frost',
     icon: 'spell_deathknight_iceboundfortitude',
   },
+  EXCESS_FIRE_BUFF: {
+    id: 438624,
+    name: 'Excess Fire',
+    icon: 'ability_mage_fierypayback',
+  },
   MANA_ADDICTION_BUFF_FIRE: {
     id: 449314,
     name: 'Mana Addiction',


### PR DESCRIPTION
### Description

Removed shatter check for frostfire glacial spike, fix the usage of `TALENT` rather than `BUFF` for condition check, added simple support for boltspam build.

### Testing

- Test report URL: `/report/vnXQy629RMB81NWg` - this is the removal of shatter requirement
- Screenshot(s): 
![image](https://github.com/user-attachments/assets/e1c0e3e7-1ac4-474a-a5e5-89b412e8cd65)

- Test report URL: `/report/H9Lb8pfRn3FyCzxk` - this is support for boltspam
- Screenshot(s): 
![image](https://github.com/user-attachments/assets/fe6bfbba-d89f-4392-9668-5dc68f6fd10d)

