### PR TITLE
issue 6969 demo warlock - vilefiend pet enhancements

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2715,3 +2715,16 @@ export const swirl: Contributor = {
     },
   ],
 };
+
+export const Leftyxiv: Contributor = {
+  nickname: 'Manny',
+  github: 'Leftyxiv',
+  discord: 'onearmmanny',
+  mains: [
+    {
+      name: 'Magicmushies',
+      spec: SPECS.DEMONOLOGY_WARLOCK,
+      link: 'https://www.warcraftlogs.com/character/us/area-52/magicmushies?zone=43',
+    },
+  ],
+};

--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -1,7 +1,7 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_WARLOCK } from 'common/TALENTS';
-import { Sharrq, Zeboot, Meldris, ToppleTheNun, Jonfanz, Mae, dodse, Arlie, Putro, Zyer, Gazh} from 'CONTRIBUTORS';
+import { Sharrq, Zeboot, Meldris, ToppleTheNun, Jonfanz, Mae, dodse, Arlie, Putro, Zyer, Gazh, Leftyxiv} from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [

--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Sharrq, Zeboot, Meldris, ToppleTheNun, Jonfanz, Mae, dodse, Arlie, Putr
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2025, 5, 24), <>Enhanced <SpellLink spell={SPELLS.CHARHOUND_SUMMON} /> and <SpellLink spell={SPELLS.GLOOMHOUND_SUMMON} /> tracking with cast efficiency, damage breakdown, and pet ability monitoring</>, Leftyxiv),
   change(date(2024, 10, 1), <>Add support for <SpellLink spell={SPELLS.DEMONIC_HEALTHSTONE} /> </>, Gazh),
   change(date(2024, 9, 28), <>Add support for <SpellLink spell={TALENTS_WARLOCK.MARK_OF_FHARG_TALENT}/> & <SpellLink spell={TALENTS_WARLOCK.MARK_OF_SHATUG_TALENT}/></>, Gazh),
   change(date(2024, 9, 26), "Add support for Hero Talents", Gazh),

--- a/src/analysis/retail/warlock/demonology/modules/talents/SummonVilefiend.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/talents/SummonVilefiend.tsx
@@ -1,6 +1,11 @@
+import { defineMessage } from '@lingui/core/macro';
 import { formatThousands } from 'common/format';
+import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
-import Analyzer, { Options } from 'parser/core/Analyzer';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
@@ -15,39 +20,228 @@ class SummonVilefiend extends Analyzer {
   };
 
   demoPets!: DemoPets;
-  damage = 0;
+
+  private vilefiendCasts = 0;
+  private charhoundCasts = 0;
+  private gloomhoundCasts = 0;
+
+  // Shared abilities (used by multiple pet types)
+  private totalBileSpitDamage = 0;
+  private totalHeadbuttDamage = 0;
+
+  private charhoundInfernalPresenceDamage = 0;
+  private gloomhoundGloomSlashDamage = 0;
 
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.SUMMON_VILEFIEND_TALENT);
+
+    if (!this.active) {
+      return;
+    }
+
+    // Track summon casts
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.SUMMON_VILEFIEND_TALENT),
+      this.onVilefiendCast,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.CHARHOUND_SUMMON),
+      this.onCharhoundCast,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.GLOOMHOUND_SUMMON),
+      this.onGloomhoundCast,
+    );
+
+    // Track pet ability damage
+    this.addEventListener(
+      Events.damage
+        .by(SELECTED_PLAYER_PET)
+        .spell([
+          SPELLS.VILEFIEND_BILE_SPIT,
+          SPELLS.VILEFIEND_HEADBUTT,
+          SPELLS.CHARHOUND_INFERNAL_PRESENCE,
+          SPELLS.GLOOMHOUND_GLOOM_SLASH,
+        ]),
+      this.onPetAbilityDamage,
+    );
+  }
+
+  private onVilefiendCast(event: CastEvent) {
+    this.vilefiendCasts++;
+  }
+
+  private onCharhoundCast(event: CastEvent) {
+    this.charhoundCasts++;
+  }
+
+  private onGloomhoundCast(event: CastEvent) {
+    this.gloomhoundCasts++;
+  }
+
+  private onPetAbilityDamage(event: DamageEvent) {
+    const damage = (event.amount || 0) + (event.absorbed || 0);
+
+    switch (event.ability.guid) {
+      case SPELLS.VILEFIEND_BILE_SPIT.id:
+        this.totalBileSpitDamage += damage;
+        break;
+      case SPELLS.VILEFIEND_HEADBUTT.id:
+        this.totalHeadbuttDamage += damage;
+        break;
+      case SPELLS.CHARHOUND_INFERNAL_PRESENCE.id:
+        this.charhoundInfernalPresenceDamage += damage;
+        break;
+      case SPELLS.GLOOMHOUND_GLOOM_SLASH.id:
+        this.gloomhoundGloomSlashDamage += damage;
+        break;
+    }
+  }
+
+  private get isCharhound() {
+    return this.selectedCombatant.hasTalent(TALENTS.MARK_OF_FHARG_TALENT);
+  }
+
+  private get isGloomhound() {
+    return this.selectedCombatant.hasTalent(TALENTS.MARK_OF_SHATUG_TALENT);
   }
 
   getCurrentPetGUID() {
-    return this.selectedCombatant.hasTalent(TALENTS.MARK_OF_FHARG_TALENT)
-      ? PETS.CHARHOUND.guid
-      : this.selectedCombatant.hasTalent(TALENTS.MARK_OF_SHATUG_TALENT)
-        ? PETS.GLOOMHOUND.guid
-        : PETS.VILEFIEND.guid;
+    if (this.isCharhound) return PETS.CHARHOUND.guid;
+    if (this.isGloomhound) return PETS.GLOOMHOUND.guid;
+    return PETS.VILEFIEND.guid;
   }
 
   getCurrentTalentUsed() {
-    return this.selectedCombatant.hasTalent(TALENTS.MARK_OF_FHARG_TALENT)
-      ? TALENTS.MARK_OF_FHARG_TALENT
-      : this.selectedCombatant.hasTalent(TALENTS.MARK_OF_SHATUG_TALENT)
-        ? TALENTS.MARK_OF_SHATUG_TALENT
-        : TALENTS.SUMMON_VILEFIEND_TALENT;
+    if (this.isCharhound) return TALENTS.MARK_OF_FHARG_TALENT;
+    if (this.isGloomhound) return TALENTS.MARK_OF_SHATUG_TALENT;
+    return TALENTS.SUMMON_VILEFIEND_TALENT;
+  }
+
+  getCurrentSpellUsed() {
+    if (this.isCharhound) return SPELLS.CHARHOUND_SUMMON;
+    if (this.isGloomhound) return SPELLS.GLOOMHOUND_SUMMON;
+    return TALENTS.SUMMON_VILEFIEND_TALENT;
+  }
+
+  getCurrentCastCount() {
+    if (this.isCharhound) return this.charhoundCasts;
+    if (this.isGloomhound) return this.gloomhoundCasts;
+    return this.vilefiendCasts;
+  }
+
+  getCurrentCooldown() {
+    // Charhound and Gloomhound have 30s cooldown, Vilefiend has 45s
+    return this.isCharhound || this.isGloomhound ? 30000 : 45000;
+  }
+
+  get suggestionThresholds() {
+    const totalCasts = this.getCurrentCastCount();
+    const cooldownMs = this.getCurrentCooldown();
+    const expectedCasts = Math.floor(this.owner.fightDuration / cooldownMs);
+    const efficiency = expectedCasts > 0 ? totalCasts / expectedCasts : 1;
+
+    return {
+      actual: efficiency,
+      isLessThan: {
+        minor: 0.9,
+        average: 0.8,
+        major: 0.7,
+      },
+      style: ThresholdStyle.PERCENTAGE,
+    };
+  }
+
+  suggestions(when: When) {
+    const spellUsed = this.getCurrentSpellUsed();
+    const cooldownSec = this.getCurrentCooldown() / 1000;
+
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) =>
+      suggest(
+        <>
+          You can improve your <SpellLink spell={spellUsed} /> cast efficiency. This is a{' '}
+          {cooldownSec}-second cooldown that provides significant damage and should be used
+          consistently throughout the fight.
+        </>,
+      )
+        .icon(spellUsed.icon)
+        .actual(
+          defineMessage({
+            id: 'warlock.demonology.suggestions.summonvilefiend.efficiency',
+            message: `${Math.round(actual * 100)}% cast efficiency`,
+          }),
+        )
+        .recommended(`>${Math.round(recommended * 100)}% is recommended`),
+    );
   }
 
   statistic() {
     const damage = this.demoPets.getPetDamage(this.getCurrentPetGUID());
+    const castCount = this.getCurrentCastCount();
+    const spellUsed = this.getCurrentSpellUsed();
+
+    const abilityBreakdown: JSX.Element[] = [];
+
+    if (this.isCharhound) {
+      // Charhound unique abilities
+      if (this.charhoundInfernalPresenceDamage > 0) {
+        abilityBreakdown.push(
+          <div key="infernalPresence">
+            Infernal Presence: {formatThousands(this.charhoundInfernalPresenceDamage)}
+          </div>,
+        );
+      }
+    } else if (this.isGloomhound) {
+      // Gloomhound unique abilities
+      if (this.gloomhoundGloomSlashDamage > 0) {
+        abilityBreakdown.push(
+          <div key="slash">Gloom Slash: {formatThousands(this.gloomhoundGloomSlashDamage)}</div>,
+        );
+      }
+    }
+
+    // Add shared abilities (Bile Spit and Headbutt) for all pet types
+    if (this.totalBileSpitDamage > 0) {
+      abilityBreakdown.push(
+        <div key="bile">Bile Spit: {formatThousands(this.totalBileSpitDamage)}</div>,
+      );
+    }
+    if (this.totalHeadbuttDamage > 0) {
+      abilityBreakdown.push(
+        <div key="headbutt">Headbutt: {formatThousands(this.totalHeadbuttDamage)}</div>,
+      );
+    }
+
     return (
       <Statistic
         category={STATISTIC_CATEGORY.TALENTS}
         size="flexible"
-        tooltip={`${formatThousands(damage)} damage`}
+        tooltip={
+          <>
+            {formatThousands(damage)} total damage
+            <br />
+            {castCount} summons cast
+            {abilityBreakdown.length > 0 && (
+              <>
+                <br />
+                <strong>Pet Abilities:</strong>
+                {abilityBreakdown}
+              </>
+            )}
+          </>
+        }
       >
-        <BoringSpellValueText spell={this.getCurrentTalentUsed()}>
-          <ItemDamageDone amount={damage} />
+        <BoringSpellValueText spell={spellUsed}>
+          {(this.isCharhound || this.isGloomhound) && (
+            <small>
+              <SpellLink spell={this.getCurrentTalentUsed()} />
+            </small>
+          )}
+          <div>
+            <ItemDamageDone amount={damage} />
+          </div>
+          {castCount} <small>summons</small>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -469,10 +469,20 @@ const spells = {
     name: 'Summon Charhound',
     icon: 'inv_felhound3_shadow_fire',
   },
+  CHARHOUND_INFERNAL_PRESENCE: {
+    id: 428455,
+    name: 'Infernal Presence',
+    icon: 'spell_fire_meteorstorm',
+  },
   GLOOMHOUND_SUMMON: {
     id: 455465,
     name: 'Summon Gloomhound',
     icon: 'inv_felhound3_shadow_mount',
+  },
+  GLOOMHOUND_GLOOM_SLASH: {
+    id: 455491,
+    name: 'Gloom Slash',
+    icon: 'ability_rogue_shadowstrike',
   },
   IMP_SINGE_MAGIC: {
     id: 119905,


### PR DESCRIPTION
## Description

Enhanced Demonology Warlock pet support for **Gloomhounds** and **Charhounds** in WoW Analyzer with comprehensive ability tracking and improved UI.

### Key Changes:

**🐕 Enhanced Pet Support:**
- Added comprehensive tracking for **Charhound** (Mark of F'harg) and **Gloomhound** (Mark of Shatug) variants
- Added missing pet ability spell IDs discovered from real combat log analysis

**📊 Detailed Ability Tracking:**
- Individual pet ability damage tracking with tooltip breakdown:
  - **Charhound**: Infernal Presence, Bile Spit, Headbutt  
  - **Gloomhound**: Gloom Slash, Bile Spit, Headbutt
  - **Vilefiend**: Bile Spit, Headbutt
- Combined damage tracking for shared abilities (Bile Spit/Headbutt) across all pet types

**🎯 Cast Efficiency & Suggestions:**
- Dynamic cooldown tracking (30s for hounds, 45s for Vilefiend)
- Tailored cast efficiency suggestions based on active pet variant
- Proper spell/talent recognition for each pet type

**🖼️ UI Improvements:**
- Dynamic statistic display showing active pet variant  
- Talent links displayed under summon abilities (Mark of F'harg/Shatug)
- Enhanced tooltips with individual ability damage breakdown

**📝 Spell Additions:**
- Added `CHARHOUND_INFERNAL_PRESENCE` (428455) 
- Added `GLOOMHOUND_GLOOM_SLASH` (455491)
- Updated CHANGELOG with new features

## Testing

**🔍 Manual Testing Steps:**

1. **Load a Demonology Warlock log** with different pet variants:
   - **Vilefiend only**: Default Summon Vilefiend without hound talents
   - **Charhound**: With Mark of F'harg talent selected  
   - **Gloomhound**: With Mark of Shatug talent selected

2. **Verify Statistic Display:**
   - Check the tile shows correct spell name ("Summon Vilefiend/Charhound/Gloomhound")
   - Confirm talent link appears under hound variants (Mark of F'harg/Shatug)
   - Verify damage numbers and cast counts are accurate

3. **Test Tooltip Breakdown:**
   - Hover over statistic to view tooltip
   - Confirm individual pet abilities are listed with damage amounts:
     - Charhound: Should show "Infernal Presence" at top, then shared abilities
     - Gloomhound: Should show "Gloom Slash" first, then shared abilities  
     - Vilefiend: Should show only "Bile Spit" and "Headbutt"

4. **Verify Cast Efficiency:**
   - Check suggestions tab for cast efficiency warnings
   - Confirm cooldown calculations (30s for hounds, 45s for Vilefiend)

**📋 Test Cases:**
- ✅ **Charhound log**: `GrtgwL4zJTN29jRF` (Mark of F'harg)
- ✅ **Gloomhound log**: `vmWZBPMf34GdbyhC` fight 28 (Mark of Shatug)
- ✅ Test with baseline Vilefiend builds
- ✅ Verify no console errors or missing spell references

**🎯 Expected Results:**
- All pet variants display correctly with appropriate icons/names
- Ability damage tracking works for all spell IDs
- UI shows relevant talent information
- Cast efficiency suggestions adapt to pet type


- Test report URL: Charhound https://www.warcraftlogs.com/reports/GrtgwL4zJTN29jRF?fight=2&type=damage-done&source=2
gloomhound: https://www.warcraftlogs.com/reports/vmWZBPMf34GdbyhC?fight=22&type=damage-done&source=2
- Screenshot(s):
![gloomhoundtooltip](https://github.com/user-attachments/assets/8cbad6b2-db25-444e-97f9-a0542a263678)
![charhoundtooltip](https://github.com/user-attachments/assets/0f613e1e-b8de-4cd1-819a-472f47a09361)
