### PR TITLE
[Mistweaver] Update Thunder Focus Tea for 11.1

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Trevor, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date (2025, 2, 4), <>Added <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT}/> to list of correct <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT}/></>, Vohrr),
   change(date (2024, 12, 16), <>Got rid of TODO in <SpellLink spell={SPELLS.VIVIFY}/> cast performance breakdown.</>, Vohrr),
   change(date (2024, 11, 6), <>Fixed some missed <SpellLink spell={TALENTS_MONK.RUSHING_WIND_KICK_TALENT}/> checks in Celestial Conduit modules.</>, Vohrr),
   change(date (2024, 10, 31), <>Rewrote <SpellLink spell={TALENTS_MONK.MIST_WRAP_TALENT}/> for accuracy and to include value gained from <SpellLink spell={TALENTS_MONK.MENDING_PROLIFERATION_TALENT}/>. Updated several other modules to filter out healing that is not affected by healing increases.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -79,7 +79,10 @@ class ThunderFocusTea extends Analyzer {
       this.buffedCast,
     );
     if (this.selectedCombatant.hasTalent(TALENTS_MONK.RISING_MIST_TALENT)) {
-      this.correctCapstoneSpells = [TALENTS_MONK.RENEWING_MIST_TALENT.id];
+      this.correctCapstoneSpells = [
+        TALENTS_MONK.RENEWING_MIST_TALENT.id,
+        TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
+      ];
       this.okCapstoneSpells = [this.currentRskTalent.id];
     } else if (this.selectedCombatant.hasTalent(TALENTS_MONK.TEAR_OF_MORNING_TALENT)) {
       this.correctCapstoneSpells = [
@@ -91,7 +94,10 @@ class ThunderFocusTea extends Analyzer {
         TALENTS_MONK.RENEWING_MIST_TALENT.id,
       ];
     } else {
-      this.correctCapstoneSpells = [TALENTS_MONK.RENEWING_MIST_TALENT.id];
+      this.correctCapstoneSpells = [
+        TALENTS_MONK.RENEWING_MIST_TALENT.id,
+        TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
+      ];
     }
   }
 
@@ -112,7 +118,7 @@ class ThunderFocusTea extends Analyzer {
     } else if (this.selectedCombatant.hasTalent(TALENTS_MONK.SECRET_INFUSION_TALENT)) {
       return isOk && this.selectedCombatant.hasTalent(TALENTS_MONK.TEAR_OF_MORNING_TALENT)
         ? spellId === TALENTS_MONK.ENVELOPING_MIST_TALENT.id
-        : spellId === TALENTS_MONK.RENEWING_MIST_TALENT.id;
+        : spellMap.includes(spellId);
     } else {
       return spellMap.includes(spellId);
     }


### PR DESCRIPTION
Added Enveloping Mist to the list of correct casts for thunder focus tea when talented into rising mist 
