### PR TITLE
[Devastation] Update Empower Performance evaluation for TWW2 module

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_EVOKER } from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2025, 3, 25), <>Update Empower performance evaluation for <SpellLink spell={SPELLS.JACKPOT_BUFF}/> module</>, Vollmer),
   change(date(2025, 3, 24), <>Add a Guide Section for <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT}/></>, Vollmer),
   change(date(2025, 3, 3), <>Implement TWW S2 4pc module</>, Vollmer),
   change(date(2025, 2, 25), <>Update various modules & abilities for 11.1</>, Vollmer),


### PR DESCRIPTION
### Description

Updates the Empower Performance evaluation for Jackpot! consumption.
Also now shows which Empower spell was consumed when playing Scalecommander.

### Testing

- Test report URL: 
SC: `/report/pzCAF3am8dDH2Zwg/94-Mythic+Rik+Reverb+-+Kill+(5:45)/Seevo/standard/overview`
FS: `/report/mcphtXKf4n7jA1wz/44-Mythic+Sprocketmonger+Lockenstock+-+Kill+(5:35)/Shamvoke/standard/overview`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/e4839c0b-05fa-48f6-acea-14c5d2b1880b)
![image](https://github.com/user-attachments/assets/b1fab4df-46e0-4618-9b26-426267e8282b)
