### PR TITLE
[Unholy] Update Unholy Death Knight Buffs for Patch 11.1.5

### DIFF
--- a/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/deathknight';
 
 export default [
+  change(date(2025, 6, 23), 'Update Unholy Death Knight Buffs for Patch 11.1.5', Brandrewsss),
   change(date(2025, 6, 8), 'Update Unholy Death Knight Abilities and Talents for Patch 11.1.5', Brandrewsss),
   change(date(2024, 12, 9), 'Update spec config to reflect lack of long term maintainers', Khazak),
   change(date(2024, 10, 7), <>Correct GCD and cooldown of <SpellLink spell={SPELLS.ANTI_MAGIC_SHELL.id} /> when paired with <SpellLink spell={TALENTS.ANTI_MAGIC_BARRIER_TALENT.id} /> and <SpellLink spell={TALENTS.UNYIELDING_WILL_TALENT.id} />.</>, Vetyst),

--- a/src/analysis/retail/deathknight/unholy/modules/Buffs.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/Buffs.tsx
@@ -1,65 +1,100 @@
-import CoreAuras, { AuraOptions } from 'parser/core/modules/Auras';
-import talents from 'common/TALENTS/deathknight';
+import CoreAuras from 'parser/core/modules/Auras';
+import TALENTS from 'common/TALENTS/deathknight';
 import SPELLS from 'common/SPELLS/deathknight';
 
 class Buffs extends CoreAuras {
-  auras(options: AuraOptions) {
+  auras() {
     const combatant = this.selectedCombatant;
 
     // This should include ALL buffs that can be applied by your spec.
     // This data can be used by various kinds of modules to improve their results, and modules added in the future may rely on buffs that aren't used today.
     return [
-      ...super.auras(options),
-      {
-        spellId: SPELLS.LICHBORNE.id,
-        timelineHighlight: true,
-      },
-      {
-        spellId: talents.EMPOWER_RUNE_WEAPON_TALENT.id,
-        enabled: combatant.hasTalent(talents.EMPOWER_RUNE_WEAPON_TALENT),
-        timelineHighlight: true,
-      },
+      // region Rotational
       {
         spellId: SPELLS.DEATH_AND_DECAY_BUFF.id,
-        triggeredBySpellId: SPELLS.DEATH_AND_DECAY.id,
-        enabled: !combatant.hasTalent(talents.DEFILE_TALENT),
+        triggeredBySpellId: [SPELLS.DEATH_AND_DECAY.id, TALENTS.DEFILE_TALENT.id],
         timelineHighlight: true,
       },
       {
         spellId: SPELLS.UNHOLY_GROUND_HASTE_BUFF.id,
-        triggeredBySpellId: SPELLS.DEATH_AND_DECAY.id,
-        enabled: combatant.hasTalent(talents.UNHOLY_GROUND_TALENT),
+        triggeredBySpellId: [SPELLS.DEATH_AND_DECAY.id, TALENTS.DEFILE_TALENT.id],
+        enabled: combatant.hasTalent(TALENTS.UNHOLY_GROUND_TALENT),
         timelineHighlight: false,
-      },
-      {
-        spellId: talents.ABOMINATION_LIMB_TALENT.id,
-        enabled: combatant.hasTalent(talents.ABOMINATION_LIMB_TALENT),
-        timelineHighlight: true,
       },
       {
         spellId: SPELLS.MOGRAINES_MIGHT.id,
-        triggeredBySpellId: SPELLS.DEATH_AND_DECAY.id,
-        enabled: !combatant.hasTalent(talents.MOGRAINES_MIGHT_TALENT),
+        triggeredBySpellId: [SPELLS.DEATH_AND_DECAY.id, TALENTS.DEFILE_TALENT.id],
+        enabled: combatant.hasTalent(TALENTS.MOGRAINES_MIGHT_TALENT),
         timelineHighlight: false,
       },
       {
-        spellId: talents.UNHOLY_ASSAULT_TALENT.id,
-        enabled: combatant.hasTalent(talents.UNHOLY_ASSAULT_TALENT),
+        spellId: SPELLS.PLAGUEBRINGER_BUFF.id,
+        triggeredBySpellId: TALENTS.SCOURGE_STRIKE_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.PLAGUEBRINGER_TALENT),
+        timelineHighlight: true,
+      },
+      { spellId: SPELLS.SUDDEN_DOOM_BUFF.id, timelineHighlight: true },
+      { spellId: TALENTS.FESTERMIGHT_TALENT.id, timelineHighlight: true },
+      {
+        spellId: SPELLS.ESSENCE_OF_THE_BLOOD_QUEEN_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS.GIFT_OF_THE_SANLAYN_TALENT),
         timelineHighlight: true,
       },
       {
-        spellId: talents.ICEBOUND_FORTITUDE_TALENT.id,
-        enabled: combatant.hasTalent(talents.ICEBOUND_FORTITUDE_TALENT),
+        spellId: TALENTS.CLEAVING_STRIKES_TALENT.id, // Note: Consider using a duration tracker in another module if cleave lingers after DnD ends.
+        triggeredBySpellId: [SPELLS.DEATH_AND_DECAY.id, TALENTS.DEFILE_TALENT.id],
+        enabled: combatant.hasTalent(TALENTS.CLEAVING_STRIKES_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: SPELLS.COMMANDER_OF_THE_DEAD_BUFF.id,
+        triggeredBySpellId: TALENTS.DARK_TRANSFORMATION_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.DARK_TRANSFORMATION_TALENT),
+
+        timelineHighlight: true,
+      },
+      {
+        spellId: TALENTS.DEATH_ROT_TALENT.id,
+        triggeredBySpellId: [SPELLS.DEATH_COIL.id, SPELLS.EPIDEMIC.id],
+        timelineHighlight: true,
+      },
+
+      // region Cooldowns
+      {
+        spellId: TALENTS.EMPOWER_RUNE_WEAPON_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.EMPOWER_RUNE_WEAPON_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: TALENTS.ABOMINATION_LIMB_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.ABOMINATION_LIMB_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: TALENTS.UNHOLY_ASSAULT_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.UNHOLY_ASSAULT_TALENT),
+        timelineHighlight: true,
+      },
+
+      // region Defensive
+      {
+        spellId: SPELLS.LICHBORNE.id,
+        timelineHighlight: true,
+      },
+
+      {
+        spellId: TALENTS.ICEBOUND_FORTITUDE_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.ICEBOUND_FORTITUDE_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: TALENTS.ANTI_MAGIC_ZONE_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.ANTI_MAGIC_ZONE_TALENT),
         timelineHighlight: true,
       },
       {
         spellId: SPELLS.GHOULISH_FRENZY.id,
-        enabled: combatant.hasTalent(talents.DARK_TRANSFORMATION_TALENT),
-        timelineHighlight: true,
-      },
-      {
-        spellId: talents.ANTI_MAGIC_ZONE_TALENT.id,
-        enabled: combatant.hasTalent(talents.ANTI_MAGIC_ZONE_TALENT),
+        enabled: combatant.hasTalent(TALENTS.DARK_TRANSFORMATION_TALENT),
         timelineHighlight: true,
       },
     ];

--- a/src/analysis/retail/deathknight/unholy/modules/Buffs.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/Buffs.tsx
@@ -44,7 +44,7 @@ class Buffs extends CoreAuras {
         spellId: TALENTS.CLEAVING_STRIKES_TALENT.id, // Note: Consider using a duration tracker in another module if cleave lingers after DnD ends.
         triggeredBySpellId: [SPELLS.DEATH_AND_DECAY.id, TALENTS.DEFILE_TALENT.id],
         enabled: combatant.hasTalent(TALENTS.CLEAVING_STRIKES_TALENT),
-        timelineHighlight: true,
+        timelineHighlight: false,
       },
       {
         spellId: SPELLS.COMMANDER_OF_THE_DEAD_BUFF.id,


### PR DESCRIPTION
### Summary

This PR updates the `Buffs.tsx` file for the Unholy Death Knight specialization based on Patch 11.1.5, completing the next phase of the Unholy DK modernization plan.


### What’s Included
- ✅ Fully updated `src/analysis/retail/deathknight/unholy/modules/Buffs.tsx` to reflect all rotationally relevant buffs for 11.1.5  
- ✅ Added dual triggering for Death and Decay or Defile depending on talents chosen 


### What’s Not Included (coming in future PRs)
- ⬜ Update Cooldown Logic
- ⬜ Rotation tracking and Spell Priorities
- ⬜ Suggestions for Optimizations and Improvements


### Related Issue

This PR contributes to: [#7375]