### PR TITLE
[Evoker] Update Example Reports for Deva & Aug

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2025, 6, 20), "Update example report", Vollmer),
   change(date(2025, 6, 12), <>Update <SpellLink spell={TALENTS.PRESCIENCE_TALENT}/> module</>, KYZ),
   change(date(2025, 5, 16), <>Fix <SpellLink spell={TALENTS.TIME_SKIP_TALENT}/> CDR handling for Abilities with charges</>, Vollmer),
   change(date(2025, 3, 13), <>Implement <SpellLink spell={TALENTS.MOTES_OF_POSSIBILITY_TALENT}/> module</>, KYZ),

--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 
 export default [
-  change(date(2025, 6, 20), "Update example report", Vollmer),
+  change(date(2025, 6, 20), "Update example report for 11.1.7", Vollmer),
   change(date(2025, 6, 12), <>Update <SpellLink spell={TALENTS.PRESCIENCE_TALENT}/> module</>, KYZ),
   change(date(2025, 5, 16), <>Fix <SpellLink spell={TALENTS.TIME_SKIP_TALENT}/> CDR handling for Abilities with charges</>, Vollmer),
   change(date(2025, 3, 13), <>Implement <SpellLink spell={TALENTS.MOTES_OF_POSSIBILITY_TALENT}/> module</>, KYZ),

--- a/src/analysis/retail/evoker/augmentation/CONFIG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CONFIG.tsx
@@ -27,7 +27,8 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/zRrwPYTqGmk92d1M/35-Mythic+Volcoross+-+Kill+(2:47)/Tazera/standard',
+  exampleReport:
+    "/report/GNyjgnAz6rDLxJ4b/13-Mythic+Mug'Zee,+Heads+of+Security+-+Kill+(5:30)/Pandragons/standard",
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import { TALENTS_EVOKER } from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
-  change(date(2025, 6, 20), "Update example report", Vollmer),
+  change(date(2025, 6, 20), "Update example report for 11.1.7", Vollmer),
   change(date(2025, 4, 17), <>Update Empower performance evaluation for <SpellLink spell={SPELLS.JACKPOT_BUFF}/> module</>, Vollmer),
   change(date(2025, 4, 11), <>Fix consumption tracking for <SpellLink spell={SPELLS.JACKPOT_BUFF} /> module</>, Vollmer),
   change(date(2025, 4, 11), <>Update Guide section for <SpellLink spell={SPELLS.DISINTEGRATE}/></>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { TALENTS_EVOKER } from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS/evoker';
 
 export default [
+  change(date(2025, 6, 20), "Update example report", Vollmer),
   change(date(2025, 4, 17), <>Update Empower performance evaluation for <SpellLink spell={SPELLS.JACKPOT_BUFF}/> module</>, Vollmer),
   change(date(2025, 4, 11), <>Fix consumption tracking for <SpellLink spell={SPELLS.JACKPOT_BUFF} /> module</>, Vollmer),
   change(date(2025, 4, 11), <>Update Guide section for <SpellLink spell={SPELLS.DISINTEGRATE}/></>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/CONFIG.tsx
+++ b/src/analysis/retail/evoker/devastation/CONFIG.tsx
@@ -28,7 +28,8 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/rbnq6W7xGRNJ3Pvd/1-Mythic+Volcoross+-+Kill+(2:05)/Sonofja/standard',
+  exampleReport:
+    "/report/hLbrvnX7q68dzmTM/17-Mythic+Mug'Zee,+Heads+of+Security+-+Kill+(4:46)/Spankvoker/standard",
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/evoker/devastation/CONFIG.tsx
+++ b/src/analysis/retail/evoker/devastation/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Tyndi, Vireve, Vollmer } from 'CONTRIBUTORS';
+import { Vollmer } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Vireve, Tyndi, Vollmer],
+  contributors: [Vollmer],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '11.1.5',

--- a/src/analysis/retail/evoker/devastation/modules/guide/IntroSection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/IntroSection.tsx
@@ -10,15 +10,14 @@ export function IntroSection() {
           Wowhead
         </a>
         , <a href="https://www.icy-veins.com/wow/devastation-evoker-pve-dps-guide">Icy Veins</a>,{' '}
-        <a href="https://jereico.com/devastation-evoker-guide/">Jereico's Evoker Compendium</a> and{' '}
-        <a href="https://discord.com/invite/evoker">Evoker Discord</a>.
+        and <a href="https://discord.com/invite/evoker">Evoker Discord</a>.
       </p>
       <p>
         The accuracy and problems pointed out here are <b>guidelines</b> and don't factor in raid
         conditions or edge cases. To find a good measure of success, you should compare your results
         to other top Evokers in the same fight with Warcraft Logs (e.g{' '}
-        <a href="https://www.warcraftlogs.com/zone/rankings/31#boss=2639&class=Evoker&spec=Devastation">
-          Mythic Terros Top 100
+        <a href="https://www.warcraftlogs.com/zone/rankings/42?boss=3015&class=Evoker&spec=Devastation">
+          Mythic Mug'Zee Top 100
         </a>
         ).
       </p>


### PR DESCRIPTION
### Description

Updates the Example Reports for 11.1.7 - They were still linking to Volcoross >.>