### PR TITLE
Revisited Horrific Visions Enchant suggestions

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -44,6 +44,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 6, 4),<>Add Horrific Vision enchants suggestions.</>, Vetyst),
   change(date(2025, 6, 3),<>Mark <ItemLink id={ITEMS.COUNCILS_GUILE_R3.id} />, <ItemLink id={ITEMS.OATHSWORNS_TENACITY_R3.id} />, <ItemLink id={ITEMS.STONEBOUND_ARTISTRY_R3.id} />, and <ItemLink id={ITEMS.STORMRIDERS_FURY_R3.id} /> as max rank enchants</>, Vollmer),
   change(date(2025, 5, 30), 'Add WCL user sign-in & private logs support', Vollmer),
   change(date(2025, 5, 23), 'Regenerate talents for 11.1.5', Vollmer),

--- a/src/common/ITEMS/thewarwithin/enchants.ts
+++ b/src/common/ITEMS/thewarwithin/enchants.ts
@@ -1104,6 +1104,81 @@ const enchants = {
   },
   // #endregion
 
+  // #region TWW - Revisited Horrific Visions
+  LESSER_TWILIGHT_DEVASTATION: {
+    id: 1225074,
+    name: 'Lesser Rune of Twilight Devastation',
+    icon: 'inv_inscription_minorglyph12',
+    effectId: 7912,
+  },
+  GREATER_TWILIGHT_DEVASTATION: {
+    id: 1233223,
+    name: 'Greater Rune of Twilight Devastation',
+    icon: 'inv_inscription_majorglyph12',
+    effectId: 7914,
+  },
+  LESSER_ECHOING_VOID: {
+    id: 1233355,
+    name: 'Lesser Rune of the Echoing Void',
+    icon: 'inv_inscription_minorglyph02',
+    effectId: 7915,
+  },
+  GREATER_ECHOING_VOID: {
+    id: 1225873,
+    name: 'Greater Rune of the Echoing Void',
+    icon: 'inv_inscription_majorglyph02',
+    effectId: 7917,
+  },
+  LESSER_INFINITE_STARS: {
+    id: 1233375,
+    name: 'Lesser Rune of Infinite Stars',
+    icon: 'inv_inscription_minorglyph03',
+    effectId: 7922,
+  },
+  GREATER_INFINITE_STARS: {
+    id: 1227206,
+    name: 'Greater Rune of Infinite Stars',
+    icon: 'inv_inscription_majorglyph03',
+    effectId: 7924,
+  },
+  LESSER_GUSHING_WOUND: {
+    id: 1233385,
+    name: 'Lesser Rune of Gushing Wound',
+    icon: 'inv_inscription_majorglyph01',
+    effectId: 7925,
+  },
+  GREATER_GUSHING_WOUND: {
+    id: 239086,
+    name: 'Greater Rune of Gushing Wound',
+    icon: 'inv_inscription_majorglyph01',
+    effectId: 7927,
+  },
+  LESSER_TWISTED_APPENDAGE: {
+    id: 1233392,
+    name: 'Lesser Rune of the Twisted Appendage',
+    icon: 'inv_inscription_minorglyph14',
+    effectId: 7928,
+  },
+  GREATER_TWISTED_APPENDAGE: {
+    id: 239090,
+    name: 'Greater Rune of the Twisted Appendage',
+    icon: 'inv_inscription_majorglyph14',
+    effectId: 7930,
+  },
+  LESSER_VOID_RITUAL: {
+    id: 1233394,
+    name: 'Lesser Rune of Echoing Void',
+    icon: 'inv_inscription_minorglyph20',
+    effectId: 7931,
+  },
+  GREATER_VOID_RITUAL: {
+    id: 1227311,
+    name: 'Greater Rune of Echoing Void',
+    icon: 'inv_inscription_majorglyph20',
+    effectId: 7933,
+  },
+  // #endregion
+
   /* Template */
   // X_R1: {
   //   id: 0,

--- a/src/interface/report/Results/PlayerInfo.tsx
+++ b/src/interface/report/Results/PlayerInfo.tsx
@@ -44,7 +44,6 @@ const PlayerInfo = ({ combatant }: Props) => {
   const gear: Item[] = _parseGear(combatant._combatantInfo.gear);
   const talents = combatant._combatantInfo.talentTree;
   const averageIlvl = getAverageItemLevel(gear);
-  console.log(combatant.characterProfile);
   const classBackground = combatant.characterProfile?.class
     ? classBackgroundImage(
         CLASS_NAMES[combatant.characterProfile?.class].name,

--- a/src/interface/report/Results/enchantIdMap.ts
+++ b/src/interface/report/Results/enchantIdMap.ts
@@ -3,6 +3,8 @@
     - Enchanting
     - Engineering
     - Tailoring
+
+  Rough source: https://wago.tools/db2/SpellItemEnchantment
 */
 
 const enchantIdMap: Record<number, string> = {
@@ -349,6 +351,21 @@ const enchantIdMap: Record<number, string> = {
   7599: '+650 Agility/Strength & +625 Stamina',
   7600: '+790 Agility/Strength & +760 Stamina',
   7601: '+930 Agility/Strength & +895 Stamina',
+
+  // #region TWW - Revisited Horrific Visions
+  7912: 'Lesser Twilight Devastation',
+  7914: 'Greater Twilight Devastation',
+  7915: 'Lesser Echoing Void',
+  7917: 'Greater Echoing Void',
+  7922: 'Lesser Infinite Stars',
+  7924: 'Greater Infinite Stars',
+  7925: 'Lesser Gushing Wound',
+  7927: 'Greater Gushing Wound',
+  7928: 'Lesser Twisted Appendage',
+  7930: 'Greater Twisted Appendage',
+  7931: 'Lesser Void Ritual',
+  7933: 'Greater Void Ritual',
+  // #endregion
 };
 
 export default enchantIdMap;

--- a/src/parser/retail/modules/items/EnchantChecker.tsx
+++ b/src/parser/retail/modules/items/EnchantChecker.tsx
@@ -8,6 +8,7 @@ import BaseEnchantChecker from 'parser/shared/modules/items/EnchantChecker';
 // https://www.warcraftlogs.com/reports/ydxavfGq1mBrM9Vc/#fight=1&source=14
 
 const AGI_ENCHANTABLE_SLOTS = {
+  0: <Trans id="common.slots.head">Head</Trans>,
   4: <Trans id="common.slots.chest">Chest</Trans>,
   // 5: <Trans id="common.slots.belt">Belt</Trans>,
   6: <Trans id="common.slots.legs">Legs</Trans>,
@@ -21,6 +22,7 @@ const AGI_ENCHANTABLE_SLOTS = {
 };
 
 const STR_ENCHANTABLE_SLOTS = {
+  0: <Trans id="common.slots.head">Head</Trans>,
   4: <Trans id="common.slots.chest">Chest</Trans>,
   // 5: <Trans id="common.slots.belt">Belt</Trans>,
   6: <Trans id="common.slots.legs">Legs</Trans>,
@@ -34,6 +36,7 @@ const STR_ENCHANTABLE_SLOTS = {
 };
 
 const INT_ENCHANTABLE_SLOTS = {
+  0: <Trans id="common.slots.head">Head</Trans>,
   4: <Trans id="common.slots.chest">Chest</Trans>,
   // 5: <Trans id="common.slots.belt">Belt</Trans>,
   6: <Trans id="common.slots.legs">Legs</Trans>,
@@ -47,6 +50,15 @@ const INT_ENCHANTABLE_SLOTS = {
 };
 
 const MIN_ENCHANT_IDS = [
+  // #region Helm
+  ITEMS.LESSER_TWILIGHT_DEVASTATION.effectId,
+  ITEMS.LESSER_ECHOING_VOID.effectId,
+  ITEMS.LESSER_INFINITE_STARS.effectId,
+  ITEMS.LESSER_GUSHING_WOUND.effectId,
+  ITEMS.LESSER_TWISTED_APPENDAGE.effectId,
+  ITEMS.LESSER_VOID_RITUAL.effectId,
+  // #endregion
+
   // #region Chest
   ITEMS.COUNCILS_INTELLECT_R1.effectId,
   ITEMS.COUNCILS_INTELLECT_R2.effectId,
@@ -175,6 +187,15 @@ const MIN_ENCHANT_IDS = [
 ] as const satisfies number[];
 
 const MAX_ENCHANT_IDS = [
+  // #region Helm
+  ITEMS.GREATER_TWILIGHT_DEVASTATION.effectId,
+  ITEMS.GREATER_ECHOING_VOID.effectId,
+  ITEMS.GREATER_INFINITE_STARS.effectId,
+  ITEMS.GREATER_GUSHING_WOUND.effectId,
+  ITEMS.GREATER_TWISTED_APPENDAGE.effectId,
+  ITEMS.GREATER_VOID_RITUAL.effectId,
+  // #endregion
+
   // #region Chest
   ITEMS.COUNCILS_INTELLECT_R3.effectId,
   ITEMS.OATHSWORNS_STRENGTH_R3.effectId,


### PR DESCRIPTION
## Description

Added the horrific visions head enchants to all retail specs. As well as make it visible on the character tab
In addition i removed a console.log from the PlayerInfo module that i happen to forget to remove months ago 😅 

![image](https://github.com/user-attachments/assets/aee82875-5564-44a1-a961-2158c65ffb63)

## Testing

### Missing Rune
report: /report/cgbvxAzZFXPDfBTR/1-Heroic+Chrome+King+Gallywix+-+Kill+(7:35)/Hollywoodun/standard/overview

![image](https://github.com/user-attachments/assets/50fdc917-9d19-469e-948f-a18a65e9d51b)

### Lesser Rune
report: /report/cgbvxAzZFXPDfBTR/1-Heroic+Chrome+King+Gallywix+-+Kill+(7:35)/Repena/standard/overview

![image](https://github.com/user-attachments/assets/7ba247be-b1b5-45c3-b4c9-ad01305cc156)

### Greater Rune
report: /report/cgbvxAzZFXPDfBTR/1-Heroic+Chrome+King+Gallywix+-+Kill+(7:35)/Malborger/standard/overview

![image](https://github.com/user-attachments/assets/7da0f841-b86d-4d48-a6d5-b635d53ca6fd)

### Missing Rune on old version
report: /report/cgbvxAzZFXPDfBTR/1-Heroic+Chrome+King+Gallywix+-+Kill+(7:35)/Hollywoodun/standard/overview

![image](https://github.com/user-attachments/assets/ad3c2185-4df0-490a-abc5-6a418c1c89d1)

