### PR TITLE
Twins of the Sun Priestess

### DIFF
--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -1,7 +1,10 @@
 import { change, date } from 'common/changelog';
-import { Hana, fel1ne, Saeldur, Vollmer } from 'CONTRIBUTORS';
+import { Hana, fel1ne, Saeldur, Vollmer, Vetyst } from 'CONTRIBUTORS';
+import { SpellLink } from 'interface';
+import { TALENTS_PRIEST } from 'common/TALENTS';
 
 export default [
+  change(date(2025, 6, 8), <>Fix duplicate spellbook entry of <SpellLink spell={TALENTS_PRIEST.POWER_INFUSION_TALENT.id} />.</>, Vetyst),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 3, 29), <>More Updates for 11.1</>, Saeldur),
   change(date(2025, 3, 16), <>Updates for 11.1</>, Hana),

--- a/src/analysis/retail/priest/discipline/modules/Abilities.ts
+++ b/src/analysis/retail/priest/discipline/modules/Abilities.ts
@@ -291,6 +291,10 @@ class Abilities extends CoreAbilities {
           suggestion: true,
           recommendedEfficiency: 0.8,
         },
+        //With Twins of the Sun Priestess, PI is added through the TwinsOftheSunPriestess module
+        enabled:
+          combatant.hasTalent(TALENTS.POWER_INFUSION_TALENT) &&
+          !combatant.hasTalent(TALENTS.TWINS_OF_THE_SUN_PRIESTESS_TALENT),
       },
       {
         spell: TALENTS.SHADOW_WORD_DEATH_TALENT.id,

--- a/src/analysis/retail/priest/holy/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/holy/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import TALENTS, { TALENTS_PRIEST } from 'common/TALENTS/priest';
-import { Arlie, Hana, Litena, Liavre, squided, ToppleTheNun, Trevor, Saeldur, xizbow, fel1ne, Vollmer} from 'CONTRIBUTORS';
+import { Arlie, Hana, Litena, Liavre, squided, ToppleTheNun, Trevor, Saeldur, xizbow, fel1ne, Vollmer, Vetyst } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2025, 6, 8), <>Add statistics for <SpellLink spell={TALENTS_PRIEST.TWINS_OF_THE_SUN_PRIESTESS_TALENT.id} />.</>, Vetyst),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2024, 11, 14), <>Updated Holy to 11.0.7</>, Liavre),
   change(date(2024, 10, 26), <>Added <SpellLink spell={SPELLS.RESONANT_WORDS_TALENT_BUFF} /> guide analysis.</>, xizbow),

--- a/src/analysis/retail/priest/holy/CombatLogParser.tsx
+++ b/src/analysis/retail/priest/holy/CombatLogParser.tsx
@@ -1,5 +1,5 @@
 import AbilityTracker from 'analysis/retail/priest/holy/modules/core/AbilityTracker';
-import { TranslucentImage } from 'analysis/retail/priest/shared';
+import { TranslucentImage, TwinsOfTheSunPriestess } from 'analysis/retail/priest/shared';
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import ManaTracker from 'parser/core/healingEfficiency/ManaTracker';
 import LowHealthHealing from 'parser/shared/modules/features/LowHealthHealing';
@@ -74,6 +74,7 @@ class CombatLogParser extends CoreCombatLogParser {
     echoOfLightDisplay: EchoOfLightDisplay,
 
     // Spells
+    twinsOfTheSunPriestess: TwinsOfTheSunPriestess,
     divineHymn: DivineHymn,
     guardianSpirit: GuardianSpirit,
     holyNova: HolyNova,

--- a/src/analysis/retail/priest/holy/modules/Abilities.ts
+++ b/src/analysis/retail/priest/holy/modules/Abilities.ts
@@ -297,6 +297,10 @@ class Abilities extends CoreAbilities {
           averageIssueEfficiency: 0.6,
           majorIssueEfficiency: 0.4,
         },
+        //With Twins of the Sun Priestess, PI is added through the TwinsOftheSunPriestess module
+        enabled:
+          combatant.hasTalent(TALENTS.POWER_INFUSION_TALENT) &&
+          !combatant.hasTalent(TALENTS.TWINS_OF_THE_SUN_PRIESTESS_TALENT),
       },
       {
         spell: SPELLS.SHADOW_WORD_PAIN.id,


### PR DESCRIPTION
## Description

* Implemented existing module `Twins of the Sun Priestess` for `Holy Priest`
* Fixed duplicate entry of `Power Infusion` for `Disc Priest`

## Testing

### Holy Priest
Report: /report/rJ6XdqypPkYBQwz8/25-Mythic+Vexie+and+the+Geargrinders+-+Kill+(4:45)/Naisana/standard/statistics

![image](https://github.com/user-attachments/assets/612a185c-e8a9-4726-8b49-d820d40e0d3c)

### Disc Priest
Report: /report/NMPCr7Qf9z1Vk26v/1-Heroic+Vexie+and+the+Geargrinders+-+Kill+(2:51)/Fennìs/standard/about

Before:
![image](https://github.com/user-attachments/assets/6a4fe1d3-6bac-43b3-b36b-dc65beafd37d)

After:
![image](https://github.com/user-attachments/assets/b9236b20-ff19-49e8-88e3-5448f0f20885)
