### PR TITLE
add guide section for shado-pan brewmaster

### DIFF
--- a/scripts/lint-baseline/baseline.json
+++ b/scripts/lint-baseline/baseline.json
@@ -264,7 +264,7 @@
   "src/parser/core/Events.ts:1162:28__@typescript-eslint/no-explicit-any",
   "src/parser/core/Events.ts:1163:11__@typescript-eslint/no-explicit-any",
   "src/parser/core/ParseResults.tsx:385:43__@typescript-eslint/no-explicit-any",
-  "src/parser/core/SpellUsage/SpellUsageSubSection.tsx:245:5__@eslint-react/hooks-extra/no-direct-set-state-in-use-effect",
+  "src/parser/core/SpellUsage/SpellUsageSubSection.tsx:250:5__@eslint-react/hooks-extra/no-direct-set-state-in-use-effect",
   "src/parser/core/healingEfficiency/HealingEfficiencyBreakdown.tsx:177:3__@eslint-react/no-unused-class-component-members",
   "src/parser/core/healingEfficiency/HealingEfficiencyBreakdown.tsx:33:3__@eslint-react/no-unused-class-component-members",
   "src/parser/core/healingEfficiency/HealingEfficiencyBreakdown.tsx:86:3__@eslint-react/no-unused-class-component-members",

--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 4, 30), <>Add guide section for Shado-Pan.</>, emallson),
   change(date(2025, 4, 26), <>Update <SpellLink spell={talents.CHI_BURST_SHARED_TALENT} /> position in the APL as Master of Harmony.</>, emallson),
   change(date(2025, 4, 11), <>Add some rules to the APL to better handle real-world play.</>, emallson),
   change(date(2025, 3, 10), <>Update APL for Undermine, simplify <SpellLink spell={talents.FACE_PALM_TALENT} /> tracking.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
+++ b/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
@@ -57,6 +57,9 @@ import WarWithinS1TierSet from './modules/items/WarWithinS1TierSet';
 import VeteransEye from '../shared/hero/ShadoPan/VeteransEye';
 import WarWithinS2TierSet from './modules/items/WarWithinS2TierSet';
 import EfficientTraining from '../shared/hero/ShadoPan/EfficientTraining';
+import EnergyTracker from './modules/core/EnergyTracker';
+import EnergyGraph from './modules/core/EnergyGraph';
+import ShadowFlurryStrikes from './modules/talents/ShadowFlurryStrikes';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -70,6 +73,8 @@ class CombatLogParser extends CoreCombatLogParser {
     brews: SharedBrews,
     channeling: Channeling,
     globalCooldown: GlobalCooldown,
+    EnergyTracker,
+    EnergyGraph,
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
     mysticTouch: MysticTouch,
@@ -126,6 +131,7 @@ class CombatLogParser extends CoreCombatLogParser {
     stormstoutsLastKeg: StormtoutsLastKeg,
     veteransEye: VeteransEye,
     efficientTraining: EfficientTraining,
+    ShadowFlurryStrikes,
 
     apl: AplCheck,
 

--- a/src/analysis/retail/monk/brewmaster/modules/core/AplCheck/AplChoiceDescription.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/AplCheck/AplChoiceDescription.tsx
@@ -38,16 +38,14 @@ const StandardDescription = () => {
         </p>
         <ol>
           <li>
-            Always fill one <SpellIcon spell={blank} /> with either{' '}
-            <SpellLink spell={SPELLS.TIGER_PALM}>TP</SpellLink> or{' '}
-            <SpellLink spell={talents.BREATH_OF_FIRE_TALENT}>BoF</SpellLink> to spend your{' '}
-            <SpellLink spell={SPELLS.BLACKOUT_COMBO_BUFF} />
+            Always fill one <SpellIcon spell={blank} /> with{' '}
+            <SpellLink spell={SPELLS.TIGER_PALM}>TP</SpellLink> to spend your{' '}
+            <SpellLink spell={SPELLS.BLACKOUT_COMBO_BUFF} />, even in AoE
           </li>
           <li>
             If you fill a <SpellIcon spell={blank} /> with{' '}
             <SpellLink spell={talents.KEG_SMASH_TALENT} />, it should be <em>after</em>{' '}
-            <SpellLink spell={SPELLS.TIGER_PALM}>TP</SpellLink> /{' '}
-            <SpellLink spell={talents.BREATH_OF_FIRE_TALENT}>BoF</SpellLink>
+            <SpellLink spell={SPELLS.TIGER_PALM}>TP</SpellLink>
           </li>
           <li>
             Fill all other <SpellIcon spell={blank} />s with your normal rotation

--- a/src/analysis/retail/monk/brewmaster/modules/core/EnergyGraph.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/EnergyGraph.tsx
@@ -1,0 +1,14 @@
+import ResourceGraph from 'parser/shared/modules/ResourceGraph';
+import EnergyTracker from './EnergyTracker';
+
+export default class EnergyGraph extends ResourceGraph {
+  static dependencies = {
+    ...ResourceGraph.dependencies,
+    energyTracker: EnergyTracker,
+  };
+  private energyTracker!: EnergyTracker;
+
+  tracker() {
+    return this.energyTracker;
+  }
+}

--- a/src/analysis/retail/monk/brewmaster/modules/core/EnergyTracker.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/EnergyTracker.tsx
@@ -1,0 +1,36 @@
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { Options } from 'parser/core/Analyzer';
+import ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
+import {
+  QualitativePerformance,
+  evaluateQualitativePerformanceByThreshold,
+} from 'parser/ui/QualitativePerformance';
+
+const MAX_ENERGY = 100;
+const BASE_REGEN = 10;
+
+export default class EnergyTracker extends ResourceTracker {
+  static dependencies = { ...ResourceTracker.dependencies };
+  constructor(options: Options) {
+    super(options);
+
+    this.resource = RESOURCE_TYPES.ENERGY;
+    this.maxResource = MAX_ENERGY;
+    this.baseRegenRate = BASE_REGEN;
+
+    // brew can't normally miss so it is hard to validate this, but it probably works this way
+    this.refundOnMiss = true;
+  }
+
+  get performance(): QualitativePerformance {
+    return evaluateQualitativePerformanceByThreshold({
+      actual: this.percentAtCap,
+      isLessThanOrEqual: {
+        perfect: 0.05,
+        good: 0.1,
+        ok: 0.15,
+        fail: 0.2,
+      },
+    });
+  }
+}

--- a/src/analysis/retail/monk/brewmaster/modules/talents/ShadowFlurryStrikes.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/ShadowFlurryStrikes.tsx
@@ -1,0 +1,242 @@
+import SPELLS from 'common/SPELLS';
+import talents from 'common/TALENTS/monk';
+import { formatNth } from 'common/format';
+import SpellLink from 'interface/SpellLink';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  AnyEvent,
+  ApplyBuffEvent,
+  CastEvent,
+  DamageEvent,
+  FightEndEvent,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+import { createChecklistItem } from 'parser/core/MajorCooldowns/MajorCooldown';
+import { ChecklistUsageInfo, SpellUse } from 'parser/core/SpellUsage/core';
+import {
+  QualitativePerformance,
+  evaluateQualitativePerformanceByThreshold,
+} from 'parser/ui/QualitativePerformance';
+import EnergyTracker from '../core/EnergyTracker';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import ResourceLink from 'interface/ResourceLink';
+
+interface ShadowBuffData {
+  apply: AnyEvent;
+  remove?: AnyEvent;
+  flurryHits: number;
+  bobUsed: boolean;
+  offset: number;
+}
+const RECENT_WINDOW = 10_000;
+const SPEND_PER_TRIGGER = 240;
+const HITS_PER_TRIGGER = 10;
+
+export default class ShadowFlurryStrikes extends Analyzer.withDependencies({ EnergyTracker }) {
+  private mostRecentFlurryStrike: DamageEvent | undefined;
+  private recentFlurryStrikes = 0;
+
+  private shadowBuffs: ShadowBuffData[] = [];
+  private activeShadowBuff: ShadowBuffData | undefined;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(
+      Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.WOTW_SHADOW_BUFF),
+      this.onApply,
+    );
+    this.addEventListener(
+      Events.refreshbuff.to(SELECTED_PLAYER).spell(SPELLS.WOTW_SHADOW_BUFF),
+      this.onApply,
+    );
+    this.addEventListener(
+      Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.WOTW_SHADOW_BUFF),
+      this.onRemove,
+    );
+    this.addEventListener(Events.fightend, this.onRemove);
+
+    this.addEventListener(
+      Events.damage
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.FLURRY_STRIKES_DAMAGE_1, SPELLS.FLURRY_STRIKES_DAMAGE_2]),
+      this.onFlurryStrikeDamage,
+    );
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(talents.BLACK_OX_BREW_TALENT),
+      this.onBoBCast,
+    );
+  }
+
+  private onApply(event: ApplyBuffEvent | RefreshBuffEvent): void {
+    const newBuff: ShadowBuffData = {
+      apply: event,
+      flurryHits: 0,
+      bobUsed: false,
+      offset: this.recentFlurryStrikes,
+    };
+    this.shadowBuffs.push(newBuff);
+    this.activeShadowBuff = newBuff;
+  }
+
+  private onRemove(event: RemoveBuffEvent | FightEndEvent): void {
+    if (this.activeShadowBuff) {
+      this.activeShadowBuff.remove = event;
+    }
+    this.activeShadowBuff = undefined;
+  }
+
+  private onFlurryStrikeDamage(event: DamageEvent): void {
+    if (this.activeShadowBuff) {
+      this.activeShadowBuff.flurryHits += 1;
+    }
+
+    if (
+      this.mostRecentFlurryStrike &&
+      event.timestamp - this.mostRecentFlurryStrike.timestamp < RECENT_WINDOW
+    ) {
+      this.recentFlurryStrikes += 1;
+    } else {
+      this.recentFlurryStrikes = 1;
+    }
+
+    this.mostRecentFlurryStrike = event;
+  }
+
+  private onBoBCast(_event: CastEvent): void {
+    if (this.activeShadowBuff) {
+      this.activeShadowBuff.bobUsed = true;
+    }
+  }
+
+  get uses(): SpellUse[] {
+    return this.shadowBuffs.map((buff): SpellUse => {
+      const performance = evaluateQualitativePerformanceByThreshold({
+        actual: buff.flurryHits,
+        isGreaterThanOrEqual: {
+          perfect: 2.5 * HITS_PER_TRIGGER,
+          good: 2 * HITS_PER_TRIGGER,
+          ok: HITS_PER_TRIGGER,
+        },
+      });
+      const energySegment = this.deps.EnergyTracker.generateSegmentData(
+        buff.apply.timestamp,
+        buff.remove!.timestamp,
+      );
+      const disconnectWarning =
+        buff.flurryHits < Math.floor(energySegment.spent / SPEND_PER_TRIGGER) * HITS_PER_TRIGGER;
+      return {
+        event: buff.apply,
+        performance,
+        performanceExplanation: `${performance}`,
+        checklistItems: [
+          createChecklistItem(
+            'flurrystrike_hits',
+            { event: buff.apply },
+            {
+              performance: disconnectWarning ? QualitativePerformance.Fail : performance,
+              summary: (
+                <div>
+                  {buff.flurryHits} <SpellLink spell={talents.FLURRY_STRIKES_TALENT} /> hits
+                </div>
+              ),
+              details: (
+                <>
+                  You had <strong>{buff.flurryHits} hits</strong> within the buff. You should always
+                  fit at least 1 full <SpellLink spell={talents.FLURRY_STRIKES_TALENT} /> (
+                  {HITS_PER_TRIGGER} hits) into a Shadow buff. Getting 2 is good. It is possible to
+                  get 3, but pursuing a 3rd trigger can result in a damage loss.
+                  {disconnectWarning && (
+                    <div>
+                      <strong>You had fewer hits than expected for the Energy spent.</strong> This
+                      can happen if you trigger <SpellLink spell={talents.FLURRY_STRIKES_TALENT} />{' '}
+                      without being in range of a target, or leave range during the trigger.
+                    </div>
+                  )}
+                </>
+              ),
+            },
+          ),
+          createChecklistItem(
+            'flurrystrike_energy',
+            { event: buff.apply },
+            {
+              performance: evaluateQualitativePerformanceByThreshold({
+                actual: energySegment.spent,
+                isGreaterThanOrEqual: {
+                  perfect: 3 * SPEND_PER_TRIGGER,
+                  good: 2 * SPEND_PER_TRIGGER,
+                  ok: SPEND_PER_TRIGGER,
+                },
+              }),
+              summary: (
+                <div>
+                  {energySegment.spent} <ResourceLink id={RESOURCE_TYPES.ENERGY.id} /> spent
+                </div>
+              ),
+              details: (
+                <>
+                  You spent {energySegment.spent} <ResourceLink id={RESOURCE_TYPES.ENERGY.id} />{' '}
+                  during <SpellLink spell={SPELLS.WOTW_SHADOW_BUFF} />. You get 1{' '}
+                  <SpellLink spell={talents.FLURRY_STRIKES_TALENT} /> trigger per{' '}
+                  <strong>{SPEND_PER_TRIGGER}</strong> Energy.
+                </>
+              ),
+            },
+          ),
+          createChecklistItem(
+            'flurrystrike_bob',
+            { event: buff.apply },
+            {
+              performance: buff.bobUsed ? QualitativePerformance.Good : QualitativePerformance.Ok,
+              summary: (
+                <div>
+                  <SpellLink spell={talents.BLACK_OX_BREW_TALENT} /> used
+                </div>
+              ),
+              details: buff.bobUsed ? (
+                <>
+                  <SpellLink spell={talents.BLACK_OX_BREW_TALENT} /> was used during{' '}
+                  <SpellLink spell={SPELLS.WOTW_SHADOW_BUFF} />, giving additional energy to use for{' '}
+                  <SpellLink spell={talents.FLURRY_STRIKES_TALENT} />. It is not worth holding{' '}
+                  <SpellLink spell={talents.BLACK_OX_BREW_TALENT}>BoB</SpellLink> for this, but if
+                  it lines up it is helpful to get more triggers.
+                </>
+              ) : (
+                <>
+                  <SpellLink spell={talents.BLACK_OX_BREW_TALENT} /> was not used during{' '}
+                  <SpellLink spell={SPELLS.WOTW_SHADOW_BUFF} />. It is not worth holding{' '}
+                  <SpellLink spell={talents.BLACK_OX_BREW_TALENT}>BoB</SpellLink> for this, but if
+                  it lines up it is helpful to get more triggers.
+                </>
+              ),
+            },
+          ),
+          createChecklistItem(
+            'flurrystrike_offset',
+            { event: buff.apply },
+            {
+              performance:
+                buff.offset <= 3 ? QualitativePerformance.Good : QualitativePerformance.Ok,
+              summary: (
+                <div>
+                  <SpellLink spell={SPELLS.WOTW_SHADOW_BUFF} /> triggered on the{' '}
+                  {formatNth(buff.offset)} hit
+                </div>
+              ),
+              details: (
+                <>
+                  <SpellLink spell={SPELLS.WOTW_SHADOW_BUFF} /> triggered on hit {buff.offset} / 10.
+                  This statistic is purely informative for players that are trying to use{' '}
+                  <em>offsetting</em>.
+                </>
+              ),
+            },
+          ),
+        ].filter((v): v is ChecklistUsageInfo => Boolean(v)),
+      };
+    });
+  }
+}

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -1020,6 +1020,18 @@ const spells = {
     name: "Veteran's Eye",
     icon: 'ability_monk_provoke.jpg',
   },
+  WOTW_SHADOW_BUFF: {
+    ...talents.WISDOM_OF_THE_WALL_TALENT,
+    id: 452688,
+  },
+  FLURRY_STRIKES_DAMAGE_1: {
+    ...talents.FLURRY_STRIKES_TALENT,
+    id: 450620,
+  },
+  FLURRY_STRIKES_DAMAGE_2: {
+    ...talents.FLURRY_STRIKES_TALENT,
+    id: 450617,
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/parser/core/SpellUsage/SpellUsageSubSection.tsx
+++ b/src/parser/core/SpellUsage/SpellUsageSubSection.tsx
@@ -6,6 +6,7 @@ import {
   ReactNode,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 import ExplanationRow from 'interface/guide/components/ExplanationRow';
@@ -13,7 +14,7 @@ import Explanation from 'interface/guide/components/Explanation';
 import { TooltipElement } from 'interface';
 import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
 
-import { SpellUse, useSpellUsageContext } from './core';
+import { SpellUse, spellUseToBoxRowEntry, useSpellUsageContext } from './core';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { formatDuration } from 'common/format';
@@ -194,7 +195,7 @@ type SpellUsageSubSectionProps = Omit<ComponentPropsWithoutRef<typeof SubSection
   wideExplanation?: boolean;
   castBreakdownSmallText?: ReactNode;
   explanation: ReactNode;
-  performances: BoxRowEntry[];
+  performances?: BoxRowEntry[];
   uses: SpellUse[];
   onPerformanceBoxClick?: (use: SpellUse | undefined) => void;
   spellUseToPerformance?: (use: SpellUse) => BoxRowEntry;
@@ -213,7 +214,7 @@ const SpellUsageSubSection = ({
   wideExplanation,
   castBreakdownSmallText,
   explanation,
-  performances,
+  performances: rawPerformances,
   uses,
   onPerformanceBoxClick,
   spellUseToPerformance,
@@ -224,6 +225,10 @@ const SpellUsageSubSection = ({
   const [selectedUse, setSelectedUse] = useState<number | undefined>();
   const { hideGoodCasts } = useSpellUsageContext();
   const info = useInfo();
+
+  const performances = useMemo(() => {
+    return rawPerformances ?? uses.map((v) => spellUseToBoxRowEntry(v, info?.fightStart ?? 0));
+  }, [rawPerformances, uses, info?.fightStart]);
 
   const onClickBox = useCallback(
     (index) => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fc7e50a7-be4c-4708-86b9-0c4d2caca651)

long overdue. this adds energy tracking and shadow buff details for Shado-Pan brewmaster monks.

Master of Harmony is incoming but incomplete.