### PR TITLE
[Enhacement] Enchants incorrectly identified as cheap

### DIFF
--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -3,9 +3,11 @@ import TALENTS from 'common/TALENTS/shaman';
 import SPELLS from 'common/SPELLS/shaman';
 import { Seriousnes, Spruudel, emallson } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
+import ITEMS from 'common/ITEMS';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 2), <><SpellLink spell={ITEMS.STONEBOUND_ARTISTRY_R3.effectId} /> and <SpellLink spell={ITEMS.STORMRIDERS_FURY_R3.effectId} /> are considered strong enchants.</>, Seriousnes),
   change(date(2025, 3, 28), <>Fixed some inaccuracies with how <SpellLink spell={SPELLS.WHIRLING_FIRE} /> is handled</>, Spruudel),
   change(date(2025, 3, 26), <>Fixed <SpellLink spell={TALENTS.DOOM_WINDS_TALENT} /> to display on the timeline and in the cooldown throughput tracker</>, Spruudel),
   change(date(2025, 3, 13), <>Fix crash when the only <SpellLink spell={SPELLS.LIGHTNING_BOLT} /> and <SpellLink spell={TALENTS.CHAIN_LIGHTNING_TALENT} /> casts are from <SpellLink spell={TALENTS.PRIMORDIAL_STORM_TALENT} />.</>, Seriousnes),

--- a/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/enhancement/CombatLogParser.tsx
@@ -62,8 +62,13 @@ import StormbringerEventOrderNormalizer from '../shared/hero/stormbringer/normal
 import ElementalSpiritsPrepullNormalizer from './modules/normalizers/ElementalSpiritsPrepullNormalizer';
 import PrimordialStorm from './modules/talents/PrimordialStorm';
 import Reactivity from './modules/hero/totemic/Reactivity';
+import EnchantChecker from './modules/core/EnchantChecker';
 
 class CombatLogParser extends CoreCombatLogParser {
+  static defaultModules = {
+    ...CoreCombatLogParser.defaultModules,
+    enchantChecker: EnchantChecker,
+  };
   static specModules = {
     spellUsable: SpellUsable,
     globalCooldown: GlobalCooldown,

--- a/src/analysis/retail/shaman/enhancement/modules/core/EnchantChecker.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/core/EnchantChecker.tsx
@@ -1,0 +1,14 @@
+import ITEMS from 'common/ITEMS';
+import BaseEnchantChecker from 'parser/retail/modules/items/EnchantChecker';
+
+class EnchantChecker extends BaseEnchantChecker {
+  get MaxEnchantIds(): number[] {
+    return [
+      ...super.MaxEnchantIds,
+      ITEMS.STONEBOUND_ARTISTRY_R3.effectId,
+      ITEMS.STORMRIDERS_FURY_R3.effectId,
+    ];
+  }
+}
+
+export default EnchantChecker;

--- a/src/parser/retail/modules/items/EnchantChecker.tsx
+++ b/src/parser/retail/modules/items/EnchantChecker.tsx
@@ -172,6 +172,9 @@ const MIN_ENCHANT_IDS = [
   ITEMS.STONEBOUND_ARTISTRY_R1.effectId,
   ITEMS.STONEBOUND_ARTISTRY_R2.effectId,
   ITEMS.STONEBOUND_ARTISTRY_R3.effectId,
+  ITEMS.STORMRIDERS_FURY_R1.effectId,
+  ITEMS.STORMRIDERS_FURY_R2.effectId,
+  ITEMS.STORMRIDERS_FURY_R3.effectId,
   // #endregion
 ] as const satisfies number[];
 


### PR DESCRIPTION
### Description

Stormrider's Fury and Stonebound Artistry are now the strongest options for enhancement, despite being classified as "cheap"

### Testing

- Test report URL: `/report/DPR3wBptWZNXKnC7/28-Mythic+Cauldron+of+Carnage+-+Kill+(6:45)/10-Seriousnes/standard`