### PR TITLE
add some Brewmaster APL rules to better reflect real-world play

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 11), <>Add some rules to the APL to better handle real-world play.</>, emallson),
   change(date(2025, 3, 10), <>Update APL for Undermine, simplify <SpellLink spell={talents.FACE_PALM_TALENT} /> tracking.</>, emallson),
   change(date(2025, 3, 1), <>Added support for the Undermine tier set, <SpellLink spell={talents.EFFICIENT_TRAINING_TALENT} />, and updated <SpellLink spell={SPELLS.PURIFIED_CHI} /> stack tracking.</>, emallson),
   change(date(2024, 11, 20), <>Updated text for <SpellLink spell={talents.BLACKOUT_COMBO_TALENT} /> section (again).</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
@@ -5,7 +5,7 @@ import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import * as cnd from 'parser/shared/metrics/apl/conditions';
 import talents from 'common/TALENTS/monk';
 import { AnyEvent } from 'parser/core/Events';
-import { SpellLink } from 'interface';
+import { SpellLink, TooltipElement } from 'interface';
 
 const withCombo = cnd.buffPresent(SPELLS.BLACKOUT_COMBO_BUFF);
 
@@ -19,7 +19,75 @@ const SCK_AOE = {
   ),
 };
 
+const WOO_BUILDER = {
+  spell: [talents.KEG_SMASH_TALENT, talents.RISING_SUN_KICK_TALENT],
+  condition: cnd.optionalRule(
+    cnd.and(
+      cnd.buffPresent(talents.WEAPONS_OF_ORDER_TALENT),
+      cnd.or(
+        cnd.debuffStacks(SPELLS.WEAPONS_OF_ORDER_DEBUFF, { atMost: 3 }),
+        cnd.debuffMissing(SPELLS.WEAPONS_OF_ORDER_DEBUFF, {
+          duration: 10000,
+          pandemicCap: 1,
+          timeRemaining: 3000,
+        }),
+      ),
+    ),
+  ),
+  description: (
+    <>
+      <TooltipElement content="Aggressively building stacks of WoO is not meaningfuly different from letting it build during your normal rotation in most cases, but it is a common play pattern and does similar total damage.">
+        (Optional)
+      </TooltipElement>{' '}
+      Build up stacks of the <SpellLink spell={talents.WEAPONS_OF_ORDER_TALENT} /> debuff with{' '}
+      <SpellLink spell={talents.KEG_SMASH_TALENT} /> or{' '}
+      <SpellLink spell={talents.RISING_SUN_KICK_TALENT} />
+    </>
+  ),
+};
+
+const CHP_SETUP = {
+  spell: talents.BREATH_OF_FIRE_TALENT,
+  condition: cnd.optionalRule(
+    cnd.and(
+      cnd.hasTalent(talents.CHARRED_PASSIONS_TALENT),
+      cnd.not(withCombo),
+      cnd.buffMissing(SPELLS.CHARRED_PASSIONS_BUFF, {
+        duration: 8000,
+        timeRemaining: 2000,
+        pandemicCap: 1,
+      }),
+    ),
+  ),
+  description: (
+    <>
+      <TooltipElement
+        content={
+          <>
+            <p>
+              Applying <SpellLink spell={talents.CHARRED_PASSIONS_TALENT} /> before using{' '}
+              <SpellLink spell={SPELLS.BLACKOUT_KICK_BRM} /> can be a damage gain, but if you find
+              yourself doing it too often it means you are missing{' '}
+              <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} /> casts during your normal rotation.
+            </p>
+            <p>
+              You might run into this condition naturally when dealing with forced downtime, such as
+              tank mechanics that require you to run away.
+            </p>
+          </>
+        }
+      >
+        (Optional)
+      </TooltipElement>{' '}
+      Apply <SpellLink spell={talents.CHARRED_PASSIONS_TALENT} /> when it is missing before using{' '}
+      <SpellLink spell={SPELLS.BLACKOUT_KICK_BRM} />
+    </>
+  ),
+};
+
 const standardApl = build([
+  WOO_BUILDER,
+  CHP_SETUP,
   SPELLS.BLACKOUT_KICK_BRM,
   {
     spell: [
@@ -43,7 +111,20 @@ const standardApl = build([
     spell: SPELLS.TIGER_PALM,
     condition: withCombo,
   },
-  talents.KEG_SMASH_TALENT,
+  {
+    spell: talents.KEG_SMASH_TALENT,
+    condition: cnd.describe(
+      cnd.and(
+        cnd.hasTalent(talents.STORMSTOUTS_LAST_KEG_TALENT),
+        cnd.spellFractionalCharges(talents.KEG_SMASH_TALENT, { atLeast: 1.7 }),
+      ),
+      (tense) => <>when it {tenseAlt(tense, 'is', 'was')} near 2 charges</>,
+    ),
+  },
+  {
+    spell: talents.KEG_SMASH_TALENT,
+    condition: cnd.not(cnd.hasTalent(talents.STORMSTOUTS_LAST_KEG_TALENT)),
+  },
   {
     spell: talents.BREATH_OF_FIRE_TALENT,
     condition: cnd.describe(
@@ -65,6 +146,7 @@ const standardApl = build([
       ),
     ),
   },
+  talents.KEG_SMASH_TALENT,
   talents.RISING_SUN_KICK_TALENT,
   talents.CHI_BURST_SHARED_TALENT,
   talents.BREATH_OF_FIRE_TALENT,

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -787,6 +787,10 @@ const spells = {
     ...talents.PRESS_THE_ADVANTAGE_TALENT,
     id: 418360,
   },
+  WEAPONS_OF_ORDER_DEBUFF: {
+    ...talents.WEAPONS_OF_ORDER_TALENT,
+    id: 387179,
+  },
 
   // Windwalker Spells
   COMBO_STRIKES: {


### PR DESCRIPTION
### Description

These cover some common play patterns (aggressively building WoO stacks + intentionally refreshing ChP before using BoK) that currently are marked as errors in the APL. These play patterns are either a wash that isn't in the sim apl to avoid complexity, or a damage increase conditionally that doesn't matter in the context of simc (which has basically perfect ChP uptime)
