### PR TITLE
feat: add Last Emperor's Capacitor tracking

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Durpn, emallson } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 3, 21), <>Add <SpellLink spell={TALENTS_MONK.LAST_EMPERORS_CAPACITOR_TALENT} /> tracking</>, Durpn),
   change(date(2025, 3, 20), <>Update cooldowns of <SpellLink spell={TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT} /> and <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> based on talents</>, Durpn),
   change(date(2025, 3, 9), <>Update Season 2 APL</>, Durpn),
   change(date(2025, 3, 3), <>Add <SpellLink spell={SPELLS.HEART_OF_THE_JADE_SERPENT_BUFF} /> tracking</>, Durpn),

--- a/src/analysis/retail/monk/windwalker/CombatLogParser.ts
+++ b/src/analysis/retail/monk/windwalker/CombatLogParser.ts
@@ -49,6 +49,12 @@ import {
   FistsOfFuryNormalizer,
 } from './normalizers/FistsOfFuryNormalizer';
 import HeartOfTheJadeSerpent from './modules/spells/HeartOfTheJadeSerpent';
+import LastEmperorsCapacitorGraph from './modules/talents/LastEmperorsCapacitorGraph';
+import LastEmperorsCapacitorTracker from './modules/talents/LastEmperorsCapacitorTracker';
+import {
+  CracklingJadeLightningLinkNormalizer,
+  CracklingJadeLightningNormalizer,
+} from './normalizers/CracklingJadeLightningNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -60,6 +66,8 @@ class CombatLogParser extends CoreCombatLogParser {
     chiJiNormalizer: DanceOfChiJiNormalizer,
     fofNormalizer: FistsOfFuryNormalizer,
     fofLinkNormalizer: FistsOfFuryLinkNormalizer,
+    cracklingJadeLightningNormalizer: CracklingJadeLightningNormalizer,
+    cracklingJadeLightningLinkNormalizer: CracklingJadeLightningLinkNormalizer,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,
@@ -85,6 +93,8 @@ class CombatLogParser extends CoreCombatLogParser {
     // Guide helpers
     hitComboTracker: HitComboTracker,
     hitComboGraph: HitComboGraph,
+    lastEmperorsCapacitorTracker: LastEmperorsCapacitorTracker,
+    lastEmperorsCapacitorGraph: LastEmperorsCapacitorGraph,
 
     // Spells;
     comboBreaker: ComboBreaker,

--- a/src/analysis/retail/monk/windwalker/Guide.tsx
+++ b/src/analysis/retail/monk/windwalker/Guide.tsx
@@ -20,6 +20,8 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         {modules.risingSunKick.guideSubsection}
         {modules.fistsofFury.guideSubsection}
         {modules.strikeoftheWindlord.guideSubsection}
+        {info.combatant.hasTalent(TALENTS_MONK.LAST_EMPERORS_CAPACITOR_TALENT) &&
+          modules.lastEmperorsCapacitor.guideSubsection(modules.lastEmperorsCapacitorGraph.plot)}
       </Section>
       <Section title="Major cooldowns">{modules.invokeXuen.guideSubsection}</Section>
       <Section title="Core Rotation">

--- a/src/analysis/retail/monk/windwalker/modules/features/checklist/Module.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/features/checklist/Module.tsx
@@ -71,10 +71,6 @@ class Checklist extends BaseChecklist {
           hitCombo: this.hitCombo.suggestionThresholds,
           chiDetails: this.chiDetails.suggestionThresholds,
 
-          lastEmperorsCapacitorAverageStacks:
-            this.lastEmperorsCapacitor.averageStacksSuggestionThresholds,
-          lastEmperorsCapacitorWastedStacks:
-            this.lastEmperorsCapacitor.wastedStacksSuggestionThresholds,
           jadeIgnition: this.jadeIgnition.suggestionThresholds,
           xuensBattlegear: this.xuensBattlegear.suggestionThresholds,
         }}

--- a/src/analysis/retail/monk/windwalker/modules/talents/LastEmperorsCapacitor.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/LastEmperorsCapacitor.tsx
@@ -1,18 +1,18 @@
-import { Trans, defineMessage } from '@lingui/macro';
 import SPELLS from 'common/SPELLS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent } from 'parser/core/Events';
-import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import Events, { DamageEvent, EndChannelEvent } from 'parser/core/Events';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
-import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
-import ItemDamageDone from 'parser/ui/ItemDamageDone';
-import Statistic from 'parser/ui/Statistic';
-import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 
 import { CHI_SPENDERS } from '../../constants';
 import { TALENTS_MONK } from 'common/TALENTS';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { formatNumber } from 'common/format';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import DonutChart from 'parser/ui/DonutChart';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 
 const MAX_STACKS = 20;
 
@@ -30,12 +30,15 @@ class LastEmperorsCapacitor extends Analyzer {
   damage = 0;
   buffedCast = false;
 
+  totalCasts = 0;
+  totalTicks = 0;
+  inChannel = false;
+  currentChannelTicks = 0;
+  ticksHit = [0, 0, 0, 0, 0];
+  colors = ['#666', '#1eff00', '#0070ff', '#a435ee', '#ff8000'];
+
   constructor(options: Options) {
     super(options);
-    this.active = false;
-    if (!this.active) {
-      return;
-    }
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.LAST_EMPERORS_CAPACITOR_BUFF),
       this.applyBuff,
@@ -53,6 +56,24 @@ class LastEmperorsCapacitor extends Analyzer {
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.CRACKLING_JADE_LIGHTNING),
       this.cracklingJadeLightningDamage,
     );
+    this.addEventListener(
+      Events.BeginChannel.by(SELECTED_PLAYER).spell(SPELLS.CRACKLING_JADE_LIGHTNING),
+      this.onChannelBegin,
+    );
+    this.addEventListener(
+      Events.EndChannel.by(SELECTED_PLAYER).spell(SPELLS.CRACKLING_JADE_LIGHTNING),
+      this.onChannelEnd,
+    );
+  }
+
+  onChannelBegin() {
+    this.inChannel = true;
+  }
+
+  onChannelEnd(event: EndChannelEvent) {
+    this.inChannel = false;
+    this.ticksHit[this.currentChannelTicks - 1] += 1;
+    this.currentChannelTicks = 0;
   }
 
   applyBuff() {
@@ -77,6 +98,8 @@ class LastEmperorsCapacitor extends Analyzer {
       this.stacksUsed += this.currentStacks;
       this.currentStacks = 0;
     }
+
+    this.totalCasts += 1;
   }
 
   cracklingJadeLightningDamage(event: DamageEvent) {
@@ -84,114 +107,90 @@ class LastEmperorsCapacitor extends Analyzer {
       this.damage += event.amount + (event.absorbed || 0);
       this.buffedCast = false;
     }
-  }
-
-  get averageStacksUsed() {
-    return (
-      this.stacksUsed / this.abilityTracker.getAbility(SPELLS.CRACKLING_JADE_LIGHTNING.id).casts
-    );
+    if (this.inChannel) {
+      this.currentChannelTicks += 1;
+    }
+    this.totalTicks += 1;
   }
 
   get stacksWastedPerMinute() {
     return ((this.stacksWasted / this.owner.fightDuration) * 1000) / 60;
   }
 
-  get averageStacksSuggestionThresholds() {
-    return {
-      actual: this.averageStacksUsed,
-      isLessThan: {
-        minor: 18,
-        average: 16,
-        major: 14,
-      },
-      style: ThresholdStyle.NUMBER,
-    };
+  get averageTicks() {
+    return this.totalTicks / this.totalCasts;
   }
 
-  get wastedStacksSuggestionThresholds() {
-    return {
-      actual: this.stacksWastedPerMinute,
-      isGreaterThan: {
-        minor: 0,
-        average: 2,
-        major: 4,
-      },
-      style: ThresholdStyle.NUMBER,
-    };
+  donutChart(ticks: number[]) {
+    return Object.values(ticks).map((val, idx) => {
+      return { label: idx + 1, color: this.colors[idx], value: val };
+    });
   }
 
   statistic() {
     return (
       <Statistic
-        position={STATISTIC_ORDER.CORE()}
+        position={STATISTIC_ORDER.CORE(4)}
         size="flexible"
-        category={STATISTIC_CATEGORY.ITEMS}
-        tooltip={
-          <Trans id="monk.windwalker.modules.items.lastEmperorsCapacitor.tooltip">
-            Damage dealt does not account for opportunity cost
-            <br />
-            Stacks generated <b>{this.totalStacks}</b>
-            <br />
-            Stacks consumed: <b>{this.stacksUsed}</b>
-            <br />
-            Stacks wasted by generating at cap: <b>{this.stacksWasted}</b>
-            <br />
-            Average stacks spent on each cast: <b>{this.averageStacksUsed.toFixed(2)}</b>
-          </Trans>
+        tooltip={<>Crackling Jade Lightning ticks 5 times over the duration of the channel.</>}
+        dropdown={
+          <div className="pad">
+            <DonutChart items={this.donutChart(this.ticksHit)} />
+          </div>
         }
       >
-        <BoringSpellValueText spell={TALENTS_MONK.LAST_EMPERORS_CAPACITOR_TALENT}>
-          <ItemDamageDone amount={this.damage} />
+        <BoringSpellValueText spell={SPELLS.CRACKLING_JADE_LIGHTNING}>
+          {this.averageTicks.toFixed(2)} <small>Average ticks per cast</small>
         </BoringSpellValueText>
       </Statistic>
     );
   }
 
-  suggestions(when: When) {
-    when(this.wastedStacksSuggestionThresholds).addSuggestion((suggest, actual, recommended) =>
-      suggest(
-        <Trans id="monk.windwalker.modules.items.lastEmperorsCapacitor.wastedStacks">
-          {' '}
-          You wasted your <SpellLink spell={SPELLS.LAST_EMPERORS_CAPACITOR_BUFF} /> stacks by using
-          chi spenders while at 20 stacks{' '}
-        </Trans>,
-      )
-        .icon(TALENTS_MONK.LAST_EMPERORS_CAPACITOR_TALENT.icon)
-        .actual(
-          defineMessage({
-            id: 'monk.windwalker.modules.items.lastEmperorsCapacitor.wastedStacks.actual',
-            message: `${actual.toFixed(2)} Wasted stacks per minute`,
-          }),
-        )
-        .recommended(
-          defineMessage({
-            id: 'monk.windwalker.modules.items.lastEmperorsCapacitor.wastedStacks.recommended',
-            message: `${recommended} Wasted stacks per minute is recommended`,
-          }),
-        ),
+  guideSubsection(plot: JSX.Element): JSX.Element {
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS_MONK.LAST_EMPERORS_CAPACITOR_TALENT} />
+        </b>{' '}
+        causes your Chi generators to increase the damage of your next{' '}
+        <SpellLink spell={SPELLS.CRACKLING_JADE_LIGHTNING} /> by up to 400% (max {MAX_STACKS}{' '}
+        stacks).
+        <br />
+        <br />
+        This should be cast idealy with max stacks, however can be cast early to adjust for damage
+        ampliers or addspawns when talented into{' '}
+        <SpellLink spell={TALENTS_MONK.POWER_OF_THE_THUNDER_KING_TALENT} />.
+      </p>
     );
-    when(this.averageStacksSuggestionThresholds).addSuggestion((suggest, actual) =>
-      suggest(
-        <Trans id="monk.windwalker.modules.items.lastEmperorsCapacitor.averageStacks">
-          {' '}
-          Your average number of <SpellLink spell={SPELLS.LAST_EMPERORS_CAPACITOR_BUFF} /> stacks
-          used when you cast <SpellLink spell={SPELLS.CRACKLING_JADE_LIGHTNING} /> was low{' '}
-        </Trans>,
-      )
-        .icon(TALENTS_MONK.LAST_EMPERORS_CAPACITOR_TALENT.icon)
-        .actual(
-          defineMessage({
-            id: 'monk.windwalker.modules.items.lastEmperorsCapacitor.averageStacks.actual',
-            message: `${actual.toFixed(2)} average stacks used`,
-          }),
-        )
-        .recommended(
-          defineMessage({
-            id: 'monk.windwalker.modules.items.lastEmperorsCapacitor.averageStacks.recommended',
-            message: `Try to cast Crackling Jade Lightning while as close to 20 stacks as possible`,
-          }),
-        ),
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink spell={TALENTS_MONK.LAST_EMPERORS_CAPACITOR_TALENT} /> stacks
+          </strong>
+          <div style={{ fontSize: 20 }}>
+            {formatNumber(this.stacksWasted)} <small>Generated stacks wasted by being capped</small>
+          </div>
+          {plot}
+        </RoundedPanel>
+        <RoundedPanel style={{ marginTop: '1rem' }}>
+          <strong>
+            <SpellLink spell={SPELLS.CRACKLING_JADE_LIGHTNING} /> clip analysis
+          </strong>
+          <div style={{ display: 'flex' }}>
+            <div style={{ flex: '1', marginRight: '4rem' }}>
+              <DonutChart items={this.donutChart(this.ticksHit)} />
+            </div>
+            <div style={{ fontSize: 20, flex: 1 }}>
+              {this.averageTicks.toFixed(2)} <small>Ticks hit on average</small>
+            </div>
+          </div>
+        </RoundedPanel>
+      </div>
     );
+
+    return explanationAndDataSubsection(explanation, data);
   }
 }
 

--- a/src/analysis/retail/monk/windwalker/modules/talents/LastEmperorsCapacitorGraph.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/LastEmperorsCapacitorGraph.tsx
@@ -1,0 +1,14 @@
+import BuffStackGraph from 'parser/shared/modules/BuffStackGraph';
+import LastEmperorsCapacitorTracker from './LastEmperorsCapacitorTracker';
+
+export default class LastEmperorsCapacitorGraph extends BuffStackGraph {
+  static dependencies = {
+    ...BuffStackGraph.dependencies,
+    lastEmperorsTracker: LastEmperorsCapacitorTracker,
+  };
+  lastEmperorsTracker!: LastEmperorsCapacitorTracker;
+
+  tracker(): LastEmperorsCapacitorTracker {
+    return this.lastEmperorsTracker;
+  }
+}

--- a/src/analysis/retail/monk/windwalker/modules/talents/LastEmperorsCapacitorTracker.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/LastEmperorsCapacitorTracker.tsx
@@ -1,0 +1,12 @@
+import SPELLS from 'common/SPELLS';
+import { Options } from 'parser/core/Analyzer';
+import BuffStackTracker from 'parser/shared/modules/BuffStackTracker';
+
+export default class LastEmperorsCapacitorTracker extends BuffStackTracker {
+  static trackedBuff = SPELLS.LAST_EMPERORS_CAPACITOR_BUFF;
+
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(options: Options) {
+    super(options);
+  }
+}

--- a/src/analysis/retail/monk/windwalker/normalizers/CracklingJadeLightningNormalizer.tsx
+++ b/src/analysis/retail/monk/windwalker/normalizers/CracklingJadeLightningNormalizer.tsx
@@ -1,0 +1,63 @@
+import SPELLS from 'common/SPELLS';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import EventOrderNormalizer, { EventOrder } from 'parser/core/EventOrderNormalizer';
+import { EventType } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+import Channeling from 'parser/shared/normalizers/Channeling';
+
+const MAX_DELAY = 500;
+
+const EVENT_ORDERS: EventOrder[] = [
+  {
+    beforeEventId: SPELLS.CRACKLING_JADE_LIGHTNING.id,
+    beforeEventType: EventType.Damage,
+    afterEventId: SPELLS.CRACKLING_JADE_LIGHTNING.id,
+    afterEventType: EventType.RemoveBuff,
+    bufferMs: MAX_DELAY,
+    anyTarget: true,
+    updateTimestamp: true,
+  },
+  {
+    beforeEventId: SPELLS.CRACKLING_JADE_LIGHTNING.id,
+    beforeEventType: EventType.Damage,
+    afterEventId: SPELLS.CRACKLING_JADE_LIGHTNING.id,
+    afterEventType: EventType.EndChannel,
+    bufferMs: MAX_DELAY,
+    anyTarget: true,
+    updateTimestamp: true,
+  },
+];
+
+export class CracklingJadeLightningNormalizer extends EventOrderNormalizer {
+  static dependencies = {
+    ...EventOrderNormalizer.dependencies,
+    // we explicitly depend on the channeling normalizer here to make sure the endchannel event exists
+    channeling: Channeling,
+  };
+  constructor(options: Options) {
+    super(options, EVENT_ORDERS);
+  }
+}
+
+const castLink: EventLink = {
+  linkRelation: 'cjl-cast',
+  linkingEventId: SPELLS.CRACKLING_JADE_LIGHTNING.id,
+  linkingEventType: EventType.EndChannel,
+  referencedEventType: [EventType.Cast, EventType.BeginCast],
+  referencedEventId: null,
+  forwardBufferMs: 100,
+  anySource: false,
+  anyTarget: true,
+  maximumLinks: 1,
+};
+
+export class CracklingJadeLightningLinkNormalizer extends EventLinkNormalizer {
+  static dependencies = {
+    ...EventLinkNormalizer.dependencies,
+    // we explicitly depend on the channeling normalizer here to make sure the endchannel event exists
+    channeling: Channeling,
+  };
+  constructor(options: Options) {
+    super(options, [castLink]);
+  }
+}


### PR DESCRIPTION
### Description

Add graph and statistic describing stacks of Last Emperor's Capacitor. 

### Testing

- Test report URL: `/report/BT4CHh39r2pJdGwF/101-Mythic+Cauldron+of+Carnage+-+Kill+(5:41)/Styphi/standard/overview`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/1d1174f5-e1ac-4421-b732-1d9483df5859)

