### PR TITLE
fix: correct cooldown on Xuen and SotWL based on chosen talents

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Durpn, emallson } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 3, 20), <>Update cooldowns of <SpellLink spell={TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT} /> and <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> based on talents</>, Durpn),
   change(date(2025, 3, 9), <>Update Season 2 APL</>, Durpn),
   change(date(2025, 3, 3), <>Add <SpellLink spell={SPELLS.HEART_OF_THE_JADE_SERPENT_BUFF} /> tracking</>, Durpn),
   change(date(2025, 2, 6), <>Correct spell data for <SpellLink spell={SPELLS.FORTIFYING_BREW_CAST} /></>, emallson),

--- a/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
@@ -147,7 +147,7 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 120,
+        cooldown: combatant.hasTalent(TALENTS_MONK.XUENS_BOND_TALENT) ? 90 : 120,
         gcd: {
           base: 1000,
           minimum: 750,
@@ -160,7 +160,7 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 40,
+        cooldown: combatant.hasTalent(TALENTS_MONK.COMMUNION_WITH_WIND_TALENT) ? 30 : 40,
         gcd: {
           static: 1000,
         },

--- a/src/analysis/retail/monk/windwalker/modules/spells/HeartOfTheJadeSerpent.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/HeartOfTheJadeSerpent.tsx
@@ -157,6 +157,11 @@ class HeartOfTheJadeSerpent extends HotJS {
         window short, casting either of them while{' '}
         <SpellLink spell={TALENTS_MONK.HEART_OF_THE_JADE_SERPENT_TALENT} /> is active should be
         avoided.
+        <br />
+        <br />
+        While active, muliple major abilities have massively hastened cooldowns. These can easily
+        reset atleast once during the duration with high enough haste, or with help from{' '}
+        <SpellLink spell={spells.BLACKOUT_KICK} />.
       </p>
     );
 


### PR DESCRIPTION
### Description

Analyzer was not correctly considering the cooldown reduction on Xuen / Strike of the Windlord based on chosen talents.

### Testing

http://localhost:3000/report/9bxVkfYFXyT7jzdC/60-Mythic+Cauldron+of+Carnage+-+Kill+(6:37)/Protmonkey/standard/overview

- Test report URL: `/report/...`
- Screenshot(s):

before: 
![image](https://github.com/user-attachments/assets/cddea3cf-cf37-4de6-ace5-e30811975b27)

after: 
![image](https://github.com/user-attachments/assets/abe3f8d1-86ae-4f6b-bc97-a2579407c4a7)

