### PR TITLE
Update Brewmaster for 11.1

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -1,10 +1,12 @@
 import { change, date } from 'common/changelog';
+import SPELLS from 'common/SPELLS';
 import talents from 'common/TALENTS/monk';
 import { emallson } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 3, 1), <>Added support for the Undermine tier set, <SpellLink spell={talents.EFFICIENT_TRAINING_TALENT} />, and updated <SpellLink spell={SPELLS.PURIFIED_CHI} /> stack tracking.</>, emallson),
   change(date(2024, 11, 20), <>Updated text for <SpellLink spell={talents.BLACKOUT_COMBO_TALENT} /> section (again).</>, emallson),
   change(date(2024, 10, 13), <>Updated text for <SpellLink spell={talents.BLACKOUT_COMBO_TALENT} /> section.</>, emallson),
   change(date(2024, 8, 31), <>Updated <SpellLink spell={talents.ANVIL__STAVE_TALENT} /> implementation to better fit TWW behavior.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/CONFIG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [emallson],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '11.0.2',
+  patchCompatibility: '11.1.0',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
+++ b/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
@@ -54,6 +54,9 @@ import SpinningCraneKickLinkNormalizer from './normalizers/SpinningCraneKick';
 import PressTheAdvantage from './modules/talents/PressTheAdvantage';
 import PressTheAdvantageNormalizer from './modules/talents/PressTheAdvantage/normalizer';
 import WarWithinS1TierSet from './modules/items/WarWithinS1TierSet';
+import VeteransEye from '../shared/hero/ShadoPan/VeteransEye';
+import WarWithinS2TierSet from './modules/items/WarWithinS2TierSet';
+import EfficientTraining from '../shared/hero/ShadoPan/EfficientTraining';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -98,6 +101,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Items
     WarWithinS1TierSet,
+    WarWithinS2TierSet,
 
     // normalizers
     gotoxNorm: GiftOfTheOx,
@@ -120,6 +124,8 @@ class CombatLogParser extends CoreCombatLogParser {
     chiSurge: ChiSurge,
     pta: PressTheAdvantage,
     stormstoutsLastKeg: StormtoutsLastKeg,
+    veteransEye: VeteransEye,
+    efficientTraining: EfficientTraining,
 
     apl: AplCheck,
 

--- a/src/analysis/retail/monk/brewmaster/Guide.tsx
+++ b/src/analysis/retail/monk/brewmaster/Guide.tsx
@@ -16,9 +16,6 @@ import { GapHighlight } from 'parser/ui/CooldownBar';
 import Explanation from 'interface/guide/components/Explanation';
 import { Highlight } from 'interface/Highlight';
 import BlackoutComboSection from './modules/spells/BlackoutCombo/BlackoutComboSection';
-import ActiveTimeGraph from 'parser/ui/ActiveTimeGraph';
-import { formatPercentage } from 'common/format';
-import PerformanceStrong from 'interface/PerformanceStrong';
 import { FoundationDowntimeSection } from 'interface/guide/foundation/FoundationDowntimeSection';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
@@ -48,40 +45,6 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         <AplChoiceDescription aplChoice={AplCheck.chooseApl(info)} />
         <SubSection>
           <AplSectionData checker={AplCheck.check} apl={AplCheck.apl(info)} />
-        </SubSection>
-        <SubSection title="Always Be Casting">
-          <Explanation>
-            <p>
-              Brewmaster is currently a high-APM spec, with the ability to use an ability every time
-              your global cooldown (GCD) ends. The only talent that changes this is{' '}
-              <SpellLink spell={talents.PRESS_THE_ADVANTAGE_TALENT} />, which introduces downtime
-              where you would otherwise press <SpellLink spell={SPELLS.TIGER_PALM} /> in
-              single-target. However, even with{' '}
-              <SpellLink spell={talents.PRESS_THE_ADVANTAGE_TALENT}>PtA</SpellLink>, you can still
-              fill <em>almost</em> every GCD with an ability.
-            </p>
-            <p>
-              It is better for you to use an ability&mdash;<em>any</em> ability&mdash;each GCD than
-              to think carefully about each button press and have gaps between ability uses. You
-              should <strong>Always Be Casting</strong>. With practice, you will be able to fill
-              every GCD <em>and</em> while using the correct ability in each global.
-            </p>
-            <p>
-              The chart below should generally be near <strong>100%</strong> during periods where
-              you are able to attack the boss.
-            </p>
-          </Explanation>
-          <p>
-            Active Time:{' '}
-            <PerformanceStrong performance={modules.alwaysBeCasting.DowntimePerformance}>
-              {formatPercentage(modules.alwaysBeCasting.activeTimePercentage, 1)}%
-            </PerformanceStrong>
-          </p>
-          <ActiveTimeGraph
-            activeTimeSegments={modules.alwaysBeCasting.activeTimeSegments}
-            fightStart={info.fightStart}
-            fightEnd={info.fightEnd}
-          />
         </SubSection>
         <BlackoutComboSection />
         <SubSection title="Major Cooldowns">

--- a/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
@@ -77,7 +77,7 @@ class Abilities extends CoreAbilities {
           suggestion: false,
         },
         gcd: {
-          static: 1000,
+          base: 1000,
         },
       },
       {

--- a/src/analysis/retail/monk/brewmaster/modules/items/WarWithinS2TierSet.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/items/WarWithinS2TierSet.tsx
@@ -1,0 +1,36 @@
+import SPELLS from 'common/SPELLS';
+import { TIERS } from 'game/TIERS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+
+/**
+ * When you gain Insurance!, your next 2 Blackout Kicks deal 150% increased damage and have
+ * a 2 second reduced cooldown.
+ *
+ * ## Implementation
+ * There is a separate buff for this (Opportunistic Strikes), so it is easy to track. We just reduce the cooldown after the cast if the buff is present.
+ * The buff falls off shortly after the cast (or at least did on ptr).
+ */
+export default class WarWithinS2TierSet extends Analyzer.withDependencies({
+  spellUsable: SpellUsable,
+}) {
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.has4PieceByTier(TIERS.TWW2);
+
+    this.addEventListener(
+      Events.cast.spell(SPELLS.BLACKOUT_KICK_BRM).by(SELECTED_PLAYER),
+      this.reduceCooldown,
+    );
+  }
+
+  private reduceCooldown(event: CastEvent) {
+    if (this.selectedCombatant.hasBuff(SPELLS.OPPORTUNISTIC_STRIKE_BUFF)) {
+      this.deps.spellUsable.reduceCooldown(SPELLS.BLACKOUT_KICK_BRM.id, OPPORTUNISTIC_STRIKE_CDR);
+    }
+  }
+}
+
+const OPPORTUNISTIC_STRIKE_CDR = 2000;

--- a/src/analysis/retail/monk/brewmaster/modules/problems/PurifyingBrew/analyzer.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/problems/PurifyingBrew/analyzer.ts
@@ -134,7 +134,7 @@ export default class PurifyingBrewProblems extends Analyzer {
 
   get bigHitThreshold() {
     if (this.maxHpEventCount === 0) {
-      return 25000;
+      return 2_500_000;
     }
     return this.totalSeenMaxHp / this.maxHpEventCount / 4;
   }

--- a/src/analysis/retail/monk/brewmaster/modules/spells/BlackoutCombo/BlackoutComboSection.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/BlackoutCombo/BlackoutComboSection.tsx
@@ -127,7 +127,7 @@ export default function BlackoutComboSection(): JSX.Element | null {
                   content={
                     <>
                       These are stacks of <SpellLink spell={SPELLS.PURIFIED_CHI} />, which is
-                      limited to 10 stacks total (including the 3 bonus from{' '}
+                      limited to 6 stacks total (including the 3 bonus from{' '}
                       <SpellLink spell={talents.BLACKOUT_COMBO_TALENT} />
                       ).
                     </>

--- a/src/analysis/retail/monk/brewmaster/modules/spells/CelestialBrew/index.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/CelestialBrew/index.tsx
@@ -26,13 +26,13 @@ import { ReactNode } from 'react';
 import CountsAsBrew from '../../components/CountsAsBrew';
 import { damageEvent } from './normalizer';
 
-const PURIFIED_CHI_PCT = 0.2;
+const PURIFIED_CHI_PCT = 0.35;
 const PURIFIED_CHI_WINDOW = 150;
 
 /**
  * The number of stacks needed to get a 100% bonus to the shield.
  */
-const PURIFIED_CHI_STACKS_PER_100 = 5;
+const PURIFIED_CHI_STACKS_PER_100 = Math.ceil(1 / PURIFIED_CHI_PCT);
 const WASTED_THRESHOLD = 0.75;
 
 type AbsorbExtras = {
@@ -118,9 +118,13 @@ class CelestialBrew extends MajorDefensiveBuff {
       <div>
         <p>
           <SpellLink spell={talents.CELESTIAL_BREW_TALENT} /> provides a low-cooldown shield for
-          30-100% of your health bar. <CountsAsBrew baseCooldown={60} lightBrewing /> To use it
-          effectively, you need to balance two goals: using it to <em>cover major damage events</em>
-          , and using it <em>often</em>.
+          30-100% of your health bar.{' '}
+          <CountsAsBrew
+            baseCooldown={60}
+            lightBrewing={this.selectedCombatant.hasTalent(talents.LIGHT_BREWING_TALENT)}
+          />{' '}
+          To use it effectively, you need to balance two goals: using it to{' '}
+          <em>cover major damage events</em>, and using it <em>often</em>.
         </p>
       </div>
     );

--- a/src/analysis/retail/monk/shared/TouchOfDeath.jsx
+++ b/src/analysis/retail/monk/shared/TouchOfDeath.jsx
@@ -28,7 +28,7 @@ class TouchOfDeath extends ExecuteHelper {
     options.abilities.add({
       spell: SPELLS.TOUCH_OF_DEATH.id,
       category: SPELL_CATEGORY.COOLDOWNS,
-      cooldown: 180 - 45 * this.selectedCombatant.getTalentRank(TALENTS_MONK.FATAL_TOUCH_TALENT),
+      cooldown: 180 - 90 * this.selectedCombatant.getTalentRank(TALENTS_MONK.FATAL_TOUCH_TALENT),
       gcd:
         this.selectedCombatant.specId === SPECS.MISTWEAVER_MONK ? { base: 1500 } : { static: 1000 },
       castEfficiency: {

--- a/src/analysis/retail/monk/shared/hero/ShadoPan/EfficientTraining.tsx
+++ b/src/analysis/retail/monk/shared/hero/ShadoPan/EfficientTraining.tsx
@@ -1,0 +1,76 @@
+import Spell from 'common/SPELLS/Spell';
+import talents from 'common/TALENTS/monk';
+import { formatDurationMinSec } from 'common/format';
+import RESOURCE_TYPES, { getResource } from 'game/RESOURCE_TYPES';
+import SPECS from 'game/SPECS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import Statistic from 'parser/ui/Statistic';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import { ReactNode } from 'react';
+
+export default class EfficientTraining extends Analyzer.withDependencies({
+  spellUsable: SpellUsable,
+}) {
+  readonly cdrSpell: Spell;
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(talents.EFFICIENT_TRAINING_TALENT);
+    this.cdrSpell =
+      this.selectedCombatant.specId === SPECS.BREWMASTER_MONK.id
+        ? talents.WEAPONS_OF_ORDER_TALENT
+        : talents.STORM_EARTH_AND_FIRE_TALENT;
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.processEnergySpent);
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(this.cdrSpell),
+      this.updateCastCount,
+    );
+  }
+
+  private energyCounter = 0;
+  private totalCdr = 0;
+  private castCount = 0;
+
+  private updateCastCount() {
+    this.castCount += 1;
+  }
+
+  private processEnergySpent(event: CastEvent) {
+    if (!event.classResources) {
+      // no resources -> no energy spent
+      return;
+    }
+    const energyChange = getResource(event.classResources, RESOURCE_TYPES.ENERGY.id);
+
+    if (!energyChange || !energyChange.cost) {
+      return;
+    }
+
+    this.energyCounter += energyChange.cost;
+
+    if (this.energyCounter >= CDR_THRESHOLD) {
+      this.energyCounter -= CDR_THRESHOLD;
+      this.totalCdr += this.deps.spellUsable.reduceCooldown(this.cdrSpell.id, CDR_AMOUNT);
+    }
+  }
+
+  statistic(): ReactNode {
+    return (
+      <Statistic category={STATISTIC_CATEGORY.HERO_TALENTS} size="flexible">
+        <TalentSpellText talent={talents.EFFICIENT_TRAINING_TALENT}>
+          {formatDurationMinSec(this.totalCdr / 1000)} CDR{' '}
+          <small>
+            ({formatDurationMinSec(this.totalCdr / 1000 / Math.max(1, this.castCount))} per cast)
+          </small>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+const CDR_THRESHOLD = 50;
+const CDR_AMOUNT = 1000;

--- a/src/analysis/retail/monk/shared/hero/ShadoPan/VeteransEye.ts
+++ b/src/analysis/retail/monk/shared/hero/ShadoPan/VeteransEye.ts
@@ -1,0 +1,18 @@
+import SPELLS from 'common/SPELLS';
+import talents from 'common/TALENTS/monk';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Haste from 'parser/shared/modules/Haste';
+
+export default class VeteransEye extends Analyzer.withDependencies({
+  haste: Haste,
+}) {
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(talents.VETERANS_EYE_TALENT);
+
+    this.deps.haste.addHasteBuff(SPELLS.VETERANS_EYE_BUFF.id, {
+      hastePerStack: 0.01,
+    });
+  }
+}

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -968,6 +968,13 @@ const spells = {
     name: 'Flow of Battle',
     icon: 'ability_monk_energizingwine.jpg',
   },
+  // TWW S2 Brewmaster 4-set
+  OPPORTUNISTIC_STRIKE_BUFF: {
+    id: 1217999,
+    name: 'Opportunistic Strike',
+    icon: '70_inscription_deck_dominion.jpg',
+  },
+  // Master of Harmony
   ASPECT_OF_HARMONY_DOT: {
     id: 450763,
     name: 'Aspect of Harmony',
@@ -982,6 +989,12 @@ const spells = {
     id: 450711,
     name: 'Aspect of Harmony',
     icon: 'ability_evoker_essenceburst3',
+  },
+  // Shado-Pan
+  VETERANS_EYE_BUFF: {
+    id: 451085,
+    name: "Veteran's Eye",
+    icon: 'ability_monk_provoke.jpg',
   },
 } satisfies Record<string, Spell>;
 

--- a/src/interface/guide/components/MajorDefensives/MajorDefensiveAnalyzer.tsx
+++ b/src/interface/guide/components/MajorDefensives/MajorDefensiveAnalyzer.tsx
@@ -118,7 +118,7 @@ export function absoluteMitigation(event: DamageEvent, mitPct: number): number {
  */
 export const MitigationRowContainer = styled.div`
   display: grid;
-  grid-template-columns: 2em 2em 100px;
+  grid-template-columns: 2em min-content 100px;
   gap: 1em;
   align-items: center;
 

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -23,6 +23,7 @@ const spells: number[] = [
   SPELLS.DIVINE_HYMN_HEAL.id, //The heal component of divine hymn
   SPELLS.CHARGE_2.id, // The damage component of charge
   SPELLS.BLOOD_ELF_ILLUSION.id, // Orb of the Sin'dorei
+  SPELLS.CHI_SURGE_DEBUFF.id,
 
   //region Boss abilities
   SPELLS.RIONTHUS_DISINTEGRATE.id, // targeted player is shown as 'casting' this spell


### PR DESCRIPTION
update brewmaster for 11.1. most of the changes are actually hero tree stuff that i missed in 11.0

the patch stuff is:

- adjustments to Purified Chi tracking to account to the new stacking behavior (35% per stack, 6 stack cap)
- add the new tier set cdr