### PR TITLE
Azjol nerub special case

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -43,6 +43,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [  
+  change(date(2025, 4, 25, 'Fix Azjol-Nerub special case for Armory Link','Ceric'),
   change(date(2025, 4, 22), 'Added Gems to Preparation Section with general recommendations.', [emallson,Ceric]),
   change(date(2025, 4, 17), 'Add patch 11.1.5.', Vollmer),
   change(date(2025, 4, 12), 'Changed Momentum talent to Exergy for Havoc', oneunreadmail),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -43,7 +43,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [  
-  change(date(2025, 4, 25), 'Fix Azjol-Nerub special case for Armory Link','Ceric'),
+  change(date(2025, 4, 25), 'Fix Azjol-Nerub special case for Armory Link', Ceric),
   change(date(2025, 4, 22), 'Added Gems to Preparation Section with general recommendations.', [emallson,Ceric]),
   change(date(2025, 4, 17), 'Add patch 11.1.5.', Vollmer),
   change(date(2025, 4, 12), 'Changed Momentum talent to Exergy for Havoc', oneunreadmail),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -43,7 +43,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [  
-  change(date(2025, 4, 25, 'Fix Azjol-Nerub special case for Armory Link','Ceric'),
+  change(date(2025, 4, 25), 'Fix Azjol-Nerub special case for Armory Link','Ceric'),
   change(date(2025, 4, 22), 'Added Gems to Preparation Section with general recommendations.', [emallson,Ceric]),
   change(date(2025, 4, 17), 'Add patch 11.1.5.', Vollmer),
   change(date(2025, 4, 12), 'Changed Momentum talent to Exergy for Havoc', oneunreadmail),

--- a/src/interface/makeAnalyzerUrl.ts
+++ b/src/interface/makeAnalyzerUrl.ts
@@ -79,17 +79,18 @@ export function makeArmoryUrl(player: Combatant) {
   if (!profile) {
     return '#';
   }
-  let battleNetUrl = `https://worldofwarcraft.com/en-us/character/${profile.region}/${profile.realm
-    .replace(/'/g, '')
+
+  const realm: string = profile.realm
+    .replace(/'/g, '') // remove apostrophes to match armory (Blackhand special case)
+    .replace('-', '') // remove dashes to match armory (Azjol-Nerub special case)
     .replace(/\s/g, '-')
-    .toLowerCase()}/${player.name}`;
+    .toLowerCase();
+
   if (profile.region === 'CN') {
-    battleNetUrl = `https://www.wowchina.com/zh-cn/character/${profile.realm
-      .replace(/'/g, '')
-      .replace(/\s/g, '-')
-      .toLowerCase()}/${player.name}`;
+    return `https://www.wowchina.com/zh-cn/character/${profile.region.toLowerCase()}/${realm}/${player.name.toLowerCase()}`;
   }
-  return battleNetUrl;
+
+  return `https://worldofwarcraft.com/en-us/character/${profile.region.toLowerCase()}/${realm}/${player.name.toLowerCase()}`;
 }
 
 export function makeThumbnailUrl(characterInfo: CharacterProfile, classic: boolean) {


### PR DESCRIPTION
### Description
Azjol-Nerub is the only realm with a - so blizzard converts spaces to - in there url and - to nothing.

This caused the armory link to break in this special case.

### Testing
https://www.wowanalyzer.com/report/rQvnLVGRZXk3MYd6/23-Heroic+Chrome+King+Gallywix+-+Wipe+10+(1:53)/Locsul/standard/character
Armory Link: https://worldofwarcraft.com/en-us/character/us/azjol-nerub/Locsul
Fixed Armory Link: https://worldofwarcraft.com/en-us/character/us/azjolnerub/Locsul

