### PR TITLE
[Warrior] [Arms] [Fury] Remove Storm Bolt suggestion and fix Brutal Finish buff application event

### DIFF
--- a/src/analysis/retail/warrior/arms/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/arms/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { change, date } from 'common/changelog';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 5, 6), 'Remove Storm Bolt suggestion', Nevdok),
   change(date(2025, 3, 22), 'Update APL with support for Ravager Slayer', Nevdok),
   change(date(2025, 3, 1), 'Update config to reflect 11.1 support', Nevdok),
   change(date(2025, 2, 24), 'Update Arms APL for 11.1', Nevdok),

--- a/src/analysis/retail/warrior/arms/modules/Abilities.ts
+++ b/src/analysis/retail/warrior/arms/modules/Abilities.ts
@@ -331,7 +331,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         castEfficiency: {
-          suggestion: true,
+          suggestion: false,
           recommendedEfficiency: 0.4,
           extraSuggestion:
             "If you're picking a utility talent over something that increases your mobility or survivability, you better use it.",

--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { Nevdok, nullDozzer } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2025, 5, 6), 'Remove Storm Bolt suggestion, fix Brutal Finish buff event', Nevdok),
   change(date(2025, 3, 22), 'Update Whirlwind suggestions', Nevdok),
   change(date(2025, 3, 1), 'Update config to reflect 11.1 support', Nevdok),
   change(date(2025, 2, 25), 'Update rotation recommendations for 11.1', Nevdok),

--- a/src/analysis/retail/warrior/fury/CombatLogParser.ts
+++ b/src/analysis/retail/warrior/fury/CombatLogParser.ts
@@ -36,6 +36,7 @@ import SuddenDeath from './modules/talents/SuddenDeath';
 import Warpaint from './modules/talents/Warpaint';
 import Channeling from 'parser/shared/normalizers/Channeling';
 import WhirlwindBuffOrderNormalizer from './modules/normalizers/WhirlwindBuffOrderNormalizer';
+import BrutalFinishBuffNormalizer from './modules/normalizers/BrutalFinishBuffNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -49,6 +50,7 @@ class CombatLogParser extends CoreCombatLogParser {
     rageGenerationEventLinkNormalizer: RageGenerationEventLinkNormalizer,
     unhingedBloodthirstNormalizer: UnhingedBloodthirstNormalizer,
     whirlwindBuffOrderNormalizer: WhirlwindBuffOrderNormalizer,
+    brutalFinishBuffNormalizer: BrutalFinishBuffNormalizer,
 
     enrageRefreshNormalizer: EnrageRefreshNormalizer,
     enrageBeforeBloodthirst: EnrageBeforeBloodthirst,

--- a/src/analysis/retail/warrior/fury/modules/Abilities.ts
+++ b/src/analysis/retail/warrior/fury/modules/Abilities.ts
@@ -273,7 +273,7 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         castEfficiency: {
-          suggestion: true,
+          suggestion: false,
           recommendedEfficiency: 0.4,
           extraSuggestion:
             "If you're picking a utility talent over something that increases your mobility or survivability, you better use it.",

--- a/src/analysis/retail/warrior/fury/modules/normalizers/BrutalFinishBuffNormalizer.tsx
+++ b/src/analysis/retail/warrior/fury/modules/normalizers/BrutalFinishBuffNormalizer.tsx
@@ -1,0 +1,59 @@
+import SPELLS from 'common/SPELLS';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { AnyEvent, EventType, GetRelatedEvent, HasRelatedEvent } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+
+/**
+ * Brutal Finish is a buff that is applied when Bladestorm is finished channeling
+ * But that buff doesn't actually get applied for 100-200ms after the bladestorm finishes
+ * so it's possible for the player to queue up a spell to cast in that 100-200ms window
+ * and any checks on that cast event related to having the Brutal Finish buff or not are incorrect
+ *
+ * This normalizer links the Brutal Finish buff apply events to the Bladestorm end event which
+ * applied it, and replaces the buff apply event so that it's effectively applied instantly
+ *
+ * Sample report: /report/FwpATytC4fjR1YMn/22-Heroic+Sprocketmonger+Lockenstock+-+Kill+(4:25)/Nesquik/standard/timeline - the Raging Blow at 2:31 was previously flagged as incorrect because the cast event happens between the Bladestorm
+ * end event and the Brutal Finish apply event
+ */
+
+const BRUTAL_FINISH_ON_BLADESTORM_END = 'Brutal-Finish-On-Bladestorm-End';
+const BLADESTORM_BUFF_END_BUFFER_MS = 200; // Brutal Finish buff is applied 100-200ms after Bladestorm ends
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: BRUTAL_FINISH_ON_BLADESTORM_END,
+    linkingEventId: SPELLS.BRUTAL_FINISH_BUFF.id,
+    linkingEventType: EventType.ApplyBuff,
+    referencedEventId: SPELLS.BLADESTORM.id,
+    referencedEventType: EventType.RemoveBuff,
+    forwardBufferMs: BLADESTORM_BUFF_END_BUFFER_MS,
+    backwardBufferMs: BLADESTORM_BUFF_END_BUFFER_MS,
+    anyTarget: true,
+  },
+];
+
+class BrutalFinishBuffNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+
+  normalize(rawEvents: AnyEvent[]): AnyEvent[] {
+    const events = super.normalize(rawEvents);
+
+    events.forEach((event, index) => {
+      if (
+        event.type === EventType.ApplyBuff &&
+        HasRelatedEvent(event, BRUTAL_FINISH_ON_BLADESTORM_END)
+      ) {
+        const bladestormEndEvent = GetRelatedEvent(event, BRUTAL_FINISH_ON_BLADESTORM_END);
+        events.splice(index, 1); // remove original Brutal Finish buff apply event
+        event.timestamp = bladestormEndEvent?.timestamp || event.timestamp; // replace BF buff apply timestamp with BS end
+        event.__modified = true;
+        events.push(event); // add modified event back in
+      }
+    });
+    return events;
+  }
+}
+
+export default BrutalFinishBuffNormalizer;


### PR DESCRIPTION
### Description

- Remove Storm Bolt suggestion; this is _technically_ part of the APL, but it's almost 0 damage and people have been confused frequently why it was being suggested to use a stun on raid bosses
- Use a normalizer to fix the timestamp of the Brutal Finish buff being applied relative to the end of the Bladestorm which applied it. This fixes spells being flagged as inefficient which were queued between the Bladestorm end event and the Brutal Finish apply event.

### Testing

- Test report URL: `/report/FwpATytC4fjR1YMn/22-Heroic+Sprocketmonger+Lockenstock+-+Kill+(4:25)/Nesquik/standard/timeline`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/c519ca0a-a927-412b-b282-d00f868534df)
![image](https://github.com/user-attachments/assets/f420ebc8-d295-43da-952d-a6400ae1d95e)
