### PR TITLE
windwalker: fix: add checks for cleaving + SEF

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Durpn, emallson } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 3, 21), <>Fix incorrect counting of hit <SpellLink spell={SPELLS.CRACKLING_JADE_LIGHTNING} /> ticks in cleave situations</>, Durpn),
   change(date(2025, 3, 21), <>Add <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_TALENT} /> clip analysis</>, Durpn),
   change(date(2025, 3, 21), <>Add <SpellLink spell={TALENTS_MONK.LAST_EMPERORS_CAPACITOR_TALENT} /> tracking</>, Durpn),
   change(date(2025, 3, 20), <>Update cooldowns of <SpellLink spell={TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT} /> and <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> based on talents</>, Durpn),


### PR DESCRIPTION
### Description

Add checks to only count ticks of CJL into the original target, so that we can accurately tell how long the channel was. In cleave or SEF situations, more damage events are created so most must be filtered out for this tracking.

### Testing

- Test report URL: `/report/Pq8GT3fRxhVYFmw7/12-Mythic+Rik+Reverb+-+Kill+(6:36)/Durpn/standard/overview`
- Screenshot(s):

before: 
![image](https://github.com/user-attachments/assets/f9fc6112-e261-4814-98ca-8d188de395e3)

after: 
![image](https://github.com/user-attachments/assets/d7a33e98-bbc6-49ed-bfd6-b6d891531ae6)

