### PR TITLE
Fix to innervate when ally casts it on player

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -340,6 +340,13 @@ export const Gao: Contributor = {
 export const Oratio: Contributor = {
   nickname: 'Oratio',
   github: 'karlpralow',
+  mains: [
+    {
+      name: 'Oratio',
+      spec: SPECS.RESTORATION_DRUID,
+      link: 'https://worldofwarcraft.blizzard.com/en-us/character/us/zuljin/Oratio',
+    },
+  ],
 };
 export const Ogofo: Contributor = {
   nickname: 'Ogofo',

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
-import { Sref, Vollmer } from 'CONTRIBUTORS';
+import { Oratio, Sref, Vollmer } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2025, 4, 21), <>Innervate bug fix. Also updated the recommended mana saved value.</>, Oratio),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 3, 24), <>Fixed an issue where HoTs procced by the Liberation of Undermine 4 set might not be properly attributed when Insurance! is refreshed.</>, Sref),
   change(date(2025, 3, 4), <>Updated <SpellLink spell={TALENTS_DRUID.NATURES_SWIFTNESS_TALENT} /> and added <SpellLink spell={TALENTS_DRUID.FLOURISH_TALENT} /> direct healing to account for 11.1.0 changes. Fixed an issue where <SpellLink spell={TALENTS_DRUID.FLOURISH_TALENT} /> was incorrectly assuming 8 seconds of HoT extension instead of 6.</>, Sref),

--- a/src/analysis/retail/druid/restoration/modules/spells/Innervate.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Innervate.tsx
@@ -4,7 +4,7 @@ import { SpellIcon, SpellLink } from 'interface';
 import { PassFailCheckmark } from 'interface/guide';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import CASTS_THAT_ARENT_CASTS from 'parser/core/CASTS_THAT_ARENT_CASTS';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, CastEvent } from 'parser/core/Events';
 import BoringValueText from 'parser/ui/BoringValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -19,7 +19,7 @@ import { explanationAndDataSubsection } from 'interface/guide/components/Explana
 import { abilityToSpell } from 'common/abilityToSpell';
 
 // TODO double check this is a reasonable number
-const INNERVATE_MANA_REQUIRED = 7000;
+const INNERVATE_MANA_REQUIRED = 400000;
 
 class Innervate extends Analyzer {
   casts = 0;
@@ -32,7 +32,7 @@ class Innervate extends Analyzer {
     super(options);
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
     this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.INNERVATE),
+      Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.INNERVATE),
       this.onInnervate,
     );
   }
@@ -67,7 +67,7 @@ class Innervate extends Analyzer {
     }
   }
 
-  onInnervate(event: CastEvent) {
+  onInnervate(event: ApplyBuffEvent) {
     this.casts += 1;
 
     const castTracker: InnervateCast = {


### PR DESCRIPTION
The innervate module does not correctly detect when an external player innervates the druid making it think there's more spells casted during innervate: 
Example:
![image](https://github.com/user-attachments/assets/c9a45397-b7e5-469d-be8a-850e2d0dff1c)
In the above pictures it is joining 3 innervates casted at different times into 1:
![image](https://github.com/user-attachments/assets/e8eebd2a-4d98-4449-a371-64809c15f2d5)

This behavior happens because it is creating a new tracked innerate on player cast instead of on ApplyBuffEvent.

Here's a screenshot of the result after the changes:
![image](https://github.com/user-attachments/assets/b71c3428-5bef-44a2-a7e7-b405baaf3e2d)

I also changed the recommenced saved amount to 400000 instead of 7000.
