### PR TITLE
[Devastation] Add Guide Section for Engulf

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_EVOKER } from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2025, 3, 24), <>Add a Guide Section for <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT}/></>, Vollmer),
   change(date(2025, 3, 3), <>Implement TWW S2 4pc module</>, Vollmer),
   change(date(2025, 2, 25), <>Update various modules & abilities for 11.1</>, Vollmer),
   change(date(2025, 2, 25), <>Update handling of <SpellLink spell={TALENTS_EVOKER.MASS_DISINTEGRATE_TALENT}/> ticks</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -37,6 +37,7 @@ export function DamageEfficiency(props: GuideProps<typeof CombatLogParser>) {
       <NoWastedProcsSubsection {...props} />
       {props.modules.shatteringStarGuide.guideSubsection()}
       {props.modules.tww2TierSet.guideSubsection()}
+      {props.modules.engulf.guideSubsection()}
     </Section>
   );
 }

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
@@ -35,12 +35,15 @@ export const MASS_DISINTEGRATE_DEBUFF = 'MassDisintegrateDebuff';
 export const JACKPOT_CONSUME = 'JackpotConsume';
 export const JACKPOT_APPLY_REMOVE_LINK = 'JackpotApplyRemoveLink';
 export const FIRE_BREATH_DEBUFF = 'FireBreathDebuff';
+export const ENGULF_DAMAGE = 'EngulfDamage';
+export const ENGULF_CONSUME_FLAME = 'EngulfConsumeFlame';
 
 export const PYRE_MIN_TRAVEL_TIME = 950;
 export const PYRE_MAX_TRAVEL_TIME = 1_050;
 const CAST_BUFFER_MS = 100;
 const DISINTEGRATE_TICK_BUFFER = 4_000; // Haste dependant
 const JACK_APPLY_REMOVE_BUFFER = 30_000; // Realistically it will never be this long, but we hate edgecases
+const ENGULF_TRAVEL_TIME_MS = 500;
 
 const EVENT_LINKS: EventLink[] = [
   {
@@ -278,6 +281,34 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventType: [EventType.ApplyDebuff, EventType.RefreshDebuff],
     forwardBufferMs: CAST_BUFFER_MS,
     anyTarget: true,
+  },
+  {
+    linkRelation: ENGULF_DAMAGE,
+    reverseLinkRelation: ENGULF_DAMAGE,
+    linkingEventId: TALENTS.ENGULF_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.ENGULF_DAMAGE.id,
+    referencedEventType: EventType.Damage,
+    anyTarget: true,
+    forwardBufferMs: ENGULF_TRAVEL_TIME_MS,
+    maximumLinks: 1,
+    isActive(c) {
+      return c.hasTalent(TALENTS.ENGULF_TALENT);
+    },
+  },
+  {
+    linkRelation: ENGULF_CONSUME_FLAME,
+    reverseLinkRelation: ENGULF_CONSUME_FLAME,
+    linkingEventId: SPELLS.CONSUME_FLAME_DAMAGE.id,
+    linkingEventType: EventType.Damage,
+    referencedEventId: TALENTS.ENGULF_TALENT.id,
+    referencedEventType: EventType.Cast,
+    anyTarget: true,
+    maximumLinks: 1,
+    backwardBufferMs: ENGULF_TRAVEL_TIME_MS,
+    isActive(c) {
+      return c.hasTalent(TALENTS.CONSUME_FLAME_TALENT);
+    },
   },
 ];
 

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
@@ -34,6 +34,7 @@ export const MASS_DISINTEGRATE_TICK = 'MassDisintegrateTick';
 export const MASS_DISINTEGRATE_DEBUFF = 'MassDisintegrateDebuff';
 export const JACKPOT_CONSUME = 'JackpotConsume';
 export const JACKPOT_APPLY_REMOVE_LINK = 'JackpotApplyRemoveLink';
+export const FIRE_BREATH_DEBUFF = 'FireBreathDebuff';
 
 export const PYRE_MIN_TRAVEL_TIME = 950;
 export const PYRE_MAX_TRAVEL_TIME = 1_050;
@@ -261,6 +262,16 @@ const EVENT_LINKS: EventLink[] = [
     maximumLinks: 1,
     backwardBufferMs: JACK_APPLY_REMOVE_BUFFER,
     isActive: (C) => C.has4PieceByTier(TIERS.TWW2),
+  },
+  {
+    linkRelation: FIRE_BREATH_DEBUFF,
+    reverseLinkRelation: FIRE_BREATH_DEBUFF,
+    linkingEventId: [SPELLS.FIRE_BREATH.id, SPELLS.FIRE_BREATH_FONT.id],
+    linkingEventType: EventType.EmpowerEnd,
+    referencedEventId: SPELLS.FIRE_BREATH_DOT.id,
+    referencedEventType: [EventType.ApplyDebuff, EventType.RefreshDebuff],
+    forwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
   },
 ];
 

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
@@ -3,13 +3,18 @@ import TALENTS from 'common/TALENTS/evoker';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import { Options } from 'parser/core/Module';
 import {
+  ApplyBuffEvent,
+  ApplyBuffStackEvent,
   ApplyDebuffEvent,
   CastEvent,
   DamageEvent,
+  EmpowerEndEvent,
   EventType,
+  GetRelatedEvent,
   GetRelatedEvents,
   HasRelatedEvent,
   RefreshDebuffEvent,
+  RemoveBuffEvent,
 } from 'parser/core/Events';
 import { encodeEventTargetString } from 'parser/shared/modules/Enemies';
 import { TIERS } from 'game/TIERS';
@@ -344,6 +349,36 @@ export function isMassDisintegrateTick(event: DamageEvent) {
 
 export function isMassDisintegrateDebuff(event: ApplyDebuffEvent | RefreshDebuffEvent) {
   return HasRelatedEvent(event, MASS_DISINTEGRATE_DEBUFF);
+}
+
+/** Returns the number of stacks consumed by a Jackpot! remove event or empower end event
+ * will return 0 if the event didn't consume Jackpot! */
+export function getConsumedJackpotStacks(event: EmpowerEndEvent | RemoveBuffEvent) {
+  if (event.type === EventType.EmpowerEnd) {
+    const maybeConsumeEvent = GetRelatedEvent<RemoveBuffEvent>(event, JACKPOT_CONSUME);
+
+    if (maybeConsumeEvent) {
+      event = maybeConsumeEvent;
+    }
+  }
+
+  if (event.ability.guid === SPELLS.JACKPOT_BUFF.id && event.type === EventType.RemoveBuff) {
+    const applyEvent = GetRelatedEvent<ApplyBuffEvent | ApplyBuffStackEvent>(
+      event,
+      JACKPOT_APPLY_REMOVE_LINK,
+    );
+
+    switch (applyEvent?.type) {
+      case EventType.ApplyBuff:
+        return 1;
+      case EventType.ApplyBuffStack:
+        return applyEvent.stack ?? 2;
+      default:
+        return 0;
+    }
+  }
+
+  return 0;
 }
 
 export default CastLinkNormalizer;

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
@@ -28,11 +28,13 @@ export const MASS_DISINTEGRATE_CONSUME = 'MassDisintegrateConsume';
 export const MASS_DISINTEGRATE_TICK = 'MassDisintegrateTick';
 export const MASS_DISINTEGRATE_DEBUFF = 'MassDisintegrateDebuff';
 export const JACKPOT_CONSUME = 'JackpotConsume';
+export const JACKPOT_APPLY_REMOVE_LINK = 'JackpotApplyRemoveLink';
 
 export const PYRE_MIN_TRAVEL_TIME = 950;
 export const PYRE_MAX_TRAVEL_TIME = 1_050;
 const CAST_BUFFER_MS = 100;
 const DISINTEGRATE_TICK_BUFFER = 4_000; // Haste dependant
+const JACK_APPLY_REMOVE_BUFFER = 30_000; // Realistically it will never be this long, but we hate edgecases
 
 const EVENT_LINKS: EventLink[] = [
   {
@@ -243,6 +245,17 @@ const EVENT_LINKS: EventLink[] = [
     forwardBufferMs: CAST_BUFFER_MS,
     isActive: (C) => C.has4PieceByTier(TIERS.TWW2),
     maximumLinks: 1,
+  },
+  {
+    linkRelation: JACKPOT_APPLY_REMOVE_LINK,
+    reverseLinkRelation: JACKPOT_APPLY_REMOVE_LINK,
+    linkingEventId: SPELLS.JACKPOT_BUFF.id,
+    linkingEventType: EventType.RemoveBuff,
+    referencedEventId: SPELLS.JACKPOT_BUFF.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
+    maximumLinks: 1,
+    backwardBufferMs: JACK_APPLY_REMOVE_BUFFER,
+    isActive: (C) => C.has4PieceByTier(TIERS.TWW2),
   },
 ];
 

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
@@ -77,11 +77,17 @@ const EVENT_LINKS: EventLink[] = [
     reverseLinkRelation: IRIDESCENCE_RED_CONSUME,
     linkingEventId: [SPELLS.IRIDESCENCE_RED.id],
     linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
-    referencedEventId: [SPELLS.PYRE.id, SPELLS.PYRE_DENSE_TALENT.id, SPELLS.LIVING_FLAME_CAST.id],
+    referencedEventId: [
+      SPELLS.PYRE.id,
+      SPELLS.PYRE_DENSE_TALENT.id,
+      SPELLS.LIVING_FLAME_CAST.id,
+      TALENTS.ENGULF_TALENT.id,
+    ],
     referencedEventType: EventType.Cast,
     anyTarget: true,
     forwardBufferMs: CAST_BUFFER_MS,
     backwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
     isActive(c) {
       return c.hasTalent(TALENTS.IRIDESCENCE_TALENT);
     },

--- a/src/analysis/retail/evoker/shared/modules/normalizers/DefensiveNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/DefensiveNormalizer.ts
@@ -78,6 +78,7 @@ class DefensiveNormalizer extends EventsNormalizer {
     // Make sure we push in the latests removal if it hasn't already been
     // think fightend, death, etc...
     latestBuffRemoveEvents.forEach((event) => fixedEvents.push(event));
+    fixedEvents.sort((a, b) => a.timestamp - b.timestamp);
 
     return fixedEvents;
   }

--- a/src/analysis/retail/evoker/shared/modules/talents/hero/flameshaper/Engulf.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/hero/flameshaper/Engulf.tsx
@@ -1,32 +1,72 @@
 import {
+  ENGULF_CONSUME_FLAME,
+  IRIDESCENCE_RED_CONSUME,
+} from 'analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer';
+import {
   ENGULF_PERIODIC_INCREASE,
   PERIODIC_DAMAGE_IDS,
   PERIODIC_HEALING_IDS,
 } from 'analysis/retail/evoker/shared/constants';
+import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_EVOKER } from 'common/TALENTS';
+import SPECS from 'game/SPECS';
+import SpellLink from 'interface/SpellLink';
 import { TooltipElement } from 'interface/Tooltip';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Combatant from 'parser/core/Combatant';
 import Enemy from 'parser/core/Enemy';
 import { calculateEffectiveDamage, calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
-import Events, { DamageEvent, HealEvent } from 'parser/core/Events';
+import Events, {
+  CastEvent,
+  DamageEvent,
+  GetRelatedEvents,
+  HasRelatedEvent,
+  HealEvent,
+} from 'parser/core/Events';
 import { Options } from 'parser/core/EventSubscriber';
+import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
+import ContextualSpellUsageSubSection from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
 import Combatants from 'parser/shared/modules/Combatants';
 import Enemies from 'parser/shared/modules/Enemies';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
+
+type EngulfCast = {
+  event: CastEvent;
+  fireBreathActiveOnCast: boolean;
+  fireBreathActiveAfterConsume: boolean;
+  rubyEmbersActive: boolean;
+  enkindleActive: boolean;
+  shatteringStarActive: boolean;
+  iridescenceConsumed: boolean;
+  consumeFlameTargetCount: number;
+  castOnFriendly?: string;
+  castOnUnknown?: boolean;
+};
 
 class Engulf extends Analyzer {
   static dependencies = {
     combatants: Combatants,
     enemies: Enemies,
   };
+
+  private uses: SpellUse[] = [];
+  private engulfCasts: EngulfCast[] = [];
+
+  hasIridescence = false;
+  hasRubyEmbers = false;
+  hasEnkindle = false;
+  hasShatteringStar = false;
+  hasScorchingEmbers = false;
+  currentEngulfTarget: Enemy | undefined;
+
   damagePeriodicCounts: number[] = [];
   healingPeriodicCounts: number[] = [];
   totalDamage: number = 0;
@@ -43,6 +83,24 @@ class Engulf extends Analyzer {
       this.onDamage,
     );
     this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.ENGULF_HEAL), this.onHeal);
+
+    if (this.selectedCombatant.spec === SPECS.DEVASTATION_EVOKER) {
+      this.hasIridescence = this.selectedCombatant.hasTalent(TALENTS_EVOKER.IRIDESCENCE_TALENT);
+      this.hasRubyEmbers = this.selectedCombatant.hasTalent(TALENTS_EVOKER.RUBY_EMBERS_TALENT);
+      this.hasEnkindle = this.selectedCombatant.hasTalent(TALENTS_EVOKER.ENKINDLE_TALENT);
+      this.hasShatteringStar = this.selectedCombatant.hasTalent(
+        TALENTS_EVOKER.SHATTERING_STAR_TALENT,
+      );
+      this.hasScorchingEmbers = this.selectedCombatant.hasTalent(
+        TALENTS_EVOKER.SCORCHING_EMBERS_TALENT,
+      );
+
+      this.addEventListener(
+        Events.cast.by(SELECTED_PLAYER).spell(TALENTS_EVOKER.ENGULF_TALENT),
+        this.onCast,
+      );
+      this.addEventListener(Events.fightend, this.finalize);
+    }
   }
 
   getNumPeriodicEffects(target: Combatant | Enemy) {
@@ -61,6 +119,22 @@ class Engulf extends Analyzer {
     const numPeriodics = this.getNumPeriodicEffects(enemy);
     this.damagePeriodicCounts.push(numPeriodics);
     this.damageFromInc += calculateEffectiveDamage(event, ENGULF_PERIODIC_INCREASE * numPeriodics);
+
+    if (
+      this.currentEngulfTarget === enemy &&
+      this.engulfCasts.length &&
+      !this.engulfCasts[this.engulfCasts.length - 1].castOnUnknown &&
+      !this.engulfCasts[this.engulfCasts.length - 1].castOnFriendly
+    ) {
+      this.engulfCasts[this.engulfCasts.length - 1].fireBreathActiveAfterConsume =
+        this.currentEngulfTarget.hasBuff(SPELLS.FIRE_BREATH_DOT);
+      /* console.log(
+        this.owner.formatTimestamp(event.timestamp, 3),
+        this.currentEngulfTarget.name,
+        this.currentEngulfTarget.hasBuff(SPELLS.FIRE_BREATH_DOT),
+      ); */
+      this.currentEngulfTarget = undefined;
+    }
   }
 
   onHeal(event: HealEvent) {
@@ -77,6 +151,426 @@ class Engulf extends Analyzer {
     );
   }
 
+  onCast(event: CastEvent) {
+    const enemy = this.enemies.getEntity(event);
+    if (!enemy) {
+      const friendlyTarget = this.combatants.getEntity(event);
+      if (friendlyTarget) {
+        this.engulfCasts.push({
+          event,
+          fireBreathActiveOnCast: false,
+          fireBreathActiveAfterConsume: false,
+          rubyEmbersActive: false,
+          enkindleActive: false,
+          shatteringStarActive: false,
+          iridescenceConsumed: false,
+          consumeFlameTargetCount: 0,
+          castOnFriendly: friendlyTarget.name,
+        });
+      } else {
+        this.engulfCasts.push({
+          event,
+          fireBreathActiveOnCast: false,
+          fireBreathActiveAfterConsume: false,
+          rubyEmbersActive: false,
+          enkindleActive: false,
+          shatteringStarActive: false,
+          iridescenceConsumed: false,
+          consumeFlameTargetCount: 0,
+          castOnUnknown: true,
+        });
+        //console.log('No target found!', this.owner.formatTimestamp(event.timestamp, 3), event);
+      }
+
+      this.currentEngulfTarget = undefined;
+      return;
+    }
+
+    /** When playing Scorching Embers, FB needs to be up
+     * post consume for Consume Flame to benefit from the damage amplification.
+     * But due to how buff tracking is done, we need make the future
+     * hasBuff check on the damage event */
+    if (this.hasScorchingEmbers) {
+      this.currentEngulfTarget = enemy;
+    }
+
+    this.engulfCasts.push({
+      event,
+      fireBreathActiveOnCast: enemy.hasBuff(SPELLS.FIRE_BREATH_DOT),
+      fireBreathActiveAfterConsume: false,
+      rubyEmbersActive: enemy.hasBuff(SPELLS.LIVING_FLAME_DAMAGE),
+      enkindleActive: enemy.hasBuff(SPELLS.ENKINDLE_DOT),
+      shatteringStarActive: enemy.hasBuff(TALENTS_EVOKER.SHATTERING_STAR_TALENT),
+      iridescenceConsumed: HasRelatedEvent(event, IRIDESCENCE_RED_CONSUME),
+      consumeFlameTargetCount: GetRelatedEvents(event, ENGULF_CONSUME_FLAME).length,
+    });
+  }
+
+  private finalize() {
+    // finalize performances
+    this.uses = this.engulfCasts.map((engulfCast) => this.engulfUsage(engulfCast));
+  }
+
+  private engulfUsage(engulfCast: EngulfCast): SpellUse {
+    const checklistItems: ChecklistUsageInfo[] = [];
+
+    const targetPerformance = this.getTargetPerformance(engulfCast);
+    if (targetPerformance) {
+      checklistItems.push({
+        check: 'engulf-target-performance',
+        timestamp: engulfCast.event.timestamp,
+        ...targetPerformance,
+      });
+
+      return {
+        event: engulfCast.event,
+        performance: QualitativePerformance.Ok,
+        checklistItems,
+        performanceExplanation: 'Ok Usage',
+      };
+    }
+
+    const fireBreathPerformance = this.getFireBreathPerformance(engulfCast);
+    checklistItems.push({
+      check: 'engulf-fire-breath-active-performance',
+      timestamp: engulfCast.event.timestamp,
+      ...fireBreathPerformance,
+    });
+
+    if (!engulfCast.fireBreathActiveOnCast) {
+      return {
+        event: engulfCast.event,
+        performance: QualitativePerformance.Fail,
+        checklistItems,
+        performanceExplanation: 'Bad Usage',
+      };
+    }
+
+    if (this.hasIridescence) {
+      const iridescencePerformance = this.getIridescencePerformance(engulfCast);
+      checklistItems.push({
+        check: 'engulf-iridescence-consume-performance',
+        timestamp: engulfCast.event.timestamp,
+        ...iridescencePerformance,
+      });
+    }
+
+    if (this.hasRubyEmbers) {
+      const rubyEmbersPerformance = this.getRubyEmbersPerformance(engulfCast);
+      checklistItems.push({
+        check: 'engulf-ruby-embers-active-performance',
+        timestamp: engulfCast.event.timestamp,
+        ...rubyEmbersPerformance,
+      });
+    }
+
+    if (this.hasEnkindle) {
+      const enkindlePerformance = this.getEnkindlePerformance(engulfCast);
+      checklistItems.push({
+        check: 'engulf-enkindle-active-performance',
+        timestamp: engulfCast.event.timestamp,
+        ...enkindlePerformance,
+      });
+    }
+
+    if (this.hasShatteringStar) {
+      const shatteringStarPerformance = this.getShatteringStarPerformance(engulfCast);
+      checklistItems.push({
+        check: 'engulf-shattering-star-active-performance',
+        timestamp: engulfCast.event.timestamp,
+        ...shatteringStarPerformance,
+      });
+    }
+
+    /**
+     * NOTE: This is disabled for now, since you don't really play around it in ST
+     * And for AoE, anything but your main target should be have FB up anyways
+     * Leaving it here commented out since it might be useful in the future
+     * The APL is currently changing way too rapidly... */
+    /* if (this.hasScorchingEmbers) {
+      const scorchingEmbersPerformance = this.getScorchingEmbersPerformance(engulfCast);
+      checklistItems.push({
+        check: 'engulf-scorching-embers-performance',
+        timestamp: engulfCast.event.timestamp,
+        ...scorchingEmbersPerformance,
+      });
+    } */
+
+    const consumeFlameTargetCountPerformance =
+      this.getConsumeFlameTargetCountPerformance(engulfCast);
+    if (consumeFlameTargetCountPerformance) {
+      checklistItems.push({
+        check: 'engulf-consume-flame-targets-performance',
+        timestamp: engulfCast.event.timestamp,
+        ...consumeFlameTargetCountPerformance,
+      });
+    }
+
+    /* Mark the usage as Perfect if all the checks are good
+     * This makes it easier to rate good uses for AoE
+     * Since we don't really care about anything but FB for AoE
+     * But still marking it as perfect when they are up for prio damage */
+    const actualPerformance = checklistItems.every(
+      (item) => item.performance === QualitativePerformance.Good,
+    )
+      ? QualitativePerformance.Perfect
+      : consumeFlameTargetCountPerformance
+        ? QualitativePerformance.Good
+        : combineQualitativePerformances(checklistItems.map((item) => item.performance));
+
+    return {
+      event: engulfCast.event,
+      performance: actualPerformance,
+      checklistItems,
+      performanceExplanation:
+        actualPerformance !== QualitativePerformance.Fail
+          ? `${actualPerformance} Usage`
+          : 'Bad Usage',
+    };
+  }
+
+  private getConsumeFlameTargetCountPerformance(engulfCast: EngulfCast) {
+    if (engulfCast.consumeFlameTargetCount <= 1) {
+      return;
+    }
+
+    return {
+      performance: QualitativePerformance.Good,
+      summary: (
+        <>
+          <SpellLink spell={TALENTS_EVOKER.CONSUME_FLAME_TALENT} /> hit{' '}
+          {engulfCast.consumeFlameTargetCount} targets
+        </>
+      ),
+      details: (
+        <div key="engulf-consume-flame-targets">
+          <SpellLink spell={TALENTS_EVOKER.CONSUME_FLAME_TALENT} /> hit{' '}
+          {engulfCast.consumeFlameTargetCount} targets!
+        </div>
+      ),
+    };
+  }
+
+  private getTargetPerformance(engulfCast: EngulfCast) {
+    if (engulfCast.castOnFriendly) {
+      return {
+        performance: QualitativePerformance.Fail,
+        summary: <>Cast hit a friendly target</>,
+        details: (
+          <div key="engulf-friendly-target">
+            <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT} /> was cast on friendly target:{' '}
+            {engulfCast.castOnFriendly}!
+          </div>
+        ),
+      };
+    } else if (engulfCast.castOnUnknown) {
+      return {
+        performance: QualitativePerformance.Ok,
+        summary: <>Cast hit an unknown target</>,
+        details: (
+          <div key="engulf-unknown-target">
+            <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT} /> was cast on an unknown target, and
+            can not be evaluated.
+          </div>
+        ),
+      };
+    }
+  }
+
+  private getFireBreathPerformance(engulfCast: EngulfCast) {
+    const summary = (
+      <>
+        <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT active
+      </>
+    );
+
+    if (!engulfCast.fireBreathActiveOnCast) {
+      return {
+        performance: QualitativePerformance.Fail,
+        summary,
+        details: (
+          <div key="engulf-fire-breath-active">
+            <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT wasn't active! You should <b>never</b> cast{' '}
+            <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT} /> without{' '}
+            <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT active.
+          </div>
+        ),
+      };
+    }
+
+    return {
+      performance: QualitativePerformance.Good,
+      summary,
+      details: (
+        <div key="engulf-fire-breath-active">
+          <SpellLink spell={SPELLS.FIRE_BREATH} /> DoT was active! Good job!
+        </div>
+      ),
+    };
+  }
+
+  private getIridescencePerformance(engulfCast: EngulfCast) {
+    const summary = (
+      <>
+        <SpellLink spell={SPELLS.IRIDESCENCE_RED} /> consumed
+      </>
+    );
+
+    if (!engulfCast.iridescenceConsumed) {
+      return {
+        performance: QualitativePerformance.Fail,
+        summary,
+        details: (
+          <div key="engulf-iridescence-consume">
+            <SpellLink spell={SPELLS.IRIDESCENCE_RED} /> wasn't consumed! It is important to always
+            have <SpellLink spell={SPELLS.IRIDESCENCE_RED} /> up for each cast of{' '}
+            <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT} />.
+          </div>
+        ),
+      };
+    }
+
+    return {
+      performance: QualitativePerformance.Good,
+      summary,
+      details: (
+        <div key="engulf-iridescence-consume">
+          <SpellLink spell={SPELLS.IRIDESCENCE_RED} /> was consumed! Good job!
+        </div>
+      ),
+    };
+  }
+
+  private getRubyEmbersPerformance(engulfCast: EngulfCast) {
+    const summary = (
+      <>
+        <SpellLink spell={SPELLS.LIVING_FLAME_DAMAGE} /> DoT active
+      </>
+    );
+    if (!engulfCast.rubyEmbersActive) {
+      return {
+        performance: QualitativePerformance.Fail,
+        summary,
+        details: (
+          <div key="engulf-ruby-embers-active">
+            <SpellLink spell={SPELLS.LIVING_FLAME_DAMAGE} /> DoT wasn't active! When playing{' '}
+            <SpellLink spell={TALENTS_EVOKER.RUBY_EMBERS_TALENT} />, it is important to always
+            ensure that <SpellLink spell={SPELLS.LIVING_FLAME_DAMAGE} /> DoT is active before
+            casting <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT} />.
+          </div>
+        ),
+      };
+    }
+
+    return {
+      performance: QualitativePerformance.Good,
+      summary,
+      details: (
+        <div key="engulf-ruby-embers-active">
+          <SpellLink spell={SPELLS.LIVING_FLAME_DAMAGE} /> DoT was active! Good job!
+        </div>
+      ),
+    };
+  }
+
+  private getEnkindlePerformance(engulfCast: EngulfCast) {
+    const summary = (
+      <>
+        <SpellLink spell={SPELLS.ENKINDLE_DOT} /> DoT active
+      </>
+    );
+    if (!engulfCast.enkindleActive) {
+      return {
+        performance: QualitativePerformance.Fail,
+        summary,
+        details: (
+          <div key="engulf-enkindle-active">
+            <SpellLink spell={SPELLS.ENKINDLE_DOT} /> DoT wasn't active! It is important to always
+            ensure that <SpellLink spell={SPELLS.ENKINDLE_DOT} /> DoT is active before casting{' '}
+            <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT} />.
+          </div>
+        ),
+      };
+    }
+
+    return {
+      performance: QualitativePerformance.Good,
+      summary,
+      details: (
+        <div key="engulf-enkindle-active">
+          <SpellLink spell={SPELLS.ENKINDLE_DOT} /> DoT was active! Good job!
+        </div>
+      ),
+    };
+  }
+
+  private getShatteringStarPerformance(engulfCast: EngulfCast) {
+    const summary = (
+      <>
+        <SpellLink spell={SPELLS.SHATTERING_STAR} /> active
+      </>
+    );
+    if (!engulfCast.shatteringStarActive) {
+      return {
+        performance: QualitativePerformance.Ok,
+        summary,
+        details: (
+          <div key="engulf-shattering-star-active">
+            <SpellLink spell={SPELLS.SHATTERING_STAR} /> wasn't active! This is situationally
+            correct, but ideally you should try and line up{' '}
+            <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT} /> with{' '}
+            <SpellLink spell={SPELLS.SHATTERING_STAR} /> when possible.
+          </div>
+        ),
+      };
+    }
+
+    return {
+      performance: QualitativePerformance.Good,
+      summary,
+      details: (
+        <div key="engulf-shattering-star-active">
+          <SpellLink spell={SPELLS.SHATTERING_STAR} /> was active! Good job!
+        </div>
+      ),
+    };
+  }
+
+  private getScorchingEmbersPerformance(engulfCast: EngulfCast) {
+    const summary = (
+      <>
+        <SpellLink spell={SPELLS.CONSUME_FLAME_DAMAGE} /> amplified by{' '}
+        <SpellLink spell={TALENTS_EVOKER.SCORCHING_EMBERS_TALENT} />
+      </>
+    );
+    if (!engulfCast.fireBreathActiveAfterConsume) {
+      return {
+        performance: QualitativePerformance.Ok,
+        summary,
+        details: (
+          <div key="engulf-scorching-embers-fail">
+            <SpellLink spell={SPELLS.FIRE_BREATH_DOT} /> DoT wasn't active for{' '}
+            <SpellLink spell={SPELLS.CONSUME_FLAME_DAMAGE} />!{' '}
+            <SpellLink spell={TALENTS_EVOKER.CONSUME_FLAME_TALENT} /> damage will only be amplified
+            by <SpellLink spell={TALENTS_EVOKER.SCORCHING_EMBERS_TALENT} /> if there is still
+            duration left on <SpellLink spell={SPELLS.FIRE_BREATH} /> after consumption.
+          </div>
+        ),
+      };
+    }
+
+    return {
+      performance: QualitativePerformance.Good,
+      summary,
+      details: (
+        <div key="engulf-scorching-embers-good">
+          <SpellLink spell={SPELLS.FIRE_BREATH_DOT} /> DoT was active for{' '}
+          <SpellLink spell={SPELLS.CONSUME_FLAME_DAMAGE} />! Good job!
+        </div>
+      ),
+    };
+  }
+
   get averageHealPeriodics() {
     return (
       this.healingPeriodicCounts.reduce((prev, cur) => prev + cur, 0) /
@@ -88,6 +582,68 @@ class Engulf extends Analyzer {
     return (
       this.damagePeriodicCounts.reduce((prev, cur) => prev + cur, 0) /
       (this.damagePeriodicCounts.length || 1)
+    );
+  }
+
+  guideSubsection(): JSX.Element | null {
+    if (!this.active) {
+      return null;
+    }
+
+    const explanation = (
+      <section>
+        <b>
+          <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT} />
+        </b>{' '}
+        is a powerful burst damage ability that is amplified by each of your active DoTs on the
+        target: <SpellLink spell={SPELLS.FIRE_BREATH_DOT} />,{' '}
+        <SpellLink spell={SPELLS.ENKINDLE_DOT} /> and{' '}
+        <SpellLink spell={TALENTS_EVOKER.RUBY_EMBERS_TALENT} />.
+        {this.hasIridescence && (
+          <>
+            <br />
+            <br />
+            With <SpellLink spell={TALENTS_EVOKER.IRIDESCENCE_TALENT} /> talented{' '}
+            <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT} /> should only be cast when it will
+            consume <SpellLink spell={SPELLS.IRIDESCENCE_RED} />.
+          </>
+        )}
+        {/* {this.hasScorchingEmbers && (
+          <>
+            <br />
+            <br />
+            With <SpellLink spell={TALENTS_EVOKER.SCORCHING_EMBERS_TALENT} /> talented it is
+            important to note that <SpellLink spell={TALENTS_EVOKER.CONSUME_FLAME_TALENT} /> damage
+            will only be amplified if there is still duration left on{' '}
+            <SpellLink spell={SPELLS.FIRE_BREATH} /> after consumption. As such, you shouldn't cast{' '}
+            <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT} /> with less than ~2.5 seconds left on{' '}
+            <SpellLink spell={SPELLS.FIRE_BREATH} />.
+          </>
+        )} */}
+        {this.owner.selectedCombatant.hasTalent(TALENTS_EVOKER.CONSUME_FLAME_TALENT) && (
+          <>
+            <br />
+            <br />
+            <b>Note:</b> <SpellLink spell={TALENTS_EVOKER.CONSUME_FLAME_TALENT} /> damage isn't
+            amplified by your active DoTs. Instead, it only scales with{' '}
+            <SpellLink spell={SPELLS.FIRE_BREATH_DOT} /> damage. Therefore, in AoE situations,
+            having your DoTs or <SpellLink spell={SPELLS.SHATTERING_STAR} /> active will only
+            increase damage on your main target.
+          </>
+        )}
+      </section>
+    );
+
+    return (
+      <ContextualSpellUsageSubSection
+        title="Engulf"
+        explanation={explanation}
+        uses={this.uses}
+        castBreakdownSmallText={
+          <> - These boxes represent each cast, colored by how good the usage was.</>
+        }
+        abovePerformanceDetails={<div style={{ marginBottom: 10 }}></div>}
+      />
     );
   }
 


### PR DESCRIPTION
### Description

Adds a Guide Section for Engulf to analyze uses for Devastation.

Also done a bit of cleanup for various Cast Links.

Due to the complexity of the war crime that is the current APL line for engulf, analysis will strictly encompass the amplification aspects of Engulf - ignoring the parts of when it would be optimal to hold it. Since those aspect are essentially impossible to properly analyze on a real encounter, and is frequently subject to changes.

`engulf,target_if=max:(dot.fire_breath_damage.remains-dbc.effect.1140380.base_value*action.engulf_damage.in_flight_to_target),if=(dot.fire_breath_damage.remains>=(action.engulf_damage.travel_time+dbc.effect.1140380.base_value*(action.engulf_damage.in_flight_to_target)))&(!talent.enkindle|dot.enkindle.ticking)&(!talent.ruby_embers|dot.living_flame_damage.ticking)&(!talent.shattering_star&!talent.iridescence|debuff.shattering_star_debuff.up&(!talent.iridescence|full_recharge_time<=cooldown.fire_breath.remains+4|buff.dragonrage.up)|buff.iridescence_red.up&(debuff.shattering_star_debuff.up|!talent.shattering_star|full_recharge_time<=cooldown.shattering_star.remains)|talent.scorching_embers&dot.fire_breath_damage.duration<=10&dot.fire_breath_damage.remains<=5)&(variable.next_dragonrage>=cooldown*1.2|!talent.dragonrage|full_recharge_time<=variable.next_dragonrage)&(cooldown.tip_the_scales.remains>=4|cooldown.fire_breath.remains>=8|!talent.scorching_embers|!talent.tip_the_scales)&(!talent.iridescence|buff.iridescence_red.up&(debuff.shattering_star_debuff.remains>=travel_time|cooldown.shattering_star.remains+gcd.max>buff.iridescence_red.remains|essence<3&buff.iridescence_red.stack=1|full_recharge_time<cooldown.fire_breath.remains_expected&(debuff.shattering_star_debuff.remains>=travel_time)|!talent.shattering_star))|fight_remains<=10`

### Testing

- Test report URL: 

Embers Raid: `/report/pzCAF3am8dDH2Zwg/86-Mythic+Cauldron+of+Carnage+-+Kill+(5:36)/Seevo/standard`
Embers M+: `report/Aa29TyjmRr13Q7CB/3-Mythic++Operation:+Floodgate+-+Kill+(24:40)/Vollmer/standard/overview`
Irid Raid: `/report/mcphtXKf4n7jA1wz/44-Mythic+Sprocketmonger+Lockenstock+-+Kill+(5:35)/Shamvoke/standard`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/1ceaeca3-653b-4385-8f4a-a0192b97d99e)
![image](https://github.com/user-attachments/assets/6b8d2a2d-e68c-44a7-bdb8-c0416483de14)
![image](https://github.com/user-attachments/assets/8105dcd2-3913-48dd-a4c1-b72bfbc9e130)
