### PR TITLE
[Evoker] Implement Flame Siphon module for Devastation & Preservation

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_EVOKER } from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2025, 3, 25), <>Implement <SpellLink spell={TALENTS_EVOKER.FLAME_SIPHON_TALENT}/> module</>, Vollmer), 
   change(date(2025, 3, 24), <>Add a Guide Section for <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT}/></>, Vollmer),
   change(date(2025, 3, 3), <>Implement TWW S2 4pc module</>, Vollmer),
   change(date(2025, 2, 25), <>Update various modules & abilities for 11.1</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/devastation/CombatLogParser.ts
@@ -69,6 +69,7 @@ import {
   ExpandedLungs,
   RedHot,
   TimeSpiral,
+  FlameSiphon,
 } from 'analysis/retail/evoker/shared';
 import TWW2TierSet from './modules/tier/TWW2TierSet';
 
@@ -145,6 +146,7 @@ class CombatLogParser extends MainCombatLogParser {
     unrelentingSiege: UnrelentingSiege,
     wingLeader: Wingleader,
     slipstream: Slipstream,
+    flameSiphon: FlameSiphon,
 
     // core abilities
     disintegrate: Disintegrate,

--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
-import { Trevor, Harrek, Hana, KYZ, Capybara} from 'CONTRIBUTORS';
+import { Trevor, Harrek, Hana, KYZ, Capybara, Vollmer} from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 
 // prettier-ignore
 export default [
+  change(date(2025, 3, 25), <>Implement <SpellLink spell={TALENTS_EVOKER.FLAME_SIPHON_TALENT}/> module</>, Vollmer), 
   change(date(2025, 3, 18), <>Updated DB target count for 6+ targets </>, Capybara),
   change(date(2025, 3, 2), <>Bump to 11.1.0</>, Harrek),
   change(date(2025, 3, 2), <>Implemented T33 Tierset module</>, Harrek),

--- a/src/analysis/retail/evoker/preservation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/preservation/CombatLogParser.ts
@@ -74,6 +74,7 @@ import {
   MotesOfAcceleration,
   TimeSpiral,
   MobilityCastLinkNormalizer,
+  FlameSiphon,
 } from '../shared';
 import T32Prevoker from './modules/tier/T32TierSet';
 import T33Prevoker from './modules/tier/T33TierSet';
@@ -170,6 +171,7 @@ class CombatLogParser extends CoreCombatLogParser {
     timeConvergence: TimeConvergence,
     masterOfDestiny: MasterOfDestiny,
     motesOfAcceleration: MotesOfAcceleration,
+    flameSiphon: FlameSiphon,
 
     // other
     t32Prevoker: T32Prevoker,

--- a/src/analysis/retail/evoker/shared/constants.ts
+++ b/src/analysis/retail/evoker/shared/constants.ts
@@ -72,6 +72,7 @@ export const ENGULF_PERIODIC_INCREASE = 0.5;
 export const EXPANDED_LUNG_INCREASE = 0.2;
 export const FAN_THE_FLAMES_INCREASE = 1;
 export const RED_HOT_INCREASE = 0.2;
+export const FLAME_SIPHON_CDR_MS = 6_000;
 
 export const PRIMACY_HASTE_PER_STACK = 3;
 export const THREAD_OF_FATE_BASE_DURATION_MS = 10_000;

--- a/src/analysis/retail/evoker/shared/index.ts
+++ b/src/analysis/retail/evoker/shared/index.ts
@@ -41,4 +41,5 @@ export { default as MasterOfDestiny } from './modules/talents/hero/chronowarden/
 export { default as GoldenOpportunity } from './modules/talents/hero/chronowarden/GoldenOpportunity';
 export { default as DoubleTime } from './modules/talents/hero/chronowarden/DoubleTime';
 export { default as MotesOfAcceleration } from './modules/talents/hero/chronowarden/MotesOfAcceleration';
+export { default as FlameSiphon } from './modules/talents/hero/flameshaper/FlameSiphon';
 export * from './constants';

--- a/src/analysis/retail/evoker/shared/modules/talents/hero/flameshaper/FlameSiphon.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/hero/flameshaper/FlameSiphon.tsx
@@ -1,0 +1,85 @@
+import { FLAME_SIPHON_CDR_MS } from 'analysis/retail/evoker/shared/constants';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/evoker';
+import SpellLink from 'interface/SpellLink';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+import { Options } from 'parser/core/EventSubscriber';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import DonutChart from 'parser/ui/DonutChart';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+
+/** Engulf reduces the cooldown of Fire Breath by 6 sec. */
+class FlameSiphon extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+  protected spellUsable!: SpellUsable;
+
+  totalEffectiveCDR = 0;
+  totalWastedCDR = 0;
+
+  fireBreathSpell =
+    this.selectedCombatant.hasTalent(TALENTS.FONT_OF_MAGIC_DEVASTATION_TALENT) ||
+    this.selectedCombatant.hasTalent(TALENTS.FONT_OF_MAGIC_PRESERVATION_TALENT)
+      ? SPELLS.FIRE_BREATH_FONT
+      : SPELLS.FIRE_BREATH;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.FLAME_SIPHON_TALENT);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.ENGULF_TALENT),
+      this.onCast,
+    );
+  }
+
+  onCast(event: CastEvent) {
+    const effectiveCDR = this.spellUsable.reduceCooldown(
+      this.fireBreathSpell.id,
+      FLAME_SIPHON_CDR_MS,
+    );
+    const wastedCDR = FLAME_SIPHON_CDR_MS - effectiveCDR;
+
+    this.totalEffectiveCDR += effectiveCDR / 1_000;
+    this.totalWastedCDR += wastedCDR / 1_000;
+  }
+
+  statistic() {
+    const effectiveCDRItems = [
+      {
+        color: 'rgb(123,188,93)',
+        label: 'Effective CDR',
+        valueTooltip: this.totalEffectiveCDR.toFixed(2) + 's effective CDR',
+        value: this.totalEffectiveCDR,
+      },
+      {
+        color: 'rgb(216,59,59)',
+        label: 'Wasted CDR',
+        valueTooltip: this.totalWastedCDR.toFixed(2) + 's CDR wasted',
+        value: this.totalWastedCDR,
+      },
+    ];
+
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(6)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.HERO_TALENTS}
+      >
+        <div className="pad">
+          <label>
+            <SpellLink spell={TALENTS.FLAME_SIPHON_TALENT} />
+          </label>
+          <strong>CDR efficiency:</strong>
+          <DonutChart items={effectiveCDRItems} />
+        </div>
+      </Statistic>
+    );
+  }
+}
+
+export default FlameSiphon;

--- a/src/analysis/retail/evoker/shared/modules/talents/hero/flameshaper/FlameSiphon.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/hero/flameshaper/FlameSiphon.tsx
@@ -1,6 +1,7 @@
 import { FLAME_SIPHON_CDR_MS } from 'analysis/retail/evoker/shared/constants';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/evoker';
+import SPECS from 'game/SPECS';
 import SpellLink from 'interface/SpellLink';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent } from 'parser/core/Events';
@@ -11,21 +12,30 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-/** Engulf reduces the cooldown of Fire Breath by 6 sec. */
+/** Engulf reduces the cooldown of Fire Breath and Dream Breath by 6 sec. */
 class FlameSiphon extends Analyzer {
   static dependencies = {
     spellUsable: SpellUsable,
   };
   protected spellUsable!: SpellUsable;
 
-  totalEffectiveCDR = 0;
-  totalWastedCDR = 0;
+  totalEffectiveFireBreathCDR = 0;
+  totalWastedFireBreathCDR = 0;
+
+  totalEffectiveDreamBreathCDR = 0;
+  totalWastedDreamBreathCDR = 0;
 
   fireBreathSpell =
     this.selectedCombatant.hasTalent(TALENTS.FONT_OF_MAGIC_DEVASTATION_TALENT) ||
     this.selectedCombatant.hasTalent(TALENTS.FONT_OF_MAGIC_PRESERVATION_TALENT)
       ? SPELLS.FIRE_BREATH_FONT
       : SPELLS.FIRE_BREATH;
+
+  dreamBreathSpell =
+    this.selectedCombatant.specId === SPECS.PRESERVATION_EVOKER.id &&
+    (this.selectedCombatant.hasTalent(TALENTS.FONT_OF_MAGIC_PRESERVATION_TALENT)
+      ? SPELLS.DREAM_BREATH_FONT
+      : TALENTS.DREAM_BREATH_TALENT);
 
   constructor(options: Options) {
     super(options);
@@ -38,29 +48,57 @@ class FlameSiphon extends Analyzer {
   }
 
   onCast(event: CastEvent) {
-    const effectiveCDR = this.spellUsable.reduceCooldown(
+    const effectiveFireBreathCDR = this.spellUsable.reduceCooldown(
       this.fireBreathSpell.id,
       FLAME_SIPHON_CDR_MS,
     );
-    const wastedCDR = FLAME_SIPHON_CDR_MS - effectiveCDR;
+    const wastedFireBreathCDR = FLAME_SIPHON_CDR_MS - effectiveFireBreathCDR;
 
-    this.totalEffectiveCDR += effectiveCDR / 1_000;
-    this.totalWastedCDR += wastedCDR / 1_000;
+    this.totalEffectiveFireBreathCDR += effectiveFireBreathCDR / 1_000;
+    this.totalWastedFireBreathCDR += wastedFireBreathCDR / 1_000;
+
+    if (!this.dreamBreathSpell) {
+      return;
+    }
+
+    const effectiveDreamBreathCDR = this.spellUsable.reduceCooldown(
+      this.dreamBreathSpell.id,
+      FLAME_SIPHON_CDR_MS,
+    );
+    const wastedDreamBreathCDR = FLAME_SIPHON_CDR_MS - effectiveDreamBreathCDR;
+
+    this.totalEffectiveDreamBreathCDR += effectiveDreamBreathCDR / 1_000;
+    this.totalWastedDreamBreathCDR += wastedDreamBreathCDR / 1_000;
   }
 
   statistic() {
-    const effectiveCDRItems = [
+    const effectiveFireBreathCDRItems = [
       {
         color: 'rgb(123,188,93)',
         label: 'Effective CDR',
-        valueTooltip: this.totalEffectiveCDR.toFixed(2) + 's effective CDR',
-        value: this.totalEffectiveCDR,
+        valueTooltip: this.totalEffectiveFireBreathCDR.toFixed(2) + 's effective CDR',
+        value: this.totalEffectiveFireBreathCDR,
       },
       {
         color: 'rgb(216,59,59)',
         label: 'Wasted CDR',
-        valueTooltip: this.totalWastedCDR.toFixed(2) + 's CDR wasted',
-        value: this.totalWastedCDR,
+        valueTooltip: this.totalWastedFireBreathCDR.toFixed(2) + 's CDR wasted',
+        value: this.totalWastedFireBreathCDR,
+      },
+    ];
+
+    const effectiveDreamBreathCDRItems = this.dreamBreathSpell && [
+      {
+        color: 'rgb(123,188,93)',
+        label: 'Effective CDR',
+        valueTooltip: this.totalEffectiveDreamBreathCDR.toFixed(2) + 's effective CDR',
+        value: this.totalEffectiveDreamBreathCDR,
+      },
+      {
+        color: 'rgb(216,59,59)',
+        label: 'Wasted CDR',
+        valueTooltip: this.totalWastedDreamBreathCDR.toFixed(2) + 's CDR wasted',
+        value: this.totalWastedDreamBreathCDR,
       },
     ];
 
@@ -74,9 +112,15 @@ class FlameSiphon extends Analyzer {
           <label>
             <SpellLink spell={TALENTS.FLAME_SIPHON_TALENT} />
           </label>
-          <strong>CDR efficiency:</strong>
-          <DonutChart items={effectiveCDRItems} />
+          <SpellLink spell={SPELLS.FIRE_BREATH} /> CDR:
+          <DonutChart items={effectiveFireBreathCDRItems} />
         </div>
+        {effectiveDreamBreathCDRItems && (
+          <div className="pad">
+            <SpellLink spell={SPELLS.DREAM_BREATH} /> CDR:
+            <DonutChart items={effectiveDreamBreathCDRItems} />
+          </div>
+        )}
       </Statistic>
     );
   }


### PR DESCRIPTION
### Description

Implements the talent Flame Siphon to deal with CDR provided by Engulf casts.
Also add some statistics.

@Harreks 

### Testing

- Test report URL: 
Deva: `/report/mcphtXKf4n7jA1wz/44-Mythic+Sprocketmonger+Lockenstock+-+Kill+(5:35)/Vollmer/standard/statistics`
Pres: `/report/mcphtXKf4n7jA1wz/44-Mythic+Sprocketmonger+Lockenstock+-+Kill+(5:35)/Trixxedrake/standard/statistics`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/464dca16-9102-45f7-8bd2-b411e9c78640)
![image](https://github.com/user-attachments/assets/4aa7d789-199a-4a1d-8e0a-54571835feb8)
