### PR TITLE
Update Aug for 11.1

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2025, 2, 23), <>Updated for 11.1. Updated <SpellLink spell={TALENTS.EBON_MIGHT_TALENT}/> module. Added a module for <SpellLink spell={TALENTS.UPHEAVAL_TALENT}/> <SpellLink spell={SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF}/> procs. Multiple adjustments when <SpellLink spell={TALENTS.MOTES_OF_POSSIBILITY_TALENT}/> talent is taken.</>, KYZ),
   change(date(2025, 1, 21), "Update guide section", KYZ),
   change(date(2025, 1, 16),  <>Implement <SpellLink spell={TALENTS.TIME_SPIRAL_TALENT}/>, <SpellLink spell={TALENTS.TIME_CONVERGENCE_TALENT}/>, <SpellLink spell={TALENTS.MASTER_OF_DESTINY_TALENT}/>, <SpellLink spell={TALENTS.MOTES_OF_ACCELERATION_TALENT}/>, <SpellLink spell={TALENTS.GOLDEN_OPPORTUNITY_TALENT}/>, <SpellLink spell={TALENTS.OVERLORD_TALENT}/>, and <SpellLink spell={TALENTS.HOARDED_POWER_TALENT}/> modules</>, KYZ),
   change(date(2024, 12, 30), "Update guide section", KYZ),

--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 
 export default [
-  change(date(2025, 2, 23), <>Updated for 11.1. Updated <SpellLink spell={TALENTS.EBON_MIGHT_TALENT}/> module. Added a module for <SpellLink spell={TALENTS.UPHEAVAL_TALENT}/> <SpellLink spell={SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF}/> procs. Multiple adjustments when <SpellLink spell={TALENTS.MOTES_OF_POSSIBILITY_TALENT}/> talent is taken.</>, KYZ),
+  change(date(2025, 2, 26), <>Updated for 11.1. Updated <SpellLink spell={TALENTS.EBON_MIGHT_TALENT}/> module. Added a module for <SpellLink spell={TALENTS.UPHEAVAL_TALENT}/> <SpellLink spell={SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF}/> procs. Multiple adjustments when <SpellLink spell={TALENTS.MOTES_OF_POSSIBILITY_TALENT}/> talent is taken.</>, KYZ),
   change(date(2025, 1, 21), "Update guide section", KYZ),
   change(date(2025, 1, 16),  <>Implement <SpellLink spell={TALENTS.TIME_SPIRAL_TALENT}/>, <SpellLink spell={TALENTS.TIME_CONVERGENCE_TALENT}/>, <SpellLink spell={TALENTS.MASTER_OF_DESTINY_TALENT}/>, <SpellLink spell={TALENTS.MOTES_OF_ACCELERATION_TALENT}/>, <SpellLink spell={TALENTS.GOLDEN_OPPORTUNITY_TALENT}/>, <SpellLink spell={TALENTS.OVERLORD_TALENT}/>, and <SpellLink spell={TALENTS.HOARDED_POWER_TALENT}/> modules</>, KYZ),
   change(date(2024, 12, 30), "Update guide section", KYZ),

--- a/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
@@ -37,6 +37,7 @@ import EbonMightNormalizer from './modules/normalizers/EbonMightNormalizer';
 
 // Tier
 import T32Augmentation2P from './modules/thewarwithin/T32Augmentation2P';
+import T33Augmentation4P from './modules/thewarwithin/T33Augmentation4P';
 
 //Shared
 import {
@@ -167,6 +168,7 @@ class CombatLogParser extends MainCombatLogParser {
 
     // Tier
     t32Augmentation2P: T32Augmentation2P,
+    t33Augmentation4P: T33Augmentation4P,
   };
   static guide = Guide;
 }

--- a/src/analysis/retail/evoker/augmentation/constants.tsx
+++ b/src/analysis/retail/evoker/augmentation/constants.tsx
@@ -22,9 +22,7 @@ export const DREAM_OF_SPRINGS_EXTENSION_MS = 1000;
 export const SANDS_OF_TIME_CRIT_MOD = 0.5;
 
 //Close as Clutchmates
-export const CLOSE_AS_CLUTCHMATES_MOD = 1.0;
-//Change to below on 11.1 release
-//export const CLOSE_AS_CLUTCHMATES_MOD = 1.25;
+export const CLOSE_AS_CLUTCHMATES_MOD = 1.25;
 
 // Prescience
 export const PRESCIENCE_BASE_DURATION_MS = 18000;

--- a/src/analysis/retail/evoker/augmentation/constants.tsx
+++ b/src/analysis/retail/evoker/augmentation/constants.tsx
@@ -22,7 +22,7 @@ export const DREAM_OF_SPRINGS_EXTENSION_MS = 1000;
 export const SANDS_OF_TIME_CRIT_MOD = 0.5;
 
 //Close as Clutchmates
-export const CLOSE_AS_CLUTCHMATES_MOD = 1.25;
+export const CLOSE_AS_CLUTCHMATES_MOD = 1.1;
 
 // Prescience
 export const PRESCIENCE_BASE_DURATION_MS = 18000;

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/EbonMight.tsx
@@ -46,6 +46,8 @@ import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import { formatNumber } from 'common/format';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import { UPHEAVAL_REVERBERATION_DAM_LINK } from '../normalizers/CastLinkNormalizer';
+import { InformationIcon } from 'interface/icons';
+import { formatPercentage } from 'common/format';
 
 const PANDEMIC_WINDOW = 0.3;
 
@@ -87,8 +89,8 @@ class EbonMight extends Analyzer {
   private prescienceCasts: PrescienceBuffs[] = [];
 
   private personalDamageAmp = isMythicPlus(this.owner.fight)
-    ? EBON_MIGHT_PERSONAL_DAMAGE_AMP
-    : EBON_MIGHT_PERSONAL_DAMAGE_AMP * CLOSE_AS_CLUTCHMATES_MOD;
+    ? EBON_MIGHT_PERSONAL_DAMAGE_AMP * CLOSE_AS_CLUTCHMATES_MOD
+    : EBON_MIGHT_PERSONAL_DAMAGE_AMP;
 
   ebonMightActive: boolean = false;
   currentEbonMightDuration: number = 0;
@@ -569,6 +571,9 @@ class EbonMight extends Analyzer {
   }
 
   statistic() {
+    const buffUptime =
+      this.selectedCombatant.getBuffUptime(SPELLS.EBON_MIGHT_BUFF_PERSONAL.id) /
+      this.owner.fightDuration;
     const damageSources = [
       {
         color: 'rgb(212, 81, 19)',
@@ -592,6 +597,8 @@ class EbonMight extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
       >
         <TalentSpellText talent={TALENTS.EBON_MIGHT_TALENT}>
+          <InformationIcon /> {formatPercentage(buffUptime, 2)}%<small> buff uptime</small>
+          <br />
           <ItemDamageDone amount={this.personalEbonMightDamage + this.externalEbonMightDamage} />
         </TalentSpellText>
         <div className="pad">

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/ShiftingSands.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/ShiftingSands.tsx
@@ -32,6 +32,7 @@ class ShiftingSands extends Analyzer {
 
   constructor(options: Options) {
     super(options);
+    this.active = !this.selectedCombatant.hasTalent(TALENTS_EVOKER.MOTES_OF_POSSIBILITY_TALENT);
 
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SHIFTING_SANDS_BUFF),

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -218,7 +218,9 @@ class BuffTargetHelper extends Analyzer {
 
     const fetchPromises: Promise<DamageTables>[] = [];
     while (currentTime < this.fightEnd) {
-      fetchPromises.push(this.getDamage(currentTime));
+      if (this.ebonRemoveTimestamps[index]) {
+        fetchPromises.push(this.getDamage(currentTime, this.ebonRemoveTimestamps[index]));
+      }
       index += 1;
       currentTime = this.ebonApplyTimestamps[index];
     }
@@ -272,12 +274,12 @@ class BuffTargetHelper extends Analyzer {
     });
   }
 
-  async getDamage(currentTime: number): Promise<DamageTables> {
+  async getDamage(currentTime: number, endTime: number): Promise<DamageTables> {
     const normalDamage = await fetchWcl<WCLDamageDoneTableResponse>(
       `report/tables/damage-done/${this.owner.report.code}`,
       {
         start: currentTime,
-        end: currentTime + this.interval,
+        end: endTime,
         filter: this.getFilter(false),
       },
     );
@@ -285,7 +287,7 @@ class BuffTargetHelper extends Analyzer {
       `report/tables/damage-done/${this.owner.report.code}`,
       {
         start: currentTime,
-        end: currentTime + this.interval,
+        end: endTime,
         filter: this.getFilter(true),
       },
     );

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -7,7 +7,12 @@ import classColor from 'game/classColor';
 import ROLES from 'game/ROLES';
 import SPECS from 'game/SPECS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, RefreshBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
+import Events, {
+  ApplyBuffEvent,
+  FightEndEvent,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
 import Combatants from 'parser/shared/modules/Combatants';
 import { isMythicPlus } from 'common/isMythicPlus';
 import '../../Styling.scss';
@@ -135,6 +140,7 @@ class BuffTargetHelper extends Analyzer {
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.EBON_MIGHT_BUFF_PERSONAL),
       this.onEbonRemove,
     );
+    this.addEventListener(Events.fightend, this.onEbonRemoveFightEnd);
     /** Populate our whitelist */
     this.addEventListener(Events.fightend, () => {
       const players = Object.values(this.combatants.players);
@@ -165,6 +171,10 @@ class BuffTargetHelper extends Analyzer {
   }
 
   onEbonRemove(event: RemoveBuffEvent) {
+    this.ebonRemoveTimestamps.push(event.timestamp);
+  }
+
+  onEbonRemoveFightEnd(event: FightEndEvent) {
     this.ebonRemoveTimestamps.push(event.timestamp);
   }
 
@@ -351,7 +361,7 @@ class BuffTargetHelper extends Analyzer {
 
     for (let i = 0; i < topPumpersData.length; i += 1) {
       const intervalStart = this.owner.formatTimestamp(this.ebonApplyTimestamps[i]);
-      const intervalEnd = this.owner.formatTimestamp(this.ebonApplyTimestamps[i] + this.interval);
+      const intervalEnd = this.owner.formatTimestamp(this.ebonRemoveTimestamps[i]);
 
       const formattedEntriesTable = top4PumpersData[i].map(([name, values]) => (
         <td key={name}>
@@ -394,14 +404,14 @@ class BuffTargetHelper extends Analyzer {
             </tbody>
           </table>
         </div>
-        <div className="button-container">
+        {/*         <div className="button-container">
           <button className="button" onClick={this.handlePrescienceHelperCopyClick}>
             Copy Prescience Helper MRT note
           </button>
           <button className="button" onClick={this.handleFourTargetCopyClick}>
             Copy Frame Glow MRT note
           </button>
-        </div>
+        </div> */}
       </div>
     );
   }
@@ -590,15 +600,13 @@ class BuffTargetHelper extends Analyzer {
               This module will help you with finding the optimal buff targets for{' '}
               <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> and{' '}
               <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. It will show you the top 4 DPS for
-              each 30 second interval (27 with{' '}
-              <SpellLink spell={TALENTS.INTERWOVEN_THREADS_TALENT} /> talented)
+              each of your Ebon Might windows. Refreshing Ebon Might is counted as a new window.
             </p>
             <p>
               Damage events that doesn't get amplified by your buffs will be ignored. <br />
               Tanks, Healers and other Augmentations are not included. <br />
-              Phases are also not accounted for for now.
             </p>
-            <p>
+            {/*             <p>
               This module will also produce a note for{' '}
               <a href="https://www.curseforge.com/wow/addons/method-raid-tools">
                 Method Raid Tools
@@ -609,7 +617,7 @@ class BuffTargetHelper extends Analyzer {
               <a href="https://wago.io/yrmx6ZQSG">Prescience Helper</a> WeakAura made by{' '}
               <b>HenryG</b> or the <a href="https://wago.io/KP-BlDV58">Frame Glows</a> WeakAura made
               by <b>Zephy</b> based on which Weak Aura you use.
-            </p>
+            </p> */}
 
             {this.has4Pc && <BuffTargetHelperInfoLabel />}
           </div>

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -175,7 +175,9 @@ class BuffTargetHelper extends Analyzer {
   }
 
   onEbonRemoveFightEnd(event: FightEndEvent) {
-    this.ebonRemoveTimestamps.push(event.timestamp);
+    if (this.selectedCombatant.hasBuff(SPELLS.EBON_MIGHT_BUFF_PERSONAL)) {
+      this.ebonRemoveTimestamps.push(event.timestamp);
+    }
   }
 
   /** Generate filter based on our ability filters */

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -1,12 +1,13 @@
 import TALENTS from 'common/TALENTS/evoker';
+import SPELLS from 'common/SPELLS/evoker';
 import { WCLDamageDoneTableResponse } from 'common/WCL_TYPES';
 import fetchWcl from 'common/fetchWclApi';
 import { formatDuration, formatMilliseconds, formatNumber } from 'common/format';
 import classColor from 'game/classColor';
 import ROLES from 'game/ROLES';
 import SPECS from 'game/SPECS';
-import Analyzer, { Options } from 'parser/core/Analyzer';
-import Events from 'parser/core/Events';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { ApplyBuffEvent, RefreshBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
 import Combatants from 'parser/shared/modules/Combatants';
 import { isMythicPlus } from 'common/isMythicPlus';
 import '../../Styling.scss';
@@ -114,11 +115,26 @@ class BuffTargetHelper extends Analyzer {
   abilityBlacklist: string = [...ABILITY_BLACKLIST].join(', ');
   abilityFilter = [...ABILITY_NO_BOE_SCALING].join(', ');
 
+  ebonApplyTimestamps: number[] = [];
+  ebonRemoveTimestamps: number[] = [];
+
   constructor(options: Options) {
     super(options);
     /** No need to show this in dungeon runs, for obvious reasons */
     this.active = !isMythicPlus(this.owner.fight);
 
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.EBON_MIGHT_BUFF_PERSONAL),
+      this.onEbonApply,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.EBON_MIGHT_BUFF_PERSONAL),
+      this.onEbonRefresh,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.EBON_MIGHT_BUFF_PERSONAL),
+      this.onEbonRemove,
+    );
     /** Populate our whitelist */
     this.addEventListener(Events.fightend, () => {
       const players = Object.values(this.combatants.players);
@@ -138,6 +154,20 @@ class BuffTargetHelper extends Analyzer {
       });
     });
   }
+
+  onEbonApply(event: ApplyBuffEvent) {
+    this.ebonApplyTimestamps.push(event.timestamp);
+  }
+
+  onEbonRefresh(event: RefreshBuffEvent) {
+    this.ebonRemoveTimestamps.push(event.timestamp);
+    this.ebonApplyTimestamps.push(event.timestamp);
+  }
+
+  onEbonRemove(event: RemoveBuffEvent) {
+    this.ebonRemoveTimestamps.push(event.timestamp);
+  }
+
   /** Generate filter based on our ability filters */
   getFilter(noEbonScaling: boolean) {
     let filter = `(not ability.id in(${this.abilityBlacklist})) 
@@ -171,12 +201,14 @@ class BuffTargetHelper extends Analyzer {
 
     // Start 4 seconds in since you start the fight with 2x Prescience -> Ebon Might
     // This will also show MUCH better value targets
-    let currentTime = this.fightStart + this.fightStartDelay;
+    let index = 0;
+    let currentTime = this.ebonApplyTimestamps[index];
 
     const fetchPromises: Promise<DamageTables>[] = [];
     while (currentTime < this.fightEnd) {
       fetchPromises.push(this.getDamage(currentTime));
-      currentTime += this.interval;
+      index += 1;
+      currentTime = this.ebonApplyTimestamps[index];
     }
 
     const result = await Promise.all(fetchPromises);
@@ -318,10 +350,8 @@ class BuffTargetHelper extends Analyzer {
     );
 
     for (let i = 0; i < topPumpersData.length; i += 1) {
-      const intervalStart = formatDuration(i * this.interval + this.fightStartDelay);
-      const intervalEnd = formatDuration(
-        Math.min((i + 1) * this.interval + this.fightStartDelay, this.fightEnd - this.fightStart),
-      );
+      const intervalStart = this.owner.formatTimestamp(this.ebonApplyTimestamps[i]);
+      const intervalEnd = this.owner.formatTimestamp(this.ebonApplyTimestamps[i] + this.interval);
 
       const formattedEntriesTable = top4PumpersData[i].map(([name, values]) => (
         <td key={name}>

--- a/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/features/BuffTargetHelper/BuffTargetHelper.tsx
@@ -213,16 +213,13 @@ class BuffTargetHelper extends Analyzer {
 
     // Start 4 seconds in since you start the fight with 2x Prescience -> Ebon Might
     // This will also show MUCH better value targets
-    let index = 0;
-    let currentTime = this.ebonApplyTimestamps[index];
-
     const fetchPromises: Promise<DamageTables>[] = [];
-    while (currentTime < this.fightEnd) {
-      if (this.ebonRemoveTimestamps[index]) {
-        fetchPromises.push(this.getDamage(currentTime, this.ebonRemoveTimestamps[index]));
+    for (let i = 0; i < this.ebonApplyTimestamps.length; i += 1) {
+      if (this.ebonApplyTimestamps[i] && this.ebonRemoveTimestamps[i]) {
+        fetchPromises.push(
+          this.getDamage(this.ebonApplyTimestamps[i], this.ebonRemoveTimestamps[i]),
+        );
       }
-      index += 1;
-      currentTime = this.ebonApplyTimestamps[index];
     }
 
     const result = await Promise.all(fetchPromises);

--- a/src/analysis/retail/evoker/augmentation/modules/guide/CoreRotation.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/guide/CoreRotation.tsx
@@ -62,6 +62,8 @@ export function CoreRotationSection({ modules, events, info }: GuideProps<typeof
 
       {modules.shiftingSands.guideSubsection()}
 
+      {modules.t33Augmentation4P.guideSubsection()}
+
       {modules.moltenEmbers.guideSubsection()}
     </Section>
   );

--- a/src/analysis/retail/evoker/augmentation/modules/talents/SymbioticBloom.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/SymbioticBloom.tsx
@@ -22,14 +22,17 @@ import { SYMBIOTIC_HEALING_INCREASE } from '../../constants';
 class SymbioticBloom extends Analyzer {
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.hasTalent(TALENTS.SYMBIOTIC_BLOOM_TALENT);
+    this.active =
+      this.selectedCombatant.hasTalent(TALENTS.SYMBIOTIC_BLOOM_TALENT) ||
+      this.selectedCombatant.hasTalent(TALENTS.MOTES_OF_POSSIBILITY_TALENT);
   }
   // This is an approximation. See the reasoning below.
   totalHealingFromSymbioticBloomBuff = 0;
 
-  symbioticBloomHealIncrease =
-    SYMBIOTIC_HEALING_INCREASE *
-    this.selectedCombatant.getTalentRank(TALENTS.SYMBIOTIC_BLOOM_TALENT);
+  symbioticBloomHealIncrease = this.selectedCombatant.hasTalent(TALENTS.SYMBIOTIC_BLOOM_TALENT)
+    ? SYMBIOTIC_HEALING_INCREASE *
+      this.selectedCombatant.getTalentRank(TALENTS.SYMBIOTIC_BLOOM_TALENT)
+    : SYMBIOTIC_HEALING_INCREASE * 2;
 
   get filter() {
     return `
@@ -77,7 +80,11 @@ class SymbioticBloom extends Analyzer {
             displayPercentage={false}
           />
         }
-        label="Symbiotic Bloom Buff Contribution"
+        label={
+          this.selectedCombatant.hasTalent(TALENTS.SYMBIOTIC_BLOOM_TALENT)
+            ? 'Symbiotic Bloom Buff Contribution'
+            : 'Symbiotic Bloom Buff Contribution (Motes of Possibility)'
+        }
         tooltip={
           <>
             <SpellLink spell={TALENTS.SYMBIOTIC_BLOOM_TALENT} /> contributed{' '}

--- a/src/analysis/retail/evoker/augmentation/modules/thewarwithin/T32Augmentation2P.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/thewarwithin/T32Augmentation2P.tsx
@@ -22,13 +22,13 @@ import {
 /**
  * (4) Set Augmentation: Upheaval deals 30% increased damage and increases the damage of your next 2 Eruption casts by 30%.
  */
-class TectonicLocus extends Analyzer {
+class T32Augmentation2P extends Analyzer {
   upheavalDamageIncrease = 0;
   volcanicUpsurgeDamage = 0;
 
   constructor(options: Options) {
     super(options);
-    this.active = this.selectedCombatant.has4PieceByTier(TIERS.TWW1);
+    this.active = this.selectedCombatant.has2PieceByTier(TIERS.TWW1);
 
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell([SPELLS.UPHEAVAL_DAM, SPELLS.UPHEAVAL_DOT]),
@@ -103,4 +103,4 @@ class TectonicLocus extends Analyzer {
   }
 }
 
-export default TectonicLocus;
+export default T32Augmentation2P;

--- a/src/analysis/retail/evoker/augmentation/modules/thewarwithin/T33Augmentation4P.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/thewarwithin/T33Augmentation4P.tsx
@@ -1,0 +1,141 @@
+import SPELLS from 'common/SPELLS/evoker';
+import TALENTS from 'common/TALENTS/evoker';
+
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { EmpowerEndEvent } from 'parser/core/Events';
+import { TIERS } from 'game/TIERS';
+import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import ContextualSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
+import SpellLink from 'interface/SpellLink';
+import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
+
+type UpheavalCast = {
+  event: EmpowerEndEvent;
+  essenceBurstStacks: number;
+};
+/**
+ * (4) Set Augmentation: Upheaval deals 30% increased damage and increases the damage of your next 2 Eruption casts by 30%.
+ */
+class T33Augmentation4P extends Analyzer {
+  private uses: SpellUse[] = [];
+  private upheavalCasts: UpheavalCast[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.active =
+      this.selectedCombatant.has4PieceByTier(TIERS.TWW2) &&
+      this.selectedCombatant.hasTalent(TALENTS.ROCKFALL_TALENT);
+
+    this.addEventListener(
+      Events.empowerEnd.by(SELECTED_PLAYER).spell([TALENTS.UPHEAVAL_TALENT, SPELLS.UPHEAVAL_FONT]),
+      this.onUpheavalCast,
+    );
+
+    this.addEventListener(Events.fightend, this.finalize);
+  }
+
+  onUpheavalCast(event: EmpowerEndEvent) {
+    const essenceBurstStacks = this.selectedCombatant.getBuffStacks(
+      SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF,
+    );
+
+    this.upheavalCasts.push({
+      event,
+      essenceBurstStacks,
+    });
+  }
+
+  private finalize() {
+    // finalize performances
+    this.uses = this.upheavalCasts.map((upheavalCast) => this.upheavalUsage(upheavalCast));
+  }
+
+  private upheavalUsage(upheavalCast: UpheavalCast): SpellUse {
+    const summary = (
+      <div>
+        <SpellLink spell={SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF} /> stacks
+      </div>
+    );
+    let performance = null;
+    let details = null;
+    if (upheavalCast.essenceBurstStacks === 2) {
+      performance = QualitativePerformance.Fail;
+      details = (
+        <div>
+          You cast <SpellLink spell={TALENTS.UPHEAVAL_TALENT} /> at 2 stacks of{' '}
+          <SpellLink spell={SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF} />, which is likely to waste
+          Essence Burst procs.
+        </div>
+      );
+    } else if (upheavalCast.essenceBurstStacks === 1) {
+      performance = QualitativePerformance.Good;
+      details = (
+        <div>
+          You cast <SpellLink spell={TALENTS.UPHEAVAL_TALENT} /> at 1 stacks of{' '}
+          <SpellLink spell={SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF} />.
+        </div>
+      );
+    } else {
+      performance = QualitativePerformance.Perfect;
+      details = (
+        <div>
+          You cast <SpellLink spell={TALENTS.UPHEAVAL_TALENT} /> without any{' '}
+          <SpellLink spell={SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF} /> stacks. Good job!
+        </div>
+      );
+    }
+    const checklistItems: ChecklistUsageInfo[] = [
+      {
+        check: 'possible-extends',
+        timestamp: upheavalCast.event.timestamp,
+        performance,
+        summary,
+        details,
+      },
+    ];
+    const actualPerformance = combineQualitativePerformances(
+      checklistItems.map((item) => item.performance),
+    );
+    return {
+      event: upheavalCast.event,
+      performance: actualPerformance,
+      checklistItems,
+      performanceExplanation:
+        actualPerformance !== QualitativePerformance.Fail
+          ? `${actualPerformance} Usage`
+          : 'Bad Usage',
+    };
+  }
+
+  guideSubsection(): JSX.Element | null {
+    if (!this.active) {
+      return null;
+    }
+
+    const explanation = (
+      <section>
+        <SpellLink spell={TALENTS.ROCKFALL_TALENT} /> and Augmentation's Undermine 4 set bonus each
+        give you a high chance to generate a stack of{' '}
+        <SpellLink spell={TALENTS.ESSENCE_BURST_AUGMENTATION_TALENT} /> when casting{' '}
+        <SpellLink spell={TALENTS.UPHEAVAL_TALENT} />. For this reason, you should avoid casting it
+        when you already have 2 stacks of Essence Burst, as this is likely to waste Essence Burst
+        procs.
+      </section>
+    );
+
+    return (
+      <ContextualSpellUsageSubSection
+        title="Upheaval Essence Burst"
+        explanation={explanation}
+        uses={this.uses}
+        castBreakdownSmallText={
+          <> - These boxes represent each cast, colored by how good the usage was.</>
+        }
+        abovePerformanceDetails={<div style={{ marginBottom: 10 }}></div>}
+      />
+    );
+  }
+}
+
+export default T33Augmentation4P;

--- a/src/analysis/retail/evoker/augmentation/modules/thewarwithin/T33Augmentation4P.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/thewarwithin/T33Augmentation4P.tsx
@@ -15,7 +15,7 @@ type UpheavalCast = {
   essenceBurstStacks: number;
 };
 /**
- * (4) Set Augmentation: Upheaval deals 30% increased damage and increases the damage of your next 2 Eruption casts by 30%.
+ * (4) Set Augmentation: Upheavals have a 50% chance to grant Essence Burst. Essence Burst Eruptions deal 25% increased damage..
  */
 class T33Augmentation4P extends Analyzer {
   private uses: SpellUse[] = [];

--- a/src/analysis/retail/evoker/augmentation/modules/thewarwithin/T33Augmentation4P.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/thewarwithin/T33Augmentation4P.tsx
@@ -15,7 +15,7 @@ type UpheavalCast = {
   essenceBurstStacks: number;
 };
 /**
- * (4) Set Augmentation: Upheavals have a 50% chance to grant Essence Burst. Essence Burst Eruptions deal 25% increased damage..
+ * (4) Set Augmentation: Upheavals have a 50% chance to grant Essence Burst. Essence Burst Eruptions deal 25% increased damage.
  */
 class T33Augmentation4P extends Analyzer {
   private uses: SpellUse[] = [];

--- a/src/analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer.ts
@@ -38,6 +38,10 @@ export const EB_FROM_PRESCIENCE = 'ebFromPrescience';
 export const EB_FROM_ARCANE_VIGOR = 'ebFromArcaneVigor';
 export const EB_FROM_LF_CAST = 'ebFromLFCast';
 export const EB_FROM_LF_HEAL = 'ebFromLFHeal'; // Specifically used for Leaping Flames analysis
+export const EB_FROM_ROCKFALL = 'ebFromRockfall';
+export const EB_FROM_AUG_UNDERMINE_4PC = 'ebFromAugUndermine4pc';
+export const EB_FROM_ROCKFALL_EONS = 'ebFromRockfallEons';
+export const EB_FROM_AUG_UNDERMINE_4PC_EONS = 'ebFromAugUndermine4pcEons';
 const ESSENCE_BURST_BUFFER = 40; // Sometimes the EB comes a bit early/late
 const EB_LF_CAST_BUFFER = 1_000;
 const EMERALD_TRANCE_BUFFER = 5_000;
@@ -78,6 +82,58 @@ const EVENT_LINKS: EventLink[] = [
     isActive(c) {
       return c.hasTalent(TALENTS.ARCANE_VIGOR_TALENT);
     },
+  },
+  {
+    linkRelation: EB_FROM_ROCKFALL,
+    reverseLinkRelation: EB_FROM_ROCKFALL,
+    linkingEventId: [TALENTS.UPHEAVAL_TALENT.id, SPELLS.UPHEAVAL_FONT.id],
+    linkingEventType: EventType.EmpowerEnd,
+    referencedEventId: EB_BUFF_IDS,
+    referencedEventType: EB_GENERATION_EVENT_TYPES,
+    anyTarget: true,
+    forwardBufferMs: ESSENCE_BURST_BUFFER,
+    backwardBufferMs: ESSENCE_BURST_BUFFER,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS.ROCKFALL_TALENT),
+  },
+  {
+    linkRelation: EB_FROM_ROCKFALL_EONS,
+    reverseLinkRelation: EB_FROM_ROCKFALL_EONS,
+    linkingEventId: [TALENTS.BREATH_OF_EONS_TALENT.id, SPELLS.BREATH_OF_EONS_SCALECOMMANDER.id],
+    linkingEventType: EventType.Cast,
+    referencedEventId: EB_BUFF_IDS,
+    referencedEventType: EB_GENERATION_EVENT_TYPES,
+    anyTarget: true,
+    forwardBufferMs: ESSENCE_BURST_BUFFER,
+    backwardBufferMs: ESSENCE_BURST_BUFFER,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS.ROCKFALL_TALENT) && c.has2PieceByTier(TIERS.TWW2),
+  },
+  {
+    linkRelation: EB_FROM_AUG_UNDERMINE_4PC,
+    reverseLinkRelation: EB_FROM_AUG_UNDERMINE_4PC,
+    linkingEventId: [TALENTS.UPHEAVAL_TALENT.id, SPELLS.UPHEAVAL_FONT.id],
+    linkingEventType: EventType.EmpowerEnd,
+    referencedEventId: EB_BUFF_IDS,
+    referencedEventType: EB_GENERATION_EVENT_TYPES,
+    anyTarget: true,
+    forwardBufferMs: ESSENCE_BURST_BUFFER,
+    backwardBufferMs: ESSENCE_BURST_BUFFER,
+    maximumLinks: 1,
+    isActive: (c) => c.has4PieceByTier(TIERS.TWW2),
+  },
+  {
+    linkRelation: EB_FROM_AUG_UNDERMINE_4PC_EONS,
+    reverseLinkRelation: EB_FROM_AUG_UNDERMINE_4PC_EONS,
+    linkingEventId: [TALENTS.BREATH_OF_EONS_TALENT.id, SPELLS.BREATH_OF_EONS_SCALECOMMANDER.id],
+    linkingEventType: EventType.Cast,
+    referencedEventId: EB_BUFF_IDS,
+    referencedEventType: EB_GENERATION_EVENT_TYPES,
+    anyTarget: true,
+    forwardBufferMs: ESSENCE_BURST_BUFFER,
+    backwardBufferMs: ESSENCE_BURST_BUFFER,
+    maximumLinks: 1,
+    isActive: (c) => c.has4PieceByTier(TIERS.TWW2),
   },
   {
     linkRelation: EB_FROM_PRESCIENCE,

--- a/src/common/TALENTS/evoker.ts
+++ b/src/common/TALENTS/evoker.ts
@@ -1820,6 +1820,14 @@ const talents = {
     entryIds: [115661],
     definitionIds: [{ id: 120673, specId: 1473 }],
   },
+  FAN_THE_FLAMES_TALENT: {
+    id: 444318,
+    name: 'Fan the Flames',
+    icon: 'ability_evoker_oppressingroar2',
+    maxRanks: 1,
+    entryIds: [117520],
+    definitionIds: [{ id: 122532, specId: 1468 }],
+  },
 } satisfies Record<string, Talent>;
 
 export default talents;

--- a/src/common/TALENTS/evoker.ts
+++ b/src/common/TALENTS/evoker.ts
@@ -90,6 +90,14 @@ const talents = {
     entryIds: [115600],
     definitionIds: [{ id: 120612, specId: 1473 }],
   },
+  AZURE_CELERITY_TALENT: {
+    id: 1219723,
+    name: 'Azure Celerity',
+    icon: 'ability_evoker_masterylifebinder_blue',
+    maxRanks: 1,
+    entryIds: [115637],
+    definitionIds: [{ id: 120649, specId: 1467 }],
+  },
   AZURE_ESSENCE_BURST_TALENT: {
     id: 375721,
     name: 'Azure Essence Burst',
@@ -165,7 +173,7 @@ const talents = {
   CALL_OF_YSERA_TALENT: {
     id: 373834,
     name: 'Call of Ysera',
-    icon: '',
+    icon: 'inv_drakemountemerald',
     maxRanks: 1,
     entryIds: [115554],
     definitionIds: [{ id: 120566, specId: 1468 }],
@@ -523,8 +531,8 @@ const talents = {
     name: 'Expanded Lungs',
     icon: 'inv_fyrakk_dragonbreath',
     maxRanks: 1,
-    entryIds: [123767],
-    definitionIds: [{ id: 128605, specId: 1468 }],
+    entryIds: [128713],
+    definitionIds: [{ id: 133515, specId: 1468 }],
   },
   EXPUNGE_TALENT: {
     id: 365585,
@@ -567,14 +575,6 @@ const talents = {
     entryIds: [115630],
     definitionIds: [{ id: 120642, specId: 1467 }],
   },
-  FAN_THE_FLAMES_TALENT: {
-    id: 444318,
-    name: 'Fan the Flames',
-    icon: 'ability_evoker_oppressingroar2',
-    maxRanks: 1,
-    entryIds: [117520],
-    definitionIds: [{ id: 122532, specId: 1468 }],
-  },
   FATE_MIRROR_TALENT: {
     id: 412774,
     name: 'Fate Mirror',
@@ -614,6 +614,14 @@ const talents = {
     maxRanks: 1,
     entryIds: [115659],
     definitionIds: [{ id: 120671, specId: 1473 }],
+  },
+  FLAME_SIPHON_TALENT: {
+    id: 444140,
+    name: 'Flame Siphon',
+    icon: 'ability_evoker_infernosblessing',
+    maxRanks: 1,
+    entryIds: [123416],
+    definitionIds: [{ id: 128254, specId: 1468 }],
   },
   FLOW_STATE_TALENT: {
     id: 385696,
@@ -679,6 +687,14 @@ const talents = {
     entryIds: [115576],
     definitionIds: [{ id: 120588, specId: 1473 }],
   },
+  FULMINOUS_ROAR_TALENT: {
+    id: 1218447,
+    name: 'Fulminous Roar',
+    icon: 'ability_evoker_oppressingroar2',
+    maxRanks: 1,
+    entryIds: [117520],
+    definitionIds: [{ id: 122532, specId: 1468 }],
+  },
   GOLDEN_HOUR_TALENT: {
     id: 378196,
     name: 'Golden Hour',
@@ -732,11 +748,8 @@ const talents = {
     name: 'Hoarded Power',
     icon: 'ability_evoker_innatemagic2',
     maxRanks: 1,
-    entryIds: [115637, 115512],
-    definitionIds: [
-      { id: 120649, specId: 1467 },
-      { id: 120524, specId: 1473 },
-    ],
+    entryIds: [115512],
+    definitionIds: [{ id: 120524, specId: 1473 }],
   },
   HONED_AGGRESSION_TALENT: {
     id: 371038,
@@ -1336,6 +1349,14 @@ const talents = {
     entryIds: [115507],
     definitionIds: [{ id: 120519, specId: 1473 }],
   },
+  ROCKFALL_TALENT: {
+    id: 1219236,
+    name: 'Rockfall',
+    icon: 'ability_evoker_earthensky',
+    maxRanks: 1,
+    entryIds: [115688],
+    definitionIds: [{ id: 120700, specId: 1473 }],
+  },
   RUBY_EMBERS_TALENT: {
     id: 365937,
     name: 'Ruby Embers',
@@ -1391,14 +1412,6 @@ const talents = {
     maxRanks: 1,
     entryIds: [115622],
     definitionIds: [{ id: 120634, specId: 1467 }],
-  },
-  SEISMIC_SLAM_TALENT: {
-    id: 408543,
-    name: 'Seismic Slam',
-    icon: 'ability_evoker_seismicslam',
-    maxRanks: 1,
-    entryIds: [115688],
-    definitionIds: [{ id: 120700, specId: 1473 }],
   },
   SHAPE_OF_FLAME_TALENT: {
     id: 445074,
@@ -1700,14 +1713,6 @@ const talents = {
     maxRanks: 1,
     entryIds: [117534],
     definitionIds: [{ id: 122546, specId: 1468 }],
-  },
-  TRAVELING_FLAME_TALENT: {
-    id: 444140,
-    name: 'Traveling Flame',
-    icon: 'ability_evoker_infernosblessing',
-    maxRanks: 1,
-    entryIds: [123416],
-    definitionIds: [{ id: 128254, specId: 1468 }],
   },
   TWIN_GUARDIAN_TALENT: {
     id: 370888,


### PR DESCRIPTION
### Description

- Load Symbiotic Bloom module if the talent isn't taken but Motes of Possibility is, as motes can proc the buff.
- Disable the Shifting Sands module if Motes of Possibility is taken, as most 'failed' uses are more likely to be lucky mote streaks.
- Update Ebon Might buff helper to use the timestamps the player applied/removed Ebon Might on, rather than fixed 30/27 second intervals.
- Added a module for Upheaval Essence Burst uses.

### Testing

- Test report URLs: `https://www.warcraftlogs.com/reports/KwDT7GfLbFvVWdRn?fight=last&source=1` (Symbiotic Bloom, Upheaval); `https://www.warcraftlogs.com/reports/PdfBQVJRmDZpA6hX?fight=5&type=damage-done&source=13` (Ebon Might buff helper)
- Screenshot(s): 
![SymbioticMotes](https://github.com/user-attachments/assets/e77753b6-a59d-4423-b9c3-b51504d4ad20)
![Upheaval](https://github.com/user-attachments/assets/a5336340-32b6-448f-9e9f-d37a62b50c76)
![EbonHelper](https://github.com/user-attachments/assets/50bdb54e-bfd5-46a5-98d7-2add3a531590)
