### PR TITLE
resolve some issues with Prot Pal rotation

### DIFF
--- a/src/analysis/retail/paladin/protection/CHANGELOG.tsx
+++ b/src/analysis/retail/paladin/protection/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import { emallson } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 27), 'More rotational work for Templar', emallson),
   change(date(2025, 4, 26), 'Added rotational analysis for Templar', emallson),
   change(date(2025, 4, 11), 'Initial updates for The War Within.', emallson),
 ];

--- a/src/analysis/retail/paladin/protection/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/paladin/protection/modules/core/AplCheck.tsx
@@ -36,7 +36,10 @@ const eyeOfTyrHoLCastable: Condition<boolean> = {
 };
 
 const holCastable = cnd.always(
-  cnd.or(cnd.buffPresent(SPELLS.LIGHTS_DELIVERANCE_FREE_CAST_BUFF), eyeOfTyrHoLCastable),
+  cnd.or(
+    cnd.buffPresent(SPELLS.LIGHTS_DELIVERANCE_FREE_CAST_BUFF),
+    cnd.and(eyeOfTyrHoLCastable, cnd.hasResource(RESOURCE_TYPES.HOLY_POWER, { atLeast: 3 }, 0)),
+  ),
 );
 
 export const apl = build([
@@ -50,11 +53,13 @@ export const apl = build([
   },
   {
     spell: SPELLS.CONSECRATION_CAST,
-    condition: cnd.buffMissing(SPELLS.CONSECRATION_BUFF, {
-      duration: 12000,
-      timeRemaining: 2000,
-      pandemicCap: 1,
-    }),
+    condition: cnd.optionalRule(
+      cnd.buffMissing(SPELLS.CONSECRATION_BUFF, {
+        duration: 12000,
+        timeRemaining: 2000,
+        pandemicCap: 1,
+      }),
+    ),
   },
   {
     spell: SPELLS.SHIELD_OF_THE_RIGHTEOUS,
@@ -86,7 +91,7 @@ export const apl = build([
   {
     spell: SPELLS.SHIELD_OF_THE_RIGHTEOUS,
     condition: cnd.describe(
-      cnd.always(
+      cnd.optionalRule(
         cnd.or(
           cnd.hasResource(RESOURCE_TYPES.HOLY_POWER, { atLeast: 3 }, 0),
           cnd.buffPresent(SPELLS.DIVINE_PURPOSE_BUFF),
@@ -98,20 +103,6 @@ export const apl = build([
           <ResourceLink id={RESOURCE_TYPES.HOLY_POWER.id} />
         </>
       ),
-    ),
-  },
-  {
-    spell: SPELLS.WORD_OF_GLORY,
-    condition: cnd.optionalRule(
-      cnd.and(
-        cnd.buffPresent(SPELLS.SHAKE_THE_HEAVENS_BUFF),
-        cnd.buffPresent(SPELLS.SHINING_LIGHT),
-      ),
-      <>
-        Spending free <SpellLink spell={SPELLS.WORD_OF_GLORY} /> casts to generate additional{' '}
-        <SpellLink spell={SPELLS.EMPYREAN_HAMMER} /> hits is currently a damage gain, though you
-        need to be careful not to overspend and leave yourself vulnerable.
-      </>,
     ),
   },
   TALENTS.AVENGERS_SHIELD_TALENT,


### PR DESCRIPTION
- WoG in the APL produced too many fake issues when using it as a healing ability (and not a EH trigger)
- Cons being a required rule similarly caused a number of issues with movement (e.g. the Mug'Zee move from north to south would produce 5+ bad issues in a row telling you to cast Cons even though you'd just immediately walk out of it)
- added a Holy Power requirement to Hammer of Light when available via Eye of Tyr

(yea the changelog date is wrong. i'm actually from the past)