### PR TITLE
Fix Soul Strike overcapping tracking for Demonology Warlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ coverage/*
 
 # #vitest/ui
 html/
+src/analysis/retail/warlock/demonology/modules/resources/SoulShardTracker.test.tsx

--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,3 @@ coverage/*
 
 # #vitest/ui
 html/
-src/analysis/retail/warlock/demonology/modules/resources/SoulShardTracker.test.tsx

--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Sharrq, Zeboot, Meldris, ToppleTheNun, Jonfanz, Mae, dodse, Arlie, Putr
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2025, 6, 7), <>Fixed <SpellLink spell={TALENTS_WARLOCK.SOUL_STRIKE_TALENT}/> to properly display wasted soul shards when overcapped</>, Leftyxiv),
   change(date(2024, 6, 5), <>Add statistics for <SpellLink spell={TALENTS_WARLOCK.THE_HOUNDMASTERS_GAMBIT_TALENT}/> dreadstalker damage while vilefiend is active and <SpellLink spell={TALENTS_WARLOCK.WICKED_MAW_TALENT}/>/<SpellLink spell={TALENTS_WARLOCK.SHADOWTOUCHED_TALENT}/> damage increase</>, Leftyxiv),
   change(date(2025, 5, 24), <>Enhanced <SpellLink spell={SPELLS.CHARHOUND_SUMMON} /> and <SpellLink spell={SPELLS.GLOOMHOUND_SUMMON} /> tracking with cast efficiency, damage breakdown, and pet ability monitoring</>, Leftyxiv),
   change(date(2025, 5, 23), <>Implemented <SpellLink spell={SPELLS.DOOM_DEBUFF} /> tracking - monitors uptime, damage, and application rate for the new Doom talent</>, Leftyxiv),

--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -6,7 +6,7 @@ import { SpellLink } from 'interface';
 
 export default [
   change(date(2025, 6, 7), <>Fixed <SpellLink spell={TALENTS_WARLOCK.SOUL_STRIKE_TALENT}/> to properly display wasted soul shards when overcapped</>, Leftyxiv),
-  change(date(2024, 6, 5), <>Add statistics for <SpellLink spell={TALENTS_WARLOCK.THE_HOUNDMASTERS_GAMBIT_TALENT}/> dreadstalker damage while vilefiend is active and <SpellLink spell={TALENTS_WARLOCK.WICKED_MAW_TALENT}/>/<SpellLink spell={TALENTS_WARLOCK.SHADOWTOUCHED_TALENT}/> damage increase</>, Leftyxiv),
+  change(date(2025, 6, 5), <>Add statistics for <SpellLink spell={TALENTS_WARLOCK.THE_HOUNDMASTERS_GAMBIT_TALENT}/> dreadstalker damage while vilefiend is active and <SpellLink spell={TALENTS_WARLOCK.WICKED_MAW_TALENT}/>/<SpellLink spell={TALENTS_WARLOCK.SHADOWTOUCHED_TALENT}/> damage increase</>, Leftyxiv),
   change(date(2025, 5, 24), <>Enhanced <SpellLink spell={SPELLS.CHARHOUND_SUMMON} /> and <SpellLink spell={SPELLS.GLOOMHOUND_SUMMON} /> tracking with cast efficiency, damage breakdown, and pet ability monitoring</>, Leftyxiv),
   change(date(2025, 5, 23), <>Implemented <SpellLink spell={SPELLS.DOOM_DEBUFF} /> tracking - monitors uptime, damage, and application rate for the new Doom talent</>, Leftyxiv),
   change(date(2024, 10, 1), <>Add support for <SpellLink spell={SPELLS.DEMONIC_HEALTHSTONE} /> </>, Gazh),

--- a/src/analysis/retail/warlock/demonology/CONFIG.tsx
+++ b/src/analysis/retail/warlock/demonology/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Zyer, Gazh } from 'CONTRIBUTORS';
+import { Zyer, Gazh, Leftyxiv } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
@@ -7,10 +7,10 @@ import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Zyer, Gazh],
+  contributors: [Zyer, Gazh, Leftyxiv],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '11.0.2',
+  patchCompatibility: '11.1.5',
   supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/warlock/demonology/modules/resources/SoulShardTracker.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/resources/SoulShardTracker.tsx
@@ -42,11 +42,13 @@ class SoulShardTracker extends ResourceTracker {
   }
 
   getAdjustedGain(event: ResourceChangeEvent): { gain: number; waste: number } {
-    const { gain, waste } = super.getAdjustedGain(event);
-    return {
-      gain: gain / 10,
-      waste: waste / 10,
-    };
+    // The parent class calculates gain as (resourceChange - waste)
+    // But we need to work with the raw values from the event
+    const waste = event.waste / 10;
+    const totalChange = event.resourceChange / 10;
+    const gain = totalChange - waste;
+
+    return { gain, waste };
   }
 }
 

--- a/src/analysis/retail/warlock/demonology/modules/resources/SoulShardTracker.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/resources/SoulShardTracker.tsx
@@ -1,13 +1,22 @@
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { Options } from 'parser/core/Analyzer';
-import { CastEvent } from 'parser/core/Events';
+import { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
 import ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
 
 class SoulShardTracker extends ResourceTracker {
   constructor(options: Options) {
     super(options);
     this.resource = RESOURCE_TYPES.SOUL_SHARDS;
+  }
+
+  onEnergize(event: ResourceChangeEvent) {
+    const classResources = this.getResource(event);
+    if (classResources) {
+      classResources.amount /= 10;
+      classResources.max /= 10;
+    }
+    super.onEnergize(event);
   }
 
   onCast(event: CastEvent) {
@@ -30,6 +39,14 @@ class SoulShardTracker extends ResourceTracker {
       cost -= 1;
     }
     return cost;
+  }
+
+  getAdjustedGain(event: ResourceChangeEvent): { gain: number; waste: number } {
+    const { gain, waste } = super.getAdjustedGain(event);
+    return {
+      gain: gain / 10,
+      waste: waste / 10,
+    };
   }
 }
 

--- a/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
@@ -2,11 +2,12 @@ import { formatThousands } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 import Analyzer, { Options, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
-import Events, { DamageEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 import SoulShardTracker from '../resources/SoulShardTracker';
 
@@ -17,6 +18,8 @@ class SoulStrike extends Analyzer {
 
   soulShardTracker!: SoulShardTracker;
   damage = 0;
+  totalCasts = 0;
+  wastedShards = 0;
 
   constructor(options: Options) {
     super(options);
@@ -25,15 +28,33 @@ class SoulStrike extends Analyzer {
       Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.SOUL_STRIKE_DAMAGE),
       this.handleSoulStrikeDamage,
     );
+    this.addEventListener(
+      Events.resourcechange.by(SELECTED_PLAYER_PET).spell(SPELLS.SOUL_STRIKE_SHARD_GEN),
+      this.handleSoulStrikeShardGen,
+    );
   }
 
   handleSoulStrikeDamage(event: DamageEvent) {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
+  handleSoulStrikeShardGen(event: ResourceChangeEvent) {
+    if (event.resourceChangeType === RESOURCE_TYPES.SOUL_SHARDS.id) {
+      this.totalCasts += 1;
+
+      // Check if player was at shard cap (5 shards = 50 fragments)
+      // The event shows the state AFTER the resource change, so we need to check if waste > 0
+      if (event.waste > 0) {
+        this.wastedShards += 1;
+      }
+    }
+  }
+
+  get shardsGenerated() {
+    return this.totalCasts;
+  }
+
   statistic() {
-    const shardsGained = this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_STRIKE_SHARD_GEN.id);
-    const shardsWasted = this.soulShardTracker.getWastedBySpell(SPELLS.SOUL_STRIKE_SHARD_GEN.id);
     return (
       <Statistic
         category={STATISTIC_CATEGORY.TALENTS}
@@ -41,18 +62,20 @@ class SoulStrike extends Analyzer {
         tooltip={
           <ul>
             <li>{formatThousands(this.damage)} damage</li>
-            {shardsWasted > 0 && (
-              <li>{shardsWasted.toFixed(1)} shards wasted due to overcapping</li>
-            )}
+            {this.wastedShards > 0 && <li>{this.wastedShards} shards wasted due to overcapping</li>}
           </ul>
         }
       >
         <BoringSpellValueText spell={TALENTS.SOUL_STRIKE_TALENT}>
           <ItemDamageDone amount={this.damage} />
           <ul>
-            <li>{shardsGained} <small>Shards generated</small></li>
-            {shardsWasted > 0 && (
-              <li>{shardsWasted.toFixed(1)} <small>Shards wasted</small></li>
+            <li>
+              {this.shardsGenerated} <small>shards generated</small>
+            </li>
+            {this.wastedShards > 0 && (
+              <li>
+                {this.wastedShards} <small>shards wasted</small>
+              </li>
             )}
           </ul>
         </BoringSpellValueText>

--- a/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
@@ -33,16 +33,34 @@ class SoulStrike extends Analyzer {
 
   statistic() {
     const shardsGained = this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_STRIKE_SHARD_GEN.id);
+    const shardsWasted = this.soulShardTracker.getWastedBySpell(SPELLS.SOUL_STRIKE_SHARD_GEN.id);
     return (
       <Statistic
         category={STATISTIC_CATEGORY.TALENTS}
         size="flexible"
-        tooltip={`${formatThousands(this.damage)} damage`}
+        tooltip={
+          <>
+            {formatThousands(this.damage)} damage
+            <br />
+            {shardsWasted > 0 && (
+              <>
+                <br />
+                {shardsWasted.toFixed(1)} shards wasted due to overcapping
+              </>
+            )}
+          </>
+        }
       >
         <BoringSpellValueText spell={TALENTS.SOUL_STRIKE_TALENT}>
           <ItemDamageDone amount={this.damage} />
           <br />
           {shardsGained} <small>Shards generated</small>
+          {shardsWasted > 0 && (
+            <>
+              <br />
+              {shardsWasted.toFixed(1)} <small>Shards wasted</small>
+            </>
+          )}
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
@@ -41,7 +41,6 @@ class SoulStrike extends Analyzer {
   handleSoulStrikeShardGen(event: ResourceChangeEvent) {
     if (event.resourceChangeType === RESOURCE_TYPES.SOUL_SHARDS.id) {
       this.totalCasts += 1;
-
       // Check if player was at shard cap (5 shards = 50 fragments)
       // The event shows the state AFTER the resource change, so we need to check if waste > 0
       if (event.waste > 0) {

--- a/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
@@ -39,28 +39,22 @@ class SoulStrike extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         size="flexible"
         tooltip={
-          <>
-            {formatThousands(this.damage)} damage
-            <br />
+          <ul>
+            <li>{formatThousands(this.damage)} damage</li>
             {shardsWasted > 0 && (
-              <>
-                <br />
-                {shardsWasted.toFixed(1)} shards wasted due to overcapping
-              </>
+              <li>{shardsWasted.toFixed(1)} shards wasted due to overcapping</li>
             )}
-          </>
+          </ul>
         }
       >
         <BoringSpellValueText spell={TALENTS.SOUL_STRIKE_TALENT}>
           <ItemDamageDone amount={this.damage} />
-          <br />
-          {shardsGained} <small>Shards generated</small>
-          {shardsWasted > 0 && (
-            <>
-              <br />
-              {shardsWasted.toFixed(1)} <small>Shards wasted</small>
-            </>
-          )}
+          <ul>
+            <li>{shardsGained} <small>Shards generated</small></li>
+            {shardsWasted > 0 && (
+              <li>{shardsWasted.toFixed(1)} <small>Shards wasted</small></li>
+            )}
+          </ul>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
@@ -41,10 +41,11 @@ class SoulStrike extends Analyzer {
   handleSoulStrikeShardGen(event: ResourceChangeEvent) {
     if (event.resourceChangeType === RESOURCE_TYPES.SOUL_SHARDS.id) {
       this.totalCasts += 1;
-      // Check if player was at shard cap (5 shards = 50 fragments)
-      // The event shows the state AFTER the resource change, so we need to check if waste > 0
+
+      // Convert waste from fragments (tenths) to whole shards
+      // Each shard = 10 fragments, so divide by 10
       if (event.waste > 0) {
-        this.wastedShards += 1;
+        this.wastedShards += event.waste / 10;
       }
     }
   }


### PR DESCRIPTION
## Summary
- Fixed Soul Strike talent to properly display wasted soul shards when overcapped
- Updated Demonology Warlock patch compatibility to 11.1.5

## Changes
### Soul Strike Module (`SoulStrike.tsx`)
- Enhanced the statistic display to show wasted shards in the main statistics box

### Resource Tracking (`SoulShardTracker.tsx`)
- Added `onEnergize` method to handle resource gain events with proper decimal conversion
- Added `getAdjustedGain` method to convert gain/waste values from WoW's internal format (0-50) to player format (0-5)
- Ensures consistent handling of the `/10` conversion for soul shard values

### Patch Compatibility
- Updated from 11.0.2 to 11.1.5 to match current patch

## Test plan
- [x] Verify Soul Strike statistic displays generated shards correctly
- [x] Verify wasted shards appear when overcapping occurs
- [x] Verify wasted shards don't appear when no overcapping occurs
- [x] Check that values display correctly (e.g., 2 shards wasted)

## Screenshot
The Soul Strike statistic will now show:
```
Soul Strike
[damage amount]
[X] Shards generated
[Y] Shards wasted (only if Y > 0)
```

With tooltip showing additional overcapping details when hovering.

![Screenshot 2025-06-08 at 6 21 17 AM](https://github.com/user-attachments/assets/622d3f38-ad69-412e-9d8d-25f598ee169f)
![Screenshot 2025-06-08 at 6 21 10 AM](https://github.com/user-attachments/assets/8644b2c9-59e7-47f7-acd8-92725c73ee3e)

If I'm not mistaken this should also close out issue#6969