### PR TITLE
[Core] Empower ability handling for Cast Efficiency & Cancelled Casts modules

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -41,6 +41,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 3, 28), <>Add Empower ability handling for Cast Efficiency & Cancelled Casts modules</>, Vollmer),
   change(date(2025, 3, 28), <>Fixed internal ordering of event listener handling</>, Seriousnes),
   change(date(2025, 3, 10), 'Added ability data for Mug\'Zee and Gallywix to the Foundation downtime section', emallson),
   change(date(2025, 3, 8), 'Add missing patch 11.1.0 details.', ToppleTheNun),

--- a/src/parser/shared/modules/CastEfficiency.tsx
+++ b/src/parser/shared/modules/CastEfficiency.tsx
@@ -128,7 +128,12 @@ class CastEfficiency extends Analyzer {
       ? 0
       : this.owner.currentTimestamp - Math.max(lastRechargeTimestamp, this.owner.fight.start_time);
 
-    const castEvents = history.filter((event) => event.type === EventType.Cast);
+    /** Empower Abilities trigger Cast event on start of channel therefore
+     * EmpowerEnd event is the proper event to track instead */
+    const isEmpowerAbility = history.some((event) => event.type === EventType.EmpowerEnd);
+    const castEvents = isEmpowerAbility
+      ? history.filter((event) => event.type === EventType.EmpowerEnd)
+      : history.filter((event) => event.type === EventType.Cast);
     const casts = castEvents.length;
     const castTimestamps = castEvents.map((event) => event.timestamp - this.owner.fight.start_time);
 

--- a/src/parser/shared/modules/CastEfficiency.tsx
+++ b/src/parser/shared/modules/CastEfficiency.tsx
@@ -152,13 +152,17 @@ class CastEfficiency extends Analyzer {
       // spell either never been cast, or not in abilities list
       return 0;
     }
+    const isEmpowerAbility = history.some((event) => event.type === EventType.EmpowerEnd);
 
     let beginCastTimestamp: number | undefined;
     const timeSpentCasting = history.reduce((acc, event) => {
-      if (event.type === EventType.BeginCast) {
+      if (event.type === EventType.BeginCast || event.type === EventType.EmpowerStart) {
         beginCastTimestamp = event.timestamp;
         return acc;
-      } else if (event.type === EventType.Cast) {
+      } else if (
+        (event.type === EventType.Cast && !isEmpowerAbility) ||
+        event.type === EventType.EmpowerEnd
+      ) {
         //limit by start time in case of pre phase events
         const castTime = beginCastTimestamp
           ? event.timestamp - Math.max(beginCastTimestamp, this.owner.fight.start_time)

--- a/src/parser/shared/modules/SpellHistory.ts
+++ b/src/parser/shared/modules/SpellHistory.ts
@@ -7,6 +7,8 @@ import Events, {
   EndChannelEvent,
   RemoveBuffEvent,
   UpdateSpellUsableEvent,
+  EmpowerEndEvent,
+  EmpowerStartEvent,
 } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
@@ -20,7 +22,9 @@ type SpellHistoryEvent =
   | EndChannelEvent
   | ApplyBuffEvent
   | RemoveBuffEvent
-  | UpdateSpellUsableEvent;
+  | UpdateSpellUsableEvent
+  | EmpowerEndEvent
+  | EmpowerStartEvent;
 
 class SpellHistory extends Analyzer {
   static dependencies = {
@@ -56,6 +60,8 @@ class SpellHistory extends Analyzer {
     this.addEventListener(Events.applybuff.by(SELECTED_PLAYER), this.append);
     this.addEventListener(Events.removebuff.by(SELECTED_PLAYER), this.append);
     this.addEventListener(Events.UpdateSpellUsable.by(SELECTED_PLAYER), this.append);
+    this.addEventListener(Events.empowerEnd.by(SELECTED_PLAYER), this.append);
+    this.addEventListener(Events.empowerStart.by(SELECTED_PLAYER), this.append);
   }
 
   private getAbility(spellId: number) {


### PR DESCRIPTION
### Description

Empower abilities produce both `Cast` & `EmpowerStart` events when they begin their channel, and then a `EmpowerEnd` event once they finish channeling.

This makes the `Cast Efficiency` module over estimate the amount of actual casts, due to counting channels that were cancelled as still being cast.

![image](https://github.com/user-attachments/assets/b4f35653-2283-4060-a760-64be62f3b1be)

To fix this I've added `EmpowerStart` & `EmpowerEnd` to the `SpellHistory`, and ensured that when `SpellHistory` contains these it will make use of the Empower events instead.

![image](https://github.com/user-attachments/assets/89707e8d-0822-4cf2-a1e5-f95941e229a5)

Also adds tracking of Empowers for `Cancelled Casts` module.

The implementation should be generic enough to deal with all Empower abilities - the only caveat would be the edgecases where `EmpowerEnd` events are missing, eg. when Evokers use `Tip The Scales`, but that is already normalized for those cases.

### Testing

- Test report URL: 
Deva: `/report/JZgVNYKvDz4fn2tr/6-Mythic+Cauldron+of+Carnage+-+Kill+(5:39)/Xephyris/standard/statistics`
Pres: `/report/JZgVNYKvDz4fn2tr/6-Mythic+Cauldron+of+Carnage+-+Kill+(5:39)/Rumidormi/standard/statistics`
