### PR TITLE
Update prep section for 11.2

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -44,6 +44,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 8, 9), 'Remove Corruption helm enchants from recommendations in 11.2', emallson),
   change(date(2025, 7, 29), 'Add timeline abilities for Mogu\'shan Vaults bosses', emallson),
   change(date(2025, 7, 29), 'Add consumable data for MoP', emallson),
   change(date(2025, 7, 21), 'Add Classic MoP T14 raid zones, headshots, and placeholder image', jazminite),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -44,6 +44,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 8, 9), 'Fix handling of sockets in D.I.S.C. belt.', emallson),
   change(date(2025, 8, 9), 'Remove Corruption helm enchants from recommendations in 11.2', emallson),
   change(date(2025, 7, 29), 'Add timeline abilities for Mogu\'shan Vaults bosses', emallson),
   change(date(2025, 7, 29), 'Add consumable data for MoP', emallson),

--- a/src/common/ITEMS/thewarwithin/socketBonusId.ts
+++ b/src/common/ITEMS/thewarwithin/socketBonusId.ts
@@ -472,5 +472,5 @@ export function eventItemGemSocketCount(item: EventItem): number {
     }
   }
 
-  return 0; // No matching bonusID found
+  return item.gems?.length ?? 0; // No matching bonusID found, check gem list or just return. this handles items with inherent sockets
 }

--- a/src/parser/retail/modules/items/EnchantChecker.tsx
+++ b/src/parser/retail/modules/items/EnchantChecker.tsx
@@ -7,10 +7,7 @@ import BaseEnchantChecker from 'parser/shared/modules/items/EnchantChecker';
 // Example logs with missing enchants:
 // https://www.warcraftlogs.com/reports/ydxavfGq1mBrM9Vc/#fight=1&source=14
 
-// TODO: remove head slot in 11.2.0
-
 const AGI_ENCHANTABLE_SLOTS = {
-  0: <Trans id="common.slots.head">Head</Trans>,
   4: <Trans id="common.slots.chest">Chest</Trans>,
   // 5: <Trans id="common.slots.belt">Belt</Trans>,
   6: <Trans id="common.slots.legs">Legs</Trans>,
@@ -24,7 +21,6 @@ const AGI_ENCHANTABLE_SLOTS = {
 };
 
 const STR_ENCHANTABLE_SLOTS = {
-  0: <Trans id="common.slots.head">Head</Trans>,
   4: <Trans id="common.slots.chest">Chest</Trans>,
   // 5: <Trans id="common.slots.belt">Belt</Trans>,
   6: <Trans id="common.slots.legs">Legs</Trans>,
@@ -38,7 +34,6 @@ const STR_ENCHANTABLE_SLOTS = {
 };
 
 const INT_ENCHANTABLE_SLOTS = {
-  0: <Trans id="common.slots.head">Head</Trans>,
   4: <Trans id="common.slots.chest">Chest</Trans>,
   // 5: <Trans id="common.slots.belt">Belt</Trans>,
   6: <Trans id="common.slots.legs">Legs</Trans>,
@@ -52,15 +47,6 @@ const INT_ENCHANTABLE_SLOTS = {
 };
 
 const MIN_ENCHANT_IDS = [
-  // #region Helm
-  ITEMS.LESSER_TWILIGHT_DEVASTATION.effectId,
-  ITEMS.LESSER_ECHOING_VOID.effectId,
-  ITEMS.LESSER_INFINITE_STARS.effectId,
-  ITEMS.LESSER_GUSHING_WOUND.effectId,
-  ITEMS.LESSER_TWISTED_APPENDAGE.effectId,
-  ITEMS.LESSER_VOID_RITUAL.effectId,
-  // #endregion
-
   // #region Chest
   ITEMS.COUNCILS_INTELLECT_R1.effectId,
   ITEMS.COUNCILS_INTELLECT_R2.effectId,
@@ -189,15 +175,6 @@ const MIN_ENCHANT_IDS = [
 ] as const satisfies number[];
 
 const MAX_ENCHANT_IDS = [
-  // #region Helm
-  ITEMS.GREATER_TWILIGHT_DEVASTATION.effectId,
-  ITEMS.GREATER_ECHOING_VOID.effectId,
-  ITEMS.GREATER_INFINITE_STARS.effectId,
-  ITEMS.GREATER_GUSHING_WOUND.effectId,
-  ITEMS.GREATER_TWISTED_APPENDAGE.effectId,
-  ITEMS.GREATER_VOID_RITUAL.effectId,
-  // #endregion
-
   // #region Chest
   ITEMS.COUNCILS_INTELLECT_R3.effectId,
   ITEMS.OATHSWORNS_STRENGTH_R3.effectId,


### PR DESCRIPTION
### Description

The Corruption helm enchants are no longer active (even if you can still enchant them using existing enchant items).

This also fixes the display of gems in the DISC belt. The item has an inherent socket, so bonus ID-based detection doesn't work.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/9grdy2kmvhpZRw1K/43-Mythic+Sprocketmonger+Lockenstock+-+Kill+(4:00)/Tsufist/standard/overview`
- Screenshot(s):
*Before*
<img width="2526" height="1172" alt="image" src="https://github.com/user-attachments/assets/6c1af50a-befb-4e80-b9c6-1f6686aca9f0" />

*After*
<img width="2564" height="1172" alt="image" src="https://github.com/user-attachments/assets/63113e4a-526d-483d-9301-e7a0e15646ef" />

