### PR TITLE
Update Prescience.tsx

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2025, 6, 12), <>Update <SpellLink spell={TALENTS.PRESCIENCE_TALENT}/> module</>, KYZ),
   change(date(2025, 5, 16), <>Fix <SpellLink spell={TALENTS.TIME_SKIP_TALENT}/> CDR handling for Abilities with charges</>, Vollmer),
   change(date(2025, 3, 13), <>Implement <SpellLink spell={TALENTS.MOTES_OF_POSSIBILITY_TALENT}/> module</>, KYZ),
   change(date(2025, 3, 2), "Update config to 11.1", KYZ),

--- a/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
@@ -149,8 +149,8 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
         details = (
           <div>
             Buffed Augmentation: <span className={className}>{this.currentBuffedPlayer?.name}</span>{' '}
-            with <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. This should never happen! Make
-            sure you position yourself better to avoid this.
+            with <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. You should always try and buff DPS
+            players.
           </div>
         );
       } else {
@@ -163,14 +163,25 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
         );
       }
     } else if (cast.onTank) {
-      performance = QualitativePerformance.Ok;
-      details = (
-        <div>
-          Buffed Tank: <span className={className}>{this.currentBuffedPlayer?.name}</span> with{' '}
-          <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. This is situationally okay, but should be
-          avoided.
-        </div>
-      );
+      if (isMythicPlus(this.owner.fight)) {
+        performance = QualitativePerformance.Ok;
+        details = (
+          <div>
+            Buffed Tank: <span className={className}>{this.currentBuffedPlayer?.name}</span> with{' '}
+            <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. This is situationally okay, but should
+            be avoided. If you have an extra use of Prescience, such as due to Time Skip or Golden
+            Opportunity, you should usually prioritise buffing yourself before the tank.
+          </div>
+        );
+      } else {
+        details = (
+          <div>
+            Buffed Tank: <span className={className}>{this.currentBuffedPlayer?.name}</span> with{' '}
+            <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. You should always try and buff DPS
+            players.
+          </div>
+        );
+      }
     } else if (cast.onHealer) {
       details = (
         <div>
@@ -180,12 +191,23 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
         </div>
       );
     } else if (cast.onYourself) {
-      details = (
-        <div>
-          Buffed: yourself with <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. You should always
-          try and buff DPS players. Make sure to position yourself so you buff the intended players.
-        </div>
-      );
+      if (isMythicPlus(this.owner.fight)) {
+        performance = QualitativePerformance.Ok;
+        details = (
+          <div>
+            Buffed: yourself with <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. This is
+            acceptable in Mythic+ if you have an extra use, such as due to Time Skip or Golden
+            Opportunity, and both DPS already have Prescience active.
+          </div>
+        );
+      } else {
+        details = (
+          <div>
+            Buffed: yourself with <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. You should always
+            try and buff DPS players.
+          </div>
+        );
+      }
     } else {
       details = (
         <div>

--- a/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
@@ -169,8 +169,10 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
           <div>
             Buffed Tank: <span className={className}>{this.currentBuffedPlayer?.name}</span> with{' '}
             <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. This is situationally okay, but should
-            be avoided. If you have an extra use of Prescience, such as due to Time Skip or Golden
-            Opportunity, you should usually prioritise buffing yourself before the tank.
+            be avoided. If you have an extra use of Prescience, such as due to{' '}
+            <SpellLink spell={TALENTS.TIME_SKIP_TALENT} /> or{' '}
+            <SpellLink spell={TALENTS.GOLDEN_OPPORTUNITY_TALENT} />, you should usually prioritise
+            buffing yourself before the tank.
           </div>
         );
       } else {
@@ -196,8 +198,10 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
         details = (
           <div>
             Buffed: yourself with <SpellLink spell={TALENTS.PRESCIENCE_TALENT} />. This is
-            acceptable in Mythic+ if you have an extra use, such as due to Time Skip or Golden
-            Opportunity, and both DPS already have Prescience active.
+            acceptable in Mythic+ if you have an extra use, such as due to{' '}
+            <SpellLink spell={TALENTS.TIME_SKIP_TALENT} /> or{' '}
+            <SpellLink spell={TALENTS.GOLDEN_OPPORTUNITY_TALENT} />, and both DPS already have
+            Prescience active.
           </div>
         );
       } else {

--- a/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/Prescience.tsx
@@ -303,8 +303,8 @@ class Prescience extends MajorCooldown<PrescienceCooldownCast> {
     let buffTarget;
     const relatedBuffEvents = getPrescienceBuffEvents(event);
 
-    for (let i = 0; i < relatedBuffEvents.length; i = i + 1) {
-      const targetID = relatedBuffEvents[i].targetID;
+    for (const buffEvent of relatedBuffEvents) {
+      const targetID = buffEvent.targetID;
       if (this.combatants.players[targetID]) {
         buffTarget = targetID;
         break;


### PR DESCRIPTION
Allow buffing yourself with Prescience as an Ok use in M+. Make buffing a tank with Prescience outside of M+ a bad use. Updated evaluation comments.

![Untitled](https://github.com/user-attachments/assets/48bc2712-27ff-499f-b68b-3633d5da792e)
[Relevant log](https://www.warcraftlogs.com/reports/pABN2LXTJzKQ9Rvk?fight=21&type=auras&source=1128&by=target&options=2&ability=410089)