### PR TITLE
Fix Jade Empowerment Refresh Event

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { emallson, swirl, Trevor, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 5, 14), <>Fixed method for checking wasted buffs on <SpellLink spell={TALENTS_MONK.JADE_EMPOWERMENT_TALENT}/>.</>, swirl),
   change(date(2025, 5, 10), <>Added <SpellLink spell={TALENTS_MONK.SECRET_INFUSION_TALENT}/> performance and <SpellLink spell={SPELLS.ANCIENT_TEACHINGS}/> healing per use into <SpellLink spell={TALENTS_MONK.JADE_EMPOWERMENT_TALENT}/> module.</>, swirl),
   change(date(2025, 4, 23), <>Fixed bug in Cast Performance of <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT}/>,</>, Vohrr),
   change(date(2025, 4, 15), <>Add buff uptime to <SpellLink spell={TALENTS_MONK.RUSHING_WIND_KICK_TALENT}/> guide module</>, Trevor),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/JadeEmpowerment.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/JadeEmpowerment.tsx
@@ -6,7 +6,7 @@ import { explanationAndDataSubsection } from 'interface/guide/components/Explana
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
-  RefreshBuffEvent,
+  CastEvent,
   HealEvent,
   BeginChannelEvent,
   EndChannelEvent,
@@ -44,8 +44,8 @@ class JadeEmpowerment extends Analyzer {
     ]);
 
     this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.JADE_EMPOWERMENT_BUFF),
-      this.onRefresh,
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT),
+      this.checkForRefresh,
     );
     this.addEventListener(
       Events.BeginChannel.by(SELECTED_PLAYER).spell(SPELLS.CRACKLING_JADE_LIGHTNING),
@@ -151,8 +151,10 @@ class JadeEmpowerment extends Analyzer {
     }
   }
 
-  onRefresh(event: RefreshBuffEvent) {
-    this.wastedCharges += 1;
+  checkForRefresh(event: CastEvent) {
+    if (this.selectedCombatant.getBuffStacks(SPELLS.JADE_EMPOWERMENT_BUFF) == 2) {
+      this.wastedCharges += 1;
+    }
   }
 
   onCastEnd(event: RemoveBuffEvent | RemoveBuffStackEvent | EndChannelEvent) {


### PR DESCRIPTION
### Description

Jade Empowerment doesn't send refresh events (or any event, even) if casting Thunder Focus Tea at 2 stacks of Jade Empowerment. 
Changed the method of checking for refreshes by instead looking at buff stacks of Jade Empowerment on Thunder Focus Tea casts.
![image](https://github.com/user-attachments/assets/f055e16b-2e0d-4d10-9cfa-c4aeac529c19)


### Testing

Test report URL: `/report/yprVTGkQXaWRz1nL/1-Mythic++Operation:+Floodgate+-+Kill+(28:23)/Liviomonk/standard/about`

55 Thunder Focus Tea casts to 47 Crackling Jade Lightning casts
![image](https://github.com/user-attachments/assets/ce1af0c7-3f06-423b-b1ab-3180e9f144c9)

Live:
![image](https://github.com/user-attachments/assets/e48d1e53-79da-4e44-b6c4-7c40bb75c6c3)

Fix:
![image](https://github.com/user-attachments/assets/97516749-44ef-4dae-b750-3fd57eacb33c)

[WCL Query](https://www.warcraftlogs.com/reports/yprVTGkQXaWRz1nL?fight=last&type=casts&source=1&pins=2%24Off%24%23909049%24expression%24in+range+from+type%3D"applybuffstack"+and+ability.id+%3D+467317+and+stack+>+1+to+type+in+%28"removebuff"%2C+"removebuffstack"%29+and+ability.id%3D467317+end&ability=116680):
![image](https://github.com/user-attachments/assets/f6ac2469-64f7-4bc1-b8c6-901fc22416ee)

