### PR TITLE
Update patch compatibility and remove warning message for frost mage

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -119,6 +119,10 @@ export const ab: Contributor = {
   nickname: 'ab',
   github: 'alex-bau',
 };
+export const applebiscuit: Contributor = {
+  nickname: 'applebiscuit',
+  github: 'omegabiscuit',
+};
 export const blazyb: Contributor = {
   nickname: 'blazyb',
   github: 'buimichael',

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -119,9 +119,9 @@ export const ab: Contributor = {
   nickname: 'ab',
   github: 'alex-bau',
 };
-export const applebiscuit: Contributor = {
-  nickname: 'applebiscuit',
-  github: 'omegabiscuit',
+export const Applebiscuit: Contributor = {
+  nickname: 'Applebiscuit',
+  github: 'Omegabiscuit',
 };
 export const blazyb: Contributor = {
   nickname: 'blazyb',

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -119,8 +119,8 @@ export const ab: Contributor = {
   nickname: 'ab',
   github: 'alex-bau',
 };
-export const Applebiscuit: Contributor = {
-  nickname: 'Applebiscuit',
+export const Brigadoon: Contributor = {
+  nickname: 'Brigadoon',
   github: 'Omegabiscuit',
 };
 export const blazyb: Contributor = {

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -1,11 +1,11 @@
 import { change, date } from 'common/changelog';
 import { SpellLink } from 'interface';
-import { Sharrq, Earosselot, Soulhealer95, Vollmer, Applebiscuit } from 'CONTRIBUTORS';
+import { Sharrq, Earosselot, Soulhealer95, Vollmer, Brigadoon } from 'CONTRIBUTORS';
 import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore
 export default [
-  change(date(2025, 6, 7), <>Update Path Compatibility Version</>, Applebiscuit),
+  change(date(2025, 6, 7), <>Update Path Compatibility Version</>, Brigadoon),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 4, 20), <>Added Defensives to Guide</>, Earosselot),
   change(date(2025, 4, 11), <>Fixed <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} /> shattered evaluation</>, Earosselot),

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore
 export default [
+  change(date(2025, 6, 7), <>Update Path Compatibility Version</>, Applebiscuit),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 4, 20), <>Added Defensives to Guide</>, Earosselot),
   change(date(2025, 4, 11), <>Fixed <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} /> shattered evaluation</>, Earosselot),

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore
 export default [
-  change(date(2025, 6, 7), <>Update Path Compatibility Version</>, Brigadoon),
+  change(date(2025, 6, 7), <>Update Patch Compatibility Version</>, Brigadoon),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 4, 20), <>Added Defensives to Guide</>, Earosselot),
   change(date(2025, 4, 11), <>Fixed <SpellLink spell={TALENTS.GLACIAL_SPIKE_TALENT} /> shattered evaluation</>, Earosselot),

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -1,6 +1,6 @@
 import { change, date } from 'common/changelog';
 import { SpellLink } from 'interface';
-import { Sharrq, Earosselot, Soulhealer95, Vollmer } from 'CONTRIBUTORS';
+import { Sharrq, Earosselot, Soulhealer95, Vollmer, Applebiscuit } from 'CONTRIBUTORS';
 import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -1,6 +1,6 @@
 import { change, date } from 'common/changelog';
 import { SpellLink } from 'interface';
-import { Sharrq, Earosselot, Soulhealer95, Vollmer, Applebiscuit } from 'CONTRIBUTORS';
+import { Sharrq, Earosselot, Soulhealer95, Vollmer } from 'CONTRIBUTORS';
 import TALENTS from 'common/TALENTS/mage';
 
 // prettier-ignore

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -3,7 +3,6 @@ import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
 import CHANGELOG from './CHANGELOG';
-import AlertWarning from 'interface/AlertWarning';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Sharrq, Earosselot],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '11.0.0',
+  patchCompatibility: '11.1.5',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -42,15 +42,6 @@ const config: Config = {
   pages: {
     overview: {
       frontmatterType: 'guide',
-      notes: (
-        <AlertWarning>
-          This analysis is a Work in Progress. Some minor changes have been added for Frost, but
-          there are still things that have yet to be implemented or added. Once Blizzard stops
-          changing things every week, and once the theorycrafters finish running numbers, then I
-          will update this. Apologies for the delays, I promise I am working on it. Ping me in the
-          Mage Discord if you have questions about this. <code>@Sharrq</code>
-        </AlertWarning>
-      ),
     },
   },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.


### PR DESCRIPTION
### Description

Frost mage appears to be up to date with the latest patch. This change is updating the patch compatibility from 11.0.0 to 11.1.5

### Testing
Viewing logs of a frost mage in 11.1.5. The message warning the user that spec is out of date should not appear.

- Test report URL: `/report/...`
- Screenshot(s):
Before
![image](https://github.com/user-attachments/assets/305cea9c-b8c1-4a60-955d-2c40aced2f94)

After
![image](https://github.com/user-attachments/assets/7f732570-d250-4f66-9a76-2c4d67008a27)

