### PR TITLE
Recommended Gems now shown to User.

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -43,7 +43,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2025, 4, 27), 'Recommend Gems now show to the User if setup', Ceric),
+  change(date(2025, 4, 27), 'Recommended Gems now show to the User if setup', Ceric),
   change(date(2025, 4, 25), 'Fix Azjol-Nerub special case for Armory Link', Ceric),
   change(date(2025, 4, 24), 'Streamlined Recommended Gems for Gem Checker', Ceric),
   change(date(2025, 4, 22), 'Added Gems to Preparation Section with general recommendations.', [emallson,Ceric]),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -43,6 +43,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 27), 'Recommend Gems now show to the User if setup', Ceric),
   change(date(2025, 4, 25), 'Fix Azjol-Nerub special case for Armory Link', Ceric),
   change(date(2025, 4, 24), 'Streamlined Recommended Gems for Gem Checker', Ceric),
   change(date(2025, 4, 22), 'Added Gems to Preparation Section with general recommendations.', [emallson,Ceric]),

--- a/src/interface/guide/components/Preparation/GemSubSection/GemBoxRow.module.scss
+++ b/src/interface/guide/components/Preparation/GemSubSection/GemBoxRow.module.scss
@@ -64,3 +64,7 @@ $potential-perf-color: hsl(329, 10%, 23%);
   display: flex; /* Use flexbox */
   flex-direction: row; /* Align items horizontally */
 }
+
+header {
+  font-weight: bold;
+}

--- a/src/interface/guide/components/Preparation/GemSubSection/index.tsx
+++ b/src/interface/guide/components/Preparation/GemSubSection/index.tsx
@@ -2,6 +2,7 @@ import { SubSection, useAnalyzer, useInfo } from 'interface/guide/index';
 import GemChecker from 'parser/shared/modules/items/GemChecker';
 import GemBoxRow from 'interface/guide/components/Preparation/GemSubSection/GemBoxRow';
 import { Trans } from '@lingui/react/macro';
+import ItemLink from 'interface/ItemLink';
 
 interface Props {
   recommendedGems?: number[];
@@ -24,6 +25,19 @@ const GemSubSection = ({ recommendedGems }: Props) => {
         </Trans>
       </p>
       <GemBoxRow values={gemChecker.getGemBoxRowEntries(recommendedGems)} />
+      {/* Show recommended gems if populated */}
+      {recommendedGems && recommendedGems.length > 0 && (
+        <div>
+          <header>Recommended Gems</header>
+          <ul>
+            {recommendedGems.map((gemId) => (
+              <li key={gemId}>
+                <ItemLink id={gemId} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </SubSection>
   );
 };


### PR DESCRIPTION
### Description

Was documenting how to add Recommended Gems and thought back to a point that emallson made in the original PR for the feature about the individual gem qualities showing up on the UI.  If you know how the underlying code works that makes sense but if not it really doesn't.  As we are trying to help the users perform better or know more I added in the Recommended Gems showing if there are some with item links.

### Testing
[Setup some recommend gems](https://github.com/WoWAnalyzer/WoWAnalyzer/wiki/Setting-up-Recommended-Gems)
Go to any report for that class and spec.  Now you will see the recommended gems listed out under the gear in the gem area.

Screenshot(s):
Before:
![image](https://github.com/user-attachments/assets/cd0d6f33-45ac-4dc9-b605-6b387b8370c5)

After:
Recommended Setup:
![image](https://github.com/user-attachments/assets/82735f91-62e1-4261-bf2a-9d06504a3e1a)

Recommended not Setup:
![image](https://github.com/user-attachments/assets/6f53281b-932a-4bef-b36d-fa0c25178c30)

(Sidenote for anyone curious I'm trying to setup signed commits.)
