### PR TITLE
update supported specs example reports to TWW reports

### DIFF
--- a/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
-import { ToppleTheNun } from 'CONTRIBUTORS';
+import { ToppleTheNun, Vollmer } from 'CONTRIBUTORS';
 import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2024, 9, 23), <>Improve handling of <SpellLink spell={TALENTS.EYE_BEAM_TALENT} /> in preparation for Demonsurge.</>, ToppleTheNun),
   change(date(2024, 9, 3), 'Add Aldrachi Reaver and Fel-scarred abilities to the spellbook.', ToppleTheNun),
   change(date(2024, 6, 17), 'Begin working on support for The War Within.', ToppleTheNun),

--- a/src/analysis/retail/demonhunter/havoc/CONFIG.tsx
+++ b/src/analysis/retail/demonhunter/havoc/CONFIG.tsx
@@ -49,7 +49,7 @@ const CONFIG: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/akZLCTYbN2XpQFmg/63-Mythic+Smolderon+-+Kill+(5:44)/Femboygodx/standard',
+  exampleReport: '/report/grtLJNGQXDf4qB71/60-Mythic+One-Armed+Bandit+-+Kill+(6:49)/Desti/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
-import { Quaarkz, ToppleTheNun } from 'CONTRIBUTORS';
+import { Quaarkz, ToppleTheNun, Vollmer } from 'CONTRIBUTORS';
 import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2024, 9, 23), <>Clean up <SpellLink spell={TALENTS.FRACTURE_TALENT} /> analyzer.</>, ToppleTheNun),
   change(date(2024, 10, 17), 'Untethered Fury talent taken into consideration for Fracture analysis.', Quaarkz),
   change(date(2024, 9, 23), <>Improve handling of <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} /> in preparation for Demonsurge.</>, ToppleTheNun),

--- a/src/analysis/retail/demonhunter/vengeance/CONFIG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CONFIG.tsx
@@ -68,7 +68,8 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/akZLCTYbN2XpQFmg/63-Mythic+Smolderon+-+Kill+(5:44)/Toppledh/standard',
+  exampleReport:
+    '/report/fCx3FXwYRQ1pdLya/8-Mythic+One-Armed+Bandit+-+Kill+(6:43)/Meldmedaddy/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/druid/balance/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/balance/CHANGELOG.tsx
@@ -1,9 +1,10 @@
 import { change, date } from 'common/changelog';
-import { Sref } from 'CONTRIBUTORS';
+import { Sref, Vollmer } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 3, 4), <>Marked as updated for 11.1.0.</>, Sref),
   change(date(2024, 11, 18), <>Fixed an issue where <SpellLink spell={TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT} /> wouldn't show in cooldowns tab when <SpellLink spell={TALENTS_DRUID.ORBITAL_STRIKE_TALENT} /> talent is chosen.</>, Sref),
   change(date(2024, 10, 26), <>Update underlying talent data for 11.0.5. Fixed cooldown display with <SpellLink spell={TALENTS_DRUID.WHIRLING_STARS_TALENT} />. Added support for <SpellLink spell={TALENTS_DRUID.LUNAR_CALLING_TALENT} /> in Guide text. Fixed an issue where Mushroom cooldown graph would be shown when player takes <SpellLink spell={TALENTS_DRUID.SUNSEEKER_MUSHROOM_TALENT} />. </>, Sref),

--- a/src/analysis/retail/druid/balance/CONFIG.tsx
+++ b/src/analysis/retail/druid/balance/CONFIG.tsx
@@ -50,7 +50,8 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/XJytz49PfbYL6mvR/14-Mythic+Smolderon+-+Kill+(3:45)/Zulyd/standard',
+  exampleReport:
+    '/report/9KT74WFLZabdph8k/13-Mythic+One-Armed+Bandit+-+Kill+(6:55)/Clecia/standard',
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.BALANCE_DRUID,

--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
-import { Sref } from 'CONTRIBUTORS';
+import { Sref, Vollmer } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import { TALENTS_DRUID } from 'common/TALENTS/druid';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 3, 16), <>Added statistic for <SpellLink spell={TALENTS_DRUID.MERCILESS_CLAWS_TALENT} /></>, Sref),
   change(date(2025, 3, 4), <>Marked as updated for 11.1.0.</>, Sref),
   change(date(2025, 2, 16), <>Added support for the Liberation of Undermine tier set.</>, Sref),

--- a/src/analysis/retail/druid/feral/CONFIG.tsx
+++ b/src/analysis/retail/druid/feral/CONFIG.tsx
@@ -48,7 +48,8 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/wzmkrAF4WXbGBqZd/16-Mythic+Smolderon+-+Kill+(3:56)/Boogiecat/standard',
+  exampleReport:
+    '/report/7q4wXjc3V9GJbC1H/53-Mythic+One-Armed+Bandit+-+Kill+(7:09)/Elviiradruid/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/druid/guardian/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/guardian/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
-import { Sref } from 'CONTRIBUTORS';
+import { Sref, Vollmer } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 3, 4), <>Updated Frenzied Regeneration cooldown to account for changes to <SpellLink spell={TALENTS_DRUID.REINVIGORATION_TALENT} />. Marked as updated for 11.1.0.</>, Sref),
   change(date(2024, 10, 27), <>Updated patch compatibility to 11.0.5.</>, Sref),
   change(date(2024, 9, 23), <>Fixed an issue where active defensives weren't showing on the Timeline or Death Recap views. Added <SpellLink spell={TALENTS_DRUID.LUNAR_BEAM_TALENT} /> to the defensives list.</>, Sref),

--- a/src/analysis/retail/druid/guardian/CONFIG.tsx
+++ b/src/analysis/retail/druid/guardian/CONFIG.tsx
@@ -50,7 +50,7 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/R6CJMyPkfdmWacgQ/15-Mythic+Smolderon+-+Kill+(4:43)/Stormstríke/standard',
+  exampleReport: '/report/34V2WhNLp9jzd1fX/60-Mythic+One-Armed+Bandit+-+Kill+(6:48)/Pumps/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
-import { Sref } from 'CONTRIBUTORS';
+import { Sref, Vollmer } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 3, 24), <>Fixed an issue where HoTs procced by the Liberation of Undermine 4 set might not be properly attributed when Insurance! is refreshed.</>, Sref),
   change(date(2025, 3, 4), <>Updated <SpellLink spell={TALENTS_DRUID.NATURES_SWIFTNESS_TALENT} /> and added <SpellLink spell={TALENTS_DRUID.FLOURISH_TALENT} /> direct healing to account for 11.1.0 changes. Fixed an issue where <SpellLink spell={TALENTS_DRUID.FLOURISH_TALENT} /> was incorrectly assuming 8 seconds of HoT extension instead of 6.</>, Sref),
   change(date(2025, 3, 1), <>Updated Mastery calculations to account for 11.1 changes. Marked as updated for 11.1.0.</>, Sref),

--- a/src/analysis/retail/druid/restoration/CONFIG.tsx
+++ b/src/analysis/retail/druid/restoration/CONFIG.tsx
@@ -48,7 +48,8 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/dfv4tpJAyVakGFK9/6-Mythic+Smolderon+-+Kill+(3:53)/Nikosux/standard',
+  exampleReport:
+    '/report/34V2WhNLp9jzd1fX/60-Mythic+One-Armed+Bandit+-+Kill+(6:48)/Ninjaristic/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
-import { Putro, Arlie, ToppleTheNun, SebShady } from 'CONTRIBUTORS';
+import { Putro, Arlie, ToppleTheNun, SebShady, Vollmer } from 'CONTRIBUTORS';
 import { ResourceLink, SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/hunter';
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2024, 9, 27), <>Initial TWW compability update as of 11.0.2 patch. </>, SebShady),
   change(date(2024, 2, 15), <>Try to workaround weird buff events on bosses like Volcoross for <SpellLink spell={SPELLS.BARBED_SHOT_PET_BUFF} /> </>, Putro),
   change(date(2023, 11, 21), <>Update when <SpellLink spell={TALENTS.BARBED_SHOT_TALENT}  /> are marked as good or bad casts. </>, Putro),

--- a/src/analysis/retail/hunter/beastmastery/CONFIG.tsx
+++ b/src/analysis/retail/hunter/beastmastery/CONFIG.tsx
@@ -51,7 +51,8 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/zrb9CRPkhn2TpFyK/4-Heroic+Kazzara,+the+Hellforged+-+Kill+(2:00)/Ispase',
+  exampleReport:
+    '/report/NFpVzkxLJKh8r3Pf/48-Mythic+One-Armed+Bandit+-+Kill+(6:48)/Imnotanorc/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -2,10 +2,11 @@ import TALENTS from 'common/TALENTS/mage';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'interface/SpellLink';
 import { change, date } from 'common/changelog';
-import { Sharrq } from 'CONTRIBUTORS';
+import { Sharrq, Vollmer } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2024, 11, 22), <>Removed Checklist.</>, Sharrq),
   change(date(2024, 11, 22), <>Updated <SpellLink spell={TALENTS.COMBUSTION_TALENT} />, <SpellLink spell={SPELLS.HOT_STREAK} />, <SpellLink spell={SPELLS.HEATING_UP} />, and <SpellLink spell={TALENTS.FEEL_THE_BURN_TALENT} />.</>, Sharrq),
   change(date(2024, 9, 18), <>Updated the Warning Banner explaining the current state of Fire Mage.</>, Sharrq),

--- a/src/analysis/retail/mage/fire/CONFIG.tsx
+++ b/src/analysis/retail/mage/fire/CONFIG.tsx
@@ -48,7 +48,7 @@ const config: Config = {
   },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
-    'report/XLj7amG2gr4Hwdb3/30-Heroic+Rashok,+the+Elder+-+Kill+(4:35)/Pyrenn/standard',
+    '/report/NFpVzkxLJKh8r3Pf/48-Mythic+One-Armed+Bandit+-+Kill+(6:48)/Forgyy/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import { SpellLink } from 'interface';
-import { Sharrq, Earosselot, Soulhealer95 } from 'CONTRIBUTORS';
+import { Sharrq, Earosselot, Soulhealer95, Vollmer } from 'CONTRIBUTORS';
 import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 4, 11), <>Fixed <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} /> shattered evaluation</>, Earosselot),
   change(date(2025, 3, 18), <> Frostfire APL: Updated to new simplified 11.1</>, Earosselot),
   change(date(2025, 2, 27), <>Apls: Updated for Spell Slinger and Frostfire for patch 11.1</>, Earosselot),

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -54,7 +54,7 @@ const config: Config = {
     },
   },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/RJ1MXnb2zymgQ8pF/49/20',
+  exampleReport: '/report/H4VLKcxWnwpA9PbN/56-Mythic+One-Armed+Bandit+-+Kill+(6:46)/Kitzu/standard',
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.FROST_MAGE,

--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -1,7 +1,8 @@
 import { change, date } from 'common/changelog';
-import { Hana, fel1ne, Saeldur } from 'CONTRIBUTORS';
+import { Hana, fel1ne, Saeldur, Vollmer } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 3, 29), <>More Updates for 11.1</>, Saeldur),
   change(date(2025, 3, 16), <>Updates for 11.1</>, Hana),
   change(date(2024, 12, 3), <>Add Void Blast to Words of the Pious, Void Summoner and Train of Thought.</>, Saeldur),

--- a/src/analysis/retail/priest/discipline/CONFIG.tsx
+++ b/src/analysis/retail/priest/discipline/CONFIG.tsx
@@ -37,7 +37,7 @@ const config: Config = {
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
-    '/report/bNCqm427cLFntQdZ/31-Mythic+The+Forgotten+Experiments+-+Kill+(2:57)/200-Chaddaddy',
+    '/report/dNFgWkv1TJG3wcRq/13-Mythic+One-Armed+Bandit+-+Kill+(6:49)/Groovey/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/priest/holy/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/holy/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import TALENTS, { TALENTS_PRIEST } from 'common/TALENTS/priest';
-import { Arlie, Hana, Litena, Liavre, squided, ToppleTheNun, Trevor, Saeldur, xizbow, fel1ne} from 'CONTRIBUTORS';
+import { Arlie, Hana, Litena, Liavre, squided, ToppleTheNun, Trevor, Saeldur, xizbow, fel1ne, Vollmer} from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2024, 11, 14), <>Updated Holy to 11.0.7</>, Liavre),
   change(date(2024, 10, 26), <>Added <SpellLink spell={SPELLS.RESONANT_WORDS_TALENT_BUFF} /> guide analysis.</>, xizbow),
   change(date(2024, 10, 20), <>Implement <SpellLink spell={SPELLS.TRAIL_OF_LIGHT_TALENT_HEAL}/> and <SpellLink spell={SPELLS.BINDING_HEALS_TALENT_HEAL}/> healing to Lightweaver module.</>, fel1ne),

--- a/src/analysis/retail/priest/holy/CONFIG.tsx
+++ b/src/analysis/retail/priest/holy/CONFIG.tsx
@@ -32,7 +32,7 @@ const config: Config = {
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
-    '/report/myZRBCM19TtWjQxD/6-Heroic+Council+of+Dreams+-+Kill+(6:29)/Ahaux/standard/overview',
+    '/report/fYWBL3AtVXTPmkMJ/24-Mythic+One-Armed+Bandit+-+Kill+(6:46)/Thiccspriest/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/assassination/CHANGELOG.tsx
@@ -1,5 +1,5 @@
 import { change, date } from 'common/changelog';
-import { Bigsxy, ToppleTheNun, Whispyr, SebShady, emallson } from 'CONTRIBUTORS';
+import { Bigsxy, ToppleTheNun, Whispyr, SebShady, emallson, Vollmer } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 import SPELLS from 'common/SPELLS/rogue';
 import TALENTS from 'common/TALENTS/rogue';
@@ -7,6 +7,7 @@ import SHARED_CHANGELOG from 'analysis/retail/rogue/shared/CHANGELOG';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2024, 11, 18), 'Remove Sepsis and adjust other spells updated in 11.0.5', emallson),
   change(date(2024, 9, 22), 'TWW initial compatibility update.', SebShady),
   change(date(2024, 5, 22), 'Fix spelling of Ravenholdt.', ToppleTheNun),

--- a/src/analysis/retail/rogue/assassination/CONFIG.tsx
+++ b/src/analysis/retail/rogue/assassination/CONFIG.tsx
@@ -38,7 +38,7 @@ const config: Config = {
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
-    '/report/qgQGvkm6ydHbpLaX/94-Mythic+Kazzara,+the+Hellforged+-+Kill+(5:08)/Whíspyr/standard',
+    '/report/fYWBL3AtVXTPmkMJ/24-Mythic+One-Armed+Bandit+-+Kill+(6:46)/Violent/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import TALENTS from 'common/TALENTS/shaman';
-import { emallson, Seriousnes } from 'CONTRIBUTORS';
+import { emallson, Seriousnes, Vollmer } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 3, 22), <>Remove "Old Version" view, guide cleanup, fixed <SpellLink spell={TALENTS.ASCENDANCE_ELEMENTAL_TALENT} /> cooldown analyzer.</>, Seriousnes),
   change(date(2025, 3, 9), <>Fix crash when processing Fusion of Elements data.</>, emallson),
   change(date(2025, 3, 4), <>Elemental Shaman update for TWW S2</>, Seriousnes),

--- a/src/analysis/retail/shaman/elemental/CONFIG.tsx
+++ b/src/analysis/retail/shaman/elemental/CONFIG.tsx
@@ -53,7 +53,7 @@ export default {
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
-    '/report/L1R2zVKY8ZDxCTNb/15-Mythic+Scalecommander+Sarkareth+-+Kill+(7:21)/Nerdshockz/standard',
+    '/report/69CV1RFzhry3jWGH/30-Mythic+One-Armed+Bandit+-+Kill+(6:51)/Sheffy/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -4,10 +4,11 @@ import SPELLS from 'common/SPELLS';
 import { change, date } from 'common/changelog';
 import { SHAMAN_TWW1_ID } from 'common/ITEMS/dragonflight';
 import ItemSetLink from 'interface/ItemSetLink';
-import { Seriousnes, Ypp, Texleretour, Vetyst, PandaGoesBaa, emallson, squided } from 'CONTRIBUTORS';
+import { Seriousnes, Ypp, Texleretour, Vetyst, PandaGoesBaa, emallson, squided, Vollmer } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 2, 12), <>Fix accuracy of <SpellLink spell={TALENTS_SHAMAN.TORRENT_TALENT}/> statistic.</>, squided),
   change(date(2025, 2, 8), <>Update incorrect modules and guide sections. Add missing modules for 11.0.7 talents. More totemic modules.</>, squided),
   change(date(2025, 1, 6), <>Fix crash in <SpellLink spell={TALENTS_SHAMAN.SURGING_TOTEM_TALENT} /> analysis when cast pre-pull.</>, emallson),

--- a/src/analysis/retail/shaman/restoration/CONFIG.tsx
+++ b/src/analysis/retail/shaman/restoration/CONFIG.tsx
@@ -39,7 +39,7 @@ const CONFIG: Config = {
     </Trans>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: 'report/nLqjdwhyG4r7FxJW/19-Mythic+Terros+-+Kill+(4:22)/Fakeblonde/standard',
+  exampleReport: '/report/aLXxAPjfn94bVwGr/27-Mythic+One-Armed+Bandit+-+Kill+(6:45)/Bub/standard',
   pages: {
     overview: {
       frontmatterType: 'guide',

--- a/src/analysis/retail/warrior/protection/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/protection/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warrior';
-import { Rzial } from 'CONTRIBUTORS';
+import { Rzial, Vollmer } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2024, 10, 28), <>Added Hero talent <SpellLink spell={TALENTS.BURST_OF_POWER_TALENT}/> as <SpellLink spell={SPELLS.SHIELD_SLAM} /> reset trigger.</>, Rzial),
   change(date(2024, 10, 28), <>Added The War Within Season 1 2-pieces tier set effect <SpellLink spell={SPELLS.EXPERT_STRATEGIST_BUFF}/> as <SpellLink spell={SPELLS.SHIELD_SLAM} /> reset tracker.</>, Rzial),
   change(date(2024, 10, 24), 'Initial Update for The War Within.', Rzial),

--- a/src/analysis/retail/warrior/protection/CONFIG.tsx
+++ b/src/analysis/retail/warrior/protection/CONFIG.tsx
@@ -45,7 +45,7 @@ const CONFIG: Config = {
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
-    '/report/471LzwXpgtPTJGaq/31-Mythic+Rashok,+the+Elder+-+Kill+(5:50)/Sense/standard/overview',
+    '/report/Rvh78zcZ1y9MmVWJ/18-Mythic+One-Armed+Bandit+-+Kill+(6:58)/Sarcasteick/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.


### PR DESCRIPTION
### Description

This PR updates the example reports for all the specs that support TWW, which had example reports from a previous expansion.
#7326 changed the e2e tests so they no longer handle "Previous Expansion" checks. 
