### PR TITLE
Correct Soul Shard tracking and update Soul Strike implementation

### DIFF
--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -5,7 +5,8 @@ import { Sharrq, Zeboot, Meldris, ToppleTheNun, Jonfanz, Mae, dodse, Arlie, Putr
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2024, 6, 5), <>Add statistics for <SpellLink spell={TALENTS_WARLOCK.THE_HOUNDMASTERS_GAMBIT_TALENT}/> dreadstalker damage while vilefiend is active and <SpellLink spell={TALENTS_WARLOCK.WICKED_MAW_TALENT}/>/<SpellLink spell={TALENTS_WARLOCK.SHADOWTOUCHED_TALENT}/> damage increase</>, Leftyxiv),
+  change(date(2025, 6, 7), <>Fixed <SpellLink spell={TALENTS_WARLOCK.SOUL_STRIKE_TALENT}/> to properly display wasted soul shards when overcapped</>, Leftyxiv),
+  change(date(2025, 6, 5), <>Add statistics for <SpellLink spell={TALENTS_WARLOCK.THE_HOUNDMASTERS_GAMBIT_TALENT}/> dreadstalker damage while vilefiend is active and <SpellLink spell={TALENTS_WARLOCK.WICKED_MAW_TALENT}/>/<SpellLink spell={TALENTS_WARLOCK.SHADOWTOUCHED_TALENT}/> damage increase</>, Leftyxiv),
   change(date(2025, 5, 24), <>Enhanced <SpellLink spell={SPELLS.CHARHOUND_SUMMON} /> and <SpellLink spell={SPELLS.GLOOMHOUND_SUMMON} /> tracking with cast efficiency, damage breakdown, and pet ability monitoring</>, Leftyxiv),
   change(date(2025, 5, 23), <>Implemented <SpellLink spell={SPELLS.DOOM_DEBUFF} /> tracking - monitors uptime, damage, and application rate for the new Doom talent</>, Leftyxiv),
   change(date(2024, 10, 1), <>Add support for <SpellLink spell={SPELLS.DEMONIC_HEALTHSTONE} /> </>, Gazh),

--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import { Sharrq, Zeboot, Meldris, ToppleTheNun, Jonfanz, Mae, dodse, Arlie, Putr
 import { SpellLink } from 'interface';
 
 export default [
-  change(date(2025, 6, 7), <>Fixed <SpellLink spell={TALENTS_WARLOCK.SOUL_STRIKE_TALENT}/> to properly display wasted soul shards when overcapped</>, Leftyxiv),
+  change(date(2025, 6, 17), <>Fixed <SpellLink spell={TALENTS_WARLOCK.SOUL_STRIKE_TALENT}/> to properly display wasted soul shards when overcapped</>, [Leftyxiv, Putro]),
   change(date(2025, 6, 5), <>Add statistics for <SpellLink spell={TALENTS_WARLOCK.THE_HOUNDMASTERS_GAMBIT_TALENT}/> dreadstalker damage while vilefiend is active and <SpellLink spell={TALENTS_WARLOCK.WICKED_MAW_TALENT}/>/<SpellLink spell={TALENTS_WARLOCK.SHADOWTOUCHED_TALENT}/> damage increase</>, Leftyxiv),
   change(date(2025, 5, 24), <>Enhanced <SpellLink spell={SPELLS.CHARHOUND_SUMMON} /> and <SpellLink spell={SPELLS.GLOOMHOUND_SUMMON} /> tracking with cast efficiency, damage breakdown, and pet ability monitoring</>, Leftyxiv),
   change(date(2025, 5, 23), <>Implemented <SpellLink spell={SPELLS.DOOM_DEBUFF} /> tracking - monitors uptime, damage, and application rate for the new Doom talent</>, Leftyxiv),

--- a/src/analysis/retail/warlock/demonology/CONFIG.tsx
+++ b/src/analysis/retail/warlock/demonology/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Zyer, Gazh } from 'CONTRIBUTORS';
+import { Zyer, Gazh, Leftyxiv } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
@@ -7,10 +7,10 @@ import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Zyer, Gazh],
+  contributors: [Zyer, Gazh, Leftyxiv],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '11.0.2',
+  patchCompatibility: '11.1.5',
   supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/warlock/demonology/modules/resources/SoulShardTracker.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/resources/SoulShardTracker.tsx
@@ -1,13 +1,22 @@
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { Options } from 'parser/core/Analyzer';
-import { CastEvent } from 'parser/core/Events';
+import { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
 import ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
 
 class SoulShardTracker extends ResourceTracker {
   constructor(options: Options) {
     super(options);
     this.resource = RESOURCE_TYPES.SOUL_SHARDS;
+  }
+
+  onEnergize(event: ResourceChangeEvent) {
+    const classResources = this.getResource(event);
+    if (classResources) {
+      classResources.amount /= 10;
+      classResources.max /= 10;
+    }
+    super.onEnergize(event);
   }
 
   onCast(event: CastEvent) {
@@ -30,6 +39,16 @@ class SoulShardTracker extends ResourceTracker {
       cost -= 1;
     }
     return cost;
+  }
+
+  getAdjustedGain(event: ResourceChangeEvent): { gain: number; waste: number } {
+    // The parent class calculates gain as (resourceChange - waste)
+    // But we need to work with the raw values from the event
+    const waste = event.waste / 10;
+    const totalChange = event.resourceChange / 10;
+    const gain = totalChange - waste;
+
+    return { gain, waste };
   }
 }
 

--- a/src/analysis/retail/warlock/demonology/modules/resources/SoulShardTracker.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/resources/SoulShardTracker.tsx
@@ -1,22 +1,13 @@
 import SPELLS from 'common/SPELLS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { Options } from 'parser/core/Analyzer';
-import { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
+import { CastEvent } from 'parser/core/Events';
 import ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
 
 class SoulShardTracker extends ResourceTracker {
   constructor(options: Options) {
     super(options);
     this.resource = RESOURCE_TYPES.SOUL_SHARDS;
-  }
-
-  onEnergize(event: ResourceChangeEvent) {
-    const classResources = this.getResource(event);
-    if (classResources) {
-      classResources.amount /= 10;
-      classResources.max /= 10;
-    }
-    super.onEnergize(event);
   }
 
   onCast(event: CastEvent) {
@@ -39,16 +30,6 @@ class SoulShardTracker extends ResourceTracker {
       cost -= 1;
     }
     return cost;
-  }
-
-  getAdjustedGain(event: ResourceChangeEvent): { gain: number; waste: number } {
-    // The parent class calculates gain as (resourceChange - waste)
-    // But we need to work with the raw values from the event
-    const waste = event.waste / 10;
-    const totalChange = event.resourceChange / 10;
-    const gain = totalChange - waste;
-
-    return { gain, waste };
   }
 }
 

--- a/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
@@ -2,11 +2,12 @@ import { formatThousands } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 import Analyzer, { Options, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
-import Events, { DamageEvent } from 'parser/core/Events';
+import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 import SoulShardTracker from '../resources/SoulShardTracker';
 
@@ -17,6 +18,8 @@ class SoulStrike extends Analyzer {
 
   soulShardTracker!: SoulShardTracker;
   damage = 0;
+  totalCasts = 0;
+  wastedShards = 0;
 
   constructor(options: Options) {
     super(options);
@@ -25,24 +28,56 @@ class SoulStrike extends Analyzer {
       Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.SOUL_STRIKE_DAMAGE),
       this.handleSoulStrikeDamage,
     );
+    this.addEventListener(
+      Events.resourcechange.by(SELECTED_PLAYER_PET).spell(SPELLS.SOUL_STRIKE_SHARD_GEN),
+      this.handleSoulStrikeShardGen,
+    );
   }
 
   handleSoulStrikeDamage(event: DamageEvent) {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
+  handleSoulStrikeShardGen(event: ResourceChangeEvent) {
+    if (event.resourceChangeType === RESOURCE_TYPES.SOUL_SHARDS.id) {
+      this.totalCasts += 1;
+
+      // Convert waste from fragments (tenths) to whole shards
+      // Each shard = 10 fragments, so divide by 10
+      if (event.waste > 0) {
+        this.wastedShards += event.waste / 10;
+      }
+    }
+  }
+
+  get shardsGenerated() {
+    return this.totalCasts;
+  }
+
   statistic() {
-    const shardsGained = this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_STRIKE_SHARD_GEN.id);
     return (
       <Statistic
         category={STATISTIC_CATEGORY.TALENTS}
         size="flexible"
-        tooltip={`${formatThousands(this.damage)} damage`}
+        tooltip={
+          <ul>
+            <li>{formatThousands(this.damage)} damage</li>
+            {this.wastedShards > 0 && <li>{this.wastedShards} shards wasted due to overcapping</li>}
+          </ul>
+        }
       >
         <BoringSpellValueText spell={TALENTS.SOUL_STRIKE_TALENT}>
           <ItemDamageDone amount={this.damage} />
-          <br />
-          {shardsGained} <small>Shards generated</small>
+          <ul>
+            <li>
+              {this.shardsGenerated} <small>shards generated</small>
+            </li>
+            {this.wastedShards > 0 && (
+              <li>
+                {this.wastedShards} <small>shards wasted</small>
+              </li>
+            )}
+          </ul>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/talents/SoulStrike.tsx
@@ -1,13 +1,11 @@
-import { formatThousands } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 import Analyzer, { Options, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
-import Events, { DamageEvent, ResourceChangeEvent } from 'parser/core/Events';
+import Events, { DamageEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 import SoulShardTracker from '../resources/SoulShardTracker';
 
@@ -18,8 +16,6 @@ class SoulStrike extends Analyzer {
 
   soulShardTracker!: SoulShardTracker;
   damage = 0;
-  totalCasts = 0;
-  wastedShards = 0;
 
   constructor(options: Options) {
     super(options);
@@ -28,53 +24,26 @@ class SoulStrike extends Analyzer {
       Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.SOUL_STRIKE_DAMAGE),
       this.handleSoulStrikeDamage,
     );
-    this.addEventListener(
-      Events.resourcechange.by(SELECTED_PLAYER_PET).spell(SPELLS.SOUL_STRIKE_SHARD_GEN),
-      this.handleSoulStrikeShardGen,
-    );
   }
 
   handleSoulStrikeDamage(event: DamageEvent) {
     this.damage += event.amount + (event.absorbed || 0);
   }
 
-  handleSoulStrikeShardGen(event: ResourceChangeEvent) {
-    if (event.resourceChangeType === RESOURCE_TYPES.SOUL_SHARDS.id) {
-      this.totalCasts += 1;
-
-      // Convert waste from fragments (tenths) to whole shards
-      // Each shard = 10 fragments, so divide by 10
-      if (event.waste > 0) {
-        this.wastedShards += event.waste / 10;
-      }
-    }
-  }
-
-  get shardsGenerated() {
-    return this.totalCasts;
-  }
-
   statistic() {
+    const wasted = this.soulShardTracker.getWastedBySpell(SPELLS.SOUL_STRIKE_SHARD_GEN.id);
     return (
-      <Statistic
-        category={STATISTIC_CATEGORY.TALENTS}
-        size="flexible"
-        tooltip={
-          <ul>
-            <li>{formatThousands(this.damage)} damage</li>
-            {this.wastedShards > 0 && <li>{this.wastedShards} shards wasted due to overcapping</li>}
-          </ul>
-        }
-      >
+      <Statistic category={STATISTIC_CATEGORY.TALENTS} size="flexible">
         <BoringSpellValueText spell={TALENTS.SOUL_STRIKE_TALENT}>
           <ItemDamageDone amount={this.damage} />
           <ul>
             <li>
-              {this.shardsGenerated} <small>shards generated</small>
+              {this.soulShardTracker.getGeneratedBySpell(SPELLS.SOUL_STRIKE_SHARD_GEN.id)}{' '}
+              <small>shards generated</small>
             </li>
-            {this.wastedShards > 0 && (
+            {wasted > 0 && (
               <li>
-                {this.wastedShards} <small>shards wasted</small>
+                {wasted} <small>shards wasted</small>
               </li>
             )}
           </ul>


### PR DESCRIPTION
### Description

Follow up PR to #7378. 

This removes unnecessary code that caused issues in other modules and update soul strike to just use the functions exposed from the soulshard tracker directly. Additionally there is no guarantee that Soul Strike generates 1 soul shard, that only happens with Fel Invocation talent - this change should also ensure that casts = shards only happen if the talent is spec'd (by looking directly at the resource events rather than just using a casts metric). 

Using this log https://www.warcraftlogs.com/reports/Rkx82tFbYGKW3Jzj?fight=53&type=resources&source=1289&spell=107
![image](https://github.com/user-attachments/assets/25be7bba-93b3-4df2-bca4-e817e07d5653)

The statistics now match: 
![image](https://github.com/user-attachments/assets/0557f9bc-d976-4e32-9613-f1eae628b212)
![image](https://github.com/user-attachments/assets/b766a475-2e06-42b0-8681-7c23c398bb56)


Before it was showing like this: 
![image](https://github.com/user-attachments/assets/3abf72e3-a251-43c1-b6f5-c2b894ac424b)
![image](https://github.com/user-attachments/assets/0c73c87c-077b-48ad-911e-1b1ecf5f04ad)