### PR TITLE
[Arcane Mage] Changed conditions for arcane barrage and arcane missiles for sunfury…

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2750,3 +2750,8 @@ export const Brandrewsss: Contributor = {
     },
   ],
 };
+
+export const Berlin: Contributor = {
+  nickname: 'Berlin',
+  github: 'NBerlinmuren',
+};

--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -2,9 +2,10 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/mage';
 import SpellLink from 'interface/SpellLink';
 import { change, date } from 'common/changelog';
-import { Sharrq, Sref, Earosselot } from 'CONTRIBUTORS';
+import { Sharrq, Sref, Earosselot, Berlin } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2025, 4, 20), <>Updated Arcane barrage and arcane missiles condition for 11.1.7 for Sunfury</>, Berlin),
   change(date(2025, 4, 20), <>Added Defensives to Guide</>, Earosselot),
   change(date(2024, 11, 23), <>Updated Spec Support to 11.0.5 and updated Warning.</>, Sharrq),
   change(date(2024, 11, 23), <>Fixed an issue that was preventing the Cast Delay from showing if <SpellLink spell={TALENTS.ARCANE_MISSILES_TALENT} /> ended at the exact same timestamp as the next cast (0 Delay).</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/SPELLS.ts
+++ b/src/analysis/retail/mage/arcane/SPELLS.ts
@@ -128,7 +128,7 @@ const spells = {
     icon: 'inv_soulbarrier',
   },
   INTUITION_BUFF: {
-    id: 455681,
+    id: 1223797,
     name: 'Intuition',
     icon: 'spell_shadow_brainwash',
   },

--- a/src/analysis/retail/mage/arcane/core/ArcaneBarrage.tsx
+++ b/src/analysis/retail/mage/arcane/core/ArcaneBarrage.tsx
@@ -16,6 +16,7 @@ import SpellUsable from 'parser/shared/modules/SpellUsable';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { TrackedBuffEvent } from 'parser/core/Entity';
 import { encodeTargetString } from 'parser/shared/modules/Enemies';
+import talents from 'analysis/retail/priest/holy/modules/talents';
 
 const TEMPO_DURATION = 12000;
 
@@ -33,6 +34,7 @@ export default class ArcaneBarrage extends Analyzer {
   hasArcaneSoul: boolean = this.selectedCombatant.hasTalent(TALENTS.MEMORY_OF_ALAR_TALENT);
 
   barrageCasts: ArcaneBarrageCast[] = [];
+  allCasts: CastEvent[] = [];
   lastTempoApply = 0;
 
   constructor(options: Options) {
@@ -53,10 +55,16 @@ export default class ArcaneBarrage extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.ARCANE_BARRAGE),
       this.onBarrage,
     );
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onAnyCast);
+
   }
 
   onTempo(event: ApplyBuffEvent | ApplyBuffStackEvent | RefreshBuffEvent) {
     this.lastTempoApply = event.timestamp;
+  }
+
+  onAnyCast(event: CastEvent) {
+  this.allCasts.push(event);
   }
 
   onBarrage(event: CastEvent) {
@@ -100,7 +108,7 @@ export default class ArcaneBarrage extends Analyzer {
       arcaneSoul: this.selectedCombatant.hasBuff(SPELLS.ARCANE_SOUL_BUFF.id),
       burdenOfPower: this.selectedCombatant.hasBuff(SPELLS.BURDEN_OF_POWER_BUFF.id),
       gloriousIncandescence: this.selectedCombatant.hasBuff(
-        TALENTS.GLORIOUS_INCANDESCENCE_TALENT.id,
+        SPELLS.GLORIOUS_INCANDESCENCE_BUFF.id,
       ),
       intuition: this.selectedCombatant.hasBuff(SPELLS.INTUITION_BUFF.id),
       aethervision: this.selectedCombatant.getBuff(SPELLS.AETHERVISION_BUFF.id),
@@ -112,6 +120,23 @@ export default class ArcaneBarrage extends Analyzer {
 
     this.arcaneChargeTracker.clearCharges(event);
   }
+
+suggestions() {
+  this.allCasts.sort((a, b) => a.timestamp - b.timestamp);
+  for (let i = 0; i < this.barrageCasts.length; i++) {
+    const barrage = this.barrageCasts[i];
+    const barrageIndex = this.allCasts.findIndex(
+      c => c.timestamp === barrage.cast.timestamp,
+    );
+
+    if (barrageIndex >= 0 && barrageIndex < this.allCasts.length - 1) {
+      const nextCast = this.allCasts[barrageIndex + 1];
+      if (nextCast.ability.guid === TALENTS.TOUCH_OF_THE_MAGI_TALENT.id) {
+        barrage.nextCastIsTouch = true;
+      }
+    }
+  }
+}
 }
 
 export interface ArcaneBarrageCast {
@@ -119,6 +144,7 @@ export interface ArcaneBarrageCast {
   netherPrecisionStacks?: number;
   blastPrecast?: CastEvent;
   touchCD: number;
+  nextCastIsTouch?: boolean;
   tempoRemaining?: number;
   clearcasting: boolean;
   arcaneOrb: boolean;

--- a/src/analysis/retail/mage/arcane/guide/ArcaneBarrage.tsx
+++ b/src/analysis/retail/mage/arcane/guide/ArcaneBarrage.tsx
@@ -12,7 +12,7 @@ import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBr
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../Guide';
 
-const TEMPO_REMAINING_THRESHOLD = 5000;
+const TEMPO_REMAINING_THRESHOLD = 2000;
 const TOUCH_CD_THRESHOLD = 6000;
 const NO_MANA_THRESHOLD = 0.1;
 const LOW_MANA_THRESHOLD = 0.7;
@@ -55,10 +55,17 @@ class ArcaneBarrageGuide extends Analyzer {
     return tooltip;
   }
 
+
+
   get arcaneBarrageData() {
+
+
+
     const data: BoxRowEntry[] = [];
     this.arcaneBarrage.barrageCasts.forEach((ab) => {
       const tooltipItems: { perf: QualitativePerformance; detail: string }[] = [];
+
+      const touchSoon = ab.touchCD < TOUCH_CD_THRESHOLD;
 
       const lowCharges = ab.charges < ARCANE_CHARGE_MAX_STACKS;
       if (lowCharges) {
@@ -68,11 +75,25 @@ class ArcaneBarrageGuide extends Analyzer {
         });
       }
 
+      if(!ab.netherPrecisionStacks && ab.clearcasting){
+        tooltipItems.push({
+          perf: QualitativePerformance.Ok,
+          detail: `No Netherprecision stacks even though clearcasting was available `,
+        });
+      }
+
+            if(ab.netherPrecisionStacks ){
+        tooltipItems.push({
+          perf: QualitativePerformance.Good,
+          detail: `Netherprecision`,
+        });
+      }
+
       if (ab.arcaneSoul) {
         tooltipItems.push({ perf: QualitativePerformance.Good, detail: `Had Arcane Soul` });
       }
 
-      if (ab.gloriousIncandescence) {
+      if ((ab.gloriousIncandescence || (ab.burdenOfPower && ab.blastPrecast)) && !touchSoon) {
         tooltipItems.push({
           perf: QualitativePerformance.Good,
           detail: `Had Glorious Incandescence`,
@@ -81,15 +102,6 @@ class ArcaneBarrageGuide extends Analyzer {
 
       if (ab.intuition) {
         tooltipItems.push({ perf: QualitativePerformance.Good, detail: `Had Intuition` });
-      }
-
-      const aethervisionStacks =
-        ab.aethervision && ab.aethervision.stacks >= AETHERVISION_STACK_THRESHOLD;
-      if (aethervisionStacks) {
-        tooltipItems.push({
-          perf: QualitativePerformance.Good,
-          detail: `Had ${AETHERVISION_STACK_THRESHOLD} Stacks of Aethervision`,
-        });
       }
 
       const noMana = ab.mana && ab.mana < NO_MANA_THRESHOLD;
@@ -101,33 +113,32 @@ class ArcaneBarrageGuide extends Analyzer {
       }
 
       const lowMana = ab.mana && ab.mana < LOW_MANA_THRESHOLD;
-      if (this.isSpellslinger && (ab.intuition || aethervisionStacks) && lowMana) {
+      if (this.isSpellslinger && (ab.intuition) && lowMana) {
         tooltipItems.push({ perf: QualitativePerformance.Good, detail: `Below 70% Mana` });
       }
 
       const lowHealth = ab.health && ab.health < EXECUTE_HEALTH_PERCENT;
-      if (this.isSpellslinger && (ab.intuition || aethervisionStacks) && lowHealth) {
+      if (this.isSpellslinger && (ab.intuition) && lowHealth) {
         tooltipItems.push({ perf: QualitativePerformance.Good, detail: `Target Below 35% Health` });
       }
 
-      const touchSoon = ab.touchCD < TOUCH_CD_THRESHOLD;
-      if (touchSoon) {
+      if (ab.nextCastIsTouch) {
         tooltipItems.push({
           perf: QualitativePerformance.Good,
-          detail: `Touch of the Magi Almost Available`,
+          detail: `Touch of the magi after`,
         });
       }
 
       const tempoExpiring = ab.tempoRemaining && ab.tempoRemaining <= TEMPO_REMAINING_THRESHOLD;
-      if (this.isSpellslinger && tempoExpiring) {
+      if (tempoExpiring) {
         tooltipItems.push({ perf: QualitativePerformance.Good, detail: `Arcane Tempo Expiring` });
       }
 
       const hasOrbWithCharges = ab.arcaneOrb && !lowCharges;
       if (this.isSpellslinger) {
-        if ((ab.intuition || aethervisionStacks) && ab.netherPrecisionStacks) {
+        if ((ab.intuition ) && ab.netherPrecisionStacks) {
           tooltipItems.push({ perf: QualitativePerformance.Good, detail: `Had Nether Precision` });
-        } else if ((ab.intuition || aethervisionStacks) && !ab.clearcasting) {
+        } else if ((ab.intuition ) && !ab.clearcasting) {
           tooltipItems.push({
             perf: QualitativePerformance.Good,
             detail: `Didn't Have Clearcasting`,
@@ -141,12 +152,12 @@ class ArcaneBarrageGuide extends Analyzer {
       } else if (this.isSunfury && ab.netherPrecisionStacks) {
         if (ab.gloriousIncandescence) {
           tooltipItems.push({ perf: QualitativePerformance.Good, detail: `Had Nether Precision` });
-        } else if ((ab.intuition || aethervisionStacks) && lowHealth) {
+        } else if ((ab.intuition ) && lowHealth) {
           tooltipItems.push({
             perf: QualitativePerformance.Good,
             detail: `Target had ${ab.health && formatPercentage(ab.health, 2)}% Health`,
           });
-        } else if ((ab.intuition || aethervisionStacks) && lowMana) {
+        } else if ((ab.intuition ) && lowMana) {
           tooltipItems.push({
             perf: QualitativePerformance.Good,
             detail: `Had ${ab.mana && formatPercentage(ab.mana, 2)}% Mana`,
@@ -158,26 +169,26 @@ class ArcaneBarrageGuide extends Analyzer {
       if (
         this.isSunfury &&
         (ab.netherPrecisionStacks || !ab.clearcasting) &&
-        (ab.gloriousIncandescence ||
-          ((ab.intuition || aethervisionStacks) && (lowHealth || lowMana)))
+        (ab.gloriousIncandescence || (ab.blastPrecast && ab.burdenOfPower) ||
+          (ab.intuition) || ab.nextCastIsTouch || ab.arcaneSoul || tempoExpiring )
       ) {
         overallPerf = QualitativePerformance.Perfect;
       } else if (
         this.isSpellslinger &&
         (tempoExpiring ||
-          ((ab.intuition || aethervisionStacks) &&
+          ((ab.intuition ) &&
             (ab.netherPrecisionStacks || !ab.clearcasting)) ||
           (!ab.netherPrecisionStacks && !ab.clearcasting && ab.arcaneOrb && !lowCharges))
       ) {
         overallPerf = QualitativePerformance.Perfect;
-      } else if (touchSoon || noMana) {
+      } else if (noMana) {
         overallPerf = QualitativePerformance.Good;
       } else if (
         this.isSunfury &&
-        (ab.arcaneSoul || ab.gloriousIncandescence || ab.intuition || aethervisionStacks)
+        (ab.arcaneSoul || ab.gloriousIncandescence || ab.intuition )
       ) {
         overallPerf = QualitativePerformance.Good;
-      } else if (this.isSpellslinger && (ab.intuition || aethervisionStacks)) {
+      } else if (this.isSpellslinger && (ab.intuition )) {
         overallPerf = QualitativePerformance.Good;
       }
 
@@ -211,11 +222,15 @@ class ArcaneBarrageGuide extends Analyzer {
         </div>
         <div>
           <ul>
-            <li>{touchOfTheMagi} is almost available or you are out of mana.</li>
+            <li>{touchOfTheMagi} is available and you're going to cast it while the barrage is in the air.</li>
             {this.isSunfury && (
               <li>
-                You have {arcaneSoul}, {gloriousIncandescence}, {intuition}, or two stacks of{' '}
-                {aethervision}.
+                You have {arcaneSoul} or {intuition}.
+              </li>
+            )}
+                        {this.isSunfury && (
+              <li>
+                You have {gloriousIncandescence} and {touchOfTheMagi} has more than 6 seconds left on cd.
               </li>
             )}
             {this.isSpellslinger && (
@@ -223,22 +238,9 @@ class ArcaneBarrageGuide extends Analyzer {
                 You have {intuition} or two stacks of {aethervision}.
               </li>
             )}
+            <li>{arcaneTempo} is about to expire</li>
           </ul>
         </div>
-        {this.isSunfury && (
-          <div>
-            Additionally if you have {netherPrecision} or don't have {clearcasting}, and one of the
-            below is also true, then you can include these more advanced conditions for a small
-            damage boost:
-            <ul>
-              <li>
-                You have {intuition} or two stacks of {aethervision}, and the target is below 35%
-                health or you are below 70% mana.
-              </li>
-              <li>You have {gloriousIncandescence}.</li>
-            </ul>
-          </div>
-        )}
         {this.isSpellslinger && (
           <div>
             Additionally, you can include these more advanced conditions for a small damage boost:

--- a/src/analysis/retail/mage/arcane/guide/ArcaneBarrage.tsx
+++ b/src/analysis/retail/mage/arcane/guide/ArcaneBarrage.tsx
@@ -85,7 +85,7 @@ class ArcaneBarrageGuide extends Analyzer {
             if(ab.netherPrecisionStacks ){
         tooltipItems.push({
           perf: QualitativePerformance.Good,
-          detail: `Netherprecision`,
+          detail: `Had Netherprecision`,
         });
       }
 
@@ -149,21 +149,7 @@ class ArcaneBarrageGuide extends Analyzer {
             detail: `Had Arcane Orb without Nether Precision or Clearcasting`,
           });
         }
-      } else if (this.isSunfury && ab.netherPrecisionStacks) {
-        if (ab.gloriousIncandescence) {
-          tooltipItems.push({ perf: QualitativePerformance.Good, detail: `Had Nether Precision` });
-        } else if ((ab.intuition ) && lowHealth) {
-          tooltipItems.push({
-            perf: QualitativePerformance.Good,
-            detail: `Target had ${ab.health && formatPercentage(ab.health, 2)}% Health`,
-          });
-        } else if ((ab.intuition ) && lowMana) {
-          tooltipItems.push({
-            perf: QualitativePerformance.Good,
-            detail: `Had ${ab.mana && formatPercentage(ab.mana, 2)}% Mana`,
-          });
-        }
-      }
+      } 
 
       let overallPerf = QualitativePerformance.Fail;
       if (

--- a/src/analysis/retail/mage/arcane/guide/ArcaneMissiles.tsx
+++ b/src/analysis/retail/mage/arcane/guide/ArcaneMissiles.tsx
@@ -100,11 +100,11 @@ class ArcaneMissilesGuide extends Analyzer {
         });
       }
 
-      const noClip = !am.aetherAttunement && !am.clipped;
+      const noClip = am.aetherAttunement && !am.clipped;
       if (noClip) {
         tooltipItems.push({
-          perf: QualitativePerformance.Ok,
-          detail: `Full Channeled without Aether Attunement`,
+          perf: QualitativePerformance.Perfect,
+          detail: `Full Channeled with Aether Attunement`,
         });
       }
 
@@ -112,7 +112,7 @@ class ArcaneMissilesGuide extends Analyzer {
       if (goodClip) {
         tooltipItems.push({
           perf: QualitativePerformance.Perfect,
-          detail: `Clipped at GCD With Aether Attunement`,
+          detail: `Clipped at GCD without Aether Attunement`,
         });
       }
 
@@ -128,10 +128,16 @@ class ArcaneMissilesGuide extends Analyzer {
       let overallPerf = QualitativePerformance.Fail;
       if (hadBuffNP && !am.clearcastingCapped) {
         overallPerf = QualitativePerformance.Fail;
-      } else if (noClip) {
-        overallPerf = QualitativePerformance.Ok;
-      } else if (goodClip && (!hadBuffNP || am.clearcastingCapped)) {
-        overallPerf = QualitativePerformance.Perfect;
+      } else if (goodClip && (!hadBuffNP || am.clearcastingCapped) || (noClip && !hadBuffNP)) {
+        if (am.channelEndDelay !== undefined && am.nextCast) {
+          overallPerf = this.channelDelayUtil(am.channelEndDelay)
+        }
+        else
+        {
+          overallPerf = QualitativePerformance.Perfect;
+        }
+  
+
       } else if (!hadBuffNP || (hadBuffNP && am.clearcastingCapped)) {
         overallPerf = QualitativePerformance.Good;
       }


### PR DESCRIPTION
… for 11.1.7

### Description

Changed the conditions for arcane barrage and arcane missiles to reflect the Wowhead guide for 11.1.7. 

### Testing

Try a sunfury arcane mage report and see if the arcane missiles and arcane barrage info is more correct.

- Test report URL: /reports/bxndpGJ6MzK91mDc?fight=29&type=damage-done&source=1
- Screenshot(s): https://imgur.com/a/wHCYLyS
