### PR TITLE
Update Ebon Might and guide

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 
 export default [
-  change(date(2024, 1, 21), "Update guide section", KYZ),
+  change(date(2025, 1, 21), "Update guide section", KYZ),
   change(date(2025, 1, 16),  <>Implement <SpellLink spell={TALENTS.TIME_SPIRAL_TALENT}/>, <SpellLink spell={TALENTS.TIME_CONVERGENCE_TALENT}/>, <SpellLink spell={TALENTS.MASTER_OF_DESTINY_TALENT}/>, <SpellLink spell={TALENTS.MOTES_OF_ACCELERATION_TALENT}/>, <SpellLink spell={TALENTS.GOLDEN_OPPORTUNITY_TALENT}/>, <SpellLink spell={TALENTS.OVERLORD_TALENT}/>, and <SpellLink spell={TALENTS.HOARDED_POWER_TALENT}/> modules</>, KYZ),
   change(date(2024, 12, 30), "Update guide section", KYZ),
   change(date(2024, 12, 27), <>Implement <SpellLink spell={TALENTS.MOMENTUM_SHIFT_TALENT}/>, <SpellLink spell={TALENTS.PRIMACY_TALENT}/> and <SpellLink spell={SPELLS.VOLCANIC_UPSURGE}/> modules</>, KYZ),

--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2024, 1, 21), "Update guide section", KYZ),
   change(date(2025, 1, 16),  <>Implement <SpellLink spell={TALENTS.TIME_SPIRAL_TALENT}/>, <SpellLink spell={TALENTS.TIME_CONVERGENCE_TALENT}/>, <SpellLink spell={TALENTS.MASTER_OF_DESTINY_TALENT}/>, <SpellLink spell={TALENTS.MOTES_OF_ACCELERATION_TALENT}/>, <SpellLink spell={TALENTS.GOLDEN_OPPORTUNITY_TALENT}/>, <SpellLink spell={TALENTS.OVERLORD_TALENT}/>, and <SpellLink spell={TALENTS.HOARDED_POWER_TALENT}/> modules</>, KYZ),
   change(date(2024, 12, 30), "Update guide section", KYZ),
   change(date(2024, 12, 27), <>Implement <SpellLink spell={TALENTS.MOMENTUM_SHIFT_TALENT}/>, <SpellLink spell={TALENTS.PRIMACY_TALENT}/> and <SpellLink spell={SPELLS.VOLCANIC_UPSURGE}/> modules</>, KYZ),

--- a/src/analysis/retail/evoker/augmentation/constants.tsx
+++ b/src/analysis/retail/evoker/augmentation/constants.tsx
@@ -6,6 +6,7 @@ export const ACCRETION_CDR_MS = 1000;
 
 // Ebon Might
 export const EBON_MIGHT_BASE_DURATION_MS = 10000;
+export const EBON_MIGHT_PERSONAL_DAMAGE_AMP = 0.2;
 
 // Mastery Versatility buff
 export const SHIFTING_SANDS_MASTERY_COEFFICIENT = 0.34;
@@ -19,6 +20,11 @@ export const EMPOWER_EXTENSION_MS = 2000;
 export const BREATH_OF_EONS_EXTENSION_MS = 5000;
 export const DREAM_OF_SPRINGS_EXTENSION_MS = 1000;
 export const SANDS_OF_TIME_CRIT_MOD = 0.5;
+
+//Close as Clutchmates
+export const CLOSE_AS_CLUTCHMATES_MOD = 1.0;
+//Change to below on 11.1 release
+//export const CLOSE_AS_CLUTCHMATES_MOD = 1.25;
 
 // Prescience
 export const PRESCIENCE_BASE_DURATION_MS = 18000;

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
@@ -229,7 +229,7 @@ class EbonMight extends Analyzer {
       const reverbEvents = GetRelatedEvents<DamageEvent>(event, UPHEAVAL_REVERBERATION_DAM_LINK);
 
       reverbEvents.forEach((reverbEvent) => {
-        this.personalEbonMightDamage = calculateEffectiveDamage(
+        this.personalEbonMightDamage += calculateEffectiveDamage(
           reverbEvent,
           this.personalDamageAmp,
         );

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
@@ -4,7 +4,9 @@ import Events, {
   AnyEvent,
   ApplyBuffEvent,
   CastEvent,
+  DamageEvent,
   EmpowerEndEvent,
+  GetRelatedEvents,
   RefreshBuffEvent,
   RemoveBuffEvent,
 } from 'parser/core/Events';
@@ -19,6 +21,8 @@ import {
   DREAM_OF_SPRINGS_EXTENSION_MS,
   BREATH_OF_EONS_SPELL_IDS,
   BREATH_OF_EONS_SPELLS,
+  EBON_MIGHT_PERSONAL_DAMAGE_AMP,
+  CLOSE_AS_CLUTCHMATES_MOD,
 } from 'analysis/retail/evoker/augmentation/constants';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
@@ -32,7 +36,16 @@ import Combatants from 'parser/shared/modules/Combatants';
 import classColor from 'game/classColor';
 import SPECS from 'game/SPECS';
 import ROLES from 'game/ROLES';
-import { TIERS } from 'game/TIERS';
+import { isMythicPlus } from 'common/isMythicPlus';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import DonutChart from 'parser/ui/DonutChart';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import { formatNumber } from 'common/format';
+import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
+import { UPHEAVAL_REVERBERATION_DAM_LINK } from '../normalizers/CastLinkNormalizer';
 
 const PANDEMIC_WINDOW = 0.3;
 
@@ -73,9 +86,16 @@ class EbonMight extends Analyzer {
   private ebonMightCasts: EbonMightCooldownCast[] = [];
   private prescienceCasts: PrescienceBuffs[] = [];
 
+  private personalDamageAmp = isMythicPlus(this.owner.fight)
+    ? EBON_MIGHT_PERSONAL_DAMAGE_AMP
+    : EBON_MIGHT_PERSONAL_DAMAGE_AMP * CLOSE_AS_CLUTCHMATES_MOD;
+
   ebonMightActive: boolean = false;
   currentEbonMightDuration: number = 0;
   currentEbonMightCastTime: number = 0;
+
+  personalEbonMightDamage = 0;
+  externalEbonMightDamage = 0;
 
   trackedSpells = [
     TALENTS.ERUPTION_TALENT,
@@ -84,6 +104,17 @@ class EbonMight extends Analyzer {
     SPELLS.EMERALD_BLOSSOM_CAST,
   ];
   empowers = [SPELLS.FIRE_BREATH, SPELLS.FIRE_BREATH_FONT, SPELLS.UPHEAVAL, SPELLS.UPHEAVAL_FONT];
+  personalBuffedSpells = [
+    SPELLS.DEEP_BREATH_DAM,
+    SPELLS.FIRE_BREATH_DOT,
+    SPELLS.LIVING_FLAME_DAMAGE,
+    SPELLS.AZURE_STRIKE,
+    SPELLS.UNRAVEL,
+    TALENTS.ERUPTION_TALENT,
+    SPELLS.UPHEAVAL_DAM,
+    SPELLS.MASS_ERUPTION_DAMAGE,
+    SPELLS.MELT_ARMOR,
+  ];
 
   constructor(options: Options) {
     super(options);
@@ -111,6 +142,23 @@ class EbonMight extends Analyzer {
     this.addEventListener(
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.PRESCIENCE_BUFF),
       this.onPrescienceRemove,
+    );
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(this.personalBuffedSpells),
+      this.onPersonalDamage,
+    );
+
+    if (this.selectedCombatant.hasTalent(TALENTS.REVERBERATIONS_TALENT)) {
+      this.addEventListener(
+        Events.empowerEnd.by(SELECTED_PLAYER).spell([SPELLS.UPHEAVAL, SPELLS.UPHEAVAL_FONT]),
+        this.addReverberationsDamage,
+      );
+    }
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.EBON_MIGHT_BUFF_EXTERNAL),
+      this.onExternalDamage,
     );
 
     this.addEventListener(Events.fightend, this.finalize);
@@ -168,6 +216,29 @@ class EbonMight extends Analyzer {
 
   private onCast(event: CastEvent | EmpowerEndEvent) {
     this.extendEbonMight(event);
+  }
+
+  private onPersonalDamage(event: DamageEvent) {
+    if (this.selectedCombatant.hasBuff(SPELLS.EBON_MIGHT_BUFF_PERSONAL.id)) {
+      this.personalEbonMightDamage += calculateEffectiveDamage(event, this.personalDamageAmp);
+    }
+  }
+
+  private addReverberationsDamage(event: EmpowerEndEvent) {
+    if (this.selectedCombatant.hasBuff(SPELLS.EBON_MIGHT_BUFF_PERSONAL.id)) {
+      const reverbEvents = GetRelatedEvents<DamageEvent>(event, UPHEAVAL_REVERBERATION_DAM_LINK);
+
+      reverbEvents.forEach((reverbEvent) => {
+        this.personalEbonMightDamage = calculateEffectiveDamage(
+          reverbEvent,
+          this.personalDamageAmp,
+        );
+      });
+    }
+  }
+
+  private onExternalDamage(event: DamageEvent) {
+    this.externalEbonMightDamage += event.amount;
   }
 
   /* Here we figure out how long the duration should be based on current mastery
@@ -292,21 +363,13 @@ class EbonMight extends Analyzer {
       EBON_MIGHT_BASE_DURATION_MS *
       (1 + TIMEWALKER_BASE_EXTENSION + ebonMightCooldownCast.currentMastery) *
       PANDEMIC_WINDOW;
-    const hasT31 =
-      this.selectedCombatant.has2PieceByTier(TIERS.DF3) ||
-      this.selectedCombatant.has2PieceByTier(TIERS.DF4);
 
     let performance;
     let summary;
     let details;
     let prescienceBuffsActive = 0;
 
-    /** We can only ever start the fight with 2 Prescience with current design, so don't bonk that on pull */
-    const isPullPrescience =
-      ebonMightCooldownCast.event.timestamp >= this.owner.fight.start_time + 10_000;
-
-    const PERFECT_PRESCIENCE_BUFFS = hasT31 && isPullPrescience ? 3 : 2;
-    const GOOD_PRESCIENCE_BUFFS = 2;
+    const PERFECT_PRESCIENCE_BUFFS = 2;
     const OK_PRESCIENCE_BUFFS = 1;
 
     prescienceCasts.forEach((event) => {
@@ -361,22 +424,13 @@ class EbonMight extends Analyzer {
             on cast. Good job!
           </div>
         );
-      } else if (prescienceBuffsActive === GOOD_PRESCIENCE_BUFFS && hasT31) {
-        performance = QualitativePerformance.Good;
-        details = (
-          <div>
-            You had {prescienceBuffsActive} <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> active
-            on cast. Since you have <b>T31 2pc</b> you should always aim to have 3 active, so you
-            can better control who your <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> goes on.
-          </div>
-        );
       } else if (prescienceBuffsActive === OK_PRESCIENCE_BUFFS) {
         performance = QualitativePerformance.Ok;
         details = (
           <div>
             You had {prescienceBuffsActive} <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> active
-            on cast. Try to line it up so you have {hasT31 && 'atleast '} 2 active, so you can
-            better control who your <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> goes on.
+            on cast. Try to line it up so you have 2 active, so you can better control who your{' '}
+            <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> goes on.
           </div>
         );
       } else {
@@ -480,7 +534,7 @@ class EbonMight extends Analyzer {
   }
 
   guideSubsection(): JSX.Element | null {
-    if (!this.active) {
+    if (!this.active || isMythicPlus(this.owner.fight)) {
       return null;
     }
 
@@ -511,6 +565,39 @@ class EbonMight extends Analyzer {
         }
         abovePerformanceDetails={<div style={{ marginBottom: 10 }}></div>}
       />
+    );
+  }
+
+  statistic() {
+    const damageSources = [
+      {
+        color: 'rgb(212, 81, 19)',
+        label: 'External',
+        spellId: SPELLS.EBON_MIGHT_BUFF_EXTERNAL.id,
+        valueTooltip: formatNumber(this.externalEbonMightDamage),
+        value: this.externalEbonMightDamage,
+      },
+      {
+        color: 'rgb(51, 147, 127)',
+        label: 'Personal',
+        spellId: SPELLS.EBON_MIGHT_BUFF_PERSONAL.id,
+        valueTooltip: formatNumber(this.personalEbonMightDamage),
+        value: this.personalEbonMightDamage,
+      },
+    ];
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(0)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <TalentSpellText talent={TALENTS.EBON_MIGHT_TALENT}>
+          <ItemDamageDone amount={this.personalEbonMightDamage + this.externalEbonMightDamage} />
+        </TalentSpellText>
+        <div className="pad">
+          <DonutChart items={damageSources} />
+        </div>
+      </Statistic>
     );
   }
 }

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/ShiftingSands.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/ShiftingSands.tsx
@@ -12,6 +12,7 @@ import classColor from 'game/classColor';
 import ROLES from 'game/ROLES';
 import Combatant from 'parser/core/Combatant';
 import SPECS from 'game/SPECS';
+import { TALENTS_EVOKER } from 'common/TALENTS';
 
 interface ShiftingSandsApplications {
   event: ApplyBuffEvent;
@@ -233,18 +234,38 @@ class ShiftingSands extends Analyzer {
       return null;
     }
 
-    const explanation = (
+    let explanation = (
       <section>
         <strong>
           <SpellLink spell={SPELLS.SHIFTING_SANDS_BUFF} />
         </strong>{' '}
-        gives a Versatility buff to one of your allies when you cast your empowers:{' '}
+        gives a Versatility buff to one of your allies when you cast your empowers,{' '}
         <SpellLink spell={SPELLS.UPHEAVAL} /> and <SpellLink spell={SPELLS.FIRE_BREATH} />,
         preferring targets with <SpellLink spell={SPELLS.EBON_MIGHT_BUFF_EXTERNAL} /> active.
         Ideally you should try to buff targets that also have{' '}
         <SpellLink spell={SPELLS.PRESCIENCE_BUFF} /> active.
       </section>
     );
+
+    if (this.selectedCombatant.hasTalent(TALENTS_EVOKER.MOTES_OF_POSSIBILITY_TALENT)) {
+      explanation = (
+        <section>
+          <strong>
+            <SpellLink spell={SPELLS.SHIFTING_SANDS_BUFF} />
+          </strong>{' '}
+          gives a Versatility buff to one of your allies when you cast your empowers,{' '}
+          <SpellLink spell={SPELLS.UPHEAVAL} /> and <SpellLink spell={SPELLS.FIRE_BREATH} />,
+          preferring targets with <SpellLink spell={SPELLS.EBON_MIGHT_BUFF_EXTERNAL} /> active.
+          <br />
+          <SpellLink spell={TALENTS_EVOKER.MOTES_OF_POSSIBILITY_TALENT} /> also have a 33% chance to
+          give <SpellLink spell={SPELLS.SHIFTING_SANDS_BUFF} /> to players who consume them. If you
+          personally consume a mote, it will instead apply as if you had cast an empower.
+          <br />
+          Ideally you should try to buff targets that also have{' '}
+          <SpellLink spell={SPELLS.PRESCIENCE_BUFF} /> active.
+        </section>
+      );
+    }
 
     return (
       <ContextualSpellUsageSubSection

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
@@ -198,9 +198,9 @@ const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: PUPIL_OF_ALEXSTRASZA_LINK,
     reverseLinkRelation: PUPIL_OF_ALEXSTRASZA_LINK,
-    linkingEventId: SPELLS.LIVING_FLAME_CAST.id,
+    linkingEventId: [SPELLS.LIVING_FLAME_CAST.id, SPELLS.CHRONO_FLAME_CAST.id],
     linkingEventType: EventType.Cast,
-    referencedEventId: SPELLS.LIVING_FLAME_DAMAGE.id,
+    referencedEventId: [SPELLS.LIVING_FLAME_DAMAGE.id, SPELLS.CHRONO_FLAME_DAMAGE.id],
     referencedEventType: EventType.Damage,
     anyTarget: true,
     maximumLinks: 1,

--- a/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
@@ -245,20 +245,34 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
   private getRefreshPerformance(cast: PrescienceCooldownCast) {
     if (cast.event._linkedEvents) {
       if (cast.event._linkedEvents[0].event.type === EventType.RefreshBuff) {
-        const refreshPerformance = {
-          performance: QualitativePerformance.Ok,
-          summary: <div>Target already had Prescience</div>,
-          details: (
-            <div>
-              Target already had <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> active, since{' '}
-              <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> doesn't pandemic you should always try
-              to cast on a new target so you can keep more{' '}
-              <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> active.
-            </div>
-          ),
-        };
+        if (!isMythicPlus(this.owner.fight)) {
+          const refreshPerformance = {
+            performance: QualitativePerformance.Ok,
+            summary: <div>Target already had Prescience</div>,
+            details: (
+              <div>
+                Target already had <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> active, since{' '}
+                <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> doesn't pandemic you should always
+                try to cast on a new target so you can keep more{' '}
+                <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> active.
+              </div>
+            ),
+          };
+          return refreshPerformance;
+        } else {
+          const refreshPerformance = {
+            performance: QualitativePerformance.Good,
+            summary: <div>Target already had Prescience</div>,
+            details: (
+              <div>
+                Target already had <SpellLink spell={TALENTS.PRESCIENCE_TALENT} /> active. This is
+                acceptable in Mythic+, since there's only two other DPS in the group.
+              </div>
+            ),
+          };
 
-        return refreshPerformance;
+          return refreshPerformance;
+        }
       }
     }
   }

--- a/src/analysis/retail/evoker/augmentation/modules/talents/PupilOfAlexstrasza.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/PupilOfAlexstrasza.tsx
@@ -23,7 +23,7 @@ class PupilOfAlexstrasza extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(TALENTS.PUPIL_OF_ALEXSTRASZA_TALENT);
 
     this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.LIVING_FLAME_CAST),
+      Events.cast.by(SELECTED_PLAYER).spell([SPELLS.LIVING_FLAME_CAST, SPELLS.CHRONO_FLAME_CAST]),
       this.onCast,
     );
   }

--- a/src/analysis/retail/evoker/shared/modules/talents/TimeSpiral.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/TimeSpiral.tsx
@@ -159,7 +159,7 @@ class TimeSpiral extends Analyzer {
             <br />
             <InformationIcon /> {this.externalBuffsUsed}
             <small> external buffs used</small>
-            {personalBuffsWasted > 0 && (
+            {externalBuffsWasted > 0 && (
               <>
                 <br />
                 <WarningIcon /> {externalBuffsWasted}


### PR DESCRIPTION
### Description

- Remove Ebon Might section for Mythic+, as there are very few practical scenarios in which a use can be a 'fail'.
- Add a personal vs external damage statistic for Ebon Might.
- Remove remaining references to T31 in Ebon Might module.
- Update Shifting Sands guide section to mention Motes if talented.
- Update Prescience guide section to count Prescience refreshes as a good use in Mythic+ rather than an okay use.

### Testing

- Test report URL: `[/report/...](https://www.warcraftlogs.com/reports/7jTFwYt4VHcmnZ1a?fight=25)`
- Screenshot(s): 
![Image1](https://github.com/user-attachments/assets/868f6e47-80e5-414b-b366-32f9f7d20ea5)
![Image2](https://github.com/user-attachments/assets/9ad888c5-8be9-4fdd-8407-159c1130e8b7)