### PR TITLE
Update Spellthread enchant mapping

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -44,6 +44,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 6, 8),<>Updated visual appearance of gained stats for <ItemLink id={ITEMS.SUNSET_SPELLTHREAD_R3.id} />, <ItemLink id={ITEMS.WEAVERCLOTH_SPELLTHREAD_R3.id} />, and <ItemLink id={ITEMS.DAYBREAK_SPELLTHREAD_R3.id} /> enchants on the character info tab.</>, Vetyst),
   change(date(2025, 6, 5),<>Replaced deprecated package `react-minimalist-portal` used to create tooltips.</>, Vetyst),
   change(date(2025, 6, 4),<>Add Horrific Vision enchants suggestions.</>, Vetyst),
   change(date(2025, 6, 3),<>Mark <ItemLink id={ITEMS.COUNCILS_GUILE_R3.id} />, <ItemLink id={ITEMS.OATHSWORNS_TENACITY_R3.id} />, <ItemLink id={ITEMS.STONEBOUND_ARTISTRY_R3.id} />, and <ItemLink id={ITEMS.STORMRIDERS_FURY_R3.id} /> as max rank enchants</>, Vollmer),

--- a/src/interface/report/Results/enchantIdMap.ts
+++ b/src/interface/report/Results/enchantIdMap.ts
@@ -319,7 +319,7 @@ const enchantIdMap: Record<number, string> = {
   7462: 'Authority of Radiant Power',
   7463: 'Authority of Radiant Power',
 
-  7467: '-80 Haste & +270 Critical Strike',
+  7468: '-80 Haste & +270 Critical Strike',
   7469: '-100 Haste & +335 Critical Strike',
   7470: '-115 Haste & +390 Critical Strike',
   7471: '-80 Versatility & +270 Haste',
@@ -332,15 +332,15 @@ const enchantIdMap: Record<number, string> = {
   7478: '-100 Critical Strike & +335 Mastery',
   7479: '-115 Critical Strike & +390 Mastery',
 
-  7530: '+670 Intellect & +4% Mana',
-  7531: '+747 Intellect & +5% Mana',
-
-  7533: '+670 Intellect & +211 Stamina',
-  7534: '+747 Intellect & +230 Stamina',
-
-  7535: '+479 Intellect',
-  7536: '+536 Intellect',
-  7537: '+593 Intellect',
+  7529: '+650 Intellect & +3% Mana',
+  7530: '+790 Intellect & +4% Mana',
+  7531: '+930 Intellect & +5% Mana',
+  7532: '+650 Intellect & +625 Stamina',
+  7533: '+790 Intellect & +760 Stamina',
+  7534: '+930 Intellect & +895 Stamina',
+  7535: '+430 Intellect',
+  7536: '+525 Intellect',
+  7537: '+620 Intellect',
 
   7593: '+650 Agility/Strength & +690 Armor',
   7594: '+790 Agility/Strength & +835 Armor',


### PR DESCRIPTION
### Description

Noticed that some enchant stats were incorrectly displayed on the character info tab. 

### Testing

Report: /report/rJ6XdqypPkYBQwz8/29-Mythic+Rik+Reverb+-+Kill+(4:19)/Tatooíne/standard/character

Before:
![image](https://github.com/user-attachments/assets/a3d41535-53a0-495c-9f4b-73de68cb5391)

After:
![image](https://github.com/user-attachments/assets/4c28deff-decc-4e05-bc6c-aeb65fa291b3)
