### PR TITLE
Fixed Trueshot calculation

### DIFF
--- a/src/analysis/retail/hunter/marksmanship/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/marksmanship/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/hunter';
 import ITEMS from 'common/ITEMS';
 import SPELLS from 'common/SPELLS';
 export default [
+  change(date(2025, 6, 28), <>Updated <SpellLink spell={TALENTS.CALLING_THE_SHOTS_TALENT} /> to track Spotter's Mark consumption instead of focus spending, providing 2.0 seconds CDR per consumption.</>, Putro),
   change(date(2025, 6, 26), <>Remove the focus increase aspect of <SpellLink spell={TALENTS.TRUESHOT_TALENT} /></>, Putro),
   change(date(2025, 5, 5), <>Added <SpellLink spell={TALENTS.BLEAK_ARROWS_TALENT} /> as a possible trigger for <SpellLink spell={TALENTS.LOCK_AND_LOAD_TALENT} /> </>, Putro),
   change(date(2024, 11, 15), <>Added reset logic for <SpellLink spell={SPELLS.RAPID_FIRE} /> and <SpellLink spell={TALENTS.AIMED_SHOT_TALENT} /> from <SpellLink spell={SPELLS.WAILING_ARROW_DAMAGE} /> and Readiness</>, Yellot),

--- a/src/analysis/retail/hunter/marksmanship/CombatLogParser.ts
+++ b/src/analysis/retail/hunter/marksmanship/CombatLogParser.ts
@@ -27,6 +27,7 @@ import CooldownThroughputTracker from './modules/features/CooldownThroughputTrac
 
 import SurgingShots from './modules/talents/SurgingShots';
 import Focus from './modules/resources/Focus';
+import MarksmanshipFocusCapTracker from './modules/resources/MarksmanshipFocusCapTracker';
 import MarksmanshipFocusUsage from './modules/resources/MarksmanshipFocusUsage';
 import AimedShot from './modules/talents/AimedShot';
 import LoneWolf from './modules/spells/LoneWolf';
@@ -72,6 +73,7 @@ class CombatLogParser extends CoreCombatLogParser {
     focusTracker: FocusTracker,
     focusDetails: FocusDetails,
     spellFocusCost: SpellFocusCost,
+    marksmanshipFocusCapTracker: MarksmanshipFocusCapTracker,
     focus: Focus,
     marksmanshipFocusUsage: MarksmanshipFocusUsage,
 

--- a/src/analysis/retail/hunter/marksmanship/constants.ts
+++ b/src/analysis/retail/hunter/marksmanship/constants.ts
@@ -65,8 +65,8 @@ export const STREAMLINE_AIMED_SHOT_CAST_SPEED_UP = 0.3;
 //Steady Focus increases haste by 8%
 export const STEADY_FOCUS_HASTE_PERCENT = [0, 0.08];
 /** Calling the Shots */
-//2.5 seconds per 50 focus spent
-export const CTS_CDR_PER_FOCUS = 2500 / 50;
+//2.0 seconds per Spotter's Mark consumption
+export const CTS_CDR_PER_SPOTTERS_MARK = 2000;
 /** Careful Aim */
 //Careful Aim is a execution-like talent that triggers off above 70%
 export const CAREFUL_AIM_THRESHOLD = 0.7;

--- a/src/analysis/retail/hunter/marksmanship/modules/checklist/Component.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/checklist/Component.tsx
@@ -2,7 +2,6 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_HUNTER } from 'common/TALENTS';
 import { SpellLink } from 'interface';
 import PreparationRule from 'parser/retail/modules/features/Checklist/PreparationRule';
-import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 import Checklist from 'parser/shared/modules/features/Checklist';
 import {
   AbilityRequirementProps,
@@ -13,20 +12,14 @@ import Requirement from 'parser/shared/modules/features/Checklist/Requirement';
 import Rule from 'parser/shared/modules/features/Checklist/Rule';
 import TalentCastEfficiencyRequirement from 'parser/shared/modules/features/Checklist/TalentCastEfficiencyRequirement';
 
-const AbilityRequirement = ({
-  spell,
-  castEfficiency,
-  name,
-}: AbilityRequirementProps & { castEfficiency: CastEfficiency }) => (
-  <GenericCastEfficiencyRequirement
-    castEfficiency={castEfficiency.getCastEfficiencyForSpellId(spell)}
-    spell={spell}
-    name={name}
-  />
-);
-
 const MarksmanshipChecklist = (props: ChecklistProps) => {
   const { combatant, castEfficiency, thresholds } = props;
+  const AbilityRequirement = (props: AbilityRequirementProps) => (
+    <GenericCastEfficiencyRequirement
+      castEfficiency={castEfficiency.getCastEfficiencyForSpellId(props.spell)}
+      {...props}
+    />
+  );
 
   return (
     <Checklist>
@@ -50,8 +43,8 @@ const MarksmanshipChecklist = (props: ChecklistProps) => {
         }
       >
         <TalentCastEfficiencyRequirement talent={TALENTS_HUNTER.AIMED_SHOT_TALENT} />
-        <AbilityRequirement spell={SPELLS.RAPID_FIRE.id} castEfficiency={castEfficiency} />
-        <AbilityRequirement spell={SPELLS.TRUESHOT.id} castEfficiency={castEfficiency} />
+        <AbilityRequirement spell={SPELLS.RAPID_FIRE.id} />
+        <AbilityRequirement spell={SPELLS.TRUESHOT.id} />
         <TalentCastEfficiencyRequirement talent={TALENTS_HUNTER.KILL_SHOT_SHARED_TALENT} />
 
         <TalentCastEfficiencyRequirement talent={TALENTS_HUNTER.EXPLOSIVE_SHOT_TALENT} />

--- a/src/analysis/retail/hunter/marksmanship/modules/resources/MarksmanshipFocusCapTracker.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/resources/MarksmanshipFocusCapTracker.tsx
@@ -1,0 +1,16 @@
+import { TRUESHOT_FOCUS_INCREASE } from 'analysis/retail/hunter/marksmanship/constants';
+import { FocusCapTracker } from 'analysis/retail/hunter/shared';
+import { HUNTER_BASE_FOCUS_REGEN } from 'analysis/retail/hunter/shared/constants';
+import SPELLS from 'common/SPELLS';
+
+class MarksmanshipFocusCapTracker extends FocusCapTracker {
+  getBaseRegenRate() {
+    let regenRate = HUNTER_BASE_FOCUS_REGEN;
+    if (this.selectedCombatant.hasBuff(SPELLS.TRUESHOT.id)) {
+      regenRate *= 1 + TRUESHOT_FOCUS_INCREASE;
+    }
+    return regenRate;
+  }
+}
+
+export default MarksmanshipFocusCapTracker;

--- a/src/analysis/retail/hunter/marksmanship/modules/spells/SteadyShot.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/spells/SteadyShot.tsx
@@ -1,3 +1,7 @@
+import {
+  STEADY_SHOT_FOCUS_REGEN,
+  TRUESHOT_FOCUS_INCREASE,
+} from 'analysis/retail/hunter/marksmanship/constants';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { ResourceChangeEvent } from 'parser/core/Events';
@@ -8,6 +12,8 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 class SteadyShot extends Analyzer {
   effectiveFocusGain = 0;
   focusWasted = 0;
+  additionalFocusFromTrueshot = 0;
+  possibleAdditionalFocusFromTrueshot = 0;
 
   constructor(options: Options) {
     super(options);
@@ -20,6 +26,13 @@ class SteadyShot extends Analyzer {
   onEnergize(event: ResourceChangeEvent) {
     this.effectiveFocusGain += event.resourceChange - event.waste;
     this.focusWasted += event.waste;
+    const hasTrueshot = this.selectedCombatant.hasBuff(SPELLS.TRUESHOT.id);
+    if (hasTrueshot) {
+      this.additionalFocusFromTrueshot +=
+        event.resourceChange * (1 - 1 / (1 + TRUESHOT_FOCUS_INCREASE)) -
+        Math.max(event.waste - STEADY_SHOT_FOCUS_REGEN, 0);
+      this.possibleAdditionalFocusFromTrueshot += STEADY_SHOT_FOCUS_REGEN * TRUESHOT_FOCUS_INCREASE;
+    }
   }
 
   statistic() {

--- a/src/analysis/retail/hunter/marksmanship/modules/spells/Trueshot.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/spells/Trueshot.tsx
@@ -1,16 +1,23 @@
+import { TRUESHOT_FOCUS_INCREASE } from 'analysis/retail/hunter/marksmanship/constants';
+import MarksmanshipFocusCapTracker from 'analysis/retail/hunter/marksmanship/modules/resources/MarksmanshipFocusCapTracker';
 import RapidFire from 'analysis/retail/hunter/marksmanship/modules/spells/RapidFire';
 import SteadyShot from 'analysis/retail/hunter/marksmanship/modules/spells/SteadyShot';
+import { HUNTER_BASE_FOCUS_MAX, MS_BUFFER_100 } from 'analysis/retail/hunter/shared/constants';
+import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_HUNTER } from 'common/TALENTS';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { ResourceIcon } from 'interface';
 import { SpellIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events from 'parser/core/Events';
+import Events, { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 /**
- * Critical strike chance increased by 10% and critical strike damage increased by 20%. The cooldown of Aimed Shot and Rapid Fire is reduced by 60%.
+ * Reduces the cooldown of your Aimed Shot and Rapid Fire by 70%, and causes Aimed Shot to cast 50% faster and cost 50% less focus for 15 sec.
+ * While Trueshot is active, you generate 50% additional Focus.
  * Lasts 15 sec.
  *
  * Example log:
@@ -20,13 +27,21 @@ class Trueshot extends Analyzer {
   static dependencies = {
     rapidFire: RapidFire,
     steadyShot: SteadyShot,
+    marksmanshipFocusCapTracker: MarksmanshipFocusCapTracker,
   };
 
   trueshotCasts = 0;
   aimedShotsPrTS = 0;
+  focusGained = 0;
+  passiveFocusAttributedToTrueshot = 0;
+  possiblePassiveFocusAttributedToTrueshot = 0;
+  lastKnownFocusAmount = 0;
+  lastCheckedPassiveRegenTimestamp = 0;
+  focusAtLastCheck = 0;
 
   protected rapidFire!: RapidFire;
   protected steadyShot!: SteadyShot;
+  protected marksmanshipFocusCapTracker!: MarksmanshipFocusCapTracker;
 
   constructor(options: Options) {
     super(options);
@@ -38,6 +53,8 @@ class Trueshot extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.TRUESHOT),
       this.onTrueshotCast,
     );
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.focusCheck);
+    this.addEventListener(Events.resourcechange.by(SELECTED_PLAYER), this.focusCheck);
   }
 
   get averageAimedShots() {
@@ -45,13 +62,71 @@ class Trueshot extends Analyzer {
     return isNaN(averageAimedShots) || !isFinite(averageAimedShots) ? 0 : averageAimedShots;
   }
 
-  onTrueshotCast() {
+  get effectiveFocus() {
+    return formatNumber(
+      this.steadyShot.additionalFocusFromTrueshot +
+        this.rapidFire.additionalFocusFromTrueshot +
+        this.passiveFocusAttributedToTrueshot,
+    );
+  }
+
+  get possibleFocus() {
+    return formatNumber(
+      this.steadyShot.possibleAdditionalFocusFromTrueshot +
+        this.rapidFire.possibleAdditionalFocusFromTrueshot +
+        this.possiblePassiveFocusAttributedToTrueshot,
+    );
+  }
+
+  onTrueshotCast(event: CastEvent) {
     this.trueshotCasts += 1;
+    this.lastCheckedPassiveRegenTimestamp = event.timestamp;
+    const resource = event.classResources?.find(
+      (resource) => resource.type === RESOURCE_TYPES.FOCUS.id,
+    );
+    if (!resource) {
+      return;
+    }
+    this.focusAtLastCheck = resource.amount;
   }
 
   onAimedShotCast() {
     if (this.selectedCombatant.hasBuff(SPELLS.TRUESHOT.id)) {
       this.aimedShotsPrTS += 1;
+    }
+  }
+
+  focusCheck(event: ResourceChangeEvent | CastEvent) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.TRUESHOT.id)) {
+      return;
+    }
+    const resource = event.classResources?.find(
+      (resource) => resource.type === RESOURCE_TYPES.FOCUS.id,
+    );
+    if (!resource) {
+      return;
+    }
+    if (event.timestamp >= this.lastCheckedPassiveRegenTimestamp + MS_BUFFER_100) {
+      const timeSinceLastCheck = event.timestamp - this.lastCheckedPassiveRegenTimestamp;
+      const possibleTSGainSinceLastCheck =
+        timeSinceLastCheck *
+        this.marksmanshipFocusCapTracker.naturalRegenRate() *
+        (1 - 1 / (1 + TRUESHOT_FOCUS_INCREASE));
+      const naturalRegenSinceLastCheck =
+        timeSinceLastCheck * this.marksmanshipFocusCapTracker.naturalRegenRate() -
+        possibleTSGainSinceLastCheck;
+      this.possiblePassiveFocusAttributedToTrueshot += possibleTSGainSinceLastCheck;
+      if (
+        HUNTER_BASE_FOCUS_MAX - this.focusAtLastCheck >
+        naturalRegenSinceLastCheck + possibleTSGainSinceLastCheck
+      ) {
+        this.passiveFocusAttributedToTrueshot += possibleTSGainSinceLastCheck;
+      } else if (HUNTER_BASE_FOCUS_MAX - this.focusAtLastCheck > naturalRegenSinceLastCheck) {
+        this.passiveFocusAttributedToTrueshot +=
+          HUNTER_BASE_FOCUS_MAX - this.focusAtLastCheck - naturalRegenSinceLastCheck;
+      }
+      this.lastCheckedPassiveRegenTimestamp = event.timestamp;
+      this.focusAtLastCheck = resource.amount;
     }
   }
 
@@ -61,6 +136,9 @@ class Trueshot extends Analyzer {
         <BoringSpellValueText spell={SPELLS.TRUESHOT}>
           <SpellIcon spell={TALENTS_HUNTER.AIMED_SHOT_TALENT} noLink />{' '}
           {this.averageAimedShots.toFixed(1)} <small>per Trueshot</small>
+          <br />
+          <ResourceIcon id={RESOURCE_TYPES.FOCUS.id} noLink /> {this.effectiveFocus}/
+          {this.possibleFocus} <small>Focus gained</small>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/CallingTheShots.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/CallingTheShots.tsx
@@ -1,11 +1,11 @@
 import { defineMessage } from '@lingui/core/macro';
-import { CTS_CDR_PER_FOCUS } from 'analysis/retail/hunter/marksmanship/constants';
+import { CTS_CDR_PER_SPOTTERS_MARK } from 'analysis/retail/hunter/marksmanship/constants';
 import { formatNumber, formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
 import { TALENTS_HUNTER } from 'common/TALENTS';
-import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, { RemoveDebuffEvent } from 'parser/core/Events';
 import { ThresholdStyle, When } from 'parser/core/ParseResults';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
@@ -14,7 +14,7 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 /**
- * Every 50 Focus spent reduces the cooldown of Trueshot by 2.5 sec.
+ * Consuming Spotter's Mark reduces the cooldown of Trueshot by 2.0 sec.
  *
  * Example log:
  *
@@ -27,14 +27,14 @@ class CallingTheShots extends Analyzer {
 
   effectiveTrueshotReductionMs = 0;
   wastedTrueshotReductionMs = 0;
-  lastFocusCost = 0;
+  spottedMarkConsumptions = 0;
 
   protected spellUsable!: SpellUsable;
 
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_HUNTER.CALLING_THE_SHOTS_TALENT);
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
+    this.addEventListener(Events.removedebuff.by(SELECTED_PLAYER).spell(SPELLS.SPOTTERS_MARK), this.onSpottersMarkConsumed);
   }
 
   get callingTheShotsEfficacy() {
@@ -56,20 +56,15 @@ class CallingTheShots extends Analyzer {
     };
   }
 
-  onCast(event: CastEvent) {
-    const resource = event.classResources?.find(
-      (resource) => resource.type === RESOURCE_TYPES.FOCUS.id,
-    );
-    if (!resource) {
-      return;
-    }
-
-    this.lastFocusCost = resource.cost || 0;
-    const cooldownReductionMS = CTS_CDR_PER_FOCUS * this.lastFocusCost;
+  onSpottersMarkConsumed(event: RemoveDebuffEvent) {
+    this.spottedMarkConsumptions += 1;
+    const cooldownReductionMS = CTS_CDR_PER_SPOTTERS_MARK;
+    
     if (!this.spellUsable.isOnCooldown(TALENTS_HUNTER.TRUESHOT_TALENT.id)) {
       this.wastedTrueshotReductionMs += cooldownReductionMS;
       return;
     }
+    
     if (
       this.spellUsable.cooldownRemaining(TALENTS_HUNTER.TRUESHOT_TALENT.id) < cooldownReductionMS
     ) {
@@ -81,6 +76,7 @@ class CallingTheShots extends Analyzer {
       this.wastedTrueshotReductionMs += cooldownReductionMS - effectiveReductionMs;
       return;
     }
+    
     this.effectiveTrueshotReductionMs += this.spellUsable.reduceCooldown(
       TALENTS_HUNTER.TRUESHOT_TALENT.id,
       cooldownReductionMS,
@@ -92,8 +88,9 @@ class CallingTheShots extends Analyzer {
       suggest(
         <>
           When talented into <SpellLink spell={TALENTS_HUNTER.CALLING_THE_SHOTS_TALENT} />, it is
-          important to maximize its potential by not spending focus while{' '}
-          <SpellLink spell={TALENTS_HUNTER.TRUESHOT_TALENT} /> isn't on cooldown.
+          important to maximize its potential by consuming{' '}
+          <SpellLink spell={SPELLS.SPOTTERS_MARK} /> when{' '}
+          <SpellLink spell={TALENTS_HUNTER.TRUESHOT_TALENT} /> is on cooldown.
         </>,
       )
         .icon(TALENTS_HUNTER.CALLING_THE_SHOTS_TALENT.icon)
@@ -123,6 +120,8 @@ class CallingTheShots extends Analyzer {
               (this.effectiveTrueshotReductionMs + this.wastedTrueshotReductionMs) / 1000,
             )}
             s <small>CDR</small>
+            <br />
+            {this.spottedMarkConsumptions} <small>Spotter's Mark consumed</small>
           </>
         </BoringSpellValueText>
       </Statistic>

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/CallingTheShots.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/CallingTheShots.tsx
@@ -34,7 +34,10 @@ class CallingTheShots extends Analyzer {
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_HUNTER.CALLING_THE_SHOTS_TALENT);
-    this.addEventListener(Events.removedebuff.by(SELECTED_PLAYER).spell(SPELLS.SPOTTERS_MARK), this.onSpottersMarkConsumed);
+    this.addEventListener(
+      Events.removedebuff.by(SELECTED_PLAYER).spell(SPELLS.SPOTTERS_MARK),
+      this.onSpottersMarkConsumed,
+    );
   }
 
   get callingTheShotsEfficacy() {
@@ -59,12 +62,12 @@ class CallingTheShots extends Analyzer {
   onSpottersMarkConsumed(event: RemoveDebuffEvent) {
     this.spottedMarkConsumptions += 1;
     const cooldownReductionMS = CTS_CDR_PER_SPOTTERS_MARK;
-    
+
     if (!this.spellUsable.isOnCooldown(TALENTS_HUNTER.TRUESHOT_TALENT.id)) {
       this.wastedTrueshotReductionMs += cooldownReductionMS;
       return;
     }
-    
+
     if (
       this.spellUsable.cooldownRemaining(TALENTS_HUNTER.TRUESHOT_TALENT.id) < cooldownReductionMS
     ) {
@@ -76,7 +79,7 @@ class CallingTheShots extends Analyzer {
       this.wastedTrueshotReductionMs += cooldownReductionMS - effectiveReductionMs;
       return;
     }
-    
+
     this.effectiveTrueshotReductionMs += this.spellUsable.reduceCooldown(
       TALENTS_HUNTER.TRUESHOT_TALENT.id,
       cooldownReductionMS,

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -236,6 +236,11 @@ const spells = {
     name: 'Bleak Arrows',
     icon: 'inv_quiver_1h_mawraid_d_01.jpg',
   },
+  SPOTTERS_MARK: {
+    id: 466909,
+    name: "Spotter's Mark",
+    icon: 'inv_111_hunter_ability_eaglemark',
+  },
   //endregion
 
   //region Survival

--- a/src/common/TALENTS/hunter.ts
+++ b/src/common/TALENTS/hunter.ts
@@ -1817,7 +1817,7 @@ const talents = {
     name: 'Wilderness Medicine',
     icon: 'ability_hunter_mendpet',
     maxRanks: 1,
-       entryIds: [126446],
+    entryIds: [126446],
     definitionIds: [{ id: 131272, specId: 255 }],
   },
   WILDFIRE_ARSENAL_TALENT: {

--- a/src/common/TALENTS/hunter.ts
+++ b/src/common/TALENTS/hunter.ts
@@ -751,6 +751,14 @@ const talents = {
     entryIds: [128710],
     definitionIds: [{ id: 133512, specId: 254 }],
   },
+  SPOTTERS_MARK_TALENT: {
+    id: 466908,
+    name: "Spotter's Mark",
+    icon: 'inv_111_hunter_ability_eaglemark',
+    maxRanks: 1,
+    entryIds: [128709],
+    definitionIds: [{ id: 133511, specId: 254 }],
+  },
   IMPROVED_STREAMLINE_TALENT: {
     id: 471427,
     name: 'Improved Streamline',
@@ -1809,7 +1817,7 @@ const talents = {
     name: 'Wilderness Medicine',
     icon: 'ability_hunter_mendpet',
     maxRanks: 1,
-    entryIds: [126446],
+       entryIds: [126446],
     definitionIds: [{ id: 131272, specId: 255 }],
   },
   WILDFIRE_ARSENAL_TALENT: {


### PR DESCRIPTION
### Description

This pull request introduces multiple updates and improvements to the Marksmanship Hunter analysis module. The key changes include transitioning the "Calling the Shots" talent to track Spotter's Mark consumption instead of focus spending, adding a new resource tracker for focus capping, and enhancing Trueshot analysis to account for additional focus generation. Additionally, new constants, spells, and talents were added to support these changes.

### Talent and Spell Updates:
* Updated the "Calling the Shots" talent to reduce Trueshot cooldown based on Spotter's Mark consumption instead of focus spent. This includes new logic to track Spotter's Mark debuff removal and calculate cooldown reduction accordingly. 

### Focus Tracking Enhancements:
* Introduced `MarksmanshipFocusCapTracker` to monitor focus regeneration rates, including adjustments for Trueshot's focus increase.

### Constants and Configuration:
* Replaced `CTS_CDR_PER_FOCUS` with `CTS_CDR_PER_SPOTTERS_MARK` to reflect the new cooldown reduction mechanism for "Calling the Shots."

### Cleanup and Refactoring:
* Removed unused imports and refactored the checklist component to simplify cast efficiency tracking.

### Testing

- Screenshot(s):

![Screenshot 2025-06-28 013655](https://github.com/user-attachments/assets/4bb408a2-03b0-4c9e-9a49-89cc636fadcc)