### PR TITLE
[Arcane Mage] Sunfury APL first iteration

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { change, date } from 'common/changelog';
 import { Sharrq, Sref, Earosselot } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2025, 5, 21), <>Arcane Sunfury APL</>, Earosselot),
   change(date(2025, 4, 20), <>Added Defensives to Guide</>, Earosselot),
   change(date(2024, 11, 23), <>Updated Spec Support to 11.0.5 and updated Warning.</>, Sharrq),
   change(date(2024, 11, 23), <>Fixed an issue that was preventing the Cast Delay from showing if <SpellLink spell={TALENTS.ARCANE_MISSILES_TALENT} /> ended at the exact same timestamp as the next cast (0 Delay).</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/Guide.tsx
+++ b/src/analysis/retail/mage/arcane/Guide.tsx
@@ -13,6 +13,7 @@ import ManaLevelGraph from './ManaChart/TabComponent/ManaLevelGraph';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import MajorDefensives from 'src/analysis/retail/mage/shared/defensives/DefensivesGuide';
+import AplGuideSubsection from './apl/AplGuideSection';
 
 export const GUIDE_CORE_EXPLANATION_PERCENT = 50;
 
@@ -143,6 +144,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           modules.shiftingPowerGuide.guideSubsection}
         {info.combatant.hasTalent(TALENTS.SUPERNOVA_TALENT) &&
           modules.supernovaGuide.guideSubsection}
+        <AplGuideSubsection info={info} />
       </Section>
 
       <Section title="Buffs & Procs">

--- a/src/analysis/retail/mage/arcane/SPELLS.ts
+++ b/src/analysis/retail/mage/arcane/SPELLS.ts
@@ -128,7 +128,7 @@ const spells = {
     icon: 'inv_soulbarrier',
   },
   INTUITION_BUFF: {
-    id: 455681,
+    id: 1223797,
     name: 'Intuition',
     icon: 'spell_shadow_brainwash',
   },

--- a/src/analysis/retail/mage/arcane/apl/AplGuideSection.tsx
+++ b/src/analysis/retail/mage/arcane/apl/AplGuideSection.tsx
@@ -1,0 +1,17 @@
+import { SubSection } from 'interface/guide';
+import { AplSectionData } from 'interface/guide/components/Apl';
+import { Info } from 'parser/core/metric';
+
+import TALENTS from 'common/TALENTS/mage';
+
+import * as sfApl from 'src/analysis/retail/mage/arcane/apl/SunfuryAplCheck';
+
+export default function AplGuideSubsection({ info }: { info: Info }) {
+  return (
+    <SubSection title="Action Priority List (APL)">
+      {info.combatant.hasTalent(TALENTS.MEMORY_OF_ALAR_TALENT) && (
+        <AplSectionData checker={sfApl.sunfuryCheck} apl={sfApl.sunfuryApl} />
+      )}
+    </SubSection>
+  );
+}

--- a/src/analysis/retail/mage/arcane/apl/SunfuryAplCheck.tsx
+++ b/src/analysis/retail/mage/arcane/apl/SunfuryAplCheck.tsx
@@ -1,0 +1,107 @@
+import aplCheck, { build } from 'parser/shared/metrics/apl';
+import SpellLink from 'interface/SpellLink';
+import { tenseAlt } from 'parser/shared/metrics/apl';
+
+import * as cnd from 'parser/shared/metrics/apl/conditions';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+
+import TALENTS from 'common/TALENTS/mage';
+import SPELLS from 'common/SPELLS';
+
+// Wowhead APL for Arcane Mage, [between brackets changes or things not taken into account].
+
+export const sunfuryApl = build([
+  // 1. Arcane Missiles if you have 3x Clearcasting, [clip this off the GCD no matter what,
+  // but always cast Arcane Barrage on the last GCD of Arcane Soul/Added the Arcane Soul
+  // condition to match actual raidbots APL].
+  {
+    spell: TALENTS.ARCANE_MISSILES_TALENT,
+    condition: cnd.and(
+      cnd.buffStacks(SPELLS.CLEARCASTING_ARCANE, { atLeast: 3 }),
+      cnd.buffMissing(SPELLS.NETHER_PRECISION_BUFF),
+      cnd.buffPresent(SPELLS.ARCANE_SOUL_BUFF),
+    ),
+  },
+  // 2. Arcane Barrage if you have Arcane Soul.
+  {
+    spell: SPELLS.ARCANE_BARRAGE,
+    condition: cnd.buffPresent(SPELLS.ARCANE_SOUL_BUFF),
+  },
+  // 3. Arcane Barrage if Intuition or Arcane Tempo [will expire before your next cast completes/
+  // will expire in less than 2 seconds].
+  {
+    spell: SPELLS.ARCANE_BARRAGE,
+    condition: cnd.or(
+      cnd.buffPresent(SPELLS.INTUITION_BUFF),
+      cnd.buffRemaining(SPELLS.ARCANE_TEMPO_BUFF, 12000, { atMost: 1000 }),
+    ),
+  },
+
+  // [Shifting Power after  Arcane Soul ends].
+  // [Arcane Missiles with  Aether Attunement if Touch of the Magi is about to come off cooldown,
+  // you should clip this off the GCD to enter  Touch of the Magi as quickly as possible.]
+  // 4. [Arcane Barrage if Touch of the Magi is about to come off cooldown, this is not in WoWhead APL but
+  // it is in the raidbots APL, so I added it here. Otherwise all barrage into touch were taken as bad casts.]
+  {
+    spell: SPELLS.ARCANE_BARRAGE,
+    condition: cnd.or(
+      cnd.spellCooldownRemaining(TALENTS.TOUCH_OF_THE_MAGI_TALENT, { atMost: 1000 }),
+      cnd.spellAvailable(TALENTS.TOUCH_OF_THE_MAGI_TALENT),
+    ),
+  },
+
+  // 5. Arcane Orb whenever you have less than 3x Arcane Charges.
+  {
+    spell: SPELLS.ARCANE_ORB,
+    condition: cnd.hasResource(RESOURCE_TYPES.ARCANE_CHARGES, { atLeast: 0, atMost: 2 }),
+  },
+
+  // 6. Arcane Missiles with Clearcasting when you don't have Nether Precision,
+  // [clip this off the GCD unless you have  Aether Attunement proc].
+  {
+    spell: TALENTS.ARCANE_MISSILES_TALENT,
+    condition: cnd.and(
+      cnd.buffPresent(SPELLS.CLEARCASTING_ARCANE),
+      cnd.buffMissing(SPELLS.NETHER_PRECISION_BUFF),
+    ),
+  },
+
+  // 7. Arcane Barrage if you have either Intuition or Glorious Incandescence,
+  // [don't do this for  Glorious Incandescence if  Touch of the Magi is less than 6 seconds away/
+  // Added the BoP condition to catch the cases when we queue a Barrage after BoP, then GI timespan is
+  // almost 0 and it was been treated as a bad cast].
+  {
+    spell: SPELLS.ARCANE_BARRAGE,
+    condition: cnd.describe(
+      cnd.or(
+        cnd.buffPresent(SPELLS.INTUITION_BUFF, 500),
+        cnd.buffPresent(SPELLS.GLORIOUS_INCANDESCENCE_BUFF, 500),
+        cnd.buffPresent(SPELLS.BURDEN_OF_POWER_BUFF),
+      ),
+      (tense) => (
+        <>
+          <SpellLink spell={SPELLS.INTUITION_BUFF} /> or{' '}
+          <SpellLink spell={SPELLS.GLORIOUS_INCANDESCENCE_BUFF} /> {tenseAlt(tense, 'is', 'was')}{' '}
+          present
+        </>
+      ),
+    ),
+  },
+
+  // 8. Arcane Explosion if you have less than 2 charges, yep.
+  {
+    spell: SPELLS.ARCANE_EXPLOSION,
+    condition: cnd.hasResource(RESOURCE_TYPES.ARCANE_CHARGES, { atLeast: 0, atMost: 2 }),
+  },
+
+  // 9. Arcane Blast.
+  {
+    spell: SPELLS.ARCANE_BLAST,
+    condition: cnd.hasResource(RESOURCE_TYPES.MANA, { atLeast: 10 }),
+  },
+
+  // 10. Arcane Barrage if you run out of mana.
+  SPELLS.ARCANE_BARRAGE,
+]);
+
+export const sunfuryCheck = aplCheck(sunfuryApl);

--- a/src/analysis/retail/mage/arcane/apl/SunfuryAplCheck.tsx
+++ b/src/analysis/retail/mage/arcane/apl/SunfuryAplCheck.tsx
@@ -75,7 +75,8 @@ export const sunfuryApl = build([
     condition: cnd.describe(
       cnd.or(
         cnd.buffPresent(SPELLS.INTUITION_BUFF, 500),
-        cnd.buffPresent(SPELLS.GLORIOUS_INCANDESCENCE_BUFF, 500),
+        // cnd.buffPresent(SPELLS.GLORIOUS_INCANDESCENCE_BUFF, 500),
+        cnd.buffPresent(SPELLS.GLORIOUS_INCANDESCENCE_BUFF, -200),
         cnd.buffPresent(SPELLS.BURDEN_OF_POWER_BUFF),
       ),
       (tense) => (

--- a/src/analysis/retail/mage/arcane/core/Buffs.tsx
+++ b/src/analysis/retail/mage/arcane/core/Buffs.tsx
@@ -63,7 +63,7 @@ class Buffs extends CoreAuras {
       {
         spellId: SPELLS.ARCANE_HARMONY_BUFF.id,
         enabled: combatant.hasTalent(TALENTS.ARCANE_HARMONY_TALENT),
-        timelineHighlight: true,
+        timelineHighlight: false,
       },
       {
         spellId: SPELLS.ARCANE_TEMPO_BUFF.id,
@@ -72,6 +72,21 @@ class Buffs extends CoreAuras {
       },
       {
         spellId: Object.keys(BLOODLUST_BUFFS).map((item) => Number(item)),
+        timelineHighlight: true,
+      },
+      {
+        spellId: SPELLS.INTUITION_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS.INTUITION_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: SPELLS.GLORIOUS_INCANDESCENCE_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS.GLORIOUS_INCANDESCENCE_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: SPELLS.ARCANE_SOUL_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS.MEMORY_OF_ALAR_TALENT),
         timelineHighlight: true,
       },
     ];


### PR DESCRIPTION
### Description
- First attempt to implement APL on Sunfury Arcane.
- Added Arcane Soul, Intuition and Glorious Incandescence to tracked buffs on the timeline.
- Changed Intuition Buff id (I think it waas the old one from the tierset)
- Removed Arcane Harmony as tracked buff on the timeline. I think this is very noisy and does not provide any information right now. You always gain AH when casting AM and you always lose it when Barrage...

- Issues: the Arcane Orb and Arcane Explosion conditions are not working. I think it has to do with the arcane charges condition. I think the APL is still useful witouth those condition, although it will be useful to fin a workaround to this.

### Testing

- Top report URL (no major problems): `report/yW7maX3KwMzdYN6L/29-Mythic+Sprocketmonger+Lockenstock+-+Kill+(4:59)/174-Solyoung/standard`
- Average report URL (some problems): `report/jxNymkMQ9CwvdpZr/5-Mythic+Vexie+and+the+Geargrinders+-+Kill+(6:18)/Räistlin/standard`
- Screenshot(s):
APL:
![image](https://github.com/user-attachments/assets/5d7fe707-9921-452e-8efa-2583edcd7ca7)

Timeline buffs:
![image](https://github.com/user-attachments/assets/a7d426bb-e467-4f35-9343-f62baf2bc8c4)
