### PR TITLE
[Warrior] [Arms] [Fury] Fix Sudden Death buff events

### DIFF
--- a/src/analysis/retail/warrior/arms/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/arms/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { change, date } from 'common/changelog';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 7, 2), 'Remove RefreshBuff event that gets logged when going from 2->1 stack of Sudden Death', Nevdok),
   change(date(2025, 5, 6), 'Remove Storm Bolt suggestion', Nevdok),
   change(date(2025, 3, 22), 'Update APL with support for Ravager Slayer', Nevdok),
   change(date(2025, 3, 1), 'Update config to reflect 11.1 support', Nevdok),

--- a/src/analysis/retail/warrior/arms/CombatLogParser.tsx
+++ b/src/analysis/retail/warrior/arms/CombatLogParser.tsx
@@ -52,6 +52,7 @@ import BlademastersTormentNormalizer from './modules/talents/BlademastersTorment
 import UnhingedMortalStrikeNormalizer from './normalizers/UnhingedMortalStrikeNormalizer';
 import Demolish from './modules/talents/Demolish';
 import DemolishNormalizer from './normalizers/DemolishNormalizer';
+import SuddenDeathBuffNormalizer from '../shared/modules/normalizers/SuddenDeathBuffNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -71,6 +72,7 @@ class CombatLogParser extends CoreCombatLogParser {
     blademaastersTormetNormalizer: BlademastersTormentNormalizer,
     unhingedMortalStrikeNormalizer: UnhingedMortalStrikeNormalizer,
     demolishNormalizer: DemolishNormalizer,
+    suddenDeathBuffNormalizer: SuddenDeathBuffNormalizer,
 
     // WarriorCore
     abilities: Abilities,

--- a/src/analysis/retail/warrior/arms/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/warrior/arms/modules/core/AplCheck.tsx
@@ -48,7 +48,7 @@ export const apl = (info: PlayerInfo): Apl => {
 
 export const buildSlayerApl = (
   executeThreshold: number,
-  executeUsable: Condition<any>,
+  executeUsable: Condition<boolean>,
   executeSpell: Spell,
 ): Apl => {
   return build([
@@ -60,8 +60,7 @@ export const buildSlayerApl = (
         cnd.or(
           cnd.buffRemaining(SPELLS.SUDDEN_DEATH_ARMS_TALENT_BUFF, SUDDEN_DEATH_DURATION, {
             atMost: 3000,
-          }), // TODO sudden death does wacky things with its duration and apply/refresh events,
-          // would prodbably be best to handle with a normalizer in a later update
+          }),
           cnd.buffRemaining(SPELLS.JUGGERNAUT, JUGGERNAUT_DURATION, { atMost: 3000 }),
           cnd.buffStacks(SPELLS.SUDDEN_DEATH_ARMS_TALENT_BUFF, { atLeast: 2, atMost: 2 }),
           cnd.debuffStacks(SPELLS.MARKED_FOR_EXECUTION, { atLeast: 3, atMost: 3 }),
@@ -283,7 +282,7 @@ export const buildSlayerApl = (
 
 export const buildColossusApl = (
   executeThreshold: number,
-  executeUsable: Condition<any>,
+  executeUsable: Condition<boolean>,
   executeSpell: Spell,
 ): Apl => {
   return build([

--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { Nevdok, nullDozzer } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2025, 7, 2), 'Remove RefreshBuff event that gets logged when going from 2->1 stack of Sudden Death', Nevdok),
   change(date(2025, 5, 6), 'Remove Storm Bolt suggestion, fix Brutal Finish buff event', Nevdok),
   change(date(2025, 3, 22), 'Update Whirlwind suggestions', Nevdok),
   change(date(2025, 3, 1), 'Update config to reflect 11.1 support', Nevdok),

--- a/src/analysis/retail/warrior/fury/CombatLogParser.ts
+++ b/src/analysis/retail/warrior/fury/CombatLogParser.ts
@@ -37,6 +37,7 @@ import Warpaint from './modules/talents/Warpaint';
 import Channeling from 'parser/shared/normalizers/Channeling';
 import WhirlwindBuffOrderNormalizer from './modules/normalizers/WhirlwindBuffOrderNormalizer';
 import BrutalFinishBuffNormalizer from './modules/normalizers/BrutalFinishBuffNormalizer';
+import SuddenDeathBuffNormalizer from '../shared/modules/normalizers/SuddenDeathBuffNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -51,6 +52,7 @@ class CombatLogParser extends CoreCombatLogParser {
     unhingedBloodthirstNormalizer: UnhingedBloodthirstNormalizer,
     whirlwindBuffOrderNormalizer: WhirlwindBuffOrderNormalizer,
     brutalFinishBuffNormalizer: BrutalFinishBuffNormalizer,
+    suddenDeathBuffNormalizer: SuddenDeathBuffNormalizer,
 
     enrageRefreshNormalizer: EnrageRefreshNormalizer,
     enrageBeforeBloodthirst: EnrageBeforeBloodthirst,

--- a/src/analysis/retail/warrior/shared/modules/normalizers/SuddenDeathBuffNormalizer.tsx
+++ b/src/analysis/retail/warrior/shared/modules/normalizers/SuddenDeathBuffNormalizer.tsx
@@ -1,0 +1,65 @@
+import SPELLS from 'common/SPELLS';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { AnyEvent, EventType, GetRelatedEvents, RefreshBuffEvent } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+
+/**
+ * When going from 2->1 stacks of Sudden Death, two buff events are logged
+ * 1) A Remove Buff Stack event - this is exactly what we'd expect
+ * 2) A Refresh Buff event - this makes no sense, since the buff duration is *not* refreshed in game
+ * example log: https://www.warcraftlogs.com/reports/jbnJrTBAX6Zc92Ch?fight=9&type=auras&source=63&view=events&ability=52437&start=1354600&end=1363293
+ *
+ *
+ * These RefreshBuff events cause a bug with the AplCheck, since its internal tracking of the buff duration
+ * is affected by these events, and doesn't match what's actually happening in game
+ *
+ * This normalizer finds those RefreshBuff events that are tied to the RemoveBuffStack events and removes them
+ */
+const SUDDEN_DEATH_REMOVE_BUFF_STACK = 'Sudden-Death-Remove-Buff-Stack';
+const SUDDEN_DEATH_BUFF_BUFFER_MS = 10; // RemoveBuffStack and RefreshBuff events *should* be at the exact same timestamp, but give some wiggle room
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: SUDDEN_DEATH_REMOVE_BUFF_STACK,
+    linkingEventId: [SPELLS.SUDDEN_DEATH_ARMS_TALENT_BUFF.id],
+    linkingEventType: EventType.RefreshBuff,
+    referencedEventId: SPELLS.SUDDEN_DEATH_ARMS_TALENT_BUFF.id,
+    referencedEventType: EventType.RemoveBuffStack,
+    forwardBufferMs: SUDDEN_DEATH_BUFF_BUFFER_MS,
+    backwardBufferMs: SUDDEN_DEATH_BUFF_BUFFER_MS,
+    anyTarget: true,
+  },
+  {
+    linkRelation: SUDDEN_DEATH_REMOVE_BUFF_STACK,
+    linkingEventId: [SPELLS.SUDDEN_DEATH_FURY_TALENT_BUFF.id],
+    linkingEventType: EventType.RefreshBuff,
+    referencedEventId: SPELLS.SUDDEN_DEATH_FURY_TALENT_BUFF.id,
+    referencedEventType: EventType.RemoveBuffStack,
+    forwardBufferMs: SUDDEN_DEATH_BUFF_BUFFER_MS,
+    backwardBufferMs: SUDDEN_DEATH_BUFF_BUFFER_MS,
+    anyTarget: true,
+  },
+];
+
+function isSuddenDeathRemoveBuffStack(event: RefreshBuffEvent): boolean {
+  return GetRelatedEvents(event, SUDDEN_DEATH_REMOVE_BUFF_STACK).length > 0;
+}
+
+class SuddenDeathBuffNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+
+  normalize(rawEvents: AnyEvent[]): AnyEvent[] {
+    const events = super.normalize(rawEvents);
+
+    events.forEach((event, index) => {
+      if (event.type === EventType.RefreshBuff && isSuddenDeathRemoveBuffStack(event)) {
+        events.splice(index, 1); // remove RefreshBuff event
+      }
+    });
+    return events;
+  }
+}
+
+export default SuddenDeathBuffNormalizer;


### PR DESCRIPTION
### Description

When going from 2->1 stack of the Sudden Death buff, both a `RemoveBuffStack` event and a `RefreshBuff` event are logged, but the buff duration does NOT get refreshed in game. This discrepancy causes issues with the `cnd.buffRemaining()` condition in the AplCheck, since the buff duration being calculated from those log events is different from its true value in game.

### Testing

- Test report URL: Arms Slayer: `/report/Xy2bQW3aYLN7VGw6/15-Mythic+Mug'Zee,+Heads+of+Security+-+Kill+(4:59)/Giofiveseven/standard`, Arms Colossus: `/report/8LPbGQ3HfrJqRch2/14/5`, Fury Slayer: `/report/d3Jan4TtbA9Vcr1N/64-Mythic+Mug'Zee,+Heads+of+Security+-+Kill+(5:07)/381-Bigbowwl/standard`
- Screenshot(s):
![image](https://github.com/user-attachments/assets/62782cc0-3ddf-422a-81d0-d8314160b28e)
