### PR TITLE
[Hunter] Added Focus Cap Tracker to Combat Log Parser

### DIFF
--- a/src/analysis/retail/hunter/marksmanship/CombatLogParser.ts
+++ b/src/analysis/retail/hunter/marksmanship/CombatLogParser.ts
@@ -13,6 +13,7 @@ import {
   SpellFocusCost,
   Trailblazer,
   TranquilizingShot,
+  FocusCapTracker,
 } from '../shared';
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent';
@@ -74,6 +75,7 @@ class CombatLogParser extends CoreCombatLogParser {
     spellFocusCost: SpellFocusCost,
     focus: Focus,
     marksmanshipFocusUsage: MarksmanshipFocusUsage,
+    focusCapTracker: FocusCapTracker,
 
     //Normalizers
     aimedShotPrepullNormalizer: AimedShotPrepullNormalizer,

--- a/src/analysis/retail/hunter/shared/FocusCapTracker.tsx
+++ b/src/analysis/retail/hunter/shared/FocusCapTracker.tsx
@@ -118,7 +118,7 @@ class FocusCapTracker extends RegenResourceCapTracker {
             <div className="flex-main chart">
               {this.missedRegen > 0 && (
                 <AutoSizer disableWidth>
-                  {({ height }) => (
+                  {({ height }: { height: number }) => (
                     <FlushLineChart
                       data={data}
                       duration={this.owner.fightDuration / 1000}


### PR DESCRIPTION
### Description

Saw this error 
`Error: Failed to load modules: checklist`

Addressed by adding FocusCapTracker to Combat Log Parser

### Testing

- Test report URL: `/report/QyjJpbW7xZF1Tw4M/1-LFR+Vexie+and+the+Geargrinders+-+Kill+(2:54)/Brandrews/standard`
- Screenshot(s):

![image](https://github.com/user-attachments/assets/76fb78ea-7da9-4f52-9a42-ea2190c7f61d)

