### PR TITLE
 [Devastation] Fix consumption tracking for Jackpot! module

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_EVOKER } from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2025, 4, 11), <>Fix consumption tracking for <SpellLink spell={SPELLS.JACKPOT_BUFF} /> module</>, Vollmer),
   change(date(2025, 4, 11), <>Update Guide section for <SpellLink spell={SPELLS.DISINTEGRATE}/></>, Vollmer),
   change(date(2025, 3, 27), <>Fix some issues for <SpellLink spell={TALENTS_EVOKER.ENGULF_TALENT}/> & <SpellLink spell={SPELLS.DISINTEGRATE}/> module</>, Vollmer),
   change(date(2025, 3, 25), <>Update Empower performance evaluation for <SpellLink spell={SPELLS.JACKPOT_BUFF}/> module</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
@@ -45,6 +45,7 @@ const IRIDESCENCE_RED_BACKWARDS_BUFFER_MS = 500;
 const DISINTEGRATE_TICK_BUFFER = 4_000; // Haste dependant
 const JACK_APPLY_REMOVE_BUFFER = 30_000; // Realistically it will never be this long, but we hate edgecases
 const ENGULF_TRAVEL_TIME_MS = 500;
+const JACKPOT_CONSUME_FORWARD_BUFFER_MS = 300;
 
 const EVENT_LINKS: EventLink[] = [
   {
@@ -259,7 +260,7 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventType: EventType.RemoveBuff,
     anyTarget: true,
     backwardBufferMs: CAST_BUFFER_MS,
-    forwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: JACKPOT_CONSUME_FORWARD_BUFFER_MS,
     isActive: (C) => C.has4PieceByTier(TIERS.TWW2),
     maximumLinks: 1,
   },


### PR DESCRIPTION
### Description

Fixes `JACKPOT_CONSUME` CastLinks not being properly made when the `RemoveBuff` event is overly delayed. Which caused the `Jackpot!` guide section to show incorrect usages.

![image](https://github.com/user-attachments/assets/854e2cdc-5c43-4e89-9fe6-c458cdf357a1)


### Testing

- Test report URL: `/report/DLfArz1thjZPX9vK/52-Heroic+One-Armed+Bandit+-+Kill+(5:53)/Thersera/standard/overview`
- Screenshot(s):

![image](https://github.com/user-attachments/assets/7a232564-c0cf-4e97-80a8-cfa11738b23b)

![image](https://github.com/user-attachments/assets/3ee6a6a7-4fa4-4992-8572-9dda08d82ae1)
