### PR TITLE
update Brewmaster APL and simplify Face Palm tracking

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -41,6 +41,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 3, 10), <>Adjust APL checker to prefer showing examples after the few seconds of a fight to avoid conflicting with openers.</>, emallson),
   change(date(2025, 3, 8), 'Add missing patch 11.1.0 details.', ToppleTheNun),
   change(date(2025, 2, 26), <>Revised Foundation downtime section for melee specs.</>, emallson),
   change(date(2025, 2, 18), 'Add Classic Cata Dragon Soul raid zone, headshots, and placeholder image', jazminite),

--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 3, 10), <>Update APL for Undermine, simplify <SpellLink spell={talents.FACE_PALM_TALENT} /> tracking.</>, emallson),
   change(date(2025, 3, 1), <>Added support for the Undermine tier set, <SpellLink spell={talents.EFFICIENT_TRAINING_TALENT} />, and updated <SpellLink spell={SPELLS.PURIFIED_CHI} /> stack tracking.</>, emallson),
   change(date(2024, 11, 20), <>Updated text for <SpellLink spell={talents.BLACKOUT_COMBO_TALENT} /> section (again).</>, emallson),
   change(date(2024, 10, 13), <>Updated text for <SpellLink spell={talents.BLACKOUT_COMBO_TALENT} /> section.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/Guide.tsx
+++ b/src/analysis/retail/monk/brewmaster/Guide.tsx
@@ -6,8 +6,7 @@ import CombatLogParser from './CombatLogParser';
 import { GuideProps, Section, SubSection } from 'interface/guide';
 import { PurifySection } from './modules/problems/PurifyingBrew';
 import talents from 'common/TALENTS/monk';
-import * as AplCheck from './modules/core/AplCheck';
-import { AplSectionData } from 'interface/guide/components/Apl';
+
 import { ImprovedInvokeNiuzaoSection } from './modules/problems/InvokeNiuzao';
 import MajorDefensivesSection from './modules/core/MajorDefensives';
 import AplChoiceDescription from './modules/core/AplCheck/AplChoiceDescription';
@@ -42,10 +41,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
       </Section>
       <MajorDefensivesSection />
       <Section title="Core Rotation">
-        <AplChoiceDescription aplChoice={AplCheck.chooseApl(info)} />
-        <SubSection>
-          <AplSectionData checker={AplCheck.check} apl={AplCheck.apl(info)} />
-        </SubSection>
+        <AplChoiceDescription />
         <BlackoutComboSection />
         <SubSection title="Major Cooldowns">
           <Explanation>

--- a/src/analysis/retail/monk/brewmaster/modules/core/AplCheck/AplChoiceDescription.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/AplCheck/AplChoiceDescription.tsx
@@ -1,9 +1,12 @@
 import SPELLS from 'common/SPELLS';
 import talents from 'common/TALENTS/monk';
-import { AlertWarning, SpellIcon, SpellLink } from 'interface';
-import { useInfo } from 'interface/guide';
-import { BrewmasterApl } from '../AplCheck';
+import { SpellIcon, SpellLink } from 'interface';
+import { SubSection, useInfo } from 'interface/guide';
+import * as AplCheck from '../AplCheck';
 import { SpellSeq } from 'parser/ui/SpellSeq';
+
+import { AplSectionData } from 'interface/guide/components/Apl';
+import { useMemo } from 'react';
 
 const blank = {
   id: -1,
@@ -86,33 +89,29 @@ const StandardDescription = () => {
   return <></>;
 };
 
-const PTADescription = () => (
-  <>
-    <AlertWarning>
-      Using <SpellLink spell={talents.PRESS_THE_ADVANTAGE_TALENT} /> will result in many empty GCDs.
-      While it may be tempting to use <SpellLink spell={SPELLS.SPINNING_CRANE_KICK_BRM} /> to fill
-      them, SCK can prevent you from getting stacks of{' '}
-      <SpellLink spell={talents.PRESS_THE_ADVANTAGE_TALENT} />! If you are not playing around your
-      swing timer, you should avoid casting <SpellLink spell={SPELLS.SPINNING_CRANE_KICK_BRM} /> on
-      single target!
-    </AlertWarning>
-  </>
-);
-
-const Description = ({ aplChoice }: { aplChoice: BrewmasterApl }) => {
+const Description = ({ aplChoice }: { aplChoice: AplCheck.BrewmasterApl }) => {
   switch (aplChoice) {
-    case BrewmasterApl.Standard:
+    case AplCheck.BrewmasterApl.Standard:
       return <StandardDescription />;
-    case BrewmasterApl.PTA:
-      return <PTADescription />;
   }
 };
 
-export default function AplChoiceDescription({
-  aplChoice,
-}: {
-  aplChoice: BrewmasterApl;
-}): JSX.Element {
+export default function AplChoiceDescription(): JSX.Element {
+  const info = useInfo();
+  const aplChoice = useMemo(() => (info ? AplCheck.chooseApl(info) : undefined), [info]);
+  if (aplChoice === undefined || !info) {
+    return <></>;
+  }
+
+  if (info.combatant.hasTalent(talents.PRESS_THE_ADVANTAGE_TALENT)) {
+    return (
+      <>
+        Analysis of the <SpellLink spell={talents.PRESS_THE_ADVANTAGE_TALENT} /> rotation has
+        limited support.
+      </>
+    );
+  }
+
   return (
     <>
       <p>
@@ -131,6 +130,9 @@ export default function AplChoiceDescription({
         <SpellLink spell={talents.RISING_SUN_KICK_TALENT} /> as often as possible.
       </p>
       <Description aplChoice={aplChoice} />
+      <SubSection>
+        <AplSectionData checker={AplCheck.check} apl={AplCheck.apl(info)} />
+      </SubSection>
     </>
   );
 }

--- a/src/analysis/retail/monk/brewmaster/modules/core/BrewCDR.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/BrewCDR.tsx
@@ -50,6 +50,7 @@ class BrewCDR extends Analyzer.withDependencies(deps) {
     totalCDR += ks.bocCDR;
     // ...and TP...
     totalCDR += tp.cdr;
+    totalCDR += tp.fpCdr;
     // ...and BoB...
     totalCDR += bob.cdr[talents.PURIFYING_BREW_TALENT.id];
     totalCDR += anvilStave.cdr;
@@ -64,6 +65,7 @@ class BrewCDR extends Analyzer.withDependencies(deps) {
       ks.wastedCDR +
       ks.wastedBocCDR +
       tp.wastedCDR +
+      tp.wastedFpCdr +
       bob.wastedCDR[talents.PURIFYING_BREW_TALENT.id] +
       pta.wastedBrewCDR +
       this.totalCDR
@@ -120,10 +122,19 @@ class BrewCDR extends Analyzer.withDependencies(deps) {
                 </li>
               )}
               {!pta.active && (
-                <li>
-                  {tp.totalCasts} Tiger Palm hits — <strong>{(tp.cdr / 1000).toFixed(2)}s</strong> (
-                  <strong>{(tp.wastedCDR / 1000).toFixed(2)}s</strong> wasted)
-                </li>
+                <>
+                  <li>
+                    {tp.totalCasts} Tiger Palm hits — <strong>{(tp.cdr / 1000).toFixed(2)}s</strong>{' '}
+                    (<strong>{(tp.wastedCDR / 1000).toFixed(2)}s</strong> wasted)
+                  </li>
+                  {this.selectedCombatant.hasTalent(talents.FACE_PALM_TALENT) && (
+                    <li>
+                      ~{(tp.totalCasts / 2).toFixed(0)} Face Palm procs —{' '}
+                      <strong>{(tp.fpCdr / 1000).toFixed(2)}s</strong> (
+                      <strong>{(tp.wastedFpCdr / 1000).toFixed(2)}s</strong> wasted)
+                    </li>
+                  )}
+                </>
               )}
               {bob.active && (
                 <li>

--- a/src/analysis/retail/monk/brewmaster/modules/spells/TigerPalm.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/TigerPalm.tsx
@@ -1,7 +1,5 @@
 import SPELLS from 'common/SPELLS';
-import Spell from 'common/SPELLS/Spell';
 import talents from 'common/TALENTS/monk';
-import HIT_TYPES from 'game/HIT_TYPES';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
@@ -12,14 +10,9 @@ import SharedBrews from '../core/SharedBrews';
 
 const TIGER_PALM_REDUCTION = 1000;
 const FACE_PALM_REDUCTION = 1000;
-const BUFF_BUFFER = 100;
-const TP_AP_COEFF = 0.27;
 
-const AMP_FP = 3;
-const AMP_CS = 2;
-const AMP_BOC = 2;
+const FACE_PALM_CHANCE = 0.5;
 
-// TODO: revisit with real logs
 class TigerPalm extends Analyzer {
   static dependencies = {
     brews: SharedBrews,
@@ -38,8 +31,6 @@ class TigerPalm extends Analyzer {
   protected spellUsable!: SpellUsable;
   protected castEfficiency!: CastEfficiency;
 
-  private hasBoC = false;
-  private hasCounterstrike = false;
   private hasFp = false;
 
   constructor(options: Options) {
@@ -50,69 +41,23 @@ class TigerPalm extends Analyzer {
     );
 
     this.hasFp = this.selectedCombatant.hasTalent(talents.FACE_PALM_TALENT);
-    this.hasBoC = this.selectedCombatant.hasTalent(talents.BLACKOUT_COMBO_TALENT);
-    this.hasCounterstrike = this.selectedCombatant.hasTalent(talents.COUNTERSTRIKE_TALENT);
   }
 
   get totalCasts(): number {
     return this.castEfficiency.getCastEfficiencyForSpell(SPELLS.TIGER_PALM)?.casts ?? 0;
   }
 
-  private hasAmpBuff(event: DamageEvent, spell: Spell) {
-    return this.selectedCombatant.hasBuff(spell.id, event.timestamp - BUFF_BUFFER);
-  }
-
-  private hasBoCBuff(event: DamageEvent): boolean {
-    // TODO: make this robust against off-gcd consumption by PB
-    return this.hasBoC && this.hasAmpBuff(event, SPELLS.BLACKOUT_COMBO_BUFF);
-  }
-
-  private hasCounterstrikeBuff(event: DamageEvent): boolean {
-    return this.hasCounterstrike && this.hasAmpBuff(event, SPELLS.COUNTERSTRIKE_BUFF);
-  }
-
-  /**
-   * Checking if a damage event benefits from face palm is slightly complicated. We need to know the other major damage buffs the TP benefitted from so we can check if there is a further +200% from a Face Palm proc.
-   *
-   * This is relatively robust against smaller buffs like unknown temporary versatility or damage amp buffs, since FP is *so* large (+200%!).
-   */
-  private hasFacePalmBuff(event: DamageEvent, priorAmp: number): boolean {
-    if (!this.hasFp || !event.attackPower) {
-      // bail. the latter is super uncommon, and a pain to work around
-      return false;
-    }
-
-    const expectedRawHit = (event.attackPower ?? 0) * TP_AP_COEFF;
-    const expectedPriorAmpHit = expectedRawHit * priorAmp;
-    const expectedFpHit = expectedPriorAmpHit * AMP_FP;
-
-    // unmitigated amount is spicy when looking at player-sourced damage events
-    const actualHit = event.amount + (event.absorbed ?? 0) + (event.overkill ?? 0);
-
-    return actualHit - expectedPriorAmpHit > (expectedFpHit - expectedPriorAmpHit) / 2;
-  }
-
   onDamage(event: DamageEvent) {
-    // OK SO we have a hit, lets reduce the CD by the base amount...
     const actualReduction = this.brews.reduceCooldown(TIGER_PALM_REDUCTION);
     this.cdr += actualReduction;
     this.wastedCDR += TIGER_PALM_REDUCTION - actualReduction;
 
-    let amplifier = event.hitType === HIT_TYPES.CRIT ? 2 : 1;
-    if (this.hasCounterstrikeBuff(event)) {
-      amplifier *= AMP_CS;
-    }
-
-    if (this.hasBoCBuff(event)) {
-      amplifier *= AMP_BOC;
-    }
-
-    if (this.hasFacePalmBuff(event, amplifier)) {
-      amplifier *= AMP_FP;
-      // apply FP CDR
-      const actualReduction = this.brews.reduceCooldown(FACE_PALM_REDUCTION);
+    if (this.hasFp) {
+      // apply FP CDR. FP is not practically detectable, so we just treat it as proccing exactly the average amount. this works well enough most of the time.
+      const avgCdr = FACE_PALM_REDUCTION * FACE_PALM_CHANCE;
+      const actualReduction = this.brews.reduceCooldown(avgCdr);
       this.fpCdr += actualReduction;
-      this.wastedCDR += FACE_PALM_REDUCTION - actualReduction;
+      this.wastedFpCdr += avgCdr - actualReduction;
     }
   }
 }


### PR DESCRIPTION
this is more deletion than addition.

I cut the PtA APL because the talent is basically dead. Playing it optimally is complicated plate-spinning, and playing it sub-optimally is not what this should be recommending.

I simplified the FP proc detection to just assume the average case. The existing method was quietly broken and had been for a while since apparently AP is no longer logged on damage events (only casts). But there are even worse issues with it (like: boss damage amps break it, debuff damage amps break it, etc). Assuming the average helps avoid CD errors, but since the CDR amount is so small it isn't a big factor in overall stats.

I also adjusted which problems are shown by default in the APL section to prefer examples that come *after* the first 10s of the fight. The reasoning here is that openers often behave differently and may not be properly accounted for in the APL. Brewmaster in particular has a "throw everything at the boss" opener with no real rules where you just aim to get everything on cooldown. If the only examples of a mistake are early in a fight, those will still be shown.

## Example

**Before**
![image](https://github.com/user-attachments/assets/a6094a33-d302-4181-b9fd-75bd78a1308f)

**After**
![image](https://github.com/user-attachments/assets/cfccb635-dee0-4150-912e-80180ff2f03f)
