### PR TITLE
Fix Critical Hits for Healing and Damage

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -37,12 +37,14 @@ import {
   KYZ,
   oneunreadmail,
   Ceric,
+  swirl,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 5, 16), <>Fix number of critical hits not being calculated.</>, swirl),
   change(date(2025, 5, 2), 'All Gems now show on Character Doll', Ceric),
   change(date(2025, 4, 27), 'Recommended Gems now show to the User if setup', Ceric),
   change(date(2025, 4, 25), 'Fix Azjol-Nerub special case for Armory Link', Ceric),

--- a/src/parser/shared/modules/AbilityTracker.ts
+++ b/src/parser/shared/modules/AbilityTracker.ts
@@ -121,6 +121,7 @@ class HealingTracker extends AbilityTracker {
     cast.healingHits = cast.healingHits + 1;
     cast.healingVal = cast.healingVal.addEvent(event);
     if (event.type === EventType.Heal && event.hitType === HIT_TYPES.CRIT) {
+      cast.healingCriticalHits += 1;
       cast.healingCriticalVal = cast.healingCriticalVal.addEvent(event);
     }
   }
@@ -139,6 +140,7 @@ class DamageTracker extends HealingTracker {
     cast.damageHits = cast.damageHits + 1;
     cast.damageVal = cast.damageVal.addEvent(event);
     if (event.hitType === HIT_TYPES.CRIT) {
+      cast.damageCriticalHits += 1;
       cast.damageCriticalVal = cast.damageCriticalVal.addEvent(event);
     }
   }


### PR DESCRIPTION
### Description

A change made in October removed critical hits being calculated under the Ability Tracker for both healing and damage, so I've readded it.

### Testing

- Test report URL: `/report/kfnwY1ydMJ6pBbTm/12-Mythic+Chrome+King+Gallywix+-+Kill+(9:32)/Qtkushi/standard/statistics`
- [Log crit percentages](https://www.warcraftlogs.com/reports/kfnwY1ydMJ6pBbTm/?fight=12&source=21&type=healing&ability=25914&by=source)
- Screenshot(s):

Live:
![image](https://github.com/user-attachments/assets/71b31266-75d9-46ba-9bf1-3ee045827337)

Fix:
![image](https://github.com/user-attachments/assets/e29f7f3d-099e-4e04-b7af-473f7c63b0a9)
