### PR TITLE
windwalker: add performance box for Celestial Conduit clipping

### DIFF
--- a/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/talents/CelestialConduit.tsx
+++ b/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/talents/CelestialConduit.tsx
@@ -38,7 +38,7 @@ import SpellLink from 'interface/SpellLink';
 import { PerformanceMark } from 'interface/guide';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 
-interface CastInfo {
+export interface CastInfo {
   cancelled: boolean;
   timestamp: number;
   // map talent to remaining cd before cast (-1 if not on cd)
@@ -72,9 +72,7 @@ class CelestialConduit extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active =
-      this.selectedCombatant.hasTalent(TALENTS_MONK.CELESTIAL_CONDUIT_TALENT) &&
-      this.selectedCombatant.spec === SPECS.MISTWEAVER_MONK;
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.CELESTIAL_CONDUIT_TALENT);
 
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(TALENTS_MONK.CELESTIAL_CONDUIT_TALENT),
@@ -201,7 +199,7 @@ class CelestialConduit extends Analyzer {
     return QualitativePerformance.Fail;
   }
 
-  private getChecklistForCast(castInfo: CastInfo): {
+  protected getChecklistForCast(castInfo: CastInfo): {
     perf: QualitativePerformance;
     items: CooldownExpandableItem[];
   } {

--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Durpn, emallson } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 3, 21), <>Add <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT} /> clip analysis</>, Durpn),
   change(date(2025, 3, 21), <>Add <SpellLink spell={TALENTS_MONK.LAST_EMPERORS_CAPACITOR_TALENT} /> tracking</>, Durpn),
   change(date(2025, 3, 20), <>Update cooldowns of <SpellLink spell={TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT} /> and <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> based on talents</>, Durpn),
   change(date(2025, 3, 9), <>Update Season 2 APL</>, Durpn),

--- a/src/analysis/retail/monk/windwalker/CombatLogParser.ts
+++ b/src/analysis/retail/monk/windwalker/CombatLogParser.ts
@@ -55,6 +55,7 @@ import {
   CracklingJadeLightningLinkNormalizer,
   CracklingJadeLightningNormalizer,
 } from './normalizers/CracklingJadeLightningNormalizer';
+import CelestialConduit from './modules/talents/CelestialConduit';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -89,6 +90,7 @@ class CombatLogParser extends CoreCombatLogParser {
     strikeoftheWindlord: StrikeoftheWindlord,
     chiBurst: ChiBurst,
     heartOfTheJadeSerpent: HeartOfTheJadeSerpent,
+    celestialConduit: CelestialConduit,
 
     // Guide helpers
     hitComboTracker: HitComboTracker,

--- a/src/analysis/retail/monk/windwalker/Guide.tsx
+++ b/src/analysis/retail/monk/windwalker/Guide.tsx
@@ -16,7 +16,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
       <Section title="Core Spells and Buffs">
         <MasteryGraph modules={modules} events={events} info={info} />
         {info.combatant.hasTalent(TALENTS_MONK.CELESTIAL_CONDUIT_TALENT) &&
-          modules.heartOfTheJadeSerpent.guideSubsection}
+          modules.heartOfTheJadeSerpent.guideSubsection(modules.celestialConduit.clipAnalysis)}
         {modules.risingSunKick.guideSubsection}
         {modules.fistsofFury.guideSubsection}
         {modules.strikeoftheWindlord.guideSubsection}

--- a/src/analysis/retail/monk/windwalker/modules/spells/HeartOfTheJadeSerpent.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/HeartOfTheJadeSerpent.tsx
@@ -85,6 +85,10 @@ class HeartOfTheJadeSerpent extends HotJS {
       mistakes += 1;
     }
 
+    if (this.currentUnityWithin !== 0) {
+      mistakes += 1;
+    }
+
     let value = QualitativePerformance.Fail;
     if (mistakes === 0) {
       value = QualitativePerformance.Perfect;
@@ -140,7 +144,7 @@ class HeartOfTheJadeSerpent extends HotJS {
     }
   }
 
-  get guideSubsection(): JSX.Element {
+  guideSubsection(conduitClipAnalysis: JSX.Element): JSX.Element {
     const explanation = (
       <p>
         <strong>
@@ -185,6 +189,7 @@ class HeartOfTheJadeSerpent extends HotJS {
             <PerformanceBoxRow values={this.castEntries} />
           </div>
         </RoundedPanel>
+        <RoundedPanel style={{ marginTop: '1rem' }}>{conduitClipAnalysis}</RoundedPanel>
       </div>
     );
     return explanationAndDataSubsection(explanation, data);

--- a/src/analysis/retail/monk/windwalker/modules/talents/CelestialConduit.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/CelestialConduit.tsx
@@ -1,0 +1,76 @@
+import { TALENTS_MONK } from 'common/TALENTS';
+import { Options } from 'parser/core/Module';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import {
+  CastInfo,
+  default as CommonCelestialConduit,
+} from '../../../shared/hero/ConduitOfTheCelestials/talents/CelestialConduit';
+import SpellLink from 'interface/SpellLink';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+
+class CelestialConduit extends CommonCelestialConduit {
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.CELESTIAL_CONDUIT_TALENT);
+  }
+
+  private castEntries(casts: CastInfo[]): BoxRowEntry[] {
+    const entries: BoxRowEntry[] = [];
+
+    casts.forEach((cast) => {
+      let value = QualitativePerformance.Fail;
+      if (!cast.cancelled) {
+        value = QualitativePerformance.Perfect;
+      }
+
+      entries.push({
+        value,
+      });
+    });
+
+    return entries;
+  }
+
+  get clipAnalysis() {
+    return (
+      <>
+        <strong>
+          <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT} /> utilization
+        </strong>
+        <div>
+          <strong>Clip Analysis </strong>
+          <small>
+            - Blue indicates a perfect cast (
+            <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT} /> was channeled to completion)
+          </small>
+          <br />
+          <br />
+          <PerformanceBoxRow values={this.castEntries(this.castInfoList)} />
+        </div>
+      </>
+    );
+  }
+
+  get guideCastBreakdown() {
+    const explanation = (
+      <p>
+        <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT} /> should be cast towards the end
+        of a <SpellLink spell={TALENTS_MONK.HEART_OF_THE_JADE_SERPENT_TALENT} /> window, so that the
+        secondary cast of <SpellLink spell={TALENTS_MONK.UNITY_WITHIN_TALENT} /> triggers a new
+        window. The channel should always be fully completed when possible.
+      </p>
+    );
+
+    const data = (
+      <div>
+        <RoundedPanel>{this.clipAnalysis}</RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+}
+
+export default CelestialConduit;


### PR DESCRIPTION
### Description

Add visualization for whether Celestial Conduit was channeled to completion or clipped.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `http://localhost:3000/report/9bxVkfYFXyT7jzdC/60-Mythic+Cauldron+of+Carnage+-+Kill+(6:37)/632-Protmonkey/standard`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/842d0312-9d91-4a44-876b-0fee588c4b02)
