### PR TITLE
[Havoc] changed momentum talent to exergy

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -35,12 +35,14 @@ import {
   Gazh,
   Yellot,
   KYZ,
+  oneunreadmail,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 12), 'Changed Momentum talent to Exergy for Havoc', oneunreadmail),
   change(date(2025, 3, 29), 'Update internal dependencies', emallson),
   change(date(2025, 3, 28), 'Expanded new Foundation downtime section to caster and healer specs.', emallson),
   change(date(2025, 3, 28), <>Add Empower ability handling for Cast Efficiency & Cancelled Casts modules</>, Vollmer),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2628,3 +2628,9 @@ export const Spruudel: Contributor = {
   github: 'Spruudel',
   discord: 'spruuudel',
 };
+
+export const oneunreadmail: Contributor = {
+  nickname: 'oneunreadmail',
+  github: 'oneunreadmail',
+  discord: 'oneunreadmail',
+};

--- a/src/analysis/retail/demonhunter/havoc/CombatLogParser.tsx
+++ b/src/analysis/retail/demonhunter/havoc/CombatLogParser.tsx
@@ -40,7 +40,7 @@ import EssenceBreak from './modules/talents/EssenceBreak';
 import FelBarrage from './modules/talents/FelBarrage';
 import FelEruption from './modules/talents/FelEruption';
 import GlaiveTempest from './modules/talents/GlaiveTempest';
-import Momentum from './modules/talents/Momentum';
+import Exergy from './modules/talents/Exergy';
 import Netherwalk from './modules/talents/Netherwalk';
 import TrailofRuin from './modules/talents/TrailofRuin';
 import TacticalRetreat from './modules/talents/TacticalRetreat';
@@ -102,7 +102,7 @@ class CombatLogParser extends CoreCombatLogParser {
     demonBlades: DemonBlades,
     trailofRuin: TrailofRuin,
     felBarrage: FelBarrage,
-    momentum: Momentum,
+    exergy: Exergy,
     netherwalk: Netherwalk,
     felEruption: FelEruption,
     masterOfTheGlaive: MasterOfTheGlaive,

--- a/src/analysis/retail/demonhunter/havoc/Guide.tsx
+++ b/src/analysis/retail/demonhunter/havoc/Guide.tsx
@@ -118,7 +118,7 @@ function RotationSection({ modules }: GuideProps<typeof CombatLogParser>) {
       <HideExplanationsToggle id="hide-explanations-rotations" />
       <HideGoodCastsToggle id="hide-good-casts-rotations" />
       {modules.throwGlaive.guideSubsection()}
-      {modules.momentum.guideSubsection()}
+      {modules.exergy.guideSubsection()}
       {modules.unboundChaos.guideSubsection()}
     </Section>
   );

--- a/src/analysis/retail/demonhunter/havoc/constants.ts
+++ b/src/analysis/retail/demonhunter/havoc/constants.ts
@@ -4,4 +4,4 @@ export const CYCLE_OF_HATRED_SCALING = [0, 0.5, 1];
 
 export const GROWING_INFERNO_SCALING = [0, 0.08, 0.15];
 
-export const MOMENTUM_SCALING = [0, 0.08];
+export const EXERGY_SCALING = [0, 0.08];

--- a/src/analysis/retail/demonhunter/havoc/modules/Abilities.tsx
+++ b/src/analysis/retail/demonhunter/havoc/modules/Abilities.tsx
@@ -132,7 +132,7 @@ class Abilities extends SharedAbilities {
         },
       },
       {
-        spell: TALENTS.VENGEFUL_RETREAT_TALENT.id, // Becomes a rotational ability with the Momentum talent
+        spell: TALENTS.VENGEFUL_RETREAT_TALENT.id, // Becomes a rotational ability with the Exergy talent
         category: combatant.hasTalent(TALENTS.EXERGY_TALENT)
           ? SPELL_CATEGORY.ROTATIONAL
           : SPELL_CATEGORY.UTILITY,

--- a/src/analysis/retail/demonhunter/havoc/modules/talents/Exergy.tsx
+++ b/src/analysis/retail/demonhunter/havoc/modules/talents/Exergy.tsx
@@ -9,7 +9,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
-import { MOMENTUM_SCALING } from '../../constants';
+import { EXERGY_SCALING } from '../../constants';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import uptimeBarSubStatistic from 'parser/ui/UptimeBarSubStatistic';
 
@@ -17,22 +17,22 @@ import uptimeBarSubStatistic from 'parser/ui/UptimeBarSubStatistic';
 example report: https://www.warcraftlogs.com/reports/1HRhNZa2cCkgK9AV/#fight=48&source=10
 * */
 
-class Momentum extends Analyzer {
+class Exergy extends Analyzer {
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.EXERGY_TALENT);
   }
 
   get buffUptime() {
-    return this.selectedCombatant.getBuffUptime(SPELLS.MOMENTUM_BUFF.id) / this.owner.fightDuration;
+    return this.selectedCombatant.getBuffUptime(SPELLS.EXERGY_BUFF.id) / this.owner.fightDuration;
   }
 
   get buffDuration() {
-    return this.selectedCombatant.getBuffUptime(SPELLS.MOMENTUM_BUFF.id);
+    return this.selectedCombatant.getBuffUptime(SPELLS.EXERGY_BUFF.id);
   }
 
   get buffHistory() {
-    return this.selectedCombatant.getBuffHistory(SPELLS.MOMENTUM_BUFF.id);
+    return this.selectedCombatant.getBuffHistory(SPELLS.EXERGY_BUFF.id);
   }
 
   get suggestionThresholds() {
@@ -59,13 +59,14 @@ class Momentum extends Analyzer {
         </strong>{' '}
         provides an{' '}
         {formatPercentage(
-          MOMENTUM_SCALING[this.selectedCombatant.getTalentRank(TALENTS.EXERGY_TALENT)],
+          EXERGY_SCALING[this.selectedCombatant.getTalentRank(TALENTS.EXERGY_TALENT)],
           0,
         )}
-        % damage increase for 5 seconds after casting <SpellLink spell={SPELLS.FEL_RUSH_CAST} />,{' '}
-        <SpellLink spell={TALENTS.THE_HUNT_TALENT} />, and{' '}
-        <SpellLink spell={TALENTS.VENGEFUL_RETREAT_TALENT} />. This should be treated as a
-        maintenance buff with relatively high uptime.
+        % damage increase for 20 seconds after casting <SpellLink spell={TALENTS.THE_HUNT_TALENT} />{' '}
+        and <SpellLink spell={TALENTS.VENGEFUL_RETREAT_TALENT} />. This should be treated as a
+        maintenance buff with almost 100% uptime, since{' '}
+        <SpellLink spell={TALENTS.VENGEFUL_RETREAT_TALENT} /> has a 20 seconds cooldown itself with{' '}
+        <SpellLink spell={TALENTS.TACTICAL_RETREAT_TALENT} /> taken.
       </section>
     );
     const data = (
@@ -77,7 +78,7 @@ class Momentum extends Analyzer {
           uptime
         </p>
         {uptimeBarSubStatistic(this.owner.fight, {
-          spells: [SPELLS.MOMENTUM_BUFF],
+          spells: [SPELLS.EXERGY_BUFF],
           uptimes: this.buffHistory.map((buff) => ({
             start: buff.start,
             end: buff.end ?? this.owner.fight.end_time,
@@ -85,7 +86,7 @@ class Momentum extends Analyzer {
         })}
       </RoundedPanel>
     );
-    return <ExplanationAndDataSubSection explanation={explanation} data={data} title="Momentum" />;
+    return <ExplanationAndDataSubSection explanation={explanation} data={data} title="Exergy" />;
   }
 
   suggestions(when: When) {
@@ -107,7 +108,7 @@ class Momentum extends Analyzer {
       <Statistic
         position={STATISTIC_ORDER.CORE(3)}
         size="flexible"
-        tooltip={`The Momentum buff total uptime was ${formatDuration(this.buffDuration)}.`}
+        tooltip={`The Exergy buff total uptime was ${formatDuration(this.buffDuration)}.`}
       >
         <TalentSpellText talent={TALENTS.EXERGY_TALENT}>
           <UptimeIcon /> {formatPercentage(this.buffUptime)}% <small>uptime</small>
@@ -117,4 +118,4 @@ class Momentum extends Analyzer {
   }
 }
 
-export default Momentum;
+export default Exergy;

--- a/src/common/SPELLS/demonhunter.ts
+++ b/src/common/SPELLS/demonhunter.ts
@@ -505,9 +505,9 @@ const spells = {
     name: 'Demonic Appetite',
     icon: 'spell_misc_zandalari_council_soulswap',
   },
-  MOMENTUM_BUFF: {
+  EXERGY_BUFF: {
     id: 208628,
-    name: 'Momentum',
+    name: 'Exergy',
     icon: 'ability_foundryraid_demolition',
   },
   TRAIL_OF_RUIN_DAMAGE: {


### PR DESCRIPTION
Momentum talent for demon hunters was renamed to Exergy in 11.1, triggers and duration changed too.