### PR TITLE
revert VERSIONS to 11.1.0 for retail

### DIFF
--- a/src/game/VERSIONS.ts
+++ b/src/game/VERSIONS.ts
@@ -4,7 +4,7 @@ import GameBranch from './GameBranch';
 // The current version of the game. Used to check spec patch compatibility and as a caching key.
 const VERSIONS: { [branch in GameBranch]: string } = {
   [GameBranch.Classic]: '4.4.0',
-  [GameBranch.Retail]: '11.1.5',
+  [GameBranch.Retail]: '11.1.0',
 };
 
 export default VERSIONS;


### PR DESCRIPTION
all reports are currently getting "this report is from a previous patch", which isn't true yet

context: https://github.com/WoWAnalyzer/WoWAnalyzer/commit/e89b17ead8a1d8f94ef6ce1d64fd95eb6b119923#r155591699
