### PR TITLE
Frost Mage APLs 11.1 update

### DIFF
--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore
 export default [
+  change(date(2025, 2, 27), <>Apls: Updated for Spell Slinger and Frostfire for patch 11.1</>, Earosselot),
   change(date(2024, 11, 22), <>Fixed a typo in the comet storm hit description</>, Soulhealer95),
   change(date(2024, 10, 18), <>Apls: Updated for Spell Slinger and added for Frostfire for patch 11.0.5</>, Earosselot),
   change(date(2024, 10, 17), <>Fixed Frostfire Bolt on Winters Chill module for Frostfire.</>, Earosselot),

--- a/src/analysis/retail/mage/frost/apl/FrostAplCommons.tsx
+++ b/src/analysis/retail/mage/frost/apl/FrostAplCommons.tsx
@@ -5,6 +5,11 @@ import SpellLink from 'interface/SpellLink';
 import { tenseAlt } from 'parser/shared/metrics/apl';
 
 export const precastGlacialSpike = cnd.lastSpellCast(TALENTS.GLACIAL_SPIKE_TALENT);
+export const precastGlacialSpikeAndNoWintersChill = cnd.and(
+  cnd.debuffMissing(SPELLS.WINTERS_CHILL),
+  precastGlacialSpike,
+);
+
 export const fiveIcicles = cnd.describe(
   cnd.and(cnd.buffStacks(SPELLS.ICICLES_BUFF, { atLeast: 5 }), cnd.not(precastGlacialSpike)),
   (tense) => (

--- a/src/analysis/retail/mage/frost/apl/FrostfireAplCheck.tsx
+++ b/src/analysis/retail/mage/frost/apl/FrostfireAplCheck.tsx
@@ -5,28 +5,60 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'interface/SpellLink';
 import * as apl from './FrostAplCommons';
 
+// flurry,if=buff.icicles.react<5&remaining_winters_chill=0&debuff.winters_chill.down&prev_gcd.1.glacial_spike
+// flurry,if=buff.icicles.react<5&remaining_winters_chill=0&debuff.winters_chill.down&prev_gcd.1.comet_storm
+// flurry,if=buff.icicles.react<5&remaining_winters_chill=0&debuff.winters_chill.down&prev_gcd.1.frostfire_bolt
+// flurry,if=buff.icicles.react<5&remaining_winters_chill=0&debuff.winters_chill.down&buff.excess_frost.react=2
+// flurry,if=buff.icicles.react<5&buff.brain_freeze.react&buff.excess_fire.react
+
+// 1. Flurry when (!WC and (after FFb/GS/CS or at 2 ExFr)) or BF+ExFi
+// 2. GS
+// 3. IL with FoF or WC
+// 4. FFb
+
+const lessThanFourIcicles = cnd.buffStacks(SPELLS.ICICLES_BUFF, { atMost: 4 });
 const precastFrostfireBolt = cnd.lastSpellCast(TALENTS.FROSTFIRE_BOLT_TALENT);
-const excessFrost = cnd.buffPresent(SPELLS.EXCESS_FROST_BUFF);
+const precastCommetStorm = cnd.lastSpellCast(TALENTS.COMET_STORM_TALENT);
+const excessFrostTwoStacks = cnd.buffStacks(SPELLS.EXCESS_FROST_BUFF, { atLeast: 2 });
+const excessFire = cnd.buffPresent(SPELLS.EXCESS_FIRE_BUFF);
+const brainFreeze = cnd.buffPresent(TALENTS.BRAIN_FREEZE_TALENT);
 
 const flurryFfCondition = cnd.or(
+  cnd.and(cnd.debuffMissing(SPELLS.WINTERS_CHILL), apl.precastGlacialSpike),
   cnd.and(
-    cnd.debuffMissing(SPELLS.WINTERS_CHILL),
-    cnd.or(precastFrostfireBolt, apl.precastGlacialSpike),
+    lessThanFourIcicles,
+    cnd.or(
+      cnd.and(
+        cnd.debuffMissing(SPELLS.WINTERS_CHILL),
+        cnd.or(
+          precastFrostfireBolt,
+          apl.precastGlacialSpike,
+          precastCommetStorm,
+          excessFrostTwoStacks,
+        ),
+      ),
+      cnd.and(excessFire, brainFreeze),
+    ),
   ),
-  excessFrost,
 );
 
 const flurryFfDescription = (
   <>
-    either:
+    you have less than 4 <SpellLink spell={SPELLS.ICICLES_BUFF} /> and either:
     <ul>
       <li>
-        no <SpellLink spell={SPELLS.WINTERS_CHILL} /> on target and precasted (
-        <SpellLink spell={TALENTS.FROSTFIRE_BOLT_TALENT} /> or{' '}
-        <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} />)
+        no <SpellLink spell={SPELLS.WINTERS_CHILL} /> on target and just cast{' '}
+        <SpellLink spell={TALENTS.FROSTFIRE_BOLT_TALENT} />,{' '}
+        <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} /> or{' '}
+        <SpellLink spell={TALENTS.COMET_STORM_TALENT} />
       </li>
       <li>
-        have <SpellLink spell={TALENTS.EXCESS_FROST_TALENT} />
+        no <SpellLink spell={SPELLS.WINTERS_CHILL} /> on target and have 2 stacks of{' '}
+        <SpellLink spell={SPELLS.EXCESS_FROST_BUFF} />
+      </li>
+      <li>
+        or have <SpellLink spell={SPELLS.EXCESS_FIRE_BUFF} /> and{' '}
+        <SpellLink spell={TALENTS.BRAIN_FREEZE_TALENT} />
       </li>
     </ul>
   </>
@@ -34,12 +66,12 @@ const flurryFfDescription = (
 
 export const frostfireApl = build([
   {
-    spell: TALENTS.GLACIAL_SPIKE_TALENT,
-    condition: cnd.and(apl.fiveIcicles),
-  },
-  {
     spell: TALENTS.FLURRY_TALENT,
     condition: cnd.describe(flurryFfCondition, (tense) => flurryFfDescription),
+  },
+  {
+    spell: TALENTS.GLACIAL_SPIKE_TALENT,
+    condition: cnd.and(apl.fiveIcicles),
   },
   {
     spell: TALENTS.ICE_LANCE_TALENT,

--- a/src/analysis/retail/mage/frost/apl/FrostfireAplCheck.tsx
+++ b/src/analysis/retail/mage/frost/apl/FrostfireAplCheck.tsx
@@ -2,72 +2,47 @@ import aplCheck, { build } from 'parser/shared/metrics/apl';
 import TALENTS from 'common/TALENTS/mage';
 import * as cnd from 'parser/shared/metrics/apl/conditions';
 import SPELLS from 'common/SPELLS';
-import SpellLink from 'interface/SpellLink';
 import * as apl from './FrostAplCommons';
-
-// flurry,if=buff.icicles.react<5&remaining_winters_chill=0&debuff.winters_chill.down&prev_gcd.1.glacial_spike
-// flurry,if=buff.icicles.react<5&remaining_winters_chill=0&debuff.winters_chill.down&prev_gcd.1.comet_storm
-// flurry,if=buff.icicles.react<5&remaining_winters_chill=0&debuff.winters_chill.down&prev_gcd.1.frostfire_bolt
-// flurry,if=buff.icicles.react<5&remaining_winters_chill=0&debuff.winters_chill.down&buff.excess_frost.react=2
-// flurry,if=buff.icicles.react<5&buff.brain_freeze.react&buff.excess_fire.react
-
-// 1. Flurry when (!WC and (after FFb/GS/CS or at 2 ExFr)) or BF+ExFi
-// 2. GS
-// 3. IL with FoF or WC
-// 4. FFb
 
 const lessThanFourIcicles = cnd.buffStacks(SPELLS.ICICLES_BUFF, { atMost: 4 });
 const precastFrostfireBolt = cnd.lastSpellCast(TALENTS.FROSTFIRE_BOLT_TALENT);
 const precastCommetStorm = cnd.lastSpellCast(TALENTS.COMET_STORM_TALENT);
 const excessFrostTwoStacks = cnd.buffStacks(SPELLS.EXCESS_FROST_BUFF, { atLeast: 2 });
 const excessFire = cnd.buffPresent(SPELLS.EXCESS_FIRE_BUFF);
-const brainFreeze = cnd.buffPresent(TALENTS.BRAIN_FREEZE_TALENT);
+const brainFreeze = cnd.buffPresent(SPELLS.BRAIN_FREEZE_BUFF);
 
-const flurryFfCondition = cnd.or(
-  cnd.and(cnd.debuffMissing(SPELLS.WINTERS_CHILL), apl.precastGlacialSpike),
-  cnd.and(
-    lessThanFourIcicles,
-    cnd.or(
-      cnd.and(
-        cnd.debuffMissing(SPELLS.WINTERS_CHILL),
-        cnd.or(
-          precastFrostfireBolt,
-          apl.precastGlacialSpike,
-          precastCommetStorm,
-          excessFrostTwoStacks,
-        ),
-      ),
-      cnd.and(excessFire, brainFreeze),
-    ),
-  ),
+const flurryGSCondition = cnd.and(cnd.debuffMissing(SPELLS.WINTERS_CHILL), apl.precastGlacialSpike);
+
+const flurryFfbCsCondition = cnd.and(
+  lessThanFourIcicles,
+  cnd.debuffMissing(SPELLS.WINTERS_CHILL),
+  cnd.or(precastFrostfireBolt, precastCommetStorm),
 );
 
-const flurryFfDescription = (
-  <>
-    you have less than 4 <SpellLink spell={SPELLS.ICICLES_BUFF} /> and either:
-    <ul>
-      <li>
-        no <SpellLink spell={SPELLS.WINTERS_CHILL} /> on target and just cast{' '}
-        <SpellLink spell={TALENTS.FROSTFIRE_BOLT_TALENT} />,{' '}
-        <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} /> or{' '}
-        <SpellLink spell={TALENTS.COMET_STORM_TALENT} />
-      </li>
-      <li>
-        no <SpellLink spell={SPELLS.WINTERS_CHILL} /> on target and have 2 stacks of{' '}
-        <SpellLink spell={SPELLS.EXCESS_FROST_BUFF} />
-      </li>
-      <li>
-        or have <SpellLink spell={SPELLS.EXCESS_FIRE_BUFF} /> and{' '}
-        <SpellLink spell={TALENTS.BRAIN_FREEZE_TALENT} />
-      </li>
-    </ul>
-  </>
+const flurryExFrostCondition = cnd.and(
+  lessThanFourIcicles,
+  cnd.debuffMissing(SPELLS.WINTERS_CHILL),
+  excessFrostTwoStacks,
 );
+
+const FlurryExFireCondition = cnd.and(excessFire, brainFreeze);
 
 export const frostfireApl = build([
   {
     spell: TALENTS.FLURRY_TALENT,
-    condition: cnd.describe(flurryFfCondition, (tense) => flurryFfDescription),
+    condition: flurryGSCondition,
+  },
+  {
+    spell: TALENTS.FLURRY_TALENT,
+    condition: flurryFfbCsCondition,
+  },
+  {
+    spell: TALENTS.FLURRY_TALENT,
+    condition: flurryExFrostCondition,
+  },
+  {
+    spell: TALENTS.FLURRY_TALENT,
+    condition: FlurryExFireCondition,
   },
   {
     spell: TALENTS.GLACIAL_SPIKE_TALENT,

--- a/src/analysis/retail/mage/frost/apl/FrostfireAplCheck.tsx
+++ b/src/analysis/retail/mage/frost/apl/FrostfireAplCheck.tsx
@@ -11,8 +11,6 @@ const excessFrostTwoStacks = cnd.buffStacks(SPELLS.EXCESS_FROST_BUFF, { atLeast:
 const excessFire = cnd.buffPresent(SPELLS.EXCESS_FIRE_BUFF);
 const brainFreeze = cnd.buffPresent(SPELLS.BRAIN_FREEZE_BUFF);
 
-const flurryGSCondition = cnd.and(cnd.debuffMissing(SPELLS.WINTERS_CHILL), apl.precastGlacialSpike);
-
 const flurryFfbCsCondition = cnd.and(
   lessThanFourIcicles,
   cnd.debuffMissing(SPELLS.WINTERS_CHILL),
@@ -30,7 +28,7 @@ const FlurryExFireCondition = cnd.and(excessFire, brainFreeze);
 export const frostfireApl = build([
   {
     spell: TALENTS.FLURRY_TALENT,
-    condition: flurryGSCondition,
+    condition: apl.precastGlacialSpikeAndNoWintersChill,
   },
   {
     spell: TALENTS.FLURRY_TALENT,

--- a/src/analysis/retail/mage/frost/apl/SpellslingerAplCheck.tsx
+++ b/src/analysis/retail/mage/frost/apl/SpellslingerAplCheck.tsx
@@ -5,12 +5,6 @@ import SPELLS from 'common/SPELLS';
 import SpellLink from 'interface/SpellLink';
 import * as apl from './FrostAplCommons';
 
-// 1. Flurry noWC & precasted FB / GS
-// 2. GS when can Shatter
-// 3. Frostbolt if Talent DC & IVbuff > 8 & DC < 8
-// 4. IL on 2WC or WC & BF
-// 5. Frostbolt
-
 const flurrySsCondition = cnd.and(
   cnd.debuffMissing(SPELLS.WINTERS_CHILL),
   cnd.or(apl.precastFrostbolt, apl.precastGlacialSpike),


### PR DESCRIPTION
### Description

Updated APLs for Frost Mage 11.1

I kept Flurry conditions separated for Frostfire. I know it looks a little odd to have 4 different conditions to cast Flurry. But, otherwise is very difficult to understand wich was the action you were supposed to take when you failed.

### Testing

FrostFire:
- Test report URL: `report/G6mbzPcYJVwM3jFK/8-Mythic+Ulgrax+the+Devourer+-+Kill+(3:10)/Livri/standard`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/9a1335fc-1522-432a-a9be-22daef75fb62)

Spellslinger:
- Test report URL: `report/n239azbXJAdFkhRv/13-Mythic+Ulgrax+the+Devourer+-+Kill+(3:23)/Medvepocok/standard`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/efb1aad2-25b4-4eb3-a9ce-0f7f5f5d62f1)
