### PR TITLE
Update VoidTorrent.tsx

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2585,3 +2585,9 @@ export const KYZ: Contributor = {
     },
   ],
 };
+
+export const Jordan: Contributor = {
+  nickname: 'Jordan',
+  github: 'jordantoine',
+  discord: 'jordannonumbers',
+};

--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 //import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/priest';
 import { DoxAshe } from 'CONTRIBUTORS';
+import { Jordan } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [

--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { DoxAshe } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2025, 3, 5), <>Fix typo in <SpellLink spell={TALENTS.VOID_TORRENT_TALENT}/> section of Short Cooldowns</>,Jordan),
   change(date(2025, 3, 3),  <>Fix <SpellLink spell={TALENTS.POWER_INFUSION_TALENT}/> with TWW season 2 four piece </>,DoxAshe),
   change(date(2025, 3, 2),  <>Update shadow for 11.1 changes and add support for TWW season 2 tier set </>,DoxAshe),
   change(date(2025, 1, 27),  <>Add support and statistics for Shadow's Voidweaver Hero Talent Tree  </>,DoxAshe),

--- a/src/analysis/retail/priest/shadow/modules/talents/VoidTorrent.tsx
+++ b/src/analysis/retail/priest/shadow/modules/talents/VoidTorrent.tsx
@@ -200,7 +200,7 @@ class VoidTorrent extends Analyzer {
         </b>{' '}
         deals damage and generates 24 insanity over its 3 second channel.
         <br />
-        You should cast this spell as often as you can, without overcapping insanity, whith{' '}
+        You should cast this spell as often as you can, without overcapping insanity, with{' '}
         <SpellLink spell={TALENTS.DEVOURING_PLAGUE_TALENT} /> on your target. When you use this
         spell, it should always be fully channeled.
       </p>


### PR DESCRIPTION
fix typo where "whith" should be "with"

### Description

Update description for void torrent usage. There exists a typo, this commit fixes it.

### Testing

Load a shadow priest report with Void Torrent talented

- Test report URL: `/report/...`
- Screenshot(s):
