### PR TITLE
Mage: add HYPERTHERMIA_BUFF for heating up.

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2667,3 +2667,9 @@ export const Ceric: Contributor = {
     },
   ],
 };
+
+export const DarkDiver: Contributor = {
+  nickname: 'DarkDiver',
+  github: 'sandreenko',
+  discord: 'darkdiver93',
+};

--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -2,10 +2,11 @@ import TALENTS from 'common/TALENTS/mage';
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'interface/SpellLink';
 import { change, date } from 'common/changelog';
-import { Sharrq, Earosselot, Vollmer } from 'CONTRIBUTORS';
+import { Sharrq, Earosselot, Vollmer, DarkDiver } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2025, 5, 9), <>Add HYPERTHERMIA_BUFF in addition to HYPERTHERMIA_TALENT.</>, DarkDiver),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 4, 20), <>Added Defensives to Guide</>, Earosselot),
   change(date(2024, 11, 22), <>Removed Checklist.</>, Sharrq),

--- a/src/analysis/retail/mage/fire/core/HeatingUp.tsx
+++ b/src/analysis/retail/mage/fire/core/HeatingUp.tsx
@@ -67,6 +67,8 @@ export default class HeatingUp extends Analyzer {
       buff = { active: true, buffId: TALENTS.COMBUSTION_TALENT.id };
     } else if (this.selectedCombatant.hasBuff(TALENTS.HYPERTHERMIA_TALENT.id)) {
       buff = { active: true, buffId: TALENTS.HYPERTHERMIA_TALENT.id };
+    } else if (this.selectedCombatant.hasBuff(SPELLS.HYPERTHERMIA_BUFF.id)) {
+      buff = { active: true, buffId: SPELLS.HYPERTHERMIA_BUFF.id };
     } else {
       buff = { active: false };
     }


### PR DESCRIPTION
Before only HYPERTHERMIA_TALENT was added.

### Description
The missing HYPERTHERMIA_BUFF was causing casts of IB/PF during HYPERTHERMIA to be treated as mistakes (not converting heating up to hot streak!).

https://discord.com/channels/122270271095832576/788104496604512287/1369893475868217487

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->
For this report: https://wowanalyzer.com/report/jAxGJvQBdmWYtgqb/6-Heroic+One-Armed+Bandit+-+Kill+(4:23)/Darkdiver/standard/overview
Heating Up before: Bad casts 17 -> after 13.

- Test report URL: `/report/...`
- Screenshot(s):
![Screenshot 2025-05-08 235833](https://github.com/user-attachments/assets/b6075e72-5904-4a5b-a6bb-406e7e8d918d)
