### PR TITLE
[Warrior] [Arms] [Fury] Add support for 11.2 changes

### DIFF
--- a/src/analysis/retail/warrior/arms/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/arms/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { change, date } from 'common/changelog';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 8, 5), 'Update Arms support for 11.2', Nevdok),
   change(date(2025, 7, 2), 'Remove RefreshBuff event that gets logged when going from 2->1 stack of Sudden Death', Nevdok),
   change(date(2025, 5, 6), 'Remove Storm Bolt suggestion', Nevdok),
   change(date(2025, 3, 22), 'Update APL with support for Ravager Slayer', Nevdok),

--- a/src/analysis/retail/warrior/arms/CONFIG.tsx
+++ b/src/analysis/retail/warrior/arms/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [nullDozzer, Nevdok],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '11.1.5',
+  patchCompatibility: '11.2',
   supportLevel: SupportLevel.Foundation,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { Nevdok, nullDozzer } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2025, 8, 5), 'Update rotation recommendations for 11.2', Nevdok),
   change(date(2025, 7, 2), 'Remove RefreshBuff event that gets logged when going from 2->1 stack of Sudden Death', Nevdok),
   change(date(2025, 5, 6), 'Remove Storm Bolt suggestion, fix Brutal Finish buff event', Nevdok),
   change(date(2025, 3, 22), 'Update Whirlwind suggestions', Nevdok),

--- a/src/analysis/retail/warrior/fury/CONFIG.tsx
+++ b/src/analysis/retail/warrior/fury/CONFIG.tsx
@@ -9,7 +9,7 @@ const config: Config = {
   contributors: [nullDozzer, Nevdok],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '11.1.5',
+  patchCompatibility: '11.2',
   supportLevel: SupportLevel.Foundation,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/warrior/fury/modules/spells/SlayerExecute.tsx
+++ b/src/analysis/retail/warrior/fury/modules/spells/SlayerExecute.tsx
@@ -26,9 +26,10 @@ import { addInefficientCastReason } from 'parser/core/EventMetaLib';
  */
 const ASHEN_JUGGERNAUT_DURATION = 15000;
 const SUDDEN_DEATH_DURATION = 12000;
-const BUFF_REFRESH_BUFFER = 6000;
+const BUFF_REFRESH_BUFFER = 3000;
 const RAMPAGE_RAGE_COST = 80;
-const MAX_MARKED_FOR_EXECUTION_STACKS = 3;
+const MARKED_FOR_EXECUTION_STACK_THRESHOLD = 2;
+
 // Track how many times Execute was used prematurely relative to its respective buff/debuffs
 
 class SlayerExecute extends Analyzer {
@@ -143,7 +144,7 @@ class SlayerExecute extends Analyzer {
       usedForSuddenDeath = true;
     }
 
-    if (this.markedForExecutionStacks === MAX_MARKED_FOR_EXECUTION_STACKS) {
+    if (this.markedForExecutionStacks >= MARKED_FOR_EXECUTION_STACK_THRESHOLD) {
       usedForMarkedForExecution = true;
     }
 
@@ -168,7 +169,7 @@ class SlayerExecute extends Analyzer {
       this.overusedExecutes += 1;
       addInefficientCastReason(
         event,
-        'Execute was used without 3 stacks of Marked for Execution, or when neither Ashen Juggernaut or Sudden Death were near expiring',
+        'Execute was used without high stacks of Marked for Execution, or when neither Ashen Juggernaut nor Sudden Death were near expiring',
       );
     }
   }


### PR DESCRIPTION
### Description

Update Arms and Fury with new recommendations for 11.2. Note that Arms didn't actually have any APL changes, but the config was updated to reflect that it's still accurate for the new patch.

### Testing

Manaforge Omega hasn't been released yet, so no logs are available from live servers. However, some PTR logs are available and were checked

Reports: `/report/TxwHYQmKgLN4G3cM/35/4` and `/report/JGzcMqhfnR7yLdCv/17/20`
