### PR TITLE
Resto shaman torrent fix

### DIFF
--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import { Seriousnes, Ypp, Texleretour, Vetyst, PandaGoesBaa, emallson, squided }
 
 // prettier-ignore
 export default [
+  change(date(2025, 2, 12), <>Fix accuracy of <SpellLink spell={TALENTS_SHAMAN.TORRENT_TALENT}/> statistic.</>, squided),
   change(date(2025, 2, 8), <>Update incorrect modules and guide sections. Add missing modules for 11.0.7 talents. More totemic modules.</>, squided),
   change(date(2025, 1, 6), <>Fix crash in <SpellLink spell={TALENTS_SHAMAN.SURGING_TOTEM_TALENT} /> analysis when cast pre-pull.</>, emallson),
   change(date(2024, 10, 12), <>Fixed cooldowns for totems, <SpellLink spell={TALENTS_SHAMAN.TOTEMIC_RECALL_TALENT}/>, and <SpellLink spell={TALENTS_SHAMAN.ASCENDANCE_RESTORATION_TALENT}/> not properly accounting for cooldown reduction talents like <SpellLink spell={TALENTS_SHAMAN.FIRST_ASCENDANT_TALENT}/>.</>, PandaGoesBaa),

--- a/src/analysis/retail/shaman/restoration/modules/talents/Torrent.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/Torrent.tsx
@@ -7,18 +7,33 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import { formatNumber } from 'common/format';
+import HIT_TYPES from 'game/HIT_TYPES';
+import StatTracker from 'parser/shared/modules/StatTracker';
 
-const TORRENT_HEALING_INCREASE = 0.1;
+const TORRENT_HEALING_INCREASE = 0.2;
+const TORRENT_CRIT_INCREASE = 0.1;
 
 class Torrent extends Analyzer {
+  static dependencies = {
+    statTracker: StatTracker,
+  };
+
+  protected statTracker!: StatTracker;
+
   healing = 0;
   overHealing = 0;
-  torrentIncrease = 0;
+
+  critMult = 2;
+  critIncrease = 0;
+
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.TORRENT_TALENT);
-    this.torrentIncrease =
-      TORRENT_HEALING_INCREASE * this.selectedCombatant.getTalentRank(TALENTS.TORRENT_TALENT);
+    if (!this.active) {
+      return;
+    }
+    this.critMult = this.selectedCombatant.hasTalent(TALENTS.WHITE_WATER_TALENT) ? 2.15 : 2;
+
     this.addEventListener(
       Events.heal.by(SELECTED_PLAYER).spell(TALENTS.RIPTIDE_TALENT),
       this._onHeal,
@@ -30,8 +45,19 @@ class Torrent extends Analyzer {
       return;
     }
 
-    this.healing += calculateEffectiveHealing(event, this.torrentIncrease);
-    this.overHealing += calculateOverhealing(event, this.torrentIncrease);
+    this.healing += calculateEffectiveHealing(event, TORRENT_HEALING_INCREASE);
+    this.overHealing += calculateOverhealing(event, TORRENT_HEALING_INCREASE);
+
+    if (event.hitType !== HIT_TYPES.CRIT) {
+      return;
+    }
+    const raw = event.amount + (event.absorbed || 0) + (event.overheal || 0);
+    const healingIncrease = raw - raw / this.critMult;
+    const effectiveHealing = healingIncrease - (event.overheal || 0);
+    const effectiveCritHit = Math.max(0, effectiveHealing);
+    this.critIncrease +=
+      (effectiveCritHit * TORRENT_CRIT_INCREASE) /
+      (this.statTracker.currentCritPercentage + TORRENT_CRIT_INCREASE);
   }
 
   statistic() {
@@ -43,6 +69,9 @@ class Torrent extends Analyzer {
           <>
             <strong>{formatNumber(this.healing)}</strong> bonus healing (
             {formatNumber(this.overHealing)} overhealing)
+            <br />
+            <strong>{formatNumber(this.critIncrease)}</strong> estimated bonus healing from the
+            increased critical strike chance. This is not included in the HPS value below.
           </>
         }
       >


### PR DESCRIPTION
### Description

Fix logic for torrent statistic for resto shaman talent.

### Testing

- Test report URL: https://www.warcraftlogs.com/reports/AdqHK6yF1pCgRaZV?fight=23&type=healing&source=22
- Screenshot(s):
Before: 
<img width="437" alt="image" src="https://github.com/user-attachments/assets/a71501d3-fdb5-4f96-9b87-3ed718d73f7b" />

After:
<img width="319" alt="image" src="https://github.com/user-attachments/assets/f47e7863-f227-42dd-bfe2-c30bad81028d" />
<img width="634" alt="image" src="https://github.com/user-attachments/assets/58fcf921-4226-4eb8-b885-fc2988e9cd3d" />

