### PR TITLE
small bugfixes (WW, MW)

### DIFF
--- a/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
@@ -177,8 +177,8 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.FORTIFYING_BREW_BRM.id,
-        buffSpellId: SPELLS.FORTIFYING_BREW_BRM_BUFF.id,
+        spell: SPELLS.FORTIFYING_BREW_CAST.id,
+        buffSpellId: SPELLS.FORTIFYING_BREW_BUFF.id,
         category: SPELL_CATEGORY.DEFENSIVE,
         cooldown: combatant.hasTalent(talents.EXPEDITIOUS_FORTIFICATION_TALENT) ? 240 : 360,
         gcd: null,

--- a/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/DefensiveBuffs.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/DefensiveBuffs.tsx
@@ -6,7 +6,7 @@ import Auras from 'parser/core/modules/Auras';
 
 export const MAJOR_DEFENSIVES: Array<[Talent, Spell | null]> = [
   [talents.CELESTIAL_BREW_TALENT, null],
-  [talents.FORTIFYING_BREW_TALENT, SPELLS.FORTIFYING_BREW_BRM_BUFF],
+  [talents.FORTIFYING_BREW_TALENT, SPELLS.FORTIFYING_BREW_BUFF],
   [talents.DAMPEN_HARM_TALENT, null],
   [talents.DIFFUSE_MAGIC_TALENT, null],
   [talents.ZEN_MEDITATION_TALENT, null],

--- a/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/FortifyingBrew.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/MajorDefensives/FortifyingBrew.tsx
@@ -28,7 +28,7 @@ export class FortifyingBrew extends MajorDefensiveBuff {
   private hasGaiPlins = false;
 
   constructor(options: Options) {
-    super(SPELLS.FORTIFYING_BREW_BRM, buff(SPELLS.FORTIFYING_BREW_BRM_BUFF), options);
+    super(SPELLS.FORTIFYING_BREW_CAST, buff(SPELLS.FORTIFYING_BREW_BUFF), options);
 
     this.addEventListener(Events.damage.to(SELECTED_PLAYER), this.recordDamage);
 

--- a/src/analysis/retail/monk/brewmaster/modules/core/SharedBrews.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/core/SharedBrews.ts
@@ -6,7 +6,7 @@ import SpellUsable from 'parser/shared/modules/SpellUsable';
 
 const BREWS = [
   talents.BLACK_OX_BREW_TALENT,
-  SPELLS.FORTIFYING_BREW_BRM,
+  SPELLS.FORTIFYING_BREW_CAST,
   talents.CELESTIAL_BREW_TALENT,
   talents.PURIFYING_BREW_TALENT,
 ];

--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
-import { Trevor, Vetyst, Vohrr } from 'CONTRIBUTORS';
+import { emallson, Trevor, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 2, 6), <>Fix crash in <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT} /> analysis when no casts have occurred.</>, emallson),
   change(date (2025, 2, 4), <>Added <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT}/> to list of correct <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT}/></>, Vohrr),
   change(date (2024, 12, 16), <>Got rid of TODO in <SpellLink spell={SPELLS.VIVIFY}/> cast performance breakdown.</>, Vohrr),
   change(date (2024, 11, 6), <>Fixed some missed <SpellLink spell={TALENTS_MONK.RUSHING_WIND_KICK_TALENT}/> checks in Celestial Conduit modules.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/modules/features/Abilities.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/Abilities.tsx
@@ -209,8 +209,8 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS_MONK.DIFFUSE_MAGIC_TALENT),
       },
       {
-        spell: SPELLS.FORTIFYING_BREW_BRM.id,
-        buffSpellId: SPELLS.FORTIFYING_BREW_BRM_BUFF.id,
+        spell: SPELLS.FORTIFYING_BREW_CAST.id,
+        buffSpellId: SPELLS.FORTIFYING_BREW_BUFF.id,
         category: SPELL_CATEGORY.DEFENSIVE,
         cooldown: combatant.hasTalent(TALENTS_MONK.EXPEDITIOUS_FORTIFICATION_TALENT) ? 90 : 120,
         enabled: combatant.hasTalent(TALENTS_MONK.FORTIFYING_BREW_TALENT),

--- a/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/talents/CelestialConduit.tsx
+++ b/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/talents/CelestialConduit.tsx
@@ -140,6 +140,10 @@ class CelestialConduit extends Analyzer {
   }
 
   private updateCastListCooldownMap() {
+    if (this.castInfoList.length === 0) {
+      return; // no casts, no cooldown maps
+    }
+
     if (!this.castInfoList.at(-1)?.cooldownMap) {
       this.castInfoList.at(-1)!.cooldownMap = this.getCooldownMap();
     }

--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
-import { Durpn } from 'CONTRIBUTORS';
+import { Durpn, emallson } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 2, 6), <>Correct spell data for <SpellLink spell={SPELLS.FORTIFYING_BREW_CAST} /></>, emallson),
   change(date(2024, 10, 26), <>Drop Mastery tracking for <SpellLink spell={SPELLS.FLYING_SERPENT_KICK} /></>, Durpn),
   change(date(2024, 10, 26), <>Fix Mastery tracking for <SpellLink spell={TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT} /> and <SpellLink spell={TALENTS_MONK.STORM_EARTH_AND_FIRE_TALENT} /></>, Durpn),
   change(date(2024, 9, 15), <>Initial Update for The War Within</>, Durpn),

--- a/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
@@ -290,10 +290,10 @@ class Abilities extends CoreAbilities {
       },
       // Defensives
       {
-        spell: TALENTS_MONK.FORTIFYING_BREW_TALENT.id,
-        buffSpellId: TALENTS_MONK.FORTIFYING_BREW_TALENT.id,
+        spell: SPELLS.FORTIFYING_BREW_CAST.id,
+        buffSpellId: SPELLS.FORTIFYING_BREW_BUFF.id,
         category: SPELL_CATEGORY.DEFENSIVE,
-        cooldown: combatant.hasTalent(TALENTS_MONK.IRONSHELL_BREW_TALENT) ? 240 : 360,
+        cooldown: 120 - 30 * combatant.getTalentRank(TALENTS_MONK.EXPEDITIOUS_FORTIFICATION_TALENT),
         enabled: combatant.hasTalent(TALENTS_MONK.FORTIFYING_BREW_TALENT),
         gcd: null,
       },

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -567,12 +567,12 @@ const spells = {
     name: 'Breath of Fire',
     icon: 'ability_monk_breathoffire',
   },
-  FORTIFYING_BREW_BRM: {
+  FORTIFYING_BREW_CAST: {
     id: 115203,
     name: 'Fortifying Brew',
     icon: 'ability_monk_fortifyingale_new',
   },
-  FORTIFYING_BREW_BRM_BUFF: {
+  FORTIFYING_BREW_BUFF: {
     id: 120954,
     name: 'Fortifying Brew',
     icon: 'ability_monk_fortifyingale_new',


### PR DESCRIPTION
### Windwalker: Fix Fort Brew Spell ID

the talent spell id is actually wrong for the cast/buff. it appears to have changed in TWW (?), and now both WW and Brew share Fort Brew again.

ref: https://wowanalyzer.com/report/Yt9ZW2JPL3Vn8fDa/1-Mythic++Xal'atath+-+Kill+(34:18)/Helk%C3%AFa/standard/statistics

### Mistweaver: Fix Crash in Celestial Conduit if never cast

simple enough fix. UI is slightly jank but functional in this case because we didn't really design for an empty list. 

ref: https://wowanalyzer.com/report/rc1M2DgpHz7wxTbt/3-Mythic++City+of+Threads+-+Kill+(24:11)/Ursusano/standard/overview