### PR TITLE
Druid Resto - supported 11.1 changes to Mastery and marked updated for 11.1

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2025, 3, 1), <>Updated Mastery calculations to account for 11.1 changes. Marked as updated for 11.1.0.</>, Sref),
   change(date(2025, 2, 16), <>Added support for the Liberation of Undermine tier set.</>, Sref),
   change(date(2024, 11, 18), <>Fixed an issue where <SpellLink spell={TALENTS_DRUID.HARMONIOUS_BLOOMING_TALENT} /> was counted as only 1 mastery stack.</>, Sref),
   change(date(2024, 10, 27), <>Updated for 11.0.5, handling added / changed talents and added statistics module for <SpellLink spell={TALENTS_DRUID.RENEWING_SURGE_TALENT} />. Fixed an issue where a cast efficiency bar would show for <SpellLink spell={TALENTS_DRUID.TRANQUILITY_TALENT} /> and <SpellLink spell={TALENTS_DRUID.INNERVATE_TALENT} /> even when player didn't take the talents. Fixed an issue where Grove Guardian Swiftmend healing wasn't registering.</>, Sref),

--- a/src/analysis/retail/druid/restoration/CONFIG.tsx
+++ b/src/analysis/retail/druid/restoration/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Sref],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '11.0.5',
+  patchCompatibility: '11.1.0',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/druid/restoration/constants.ts
+++ b/src/analysis/retail/druid/restoration/constants.ts
@@ -10,6 +10,27 @@ export const LIFEBLOOM_BUFFS: Spell[] = [
   SPELLS.LIFEBLOOM_UNDERGROWTH_HOT_HEAL,
 ];
 
+/** Given count of Druid HoTs on target, gets the multiplier against mastery val to apply */
+export function masteryHotCountToMult(hotsOn: number): number {
+  if (hotsOn > 10) {
+    return 3.65;
+  }
+  return MASTERY_HOT_COUNT_TO_MULT_TABLE[hotsOn];
+}
+const MASTERY_HOT_COUNT_TO_MULT_TABLE = [
+  0,
+  1,
+  1.7,
+  2.3,
+  2.8,
+  3.2,
+  3.5,
+  3.7,
+  3.8,
+  3.85,
+  3.65, // loses value here, probably a bug
+];
+
 /** Additional mastery stacks granted by Harmonius Blooming talent */
 export const HARMONIUS_BLOOMING_EXTRA_STACKS = 2;
 

--- a/src/analysis/retail/druid/restoration/modules/features/AverageHots.tsx
+++ b/src/analysis/retail/druid/restoration/modules/features/AverageHots.tsx
@@ -7,6 +7,8 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 import Mastery from '../core/Mastery';
 
+const DEBUG = false;
+
 class AverageHots extends Analyzer {
   static dependencies = {
     mastery: Mastery,
@@ -15,11 +17,12 @@ class AverageHots extends Analyzer {
   protected mastery!: Mastery;
 
   statistic() {
-    const avgTotalHots = this.mastery.getAverageTotalMasteryStacks().toFixed(2);
-    const avgDruidHots = this.mastery.getAverageDruidSpellMasteryStacks().toFixed(2);
+    const avgTotalBenefitMult = this.mastery.getAverageMasteryBonusMult().toFixed(2);
+    const avgDruidBenefitMult = this.mastery.getAverageDruidSpellMasteryBonusMult().toFixed(2);
 
-    console.log(`Total Healing: ${this.mastery.totalNoMasteryHealing}`);
-    console.log(`Total Mastery Effected Healing: ${this.mastery.druidSpellNoMasteryHealing}`);
+    DEBUG && console.log(`Total Healing: ${this.mastery.totalNoMasteryHealing}`);
+    DEBUG &&
+      console.log(`Total Mastery Effected Healing: ${this.mastery.druidSpellNoMasteryHealing}`);
 
     return (
       <Statistic
@@ -28,8 +31,9 @@ class AverageHots extends Analyzer {
         tooltip={
           <>
             <p>
-              This is the average effective number of mastery stacks your heals benefitted from,
-              weighted by healing done.
+              This is the average effective multiplier of your mastery your heals benefitted from,
+              weighted by healing done (for example if had 10% mastery and mastery increased your
+              heals by an average of 17%, the listed number would be 1.7).
             </p>
             <p>
               This number should not be read as a performance metric but rather a function of talent
@@ -39,8 +43,8 @@ class AverageHots extends Analyzer {
             </p>
             <p>
               This number includes all your healing, even heals that don't benefit from mastery
-              (like Trinkets, potions, Renewal, etc..) Your average mastery stacks counting only
-              heals that benefit from mastery is <strong>{avgDruidHots}</strong>.
+              (like Trinkets, potions, Renewal, etc..) Your average mastery multiplier counting only
+              heals that benefit from mastery is <strong>{avgDruidBenefitMult}</strong>.
             </p>
           </>
         }
@@ -48,11 +52,11 @@ class AverageHots extends Analyzer {
         <BoringValue
           label={
             <>
-              <SpellIcon spell={SPELLS.MASTERY_HARMONY} /> Average Mastery stacks
+              <SpellIcon spell={SPELLS.MASTERY_HARMONY} /> Average Mastery benefit
             </>
           }
         >
-          <>{avgTotalHots}</>
+          <>{avgTotalBenefitMult}</>
         </BoringValue>
       </Statistic>
     );

--- a/src/game/SPECS.ts
+++ b/src/game/SPECS.ts
@@ -339,7 +339,7 @@ const SPECS = {
     role: ROLES.HEALER,
     primaryStat: PRIMARY_STAT.INTELLECT,
     masterySpellId: 77495,
-    masteryCoefficient: 0.5,
+    masteryCoefficient: 0.728,
     branch: GameBranch.Retail,
     ranking: {
       class: 2,

--- a/src/game/VERSIONS.ts
+++ b/src/game/VERSIONS.ts
@@ -4,7 +4,7 @@ import GameBranch from './GameBranch';
 // The current version of the game. Used to check spec patch compatibility and as a caching key.
 const VERSIONS: { [branch in GameBranch]: string } = {
   [GameBranch.Classic]: '4.4.0',
-  [GameBranch.Retail]: '11.0.2',
+  [GameBranch.Retail]: '11.1.0',
 };
 
 export default VERSIONS;

--- a/src/parser/Config.ts
+++ b/src/parser/Config.ts
@@ -17,7 +17,10 @@ export type DragonflightPatchVersion = StringWithAutocompleteOptions<
 >;
 
 type NerubarPatchCycle = `11.0.${0 | 2 | 5}`;
-export type TwwPatchVersion = StringWithAutocompleteOptions<NerubarPatchCycle>;
+type UnderminePatchCycle = `11.1.0`;
+export type TwwPatchVersion = StringWithAutocompleteOptions<
+  NerubarPatchCycle | UnderminePatchCycle
+>;
 
 export type CataPatchVersion = StringWithAutocompleteOptions<`4.4.0`>;
 


### PR DESCRIPTION
### Description

This PR handles the mastery changes to Resto Druid in 11.1 patch and also marks as updated for 11.1. **This also adds the 11.1.0 patch to our registry and marks it as the current patch.**
