### PR TITLE
add type for spell reflect event

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -41,6 +41,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 1, 25), <>Added internal support for new <SpellLink spell={SPELLS.SPELL_REFLECTION} /> events</>, emallson),
   change(date(2025, 1, 16), <>Added <ItemLink id={ITEMS.CIRRAL_CONCOCTORY.id}/></>, KYZ),
   change(date(2024, 12, 23), 'Update Classic Guild image for Reports page', jazminite),
   change(date(2024, 12, 21), <>Added <ItemLink id={ITEMS.MERELDARS_TOLL.id}/></>, KYZ),

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -43,8 +43,11 @@ export enum EventType {
   EmpowerStart = 'empowerstart',
   EmpowerEnd = 'empowerend',
   Leech = 'leech',
+  // added in 11.0
   StaggerClear = 'staggerclear',
   StaggerPrevented = 'staggerprevented',
+  // added in 11.0.7
+  Reflect = 'reflect',
 
   // Fabricated:
   Event = 'event', // everything


### PR DESCRIPTION
this is primarily just to keep local dev from throwing an error when viewing warriors. this is just a `console.warn` in production.

context: https://discord.com/channels/180033360939319296/687319100136882360/1329050423159685130
![image](https://github.com/user-attachments/assets/e18bc1d5-22e8-4693-8a31-d316d87dbcac)
