### PR TITLE
fix Mana Usage chart

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -41,6 +41,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 2, 8), <>Fixed display error in mana usage chart.</>, emallson),
   change(date(2025, 1, 25), <>Added internal support for new <SpellLink spell={SPELLS.SPELL_REFLECTION} /> events</>, emallson),
   change(date(2025, 1, 16), <>Added <ItemLink id={ITEMS.CIRRAL_CONCOCTORY.id}/></>, KYZ),
   change(date(2024, 12, 23), 'Update Classic Guild image for Reports page', jazminite),

--- a/src/parser/shared/modules/resources/mana/ManaUsageChartComponent.tsx
+++ b/src/parser/shared/modules/resources/mana/ManaUsageChartComponent.tsx
@@ -1,29 +1,35 @@
 import { PureComponent } from 'react';
 
 import { ManaUsageGraph } from './ManaUsageGraph';
+import HealingValue from '../../HealingValue';
 
 interface Props {
   start: number;
   end: number;
   offset: number;
-  healingBySecond: any;
+  healingBySecond: Record<number, HealingValue>;
   manaUpdates: any[];
 }
 
 class HealingDoneGraph extends PureComponent<Props> {
-  groupHealingBySeconds(healingBySecond: { [second: number]: any }, interval: number): any {
-    return Object.keys(healingBySecond).reduce((obj: any, second: any) => {
-      const healing = healingBySecond[second];
+  groupHealingBySeconds(
+    healingBySecond: Record<number, HealingValue>,
+    interval: number,
+  ): Record<number, HealingValue> {
+    return Object.keys(healingBySecond)
+      .map(Number)
+      .reduce((obj: Record<number, HealingValue>, second: number) => {
+        const healing = healingBySecond[second];
 
-      const index = Math.floor(second / interval);
+        const index = Math.floor(second / interval);
 
-      if (obj[index]) {
-        obj[index] = obj[index].add(healing.regular, healing.absorbed, healing.overheal);
-      } else {
-        obj[index] = healing;
-      }
-      return obj;
-    }, {});
+        if (obj[index]) {
+          obj[index] = obj[index].add(healing);
+        } else {
+          obj[index] = healing;
+        }
+        return obj;
+      }, {});
   }
 
   render() {
@@ -32,11 +38,11 @@ class HealingDoneGraph extends PureComponent<Props> {
     // TODO: move this to vega-lite window transform
     // e.g. { window: [{op: 'mean', field: 'hps', as: 'hps'}], frame: [-2, 2] }
     const interval = 5;
-    const healingPerFrame = this.groupHealingBySeconds(healingBySecond, interval);
+    const groupedHealingBySecond = this.groupHealingBySeconds(healingBySecond, interval);
 
     let max = 0;
-    Object.keys(healingPerFrame)
-      .map((k) => healingPerFrame[k])
+    Object.keys(groupedHealingBySecond)
+      .map((k) => groupedHealingBySecond[Number(k)])
       .forEach((healingDone) => {
         const current = healingDone.effective;
         if (current > max) {
@@ -59,10 +65,12 @@ class HealingDoneGraph extends PureComponent<Props> {
     });
     const fightDurationSec = Math.ceil((end - start) / 1000);
     const labels: number[] = [];
+    const healingPerFrame: Record<number, number> = [];
     for (let i = 0; i <= fightDurationSec / interval; i += 1) {
       labels.push(Math.ceil(offset / 1000) + i * interval);
 
-      healingPerFrame[i] = healingPerFrame[i] !== undefined ? healingPerFrame[i].effective : 0;
+      healingPerFrame[i] =
+        groupedHealingBySecond[i] !== undefined ? groupedHealingBySecond[i].effective : 0;
       manaUsagePerFrame[i] = manaUsagePerFrame[i] !== undefined ? manaUsagePerFrame[i] : 0;
       manaLevelPerFrame[i] = manaLevelPerFrame[i] !== undefined ? manaLevelPerFrame[i] : null;
     }


### PR DESCRIPTION
this bug is caused by the refactor to `HealingValue`. the refactor itself is fine, but the use of `any` in this chart hid the use of the value and quietly broke it.

the actual fix is the change to the `.add(...)` call, the rest is just replacing `any` with actual types.

![image](https://github.com/user-attachments/assets/67176323-0edd-4fee-8a78-55750362ae30)

tested on this log: http://localhost:3000/report/vX98ZrmzQ7TWdncN/59-Mythic+Queen+Ansurek+-+Kill+(7:51)/Setthh/standard/statistics