### PR TITLE
[Enhancement] fixed some interactions with Whirling Fire

### DIFF
--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -6,7 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2025, 3, 28), <>Fixed the CD of <SpellLink spell={TALENTS.LAVA_LASH_TALENT} /> being incorrectly reset when the <SpellLink spell={TALENTS.HOT_HAND_TALENT} /> is from <SpellLink spell={SPELLS.WHIRLING_FIRE} /></>, Spruudel),
+  change(date(2025, 3, 28), <>Fixed some inaccuracies with how <SpellLink spell={SPELLS.WHIRLING_FIRE} /> is handled</>, Spruudel),
   change(date(2025, 3, 26), <>Fixed <SpellLink spell={TALENTS.DOOM_WINDS_TALENT} /> to display on the timeline and in the cooldown throughput tracker</>, Spruudel),
   change(date(2025, 3, 13), <>Fix crash when the only <SpellLink spell={SPELLS.LIGHTNING_BOLT} /> and <SpellLink spell={TALENTS.CHAIN_LIGHTNING_TALENT} /> casts are from <SpellLink spell={TALENTS.PRIMORDIAL_STORM_TALENT} />.</>, Seriousnes),
   change(date(2025, 3, 9), <>Fix crash when using Surging Totem pre-pull.</>, emallson),

--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 3, 28), <>Fixed the CD of <SpellLink spell={TALENTS.LAVA_LASH_TALENT} /> being incorrectly reset when the <SpellLink spell={TALENTS.HOT_HAND_TALENT} /> is from <SpellLink spell={SPELLS.WHIRLING_FIRE} /></>, Spruudel),
   change(date(2025, 3, 26), <>Fixed <SpellLink spell={TALENTS.DOOM_WINDS_TALENT} /> to display on the timeline and in the cooldown throughput tracker</>, Spruudel),
   change(date(2025, 3, 13), <>Fix crash when the only <SpellLink spell={SPELLS.LIGHTNING_BOLT} /> and <SpellLink spell={TALENTS.CHAIN_LIGHTNING_TALENT} /> casts are from <SpellLink spell={TALENTS.PRIMORDIAL_STORM_TALENT} />.</>, Seriousnes),
   change(date(2025, 3, 9), <>Fix crash when using Surging Totem pre-pull.</>, emallson),

--- a/src/analysis/retail/shaman/enhancement/constants.ts
+++ b/src/analysis/retail/shaman/enhancement/constants.ts
@@ -69,7 +69,6 @@ export enum EventLinkBuffers {
   SPLINTERED_ELEMENTS_BUFFER = 250,
   LIGHTNING_BOLT_BUFFER = 150,
   PRIMORDIAL_WAVE_DAMAGE_BUFFER = 500,
-  WHIRLING_FIRE_BUFFER = 5,
 }
 
 export enum EnhancementEventLinks {

--- a/src/analysis/retail/shaman/enhancement/constants.ts
+++ b/src/analysis/retail/shaman/enhancement/constants.ts
@@ -69,6 +69,7 @@ export enum EventLinkBuffers {
   SPLINTERED_ELEMENTS_BUFFER = 250,
   LIGHTNING_BOLT_BUFFER = 150,
   PRIMORDIAL_WAVE_DAMAGE_BUFFER = 500,
+  WHIRLING_FIRE_BUFFER = 5,
 }
 
 export enum EnhancementEventLinks {
@@ -82,6 +83,7 @@ export enum EnhancementEventLinks {
   CRASH_LIGHTNING_LINK = 'crash-lightning',
   SUNDERING_LINK = 'sundering',
   REACTIVITY_LINK = 'reactivity',
+  WHIRLING_FIRE_LINK = 'whirling-fire',
 }
 
 export const GCD_TOLERANCE = 25;

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -2,7 +2,7 @@ import { Options } from 'parser/core/Analyzer';
 import BaseEventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/shaman';
-import { EventType } from 'parser/core/Events';
+import { ApplyBuffEvent, EventType, GetRelatedEvent } from 'parser/core/Events';
 import { NormalizerOrder } from './constants';
 import {
   EnhancementEventLinks,
@@ -124,6 +124,7 @@ const whirlingFireHotHandLink: EventLink = {
   linkingEventType: EventType.ApplyBuff,
   referencedEventId: SPELLS.WHIRLING_FIRE.id,
   referencedEventType: EventType.RemoveBuff,
+  reverseLinkRelation: EnhancementEventLinks.WHIRLING_FIRE_LINK,
   forwardBufferMs: 5,
 };
 const whirlingFireLavaLashLink: EventLink = {
@@ -134,6 +135,18 @@ const whirlingFireLavaLashLink: EventLink = {
   referencedEventType: EventType.Cast,
   backwardBufferMs: EventLinkBuffers.CAST_DAMAGE_BUFFER,
   anyTarget: true,
+  additionalCondition: (le, _) => {
+    if (le.type === EventType.RemoveBuff && le.ability.guid === SPELLS.WHIRLING_FIRE.id) {
+      return (
+        GetRelatedEvent<ApplyBuffEvent>(
+          le,
+          EnhancementEventLinks.WHIRLING_FIRE_LINK,
+          (e) => e.type === EventType.ApplyBuff && e.ability.guid === SPELLS.HOT_HAND_BUFF.id,
+        ) !== undefined
+      );
+    }
+    return false;
+  },
 };
 
 class EventLinkNormalizer extends BaseEventLinkNormalizer {

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -122,9 +122,11 @@ const whirlingFireLink: EventLink = {
   linkRelation: EnhancementEventLinks.WHIRLING_FIRE_LINK,
   linkingEventId: SPELLS.HOT_HAND_BUFF.id,
   linkingEventType: EventType.ApplyBuff,
-  referencedEventId: SPELLS.WHIRLING_FIRE.id,
-  referencedEventType: EventType.RemoveBuff,
-  forwardBufferMs: EventLinkBuffers.WHIRLING_FIRE_BUFFER,
+  referencedEventId: [SPELLS.WHIRLING_FIRE.id, TALENTS.LAVA_LASH_TALENT.id],
+  referencedEventType: [EventType.RemoveBuff, EventType.Cast],
+  forwardBufferMs: 5,
+  backwardBufferMs: EventLinkBuffers.CAST_DAMAGE_BUFFER,
+  anyTarget: true,
 };
 
 class EventLinkNormalizer extends BaseEventLinkNormalizer {

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -118,6 +118,14 @@ const sunderingDamageLink: EventLink = {
   anyTarget: true,
   isActive: (c) => c.hasTalent(TALENTS.REACTIVITY_TALENT) || c.hasTalent(TALENTS.SUNDERING_TALENT),
 };
+const whirlingFireLink: EventLink = {
+  linkRelation: EnhancementEventLinks.WHIRLING_FIRE_LINK,
+  linkingEventId: SPELLS.HOT_HAND_BUFF.id,
+  linkingEventType: EventType.ApplyBuff,
+  referencedEventId: SPELLS.WHIRLING_FIRE.id,
+  referencedEventType: EventType.RemoveBuff,
+  forwardBufferMs: EventLinkBuffers.WHIRLING_FIRE_BUFFER,
+};
 
 class EventLinkNormalizer extends BaseEventLinkNormalizer {
   constructor(options: Options) {
@@ -132,6 +140,7 @@ class EventLinkNormalizer extends BaseEventLinkNormalizer {
       splinteredElementsDamageLink,
       reactivityLink,
       sunderingDamageLink,
+      whirlingFireLink,
     ]);
 
     this.priority = NormalizerOrder.EventLinkNormalizer;

--- a/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/normalizers/EventLinkNormalizer.tsx
@@ -118,13 +118,20 @@ const sunderingDamageLink: EventLink = {
   anyTarget: true,
   isActive: (c) => c.hasTalent(TALENTS.REACTIVITY_TALENT) || c.hasTalent(TALENTS.SUNDERING_TALENT),
 };
-const whirlingFireLink: EventLink = {
+const whirlingFireHotHandLink: EventLink = {
   linkRelation: EnhancementEventLinks.WHIRLING_FIRE_LINK,
   linkingEventId: SPELLS.HOT_HAND_BUFF.id,
   linkingEventType: EventType.ApplyBuff,
-  referencedEventId: [SPELLS.WHIRLING_FIRE.id, TALENTS.LAVA_LASH_TALENT.id],
-  referencedEventType: [EventType.RemoveBuff, EventType.Cast],
+  referencedEventId: SPELLS.WHIRLING_FIRE.id,
+  referencedEventType: EventType.RemoveBuff,
   forwardBufferMs: 5,
+};
+const whirlingFireLavaLashLink: EventLink = {
+  linkRelation: EnhancementEventLinks.WHIRLING_FIRE_LINK,
+  linkingEventId: SPELLS.WHIRLING_FIRE.id,
+  linkingEventType: EventType.RemoveBuff,
+  referencedEventId: TALENTS.LAVA_LASH_TALENT.id,
+  referencedEventType: EventType.Cast,
   backwardBufferMs: EventLinkBuffers.CAST_DAMAGE_BUFFER,
   anyTarget: true,
 };
@@ -142,7 +149,8 @@ class EventLinkNormalizer extends BaseEventLinkNormalizer {
       splinteredElementsDamageLink,
       reactivityLink,
       sunderingDamageLink,
-      whirlingFireLink,
+      whirlingFireHotHandLink,
+      whirlingFireLavaLashLink,
     ]);
 
     this.priority = NormalizerOrder.EventLinkNormalizer;

--- a/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
@@ -233,6 +233,13 @@ class HotHand extends MajorCooldown<HotHandProc> {
           EnhancementEventLinks.WHIRLING_FIRE_LINK,
           (e) => e.type === EventType.Cast,
         );
+        lavaLashCastEvent && addAdditionalCastInformation(
+          lavaLashCastEvent,
+          <>
+            <SpellLink spell={TALENTS.HOT_HAND_TALENT} /> was applied by{' '}
+            <SpellLink spell={SPELLS.WHIRLING_FIRE} />
+          </>,
+        );
       }
 
       this.activeWindow = {

--- a/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
@@ -213,9 +213,10 @@ class HotHand extends MajorCooldown<HotHandProc> {
     const whirlingFireRemovedEvent = GetRelatedEvent<RemoveBuffEvent>(
       event,
       EnhancementEventLinks.WHIRLING_FIRE_LINK,
+      (e) => e.type === EventType.RemoveBuff,
     );
 
-    // cooldown isn't reset if the hot hand stems from whirling fire
+    // cooldown isn't reset if the Hot Hands stems from Whirling Fire
     if (!whirlingFireRemovedEvent) {
       this.spellUsable.endCooldown(TALENTS.LAVA_LASH_TALENT.id, event.timestamp);
     }
@@ -224,12 +225,24 @@ class HotHand extends MajorCooldown<HotHandProc> {
       this.spellUsable.applyCooldownRateChange(TALENTS.LAVA_LASH_TALENT.id, this.hotHand.rate);
       this.hotHandActive.startInterval(event.timestamp);
 
+      // make sure to include first Lava Lash of the window, when triggered by Whirling Fire
+      let lavaLashCastEvent: CastEvent | undefined;
+      if (whirlingFireRemovedEvent) {
+        lavaLashCastEvent = GetRelatedEvent<CastEvent>(
+          event,
+          EnhancementEventLinks.WHIRLING_FIRE_LINK,
+          (e) => e.type === EventType.Cast,
+        );
+      }
+
       this.activeWindow = {
         event: event,
         timeline: {
-          start: Math.max(event.timestamp, this.globalCooldownEnds),
+          start: lavaLashCastEvent
+            ? lavaLashCastEvent.timestamp
+            : Math.max(event.timestamp, this.globalCooldownEnds),
           end: -1,
-          events: [],
+          events: lavaLashCastEvent ? [lavaLashCastEvent, lavaLashCastEvent.globalCooldown!] : [],
         },
         unusedGcdTime: 0,
         globalCooldowns: [],

--- a/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
@@ -44,7 +44,11 @@ import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { getApplicableRules, HighPriorityAbilities } from '../../common';
 import { EnhancementEventLinks, GCD_TOLERANCE } from '../../constants';
-import { addEnhancedCastReason, addInefficientCastReason } from 'parser/core/EventMetaLib';
+import {
+  addAdditionalCastInformation,
+  addEnhancedCastReason,
+  addInefficientCastReason,
+} from 'parser/core/EventMetaLib';
 import NPCS from 'common/NPCS';
 import Reactivity from '../hero/totemic/Reactivity';
 
@@ -229,32 +233,40 @@ class HotHand extends MajorCooldown<HotHandProc> {
       let lavaLashCastEvent: CastEvent | undefined;
       if (whirlingFireRemovedEvent) {
         lavaLashCastEvent = GetRelatedEvent<CastEvent>(
-          event,
+          whirlingFireRemovedEvent,
           EnhancementEventLinks.WHIRLING_FIRE_LINK,
           (e) => e.type === EventType.Cast,
         );
-        lavaLashCastEvent && addAdditionalCastInformation(
-          lavaLashCastEvent,
-          <>
-            <SpellLink spell={TALENTS.HOT_HAND_TALENT} /> was applied by{' '}
-            <SpellLink spell={SPELLS.WHIRLING_FIRE} />
-          </>,
-        );
+        lavaLashCastEvent &&
+          addAdditionalCastInformation(
+            lavaLashCastEvent,
+            <>
+              <SpellLink spell={TALENTS.HOT_HAND_TALENT} /> was applied by{' '}
+              <SpellLink spell={SPELLS.WHIRLING_FIRE} />
+            </>,
+          );
       }
 
       this.activeWindow = {
         event: event,
         timeline: {
-          start: lavaLashCastEvent
-            ? lavaLashCastEvent.timestamp
-            : Math.max(event.timestamp, this.globalCooldownEnds),
+          start: Math.max(event.timestamp, this.globalCooldownEnds),
           end: -1,
-          events: lavaLashCastEvent ? [lavaLashCastEvent, lavaLashCastEvent.globalCooldown!] : [],
+          events: [],
         },
         unusedGcdTime: 0,
         globalCooldowns: [],
         hasteAdjustedWastedCooldown: 0,
       };
+
+      if (lavaLashCastEvent) {
+        this.activeWindow.timeline.start = lavaLashCastEvent.timestamp;
+        this.activeWindow.timeline.events.push(
+          lavaLashCastEvent,
+          lavaLashCastEvent.globalCooldown!,
+        );
+        this.activeWindow.globalCooldowns.push(lavaLashCastEvent.globalCooldown!.duration);
+      }
     }
     this.lastCooldownWasteCheck = event.timestamp;
   }

--- a/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
@@ -12,6 +12,7 @@ import Events, {
   DeathEvent,
   EventType,
   FightEndEvent,
+  GetRelatedEvent,
   GlobalCooldownEvent,
   RefreshBuffEvent,
   RemoveBuffEvent,
@@ -42,7 +43,7 @@ import Casts from 'interface/report/Results/Timeline/Casts';
 import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { getApplicableRules, HighPriorityAbilities } from '../../common';
-import { GCD_TOLERANCE } from '../../constants';
+import { EnhancementEventLinks, GCD_TOLERANCE } from '../../constants';
 import { addEnhancedCastReason, addInefficientCastReason } from 'parser/core/EventMetaLib';
 import NPCS from 'common/NPCS';
 import Reactivity from '../hero/totemic/Reactivity';
@@ -207,8 +208,17 @@ class HotHand extends MajorCooldown<HotHandProc> {
   }
 
   startOrRefreshWindow(event: ApplyBuffEvent | RefreshBuffEvent) {
-    // on application both resets the CD and applies a mod rate
-    this.spellUsable.endCooldown(TALENTS.LAVA_LASH_TALENT.id, event.timestamp);
+    // on application applies a mod rate and also resets CD if proc was natural
+
+    const whirlingFireRemovedEvent = GetRelatedEvent<RemoveBuffEvent>(
+      event,
+      EnhancementEventLinks.WHIRLING_FIRE_LINK,
+    );
+
+    // cooldown isn't reset if the hot hand stems from whirling fire
+    if (!whirlingFireRemovedEvent) {
+      this.spellUsable.endCooldown(TALENTS.LAVA_LASH_TALENT.id, event.timestamp);
+    }
 
     if (!this.activeWindow) {
       this.spellUsable.applyCooldownRateChange(TALENTS.LAVA_LASH_TALENT.id, this.hotHand.rate);


### PR DESCRIPTION
### Description

Because the Hot Hand application event happens after the inital (already buffed) Lava Lash that triggered it, that Lava Lash was not tracked as part of that window.

Also, a Hot Hand triggered by Whirling Fire should not refund the CD of the initial Lava Lash the way a natural Hot Hand would.

To fix this, I added an `EventLink` between each Hot Hand `ApplyBuff` and the potential related Whirling Fire `RemoveBuff` and Lava Lash cast that triggered it. The `forwardBufferMs` and `backwardBufferMs` values I chose seemed to work fine when I tested a couple logs.
The Lava Lash CD is then only reset if it wasn't a Whirling Fire proc and the missing Lava Lash cast (+ GCD) is manually added.

I think I accounted for everything, but I don't think I can rule out any sideeffects given how new I am to the codebase.

### Testing

- Test report URL: `/report/Y4TDJ3FhpXrgGj9W/24-Mythic+Sprocketmonger+Lockenstock+-+Kill+(6:28)/Coneform/standard/overview`
- Log with event filters: [Log](https://www.warcraftlogs.com/reports/Y4TDJ3FhpXrgGj9W?fight=24&type=auras&source=5&view=events&pins=2%24Off%24%23244F4B%24auras-gained%24-1%240.0.0.Any%240.0.0.Any%24true%240.0.0.Any%24true%24215785%2435%5E0%24Separate%24%23909049%24auras-gained%24-1%240.0.0.Any%240.0.0.Any%24true%240.0.0.Any%24true%24453405%2436%5E0%24Off%24%23a04D8A%24expression%24%28IN+RANGE+FROM+type+%3D+%27applybuff%27+AND+ability.name+%3D+%27Whirling+Fire%27+TO+type+%3D+%27removebuff%27+AND+ability.name+%3D+%27Whirling+Fire%27+GROUP+BY+target+ON+source+END%29+AND+%28ability.id+IN+%2860103%29%29&translate=true)

### Before and After

#### CD reset
![grafik](https://github.com/user-attachments/assets/c709d42e-b9a8-4391-a15c-8d9c26328dc8)

![grafik](https://github.com/user-attachments/assets/4c050490-4be9-4124-b034-aca371c691f0)

#### Hot Hands guide
![grafik](https://github.com/user-attachments/assets/623992da-47dd-4942-b881-ae1616c059f2)

![grafik](https://github.com/user-attachments/assets/9893f6fe-0ed6-4638-86cd-219defb96456)





