### PR TITLE
Druid Feral - fixed an issue where Rake bleed and Dreadful Wound were not being counted in Adaptive Swarm boost calc

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_DRUID } from 'common/TALENTS/druid';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2025, 1, 20), <>Fixed an issue where <SpellLink spell={SPELLS.RAKE_BLEED}/> bleed and <SpellLink spell={SPELLS.DREADFUL_WOUND}/> damage was not being counted in <SpellLink spell={TALENTS_DRUID.ADAPTIVE_SWARM_TALENT}/> boost</>, Sref),
   change(date(2024, 10, 27), <>Updated patch compatibility to 11.0.5.</>, Sref),
   change(date(2024, 9, 13), <>Updated guide text to indicate finishes should always be used with 5 CPs. Fixed a typo in Rip cast breakdown.</>, Sref),
   change(date(2024, 8, 22), <><SpellLink spell={TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT}/> tracker should now correctly detect procced <SpellLink spell={TALENTS_DRUID.RAVAGE_TALENT}/> casts.</>, Sref),

--- a/src/analysis/retail/druid/feral/modules/spells/AdaptiveSwarm.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/AdaptiveSwarm.tsx
@@ -41,8 +41,9 @@ const PERIODIC_HEALS: SpellInfo[] = [
 
 const PERIODIC_DAMAGE: SpellInfo[] = [
   SPELLS.RIP,
-  SPELLS.RAKE, // adaptive swarm also boosts the direct damage, so no need for 'tick' differentiation
-  SPELLS.THRASH_FERAL, // even thrashes direct is "bleed damage"
+  SPELLS.RAKE, // swarm boosts rake direct damage for some reason
+  SPELLS.RAKE_BLEED,
+  SPELLS.THRASH_FERAL, // swarm boosts thrash direct damage for some reason
   SPELLS.THRASH_FERAL_BLEED,
   SPELLS.MOONFIRE_FERAL,
   SPELLS.MOONFIRE_DEBUFF,
@@ -50,15 +51,13 @@ const PERIODIC_DAMAGE: SpellInfo[] = [
   SPELLS.THRASH_BEAR_DOT,
   TALENTS.FERAL_FRENZY_TALENT,
   SPELLS.FERAL_FRENZY_DEBUFF,
+  SPELLS.DREADFUL_WOUND, // not in the spell data list, but confirmed in game it's boosted (1/20/25)
   // deliberately doesn't include Adaptive Swarm itself to avoid double count
 ];
 
 /**
- * This module performs calculations for Adaptive Swarm, but does not
- * display any of it. Spec specific modules should take care of display.
- *
  * **Adaptive Swarm**
- * Talent - (Feral / Restoration)
+ * Spec Talent
  *
  * Command a swarm that heals (157.5% of Spell power) or deals (150% of Spell power) Shadow damage
  * over 12 sec to a target, and increases the effectiveness of your periodic effects on them by 25%.


### PR DESCRIPTION
### Description
When Rake damage was split into two spell IDs, the Adaptive Swarm boost list wasn't properly updated. Dreadful Wound isn't on the spell data list, but we suspect it was scripted in (as is the case with many hero talents) - confirmed in game that it IS being boosted.

### Testing
- Test report URL: `/report/j1y3TfXDbcWLNQV2/6-Mythic++Siege+of+Boralus+-+Kill+(30:26)/Zindorel/standard/statistics`
