### PR TITLE
[Enhancement] update Doom Winds ID

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2622,3 +2622,9 @@ export const SamuelMaverick: Contributor = {
     },
   ],
 };
+
+export const Spruudel: Contributor = {
+  nickname: 'spruudel',
+  github: 'Spruudel',
+  discord: 'spruuudel',
+};

--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
 import TALENTS from 'common/TALENTS/shaman';
 import SPELLS from 'common/SPELLS/shaman';
-import { Seriousnes, emallson } from 'CONTRIBUTORS';
+import { Seriousnes, Spruudel, emallson } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 3, 26), <>Fixed <SpellLink spell={TALENTS.DOOM_WINDS_TALENT} /> to display on the timeline and in the cooldown throughput tracker</>, Spruudel),
   change(date(2025, 3, 13), <>Fix crash when the only <SpellLink spell={SPELLS.LIGHTNING_BOLT} /> and <SpellLink spell={TALENTS.CHAIN_LIGHTNING_TALENT} /> casts are from <SpellLink spell={TALENTS.PRIMORDIAL_STORM_TALENT} />.</>, Seriousnes),
   change(date(2025, 3, 9), <>Fix crash when using Surging Totem pre-pull.</>, emallson),
   change(date(2025, 3, 1), <>Compatibility update for 11.1</>, Seriousnes),

--- a/src/analysis/retail/shaman/enhancement/modules/Buffs.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/Buffs.tsx
@@ -28,7 +28,7 @@ class Buffs extends ClassBuffs {
         timelineHighlight: true,
       },
       {
-        spellId: TALENTS.DOOM_WINDS_TALENT.id,
+        spellId: SPELLS.DOOM_WINDS_BUFF.id,
         triggeredBySpellId: TALENTS.DOOM_WINDS_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.DOOM_WINDS_TALENT),
         timelineHighlight: true,

--- a/src/analysis/retail/shaman/enhancement/modules/features/CooldownThroughputTracker.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/features/CooldownThroughputTracker.tsx
@@ -24,7 +24,7 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
       branch: GameBranch.Retail,
     },
     {
-      spell: TALENTS_SHAMAN.DOOM_WINDS_TALENT.id,
+      spell: SPELLS.DOOM_WINDS_BUFF.id,
       summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
       branch: GameBranch.Retail,
     },


### PR DESCRIPTION
### Description

Swapped from the talent ID to the buff ID of Doom Winds, so that it correctly shows up in the timeline view and the throughput tracker.
If it's not desired to show tier set procs in the tracker, Doom Winds could be implemented as a castCooldown instead

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/ZPW2nXbG1A4jmtMN/2-Mythic+Sprocketmonger+Lockenstock+-+Kill+(6:10)/Surge/standard/timeline`
- Screenshot(s):
![grafik](https://github.com/user-attachments/assets/c56b59c6-7c8b-4d45-aede-140b7e8c8266)
![grafik](https://github.com/user-attachments/assets/79393536-6d07-414f-828d-37d9b0a13b24)

