### PR TITLE
Fix validateDomNesting warning for Gem Preperation checklist

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -44,6 +44,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 6, 8),<>Fix validateDomNesting warning for Gem Preperation checklist.</>, Vetyst),
   change(date(2025, 6, 8),<>Move <SpellLink spell={SPELLS.GLIDE_DRACTHYR.id} /> from Evoker's spellbook to Dracthyr's racial spellbook.</>, Vetyst),
   change(date(2025, 6, 5),<>Replaced deprecated package `react-minimalist-portal` used to create tooltips.</>, Vetyst),
   change(date(2025, 6, 4),<>Add Horrific Vision enchants suggestions.</>, Vetyst),

--- a/src/interface/guide/components/Preparation/GemSubSection/index.tsx
+++ b/src/interface/guide/components/Preparation/GemSubSection/index.tsx
@@ -18,10 +18,8 @@ const GemSubSection = ({ recommendedGems }: Props) => {
     <SubSection title="Gems">
       <p>
         <Trans id="interface.guide.preparation.gems.description">
-          <div>
-            Gems can increase a variety of stats. This indicates gear where you are missing Gem
-            Sockets, don't have the highest crafted gems, or have empty sockets.
-          </div>
+          Gems can increase a variety of stats. This indicates gear where you are missing Gem
+          Sockets, don't have the highest crafted gems, or have empty sockets.
         </Trans>
       </p>
       <GemBoxRow values={gemChecker.getGemBoxRowEntries(recommendedGems)} />

--- a/src/localization/en/messages.json
+++ b/src/localization/en/messages.json
@@ -333,7 +333,7 @@
   "interface.common.errorBoundary.theError": "The error",
   "interface.guide.foundation.foundational-support": "Foundational Support",
   "interface.guide.foundation.foundational-support-desc": "Foundational support covers analysis of uptime, cancelled casts, cooldowns, and other core aspects of gameplay common across all specs.",
-  "interface.guide.preparation.gems.description": "<0>Gems can increase a variety of stats. This indicates gear where you are missing Gem Sockets, don't have the highest crafted gems, or have empty sockets.</0>",
+  "interface.guide.preparation.gems.description": "Gems can increase a variety of stats. This indicates gear where you are missing Gem Sockets, don't have the highest crafted gems, or have empty sockets.",
   "interface.guildReports.errors.details": "{0}<0/>Please message us on {DISCORD} or create an issue on {GITHUB} if this issue persists and we will fix it, eventually.",
   "interface.guildReports.errors.guildNotFound": "We couldn't find your guild on Warcraft Logs",
   "interface.guildReports.errors.guildNotFoundDetails": "Please check your input and make sure that you've selected the correct region and realm.<0/>If your input was correct, then make sure that someone in your raid logged the fight for you or check out the {WCL_GUIDE} to get started with logging on your own.<1/><2/>When you know for sure that you have logs on Warcraft Logs and you still get this error, please message us on {DISCORD} or create an issue on {GITHUB}.",


### PR DESCRIPTION
### Description

Noticed a large warning throw in the console when opening random player analysis.

![Screenshot_1](https://github.com/user-attachments/assets/880adf01-f84e-4839-97ec-a5bf5d9aeb79)


### Testing

Opening your console when visiting the following report should be sufficient;

report: /report/rJ6XdqypPkYBQwz8/29-Mythic+Rik+Reverb+-+Kill+(4:19)/Tatoo%C3%ADne/standard/overview
