### PR TITLE
add rotation section for MoP Brewmaster

### DIFF
--- a/src/analysis/classic/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/classic/monk/brewmaster/CHANGELOG.tsx
@@ -1,4 +1,7 @@
 import { change, date } from 'common/changelog';
 import { emallson } from 'CONTRIBUTORS';
 
-export default [change(date(2025, 7, 30), 'Initial support for Brewmaster Monk', emallson)];
+export default [
+  change(date(2025, 8, 9), 'Add rotational analysis', emallson),
+  change(date(2025, 7, 30), 'Initial support for Brewmaster Monk', emallson),
+];

--- a/src/analysis/classic/monk/brewmaster/CombatLogParser.ts
+++ b/src/analysis/classic/monk/brewmaster/CombatLogParser.ts
@@ -11,6 +11,7 @@ import Jab from '../shared/Jab';
 import XuenNormalizer from './modules/normalizers/XuenCastNormalizer';
 import AplCheck from './modules/features/AplCheck';
 import Guide from './Guide';
+import RushingJadeWindLinkNormalizer from '../shared/RushingJadeWindLinkNormalizer';
 
 class CombatLogParser extends BaseCombatLogParser {
   static specModules = {
@@ -26,6 +27,7 @@ class CombatLogParser extends BaseCombatLogParser {
 
     // Normalizers
     XuenNormalizer,
+    RushingJadeWindLinkNormalizer,
   };
 
   static guide = Guide;

--- a/src/analysis/classic/monk/brewmaster/CombatLogParser.ts
+++ b/src/analysis/classic/monk/brewmaster/CombatLogParser.ts
@@ -6,10 +6,11 @@ import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import Buffs from './modules/features/Buffs';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import { Abilities } from './gen';
-import FoundationGuide from 'interface/guide/foundation/FoundationGuide';
 // Spells
 import Jab from '../shared/Jab';
 import XuenNormalizer from './modules/normalizers/XuenCastNormalizer';
+import AplCheck from './modules/features/AplCheck';
+import Guide from './Guide';
 
 class CombatLogParser extends BaseCombatLogParser {
   static specModules = {
@@ -19,6 +20,7 @@ class CombatLogParser extends BaseCombatLogParser {
     alwaysBeCasting: AlwaysBeCasting,
     buffs: Buffs,
     cooldownThroughputTracker: CooldownThroughputTracker,
+    aplCheck: AplCheck,
     // Spells
     jab: Jab,
 
@@ -26,7 +28,7 @@ class CombatLogParser extends BaseCombatLogParser {
     XuenNormalizer,
   };
 
-  static guide = FoundationGuide;
+  static guide = Guide;
 }
 
 export default CombatLogParser;

--- a/src/analysis/classic/monk/brewmaster/Guide.tsx
+++ b/src/analysis/classic/monk/brewmaster/Guide.tsx
@@ -1,19 +1,79 @@
-import { Section } from 'interface/guide';
+import { GuideProps, Section, useAnalyzer } from 'interface/guide';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
 import { FoundationCooldownSection } from 'interface/guide/foundation/FoundationCooldownSection';
 import { FoundationDowntimeSection } from 'interface/guide/foundation/FoundationDowntimeSection';
 import { useExpansionContext } from 'interface/report/ExpansionContext';
 import { AplSectionData } from 'interface/guide/components/Apl';
-import { check, apl } from './modules/features/AplCheck';
+import {
+  check,
+  apl,
+  parselordApl,
+  parselordCheck,
+  isUsingParseRotation,
+} from './modules/features/AplCheck';
 import Para from 'interface/guide/Para';
 import ResourceLink from 'interface/ResourceLink';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import SpellLink from 'interface/SpellLink';
 import spells from './spell-list_Monk_Brewmaster.classic';
-import AlertWarning from 'interface/AlertWarning';
+import { useMemo, useState } from 'react';
+import SPELLS from 'common/SPELLS/classic';
+import { WarningIcon } from 'interface/icons';
+import type CombatLogParser from './CombatLogParser';
+import AlertInfo from 'interface/AlertInfo';
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 
-export default function Guide(): JSX.Element {
+export default function Guide({ events, info }: GuideProps<typeof CombatLogParser>): JSX.Element {
   const { expansion } = useExpansionContext();
+  const castEff = useAnalyzer(CastEfficiency);
+
+  const parseRotationActive = useMemo(() => {
+    if (!castEff) {
+      return false;
+    }
+    return isUsingParseRotation(events, info, castEff);
+  }, [events, info, castEff]);
+
+  const aplTabs = useMemo(
+    () => [
+      {
+        label: 'Standard Rotation',
+        component: (
+          <>
+            {parseRotationActive && (
+              <AlertInfo>
+                This player appears to be using the <strong>Parsing Rotation</strong>.
+              </AlertInfo>
+            )}
+            <Para>
+              The standard rotation focuses on generating{' '}
+              <ResourceLink id={RESOURCE_TYPES.CHI.id} /> to power your defensive abilities like{' '}
+              <SpellLink spell={spells.PURIFYING_BREW} />. As a side-effect, it also generates lots
+              of <SpellLink spell={spells.ELUSIVE_BREW} /> stacks and passively maintains{' '}
+              <SpellLink spell={SPELLS.SHUFFLE} />. This is not necessarily the highest damage, but
+              it is sturdy and reliable.
+            </Para>
+            <AplSectionData checker={check} apl={apl} />
+          </>
+        ),
+      },
+      {
+        label: <>{parseRotationActive && <WarningIcon />} Parsing Rotation</>,
+        component: (
+          <>
+            <Para>
+              The "parsing" rotation focuses on damage at the expense of defensive power.{' '}
+              <ResourceLink id={RESOURCE_TYPES.CHI.id} /> generation is greatly reduced by
+              prioritizing <SpellLink spell={spells.TIGER_PALM} />, which may leave your defensive
+              abilities unavailable. It <em>does</em> do more damage, though.
+            </Para>
+            <AplSectionData checker={parselordCheck} apl={parselordApl} />
+          </>
+        ),
+      },
+    ],
+    [parseRotationActive],
+  );
   return (
     <>
       <Section title="Core Skills">
@@ -29,16 +89,54 @@ export default function Guide(): JSX.Element {
           <SpellLink spell={spells.ELUSIVE_BREW} /> are not included in this analysis, but you
           should still use them!
         </Para>
-        <AlertWarning>
+        <AlertInfo>
           In Mists of Pandaria, tank damage is heavily dependent on{' '}
           <SpellLink spell={spells.VENGEANCE_PASSIVE} />! It is so powerful that it is possible to
           execute your rotation perfectly and still do worse damage than someone with better{' '}
           <SpellLink spell={spells.VENGEANCE_PASSIVE} />. The best players will have good{' '}
           <SpellLink spell={spells.VENGEANCE_PASSIVE} /> and a good rotation.
-        </AlertWarning>
-        <AplSectionData checker={check} apl={apl} />
+        </AlertInfo>
+        <TabWrapper tabs={aplTabs} />
       </Section>
       <PreparationSection expansion={expansion} />
     </>
+  );
+}
+
+interface TabWrapperProps {
+  tabs: {
+    label: React.ReactChild;
+    component: React.ReactChild;
+  }[];
+}
+
+function TabWrapper({ tabs }: TabWrapperProps): JSX.Element | null {
+  const [selectedTab, setSelectedTab] = useState(0);
+  if (tabs.length === 0) {
+    return null;
+  }
+
+  const tab = tabs[selectedTab];
+  return (
+    <div style={{ paddingTop: '1em' }}>
+      <div
+        className="flex"
+        style={{ flexDirection: 'column', alignItems: 'end', borderBottom: '1px solid #ccc2' }}
+      >
+        <div className="btn-group">
+          {tabs.map(({ label }, index) => (
+            <button
+              type="button"
+              className={index === selectedTab ? 'btn btn-background active' : 'btn btn-background'}
+              key={index}
+              onClick={() => setSelectedTab(index)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div style={{ paddingTop: '1em' }}>{tab.component}</div>
+    </div>
   );
 }

--- a/src/analysis/classic/monk/brewmaster/Guide.tsx
+++ b/src/analysis/classic/monk/brewmaster/Guide.tsx
@@ -1,0 +1,44 @@
+import { Section } from 'interface/guide';
+import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
+import { FoundationCooldownSection } from 'interface/guide/foundation/FoundationCooldownSection';
+import { FoundationDowntimeSection } from 'interface/guide/foundation/FoundationDowntimeSection';
+import { useExpansionContext } from 'interface/report/ExpansionContext';
+import { AplSectionData } from 'interface/guide/components/Apl';
+import { check, apl } from './modules/features/AplCheck';
+import Para from 'interface/guide/Para';
+import ResourceLink from 'interface/ResourceLink';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import SpellLink from 'interface/SpellLink';
+import spells from './spell-list_Monk_Brewmaster.classic';
+import AlertWarning from 'interface/AlertWarning';
+
+export default function Guide(): JSX.Element {
+  const { expansion } = useExpansionContext();
+  return (
+    <>
+      <Section title="Core Skills">
+        <FoundationDowntimeSection />
+        <FoundationCooldownSection />
+      </Section>
+      <Section title="Rotation">
+        <Para>
+          The Brewmaster rotation in Mists of Pandaria revolves around generating{' '}
+          <ResourceLink id={RESOURCE_TYPES.CHI.id} /> efficiently with{' '}
+          <SpellLink spell={spells.KEG_SMASH} /> and <SpellLink spell={spells.EXPEL_HARM} />, then
+          spending it on <SpellLink spell={spells.BLACKOUT_KICK} />. Defensive abilities like{' '}
+          <SpellLink spell={spells.ELUSIVE_BREW} /> are not included in this analysis, but you
+          should still use them!
+        </Para>
+        <AlertWarning>
+          In Mists of Pandaria, tank damage is heavily dependent on{' '}
+          <SpellLink spell={spells.VENGEANCE_PASSIVE} />! It is so powerful that it is possible to
+          execute your rotation perfectly and still do worse damage than someone with better{' '}
+          <SpellLink spell={spells.VENGEANCE_PASSIVE} />. The best players will have good{' '}
+          <SpellLink spell={spells.VENGEANCE_PASSIVE} /> and a good rotation.
+        </AlertWarning>
+        <AplSectionData checker={check} apl={apl} />
+      </Section>
+      <PreparationSection expansion={expansion} />
+    </>
+  );
+}

--- a/src/analysis/classic/monk/brewmaster/gen.ts
+++ b/src/analysis/classic/monk/brewmaster/gen.ts
@@ -10,6 +10,8 @@ export const Abilities = genAbilities({
     spells.CHI_WAVE_TALENT,
     spells.BREATH_OF_FIRE,
     spells.SPINNING_CRANE_KICK,
+    spells.RUSHING_JADE_WIND_TALENT,
+    spells.EXPEL_HARM,
   ],
   defensives: [spells.FORTIFYING_BREW, spells.DIFFUSE_MAGIC_TALENT, spells.DAMPEN_HARM_TALENT],
   cooldowns: [spells.INVOKE_XUEN_THE_WHITE_TIGER_TALENT],

--- a/src/analysis/classic/monk/brewmaster/modules/features/AplCheck.tsx
+++ b/src/analysis/classic/monk/brewmaster/modules/features/AplCheck.tsx
@@ -1,4 +1,4 @@
-import aplCheck, { Condition, Rule, build, tenseAlt } from 'parser/shared/metrics/apl';
+import aplCheck, { Condition, PlayerInfo, Rule, build, tenseAlt } from 'parser/shared/metrics/apl';
 import * as cnd from 'parser/shared/metrics/apl/conditions';
 import spells from '../../spell-list_Monk_Brewmaster.classic';
 import SPELLS from 'common/SPELLS/classic';
@@ -8,6 +8,10 @@ import Spell from 'common/SPELLS/Spell';
 import { suggestion } from 'parser/core/Analyzer';
 import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import { hasClassicTalent } from 'parser/shared/metrics/apl/conditions/hasTalent';
+import { AnyEvent } from 'parser/core/Events';
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import { RJW_DAMAGE } from 'analysis/classic/monk/shared/RushingJadeWindLinkNormalizer';
+import SpellLink from 'interface/SpellLink';
 
 const MAX_CHI = 5;
 const MAX_CHI_ASCENSION = 6;
@@ -20,7 +24,11 @@ function generateChi(spell: Spell, chiGenerated: number, optional = false): Rule
       condition: wrapper(
         cnd.describe(
           cnd.and(
-            cnd.hasResource(RESOURCE_TYPES.CHI, { atMost: MAX_CHI_ASCENSION - chiGenerated - 1 }),
+            cnd.hasResource(
+              RESOURCE_TYPES.CHI,
+              { atMost: MAX_CHI_ASCENSION - chiGenerated - 1 },
+              2,
+            ),
             hasClassicTalent(spells.ASCENSION_TALENT),
           ),
           (tense) => (
@@ -37,7 +45,7 @@ function generateChi(spell: Spell, chiGenerated: number, optional = false): Rule
       condition: wrapper(
         cnd.describe(
           cnd.and(
-            cnd.hasResource(RESOURCE_TYPES.CHI, { atMost: MAX_CHI - chiGenerated - 1 }),
+            cnd.hasResource(RESOURCE_TYPES.CHI, { atMost: MAX_CHI - chiGenerated - 1 }, 2),
             cnd.not(hasClassicTalent(spells.ASCENSION_TALENT)),
           ),
           (tense) => (
@@ -52,12 +60,12 @@ function generateChi(spell: Spell, chiGenerated: number, optional = false): Rule
   ];
 }
 
-export const apl = build([
+export const parselordApl = build([
   {
     spell: spells.BLACKOUT_KICK,
     condition: cnd.and(
       cnd.buffMissing(SPELLS.SHUFFLE),
-      cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }),
+      cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }, 2),
     ),
   },
   {
@@ -69,7 +77,7 @@ export const apl = build([
   {
     spell: spells.BLACKOUT_KICK,
     condition: cnd.optionalRule(
-      cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }),
+      cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }, 2),
       'It is fine to cast other cooldown abilities before spending Chi',
     ),
   },
@@ -78,13 +86,77 @@ export const apl = build([
   spells.RUSHING_JADE_WIND_TALENT,
   ...generateChi(SPELLS.JAB_2H, 1, true),
   ...generateChi(SPELLS.JAB_1H, 1, true),
+  {
+    spell: spells.BREATH_OF_FIRE,
+    condition: cnd.optionalRule(
+      cnd.targetsHit({ atLeast: 3 }),
+      <>
+        <SpellLink spell={spells.BREATH_OF_FIRE} /> is a low priority because of its high{' '}
+        <ResourceLink id={RESOURCE_TYPES.CHI.id} /> cost and low utility.
+      </>,
+    ),
+  },
   spells.TIGER_PALM,
   {
     spell: spells.BLACKOUT_KICK,
-    condition: cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }),
+    condition: cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }, 2),
   },
 ]);
 
+export const apl = build([
+  {
+    spell: spells.BLACKOUT_KICK,
+    condition: cnd.and(
+      cnd.buffMissing(SPELLS.SHUFFLE),
+      cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }, 2),
+    ),
+  },
+  {
+    spell: spells.EXPEL_HARM,
+    condition: cnd.buffPresent(spells.DESPERATE_MEASURES_PASSIVE),
+  },
+  ...generateChi(spells.KEG_SMASH, 2),
+  ...generateChi(spells.EXPEL_HARM, 1),
+  {
+    spell: spells.BLACKOUT_KICK,
+    condition: cnd.optionalRule(
+      cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }, 2),
+      'It is fine to cast other cooldown abilities before spending Chi',
+    ),
+  },
+  spells.CHI_WAVE_TALENT,
+  spells.CHI_BURST_TALENT,
+  {
+    spell: spells.RUSHING_JADE_WIND_TALENT,
+    condition: cnd.optionalRule(
+      cnd.targetsHit(
+        { atLeast: 3 },
+        {
+          targetLinkRelation: RJW_DAMAGE,
+        },
+      ),
+    ),
+  },
+  ...generateChi(SPELLS.JAB_2H, 1),
+  ...generateChi(SPELLS.JAB_1H, 1),
+  spells.TIGER_PALM,
+  {
+    spell: spells.BREATH_OF_FIRE,
+    condition: cnd.optionalRule(
+      cnd.targetsHit({ atLeast: 3 }),
+      <>
+        <SpellLink spell={spells.BREATH_OF_FIRE} /> is a low priority because of its high{' '}
+        <ResourceLink id={RESOURCE_TYPES.CHI.id} /> cost and low utility.
+      </>,
+    ),
+  },
+  {
+    spell: spells.BLACKOUT_KICK,
+    condition: cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }, 2),
+  },
+]);
+
+export const parselordCheck = aplCheck(parselordApl);
 export const check = aplCheck(apl);
 
 export default suggestion((events, info) => {
@@ -92,3 +164,31 @@ export default suggestion((events, info) => {
   annotateTimeline(violations);
   return undefined;
 });
+
+// the parsing rotation is characterized by:
+// 1. high Tiger Palm casts (> Jab casts, at least 8 cpm)
+// 2. low casts of Expel Harm (<1 cpm)
+// basically prioritizing the raw damage of TP over the Chi generation of Jab/EH.
+export function isUsingParseRotation(
+  events: AnyEvent[],
+  info: PlayerInfo,
+  castEff: CastEfficiency,
+): boolean {
+  const tpCasts = castEff.getCastEfficiencyForSpell(spells.TIGER_PALM, true);
+  const jab1hCasts = castEff.getCastEfficiencyForSpell(SPELLS.JAB_1H, true);
+  const jab2hCasts = castEff.getCastEfficiencyForSpell(SPELLS.JAB_2H, true);
+  const ehCasts = castEff.getCastEfficiencyForSpell(spells.EXPEL_HARM);
+
+  if (!tpCasts) {
+    return false;
+  }
+
+  const jabCondition =
+    tpCasts.cpm >= 8 && tpCasts.cpm >= (jab1hCasts?.cpm ?? 0) + (jab2hCasts?.cpm ?? 0);
+  const ehCondition = (ehCasts?.cpm ?? 0) <= 1;
+
+  const result = parselordCheck(events, info);
+  const accuracy = result.successes.length / (result.successes.length + result.violations.length);
+
+  return accuracy >= 0.7 && jabCondition && ehCondition;
+}

--- a/src/analysis/classic/monk/brewmaster/modules/features/AplCheck.tsx
+++ b/src/analysis/classic/monk/brewmaster/modules/features/AplCheck.tsx
@@ -1,0 +1,94 @@
+import aplCheck, { Condition, Rule, build, tenseAlt } from 'parser/shared/metrics/apl';
+import * as cnd from 'parser/shared/metrics/apl/conditions';
+import spells from '../../spell-list_Monk_Brewmaster.classic';
+import SPELLS from 'common/SPELLS/classic';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import ResourceLink from 'interface/ResourceLink';
+import Spell from 'common/SPELLS/Spell';
+import { suggestion } from 'parser/core/Analyzer';
+import annotateTimeline from 'parser/shared/metrics/apl/annotate';
+import { hasClassicTalent } from 'parser/shared/metrics/apl/conditions/hasTalent';
+
+const MAX_CHI = 5;
+const MAX_CHI_ASCENSION = 6;
+
+function generateChi(spell: Spell, chiGenerated: number, optional = false): Rule[] {
+  const wrapper = optional ? cnd.optionalRule : (inner: Condition<unknown>) => inner;
+  return [
+    {
+      spell,
+      condition: wrapper(
+        cnd.describe(
+          cnd.and(
+            cnd.hasResource(RESOURCE_TYPES.CHI, { atMost: MAX_CHI_ASCENSION - chiGenerated - 1 }),
+            hasClassicTalent(spells.ASCENSION_TALENT),
+          ),
+          (tense) => (
+            <>
+              you {tenseAlt(tense, "won't", "wouldn't")} overcap on{' '}
+              <ResourceLink id={RESOURCE_TYPES.CHI.id} />
+            </>
+          ),
+        ),
+      ),
+    },
+    {
+      spell,
+      condition: wrapper(
+        cnd.describe(
+          cnd.and(
+            cnd.hasResource(RESOURCE_TYPES.CHI, { atMost: MAX_CHI - chiGenerated - 1 }),
+            cnd.not(hasClassicTalent(spells.ASCENSION_TALENT)),
+          ),
+          (tense) => (
+            <>
+              you {tenseAlt(tense, "won't", "wouldn't")} overcap on{' '}
+              <ResourceLink id={RESOURCE_TYPES.CHI.id} />
+            </>
+          ),
+        ),
+      ),
+    },
+  ];
+}
+
+export const apl = build([
+  {
+    spell: spells.BLACKOUT_KICK,
+    condition: cnd.and(
+      cnd.buffMissing(SPELLS.SHUFFLE),
+      cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }),
+    ),
+  },
+  {
+    spell: spells.EXPEL_HARM,
+    condition: cnd.buffPresent(spells.DESPERATE_MEASURES_PASSIVE),
+  },
+  ...generateChi(spells.KEG_SMASH, 2),
+  ...generateChi(spells.EXPEL_HARM, 1, true),
+  {
+    spell: spells.BLACKOUT_KICK,
+    condition: cnd.optionalRule(
+      cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }),
+      'It is fine to cast other cooldown abilities before spending Chi',
+    ),
+  },
+  spells.CHI_WAVE_TALENT,
+  spells.CHI_BURST_TALENT,
+  spells.RUSHING_JADE_WIND_TALENT,
+  ...generateChi(SPELLS.JAB_2H, 1, true),
+  ...generateChi(SPELLS.JAB_1H, 1, true),
+  spells.TIGER_PALM,
+  {
+    spell: spells.BLACKOUT_KICK,
+    condition: cnd.hasResource(RESOURCE_TYPES.CHI, { atLeast: 2 }),
+  },
+]);
+
+export const check = aplCheck(apl);
+
+export default suggestion((events, info) => {
+  const { violations } = check(events, info);
+  annotateTimeline(violations);
+  return undefined;
+});

--- a/src/analysis/classic/monk/shared/RushingJadeWindLinkNormalizer.tsx
+++ b/src/analysis/classic/monk/shared/RushingJadeWindLinkNormalizer.tsx
@@ -1,0 +1,29 @@
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { EventType } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+
+export const RJW_DAMAGE = 'rjw-damage';
+export const RJW_CAST = 'rjw-cast';
+
+const RJW_SPELL_DAMAGE = 148187;
+const RJW_SPELL_CAST = 116847;
+const RJW_DURATION = 6000;
+
+const damageLink = {
+  linkRelation: RJW_CAST,
+  reverseLinkRelation: RJW_DAMAGE,
+  linkingEventId: RJW_SPELL_DAMAGE,
+  linkingEventType: EventType.Damage,
+  anyTarget: true,
+  referencedEventId: RJW_SPELL_CAST,
+  referencedEventType: EventType.Cast,
+  maximumLinks: 1,
+  // larger backward buffer to help with extensions
+  backwardBufferMs: 1.2 * RJW_DURATION,
+} satisfies EventLink;
+
+export default class RushingJadeWindLinkNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, [damageLink]);
+  }
+}

--- a/src/common/SPELLS/classic/monk.ts
+++ b/src/common/SPELLS/classic/monk.ts
@@ -11,6 +11,11 @@ const spells = {
     name: 'Spear Hand Strike',
     icon: 'ability_monk_spearhand.jpg',
   },
+  SHUFFLE: {
+    id: 115307,
+    name: 'Shuffle',
+    icon: 'ability_monk_shuffle.jpg',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/interface/App.scss
+++ b/src/interface/App.scss
@@ -109,6 +109,26 @@ a {
   }
 }
 
+.btn-background {
+  background: Theme.$backgroundColor;
+
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0;
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.4);
+
+  &.active,
+  &:hover,
+  &:focus,
+  &:active,
+  &:active:hover,
+  &:active:focus {
+    background: color.adjust(Theme.$backgroundColor, $lightness: +2%);
+    border-bottom: 1px solid Theme.$primaryColor;
+    outline: 0;
+    color: white;
+  }
+}
+
 h1,
 h2,
 h3,

--- a/src/parser/shared/metrics/apl/conditions/hasTalent.tsx
+++ b/src/parser/shared/metrics/apl/conditions/hasTalent.tsx
@@ -2,11 +2,26 @@ import { Talent } from 'common/TALENTS/types';
 import { SpellLink } from 'interface';
 
 import { Condition, tenseAlt } from '../index';
+import Spell from 'common/SPELLS/Spell';
 
 export default function hasTalent(talent: Talent): Condition<boolean> {
   return {
     key: `hasTalent-${talent.id}`,
     init: ({ combatant }) => combatant.hasTalent(talent),
+    update: (state, _event) => state,
+    validate: (state, _event) => state,
+    describe: (tense) => (
+      <>
+        you {tenseAlt(tense, 'have', 'had')} <SpellLink spell={talent.id} /> talented
+      </>
+    ),
+  };
+}
+
+export function hasClassicTalent(talent: Spell): Condition<boolean> {
+  return {
+    key: `hasClassicTalent-${talent.id}`,
+    init: ({ combatant }) => combatant.hasClassicTalent(talent),
     update: (state, _event) => state,
     validate: (state, _event) => state,
     describe: (tense) => (


### PR DESCRIPTION
(i am not actually playing MoP so this is purely based on reading)

the rotation is based on the wowhead guide, but with some light editing to better match top logs. I've reached out to the MoP brew guidewriter to ask about the diff, because there's a real chance that the top logs are doing bad things but cheesing vengeance harder than people playing the rotation better.

### Testing

- Test report URL: `/report/KtATD3zqmdPC8nZc/30-Heroic+Elegon+-+Kill+(6:09)/Zenmonk/standard`
- Screenshot(s):
<img width="2600" height="978" alt="image" src="https://github.com/user-attachments/assets/9d762599-ef49-433a-a65d-f4fa4d58bf71" />


- Test report URL: `/report/NKJLHjgAy4bWMCht/2/5`
<img width="2594" height="1090" alt="image" src="https://github.com/user-attachments/assets/1da8fd9c-cf95-4c11-ac8b-82784aef204f" />

