### PR TITLE
update KS prio in Breath-less builds

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 8, 21), <>Update priority of <SpellLink spell={talents.KEG_SMASH_TALENT} /> in breathless builds.</>, emallson),
   change(date(2025, 8, 17), <>Support <SpellLink spell={talents.CELESTIAL_INFUSION_TALENT} /> in <SpellLink spell={talents.ASPECT_OF_HARMONY_TALENT} /> analysis. Minor rotation updates.</>, emallson),
   change(date(2025, 8, 9), <>Add basic support for <SpellLink spell={talents.CELESTIAL_INFUSION_TALENT} /> and the revamped <SpellLink spell={talents.INVOKE_NIUZAO_THE_BLACK_OX_TALENT} /></>, emallson),
   change(date(2025, 7, 12), <>Fix Purifying Brew section when literally no Purifies are used.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
@@ -19,21 +19,21 @@ const SCK_AOE = {
   ),
 };
 
+const WOO_BUILD_CONDITION = cnd.and(
+  cnd.buffPresent(talents.WEAPONS_OF_ORDER_TALENT),
+  cnd.or(
+    cnd.debuffStacks(SPELLS.WEAPONS_OF_ORDER_DEBUFF, { atMost: 3 }),
+    cnd.debuffMissing(SPELLS.WEAPONS_OF_ORDER_DEBUFF, {
+      duration: 10000,
+      pandemicCap: 1,
+      timeRemaining: 3000,
+    }),
+  ),
+);
+
 const WOO_BUILDER = {
   spell: [talents.KEG_SMASH_TALENT, talents.RISING_SUN_KICK_TALENT],
-  condition: cnd.optionalRule(
-    cnd.and(
-      cnd.buffPresent(talents.WEAPONS_OF_ORDER_TALENT),
-      cnd.or(
-        cnd.debuffStacks(SPELLS.WEAPONS_OF_ORDER_DEBUFF, { atMost: 3 }),
-        cnd.debuffMissing(SPELLS.WEAPONS_OF_ORDER_DEBUFF, {
-          duration: 10000,
-          pandemicCap: 1,
-          timeRemaining: 3000,
-        }),
-      ),
-    ),
-  ),
+  condition: cnd.optionalRule(WOO_BUILD_CONDITION),
   description: (
     <>
       <TooltipElement content="Aggressively building stacks of WoO is not meaningfuly different from letting it build during your normal rotation in most cases, but it is a common play pattern and does similar total damage.">
@@ -199,7 +199,16 @@ const BREATHLESS = build([
     spell: SPELLS.TIGER_PALM,
     condition: withCombo,
   },
-  talents.KEG_SMASH_TALENT,
+  {
+    spell: talents.KEG_SMASH_TALENT,
+    condition: WOO_BUILD_CONDITION,
+    description: (
+      <>
+        Cast <SpellLink spell={talents.KEG_SMASH_TALENT} /> to build{' '}
+        <SpellLink spell={talents.WEAPONS_OF_ORDER_TALENT}>WoO</SpellLink> stacks
+      </>
+    ),
+  },
   talents.RISING_SUN_KICK_TALENT,
   {
     spell: talents.CHI_BURST_SHARED_TALENT,
@@ -210,6 +219,7 @@ const BREATHLESS = build([
       </>
     )),
   },
+  talents.KEG_SMASH_TALENT,
   talents.RUSHING_JADE_WIND_BREWMASTER_TALENT,
   SCK_AOE,
   SPELLS.TIGER_PALM,


### PR DESCRIPTION
### Description

Keg Smash is now lower priority than other spells unless you're building WoO stacks

### Testing

<img width="592" height="240" alt="image" src="https://github.com/user-attachments/assets/7030a164-602a-40a7-8e73-ebb915187138" />


`/report/X4CNwLKA17nkrfJv/4-Heroic+Plexus+Sentinel+-+Kill+(5:12)/Brewii/standard/overview`