### PR TITLE
windwalker: implement analysis for Heart of the Jade Serpent

### DIFF
--- a/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/talents/HeartOfTheJadeSerpent.tsx
+++ b/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/talents/HeartOfTheJadeSerpent.tsx
@@ -19,10 +19,9 @@ class HeartOfTheJadeSerpent extends Analyzer {
 
   constructor(options: Options) {
     super(options);
+
     this.isMW = this.selectedCombatant.specId === SPECS.MISTWEAVER_MONK.id;
-    //only enabling for mistweaver for now until support comes for Windwalker
-    this.active =
-      this.selectedCombatant.hasTalent(TALENTS_MONK.HEART_OF_THE_JADE_SERPENT_TALENT) && this.isMW;
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.HEART_OF_THE_JADE_SERPENT_TALENT);
 
     this.addEventListener(
       Events.applybuff

--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Durpn, emallson } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 3, 3), <>Add <SpellLink spell={SPELLS.HEART_OF_THE_JADE_SERPENT_BUFF} /> tracking</>, Durpn),
   change(date(2025, 2, 6), <>Correct spell data for <SpellLink spell={SPELLS.FORTIFYING_BREW_CAST} /></>, emallson),
   change(date(2024, 10, 26), <>Drop Mastery tracking for <SpellLink spell={SPELLS.FLYING_SERPENT_KICK} /></>, Durpn),
   change(date(2024, 10, 26), <>Fix Mastery tracking for <SpellLink spell={TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT} /> and <SpellLink spell={TALENTS_MONK.STORM_EARTH_AND_FIRE_TALENT} /></>, Durpn),

--- a/src/analysis/retail/monk/windwalker/CONFIG.tsx
+++ b/src/analysis/retail/monk/windwalker/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Durpn, Tenooki } from 'CONTRIBUTORS';
+import { Durpn } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
@@ -7,10 +7,10 @@ import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Durpn, Tenooki],
+  contributors: [Durpn],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '11.0.5',
+  patchCompatibility: '11.1',
   supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
@@ -34,7 +34,7 @@ const config: Config = {
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
-    '/report/1TyaDAh4YfWj8PpL/27-Mythic+Scalecommander+Sarkareth+-+Kill+(7:35)/Simplytg/standard/overview',
+    '/report/YhKxdBFwCGgJpfP3/20-Mythic+Sikran,+Captain+of+the+Sureki+-+Kill+(2:29)/4-Varis/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/monk/windwalker/CombatLogParser.ts
+++ b/src/analysis/retail/monk/windwalker/CombatLogParser.ts
@@ -48,6 +48,7 @@ import {
   FistsOfFuryLinkNormalizer,
   FistsOfFuryNormalizer,
 } from './normalizers/FistsOfFuryNormalizer';
+import HeartOfTheJadeSerpent from './modules/spells/HeartOfTheJadeSerpent';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -79,6 +80,7 @@ class CombatLogParser extends CoreCombatLogParser {
     hitCombo: HitCombo,
     strikeoftheWindlord: StrikeoftheWindlord,
     chiBurst: ChiBurst,
+    heartOfTheJadeSerpent: HeartOfTheJadeSerpent,
 
     // Guide helpers
     hitComboTracker: HitComboTracker,

--- a/src/analysis/retail/monk/windwalker/Guide.tsx
+++ b/src/analysis/retail/monk/windwalker/Guide.tsx
@@ -15,6 +15,8 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
     <>
       <Section title="Core Spells and Buffs">
         <MasteryGraph modules={modules} events={events} info={info} />
+        {info.combatant.hasTalent(TALENTS_MONK.CELESTIAL_CONDUIT_TALENT) &&
+          modules.heartOfTheJadeSerpent.guideSubsection}
         {modules.risingSunKick.guideSubsection}
         {modules.fistsofFury.guideSubsection}
         {modules.strikeoftheWindlord.guideSubsection}

--- a/src/analysis/retail/monk/windwalker/modules/spells/HeartOfTheJadeSerpent.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/HeartOfTheJadeSerpent.tsx
@@ -1,0 +1,187 @@
+import { default as HotJS } from 'analysis/retail/monk/shared/hero/ConduitOfTheCelestials/talents/HeartOfTheJadeSerpent';
+import spells from 'common/SPELLS/monk';
+import { TALENTS_MONK } from 'common/TALENTS';
+import { SpellLink } from 'interface';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  ApplyBuffEvent,
+  CastEvent,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+
+const HOTJS_BUFF_IDS = [
+  spells.HEART_OF_THE_JADE_SERPENT_BUFF,
+  spells.HEART_OF_THE_JADE_SERPENT_UNITY,
+];
+
+class HeartOfTheJadeSerpent extends HotJS {
+  castEntries: BoxRowEntry[] = [];
+
+  currentFof = 0;
+  currentSotwl = 0;
+  currentUnityWithin = 0;
+  inWindow = false;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.HEART_OF_THE_JADE_SERPENT_TALENT);
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(HOTJS_BUFF_IDS),
+      this.onApplyHotJS,
+    );
+
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(HOTJS_BUFF_IDS),
+      this.onRemoveHotJS,
+    );
+
+    this.addEventListener(
+      Events.cast
+        .by(SELECTED_PLAYER)
+        .spell([
+          spells.FISTS_OF_FURY_CAST,
+          TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT,
+          spells.UNITY_WITHIN_CAST,
+        ]),
+      this.onTrackedCast,
+    );
+  }
+
+  onApplyHotJS(event: ApplyBuffEvent | RefreshBuffEvent) {
+    if (this.inWindow) {
+      // Window is being refreshed, close and restart
+      this.closeWindow();
+    }
+
+    this.inWindow = true;
+    this.currentFof = 0;
+    this.currentSotwl = 0;
+    this.currentUnityWithin = 0;
+  }
+
+  onRemoveHotJS(event: RemoveBuffEvent) {
+    if (!this.inWindow) {
+      console.log('Unexpected state! HotJS was removed while not in an identified window');
+      return;
+    }
+    this.closeWindow();
+  }
+
+  closeWindow() {
+    this.inWindow = false;
+    let mistakes = 0;
+
+    if (this.currentFof < 1) {
+      mistakes += 1;
+    }
+
+    if (this.currentSotwl !== 0) {
+      mistakes += 1;
+    }
+
+    let value = QualitativePerformance.Fail;
+    if (mistakes === 0) {
+      value = QualitativePerformance.Perfect;
+    } else if (mistakes === 1) {
+      value = QualitativePerformance.Ok;
+    }
+
+    const tooltip = (
+      <>
+        {this.currentFof === 0 && (
+          <>
+            <SpellLink spell={spells.FISTS_OF_FURY_CAST} /> was not used during the window
+          </>
+        )}
+        {this.currentSotwl !== 0 && (
+          <>
+            <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> should not be used
+            within the window
+          </>
+        )}
+        {this.currentUnityWithin !== 0 && (
+          <>
+            <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> should not be used
+            within the window
+          </>
+        )}
+      </>
+    );
+
+    this.castEntries.push({
+      value,
+      tooltip,
+    });
+  }
+
+  onTrackedCast(event: CastEvent) {
+    if (!this.inWindow) {
+      return;
+    }
+
+    switch (event.ability.guid) {
+      case spells.FISTS_OF_FURY_CAST.id:
+        this.currentFof += 1;
+        break;
+      case TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT.id:
+        this.currentSotwl += 1;
+        break;
+      case spells.UNITY_WITHIN_CAST.id:
+        this.currentUnityWithin += 1;
+        break;
+    }
+  }
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <strong>
+          <SpellLink spell={TALENTS_MONK.HEART_OF_THE_JADE_SERPENT_TALENT} />
+        </strong>{' '}
+        massively reduces the cooldowns of your major abilities, and as such at least one{' '}
+        <SpellLink spell={spells.FISTS_OF_FURY_CAST} /> should be cast in each buff window.
+        <br />
+        <br />
+        This buff is actived whenever{' '}
+        <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> or{' '}
+        <SpellLink spell={TALENTS_MONK.UNITY_WITHIN_TALENT} /> (as part of{' '}
+        <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT} />) are cast. To avoid clipping the
+        window short, casting either of them while{' '}
+        <SpellLink spell={TALENTS_MONK.HEART_OF_THE_JADE_SERPENT_TALENT} /> is active should be
+        avoided.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink spell={TALENTS_MONK.HEART_OF_THE_JADE_SERPENT_TALENT} /> utilization
+          </strong>
+          <div>
+            <strong>Buff Windows </strong>
+            <small>
+              - Blue indicates a perfect cast (
+              <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} /> was cast atleast one time, and
+              neither <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> nor{' '}
+              <SpellLink spell={TALENTS_MONK.UNITY_WITHIN_TALENT} /> were cast), yellow indicates
+              one mistake, while red indicates multiple mistakes.
+            </small>
+            <br />
+            <br />
+            <PerformanceBoxRow values={this.castEntries} />
+          </div>
+        </RoundedPanel>
+      </div>
+    );
+    return explanationAndDataSubsection(explanation, data);
+  }
+}
+
+export default HeartOfTheJadeSerpent;


### PR DESCRIPTION
Add initial guide section for Heart of the Jade Serpent.

### Description

Add analysis of HotJS based on the rules, within a window the player should:

1. cast Fists of Fury atleast one time
2. not cast Strike of the Windlord
3. not cast Unity Within

### Testing

Conduit Guide has new section (`/report/YhKxdBFwCGgJpfP3/20/4`):
![image](https://github.com/user-attachments/assets/5e83f00d-14ec-45f9-8ea8-48c7141dff74)


Shado-Pan Guide is unchanged (`/report/JgbAYVD8QpXRHkPa/5-Mythic+Ulgrax+the+Devourer+-+Kill+(3:30)/Kmpchi/standard/overview`):
![image](https://github.com/user-attachments/assets/e8cee4d8-7206-4c57-9d15-1ed26600a335)
