### PR TITLE
Move Dracthyr glide from Evoker to be a racial ability

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -44,6 +44,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 6, 8),<>Move <SpellLink spell={SPELLS.GLIDE_DRACTHYR.id} /> from Evoker's spellbook to Dracthyr's racial spellbook.</>, Vetyst),
   change(date(2025, 6, 5),<>Replaced deprecated package `react-minimalist-portal` used to create tooltips.</>, Vetyst),
   change(date(2025, 6, 4),<>Add Horrific Vision enchants suggestions.</>, Vetyst),
   change(date(2025, 6, 3),<>Mark <ItemLink id={ITEMS.COUNCILS_GUILE_R3.id} />, <ItemLink id={ITEMS.OATHSWORNS_TENACITY_R3.id} />, <ItemLink id={ITEMS.STONEBOUND_ARTISTRY_R3.id} />, and <ItemLink id={ITEMS.STORMRIDERS_FURY_R3.id} /> as max rank enchants</>, Vollmer),

--- a/src/analysis/retail/evoker/shared/modules/Abilities.tsx
+++ b/src/analysis/retail/evoker/shared/modules/Abilities.tsx
@@ -319,11 +319,6 @@ class Abilities extends CoreAbilities {
         },
         enabled: combatant.hasTalent(TALENTS.SOURCE_OF_MAGIC_TALENT),
       },
-      {
-        spell: SPELLS.GLIDE_EVOKER.id,
-        category: SPELL_CATEGORY.OTHERS,
-        gcd: null,
-      },
       //endregion
     ];
   }

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -377,11 +377,6 @@ const spells = {
     name: 'Iridescence: Red',
     icon: 'inv_enchant_shardradientsmall',
   },
-  GLIDE_EVOKER: {
-    id: 358733,
-    name: 'Glide',
-    icon: 'ability_racial_glide',
-  },
   LEAPING_FLAMES_BUFF: {
     id: 370901,
     name: 'Leaping Flames',

--- a/src/common/SPELLS/racials.ts
+++ b/src/common/SPELLS/racials.ts
@@ -326,6 +326,11 @@ const spells = {
     name: 'Awakened',
     icon: 'ability_racial_awakened',
   },
+  GLIDE_DRACTHYR: {
+    id: 358733,
+    name: 'Glide',
+    icon: 'ability_racial_glide',
+  },
   // Earthen
   AZERITE_SURGE: {
     id: 436344,

--- a/src/parser/shared/modules/racials/OtherRacials.ts
+++ b/src/parser/shared/modules/racials/OtherRacials.ts
@@ -166,6 +166,15 @@ class OtherRacials extends Analyzer.withDependencies({
           },
         });
         break;
+      case RACES.DracthyrAlliance:
+      case RACES.DracthyrHorde:
+        this.deps.abilities.add({
+          spell: SPELLS.GLIDE_DRACTHYR.id,
+          category: SPELL_CATEGORY.OTHERS,
+          cooldown: 1,
+          gcd: null,
+        });
+        break;
     }
   }
 }


### PR DESCRIPTION
### Description

Noticed that Dracthyr races didnt have the Glide ability in their spellbook. Moved it from Evoker to Dracthyr.

### Testing

Report non-evoker: /report/rJ6XdqypPkYBQwz8/29-Mythic+Rik+Reverb+-+Kill+(4:19)/Tatoo%C3%ADne/standard/statistics
Report evoker: /report/rJ6XdqypPkYBQwz8/29-Mythic+Rik+Reverb+-+Kill+(4:19)/Apcihba/standard/statistics

![image](https://github.com/user-attachments/assets/da364a63-9b9e-4948-aa25-e0d8e3b94427)
