### PR TITLE
add rotational analysis for Templar Protection Paladin

### DIFF
--- a/src/analysis/retail/paladin/protection/CHANGELOG.tsx
+++ b/src/analysis/retail/paladin/protection/CHANGELOG.tsx
@@ -3,5 +3,6 @@ import { emallson } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 26), 'Added rotational analysis for Templar', emallson),
   change(date(2025, 4, 11), 'Initial updates for The War Within.', emallson),
 ];

--- a/src/analysis/retail/paladin/protection/Guide.tsx
+++ b/src/analysis/retail/paladin/protection/Guide.tsx
@@ -1,5 +1,5 @@
 import { GuideProps, Section, SubSection, useInfo } from 'interface/guide';
-import { ResourceLink } from 'interface';
+import { AlertWarning, ResourceLink, SpellLink } from 'interface';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import CombatLogParser from 'analysis/retail/paladin/protection/CombatLogParser';
 import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
@@ -12,6 +12,9 @@ import MajorDefensives from './modules/core/Defensives';
 import ActiveMitgation from './modules/core/Defensives/ActiveMitigation';
 import { FoundationDowntimeSection } from 'interface/guide/foundation/FoundationDowntimeSection';
 import { FoundationCooldownSection } from 'interface/guide/foundation/FoundationCooldownSection';
+import { AplSectionData } from 'interface/guide/components/Apl';
+import { apl, check } from './modules/core/AplCheck';
+import talents from 'common/TALENTS/paladin';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -21,6 +24,16 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         <FoundationCooldownSection />
       </Section>
       <ResourceUsageSection modules={modules} events={events} info={info} />
+      <Section title="Rotation">
+        {!info.combatant.hasTalent(talents.LIGHTS_GUIDANCE_TALENT) && (
+          <AlertWarning>
+            Rotational analysis for{' '}
+            <SpellLink spell={talents.HOLY_ARMAMENTS_TALENT}>Lightsmith</SpellLink> is not
+            implemented at this time.
+          </AlertWarning>
+        )}
+        <AplSectionData checker={check} apl={apl} />
+      </Section>
       <MitigationSection />
       <ActiveMitigationSection />
       <PreparationSection />

--- a/src/analysis/retail/paladin/protection/modules/Abilities.tsx
+++ b/src/analysis/retail/paladin/protection/modules/Abilities.tsx
@@ -202,7 +202,7 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS_PALADIN.BLESSING_OF_SACRIFICE_TALENT.id,
         category: SPELL_CATEGORY.UTILITY,
-        cooldown: 120,
+        cooldown: 120 - 60 * combatant.getTalentRank(TALENTS.SACRIFICE_OF_THE_JUST_TALENT),
       },
       {
         spell: TALENTS.CLEANSE_TOXINS_TALENT.id,

--- a/src/common/SPELLS/paladin.ts
+++ b/src/common/SPELLS/paladin.ts
@@ -701,6 +701,10 @@ const spells = {
     ...talents.UNDISPUTED_RULING_TALENT,
     id: 432629,
   },
+  SHAKE_THE_HEAVENS_BUFF: {
+    ...talents.SHAKE_THE_HEAVENS_TALENT,
+    id: 431536,
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/parser/shared/metrics/apl/ChecklistRule.tsx
+++ b/src/parser/shared/metrics/apl/ChecklistRule.tsx
@@ -1,3 +1,4 @@
+import TooltipWrapper from 'interface/Tooltip';
 import Spell from 'common/SPELLS/Spell';
 import { SpellLink } from 'interface';
 import { ThresholdStyle } from 'parser/core/ParseResults';
@@ -19,6 +20,7 @@ import {
   Violation,
   isRuleEqual,
 } from './index';
+import { InformationIcon } from 'interface/icons';
 
 interface Props {
   apl: Apl;
@@ -161,6 +163,14 @@ export function RuleDescription({ rule }: { rule: AplRule }): JSX.Element {
       Cast <RuleSpellsDescription rule={rule} />
       {rule.condition ? ' ' : ''}
       <ConditionDescription prefix="when" rule={rule} tense={Tense.Present} />
+      {rule.condition?.tooltip?.() && (
+        <TooltipWrapper content={rule.condition.tooltip()}>
+          <span>
+            {' '}
+            <InformationIcon style={{ fontSize: '1em' }} />
+          </span>
+        </TooltipWrapper>
+      )}
     </>
   );
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1d4baf0b-c04b-4466-ad49-a99cb2057fb9)

Based on the rotation from https://www.wowhead.com/guide/classes/paladin/protection/rotation-cooldowns-pve-tank

I didn't implement Lightsmith at this time. There's a lot Templar-specific "play around Shake the Heavens" logic that needs to be rearranged for Lightsmith.

Templar is ~98% play rate in raid and ~85% in keys so this still cover a large majority of logs.