### PR TITLE
Retribution bugfixes

### DIFF
--- a/src/analysis/retail/paladin/retribution/CHANGELOG.tsx
+++ b/src/analysis/retail/paladin/retribution/CHANGELOG.tsx
@@ -1,6 +1,7 @@
 import { change, date } from 'common/changelog';
-import { Vetyst } from 'CONTRIBUTORS';
+import { Texleretour, Vetyst } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2025, 8, 4), 'Few bugfixes and old modules cleaning', Texleretour),
   change(date(2025, 6, 9), 'Basic 11.1.5 support', Vetyst),
 ];

--- a/src/analysis/retail/paladin/retribution/CONFIG.tsx
+++ b/src/analysis/retail/paladin/retribution/CONFIG.tsx
@@ -3,9 +3,10 @@ import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
 
 import CHANGELOG from './CHANGELOG';
+import { Texleretour } from 'CONTRIBUTORS';
 
 const config: Config = {
-  contributors: [],
+  contributors: [Texleretour],
   branch: GameBranch.Retail,
   patchCompatibility: '11.1.5',
   supportLevel: SupportLevel.Foundation,

--- a/src/analysis/retail/paladin/retribution/Guide.tsx
+++ b/src/analysis/retail/paladin/retribution/Guide.tsx
@@ -4,8 +4,6 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import CombatLogParser from 'analysis/retail/paladin/retribution/CombatLogParser';
 import { RoundedPanel, SideBySidePanels } from 'interface/guide/components/GuideDivs';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
-import { HideExplanationsToggle } from 'interface/guide/components/HideExplanationsToggle';
-import { HideGoodCastsToggle } from 'interface/guide/components/HideGoodCastsToggle';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import PerformancePercentage from 'analysis/retail/demonhunter/shared/guide/PerformancePercentage';
 import DRAGONFLIGHT_OTHERS_ITEMS from 'common/ITEMS/dragonflight/others';
@@ -29,9 +27,10 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
 const PERFECT_HOLY_POWER_CAP = 0.1;
 const GOOD_HOLY_POWER_CAP = 0.15;
 const OK_HOLY_POWER_CAP = 0.2;
+
 function ResourceUsageSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
   const holyPowerWasted = modules.holyPowerTracker.wasted;
-  const holyPowerTotal = modules.holyPowerTracker.generated;
+  const holyPowerTotal = modules.holyPowerTracker.wasted + modules.holyPowerTracker.generated;
   const wastedHolyPowerPercentage = holyPowerWasted / holyPowerTotal;
   let wastedHolyPowerPercentagePerformance = QualitativePerformance.Fail;
   if (wastedHolyPowerPercentage <= PERFECT_HOLY_POWER_CAP) {
@@ -132,8 +131,6 @@ function CooldownSection() {
         order to maximize usages over the course of an encounter, you should aim to send the
         cooldown as soon as it becomes available (as long as it can do damage on target).
       </p>
-      <HideExplanationsToggle id="hide-explanations-rotation" />
-      <HideGoodCastsToggle id="hide-good-casts-rotation" />
       <CooldownGraphSubsection cooldowns={cooldowns} />
     </Section>
   );

--- a/src/analysis/retail/paladin/retribution/modules/Abilities.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/Abilities.tsx
@@ -29,6 +29,9 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.COOLDOWNS,
         buffSpellId: TALENTS_PALADIN.DIVINE_HAMMER_TALENT.id,
         cooldown: 60,
+        gcd: {
+          base: 1500,
+        },
       },
       {
         spell: SPELLS.CRUSADE.id,
@@ -90,6 +93,9 @@ class Abilities extends CoreAbilities {
         cooldown: 60,
         castEfficiency: {
           recommendedEfficiency: 0.9,
+        },
+        gcd: {
+          base: 1500,
         },
       },
 
@@ -224,11 +230,6 @@ class Abilities extends CoreAbilities {
         cooldown: 9,
         gcd: {
           base: 1500,
-        },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.25,
-          importance: ISSUE_IMPORTANCE.MINOR,
         },
       },
 

--- a/src/analysis/retail/paladin/retribution/modules/core/Consecration.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/core/Consecration.tsx
@@ -15,7 +15,10 @@ class Consecration extends Analyzer {
   totalHits = 0;
 
   constructor(options: Options) {
+    // With Consecrated Blade being baseline, this has no point anymore
     super(options);
+    this.active = false;
+
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.CONSECRATION_DAMAGE),
       this.onConsecrationDamage,

--- a/src/analysis/retail/paladin/shared/DivinePurpose.tsx
+++ b/src/analysis/retail/paladin/shared/DivinePurpose.tsx
@@ -76,6 +76,19 @@ class DivinePurpose extends Analyzer {
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.DIVINE_PURPOSE_BUFF),
       this.removeBuff,
     );
+    // Ret has a different version (and ID) of Divine Purpose probably thanks to balance nuances.
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.DIVINE_PURPOSE_BUFF_RET),
+      this.applyBuff,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.DIVINE_PURPOSE_BUFF_RET),
+      this.applyBuff,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.DIVINE_PURPOSE_BUFF_RET),
+      this.removeBuff,
+    );
   }
 
   castCounter() {

--- a/src/common/SPELLS/paladin.ts
+++ b/src/common/SPELLS/paladin.ts
@@ -403,6 +403,11 @@ const spells = {
     name: 'Divine Purpose',
     icon: 'spell_holy_mindvision',
   },
+  DIVINE_PURPOSE_BUFF_RET: {
+    id: 408458,
+    name: 'Divine Purpose',
+    icon: 'spell_holy_mindvision',
+  },
   AVENGING_CRUSADER: {
     id: 216331,
     name: 'Avenging Crusader',


### PR DESCRIPTION
### Description

Few bugfixes:
- Divine Purpose module is now working (was incorrectly using the holy/prot buff ID)
- Divine Hammer and Divine Toll now have their GCD registered
- Guide and Statistics now show the same wasted holy power percentage

Cleaning old modules: 
- Consecration module for Retribution is now inactive (I let it there in case Consecrated Blade is ever removed)
- Consecration is now ignored in the ability uptime suggestions under the statistics pane

Also removed the explanation toggles that were not doing anything

I plan on working on more of the analysis side if there's anything interested to do in 11.2.

### Testing


- Test report URL: `/report/Fv8cqLVpCrgYTf4x/35-Mythic+Sprocketmonger+Lockenstock+-+Kill+(2:52)/Bolas/standard/overview`