### PR TITLE
add vengeance section for Classic MoP Brewmaster

### DIFF
--- a/src/analysis/classic/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/classic/monk/brewmaster/CHANGELOG.tsx
@@ -1,7 +1,16 @@
 import { change, date } from 'common/changelog';
+import SPELLS from 'common/SPELLS/classic';
 import { emallson } from 'CONTRIBUTORS';
+import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(
+    date(2025, 8, 25),
+    <>
+      Add <SpellLink spell={SPELLS.VENGEANCE_BUFF} /> section and adjust parsing rotation detection
+    </>,
+    emallson,
+  ),
   change(date(2025, 8, 9), 'Add rotational analysis', emallson),
   change(date(2025, 7, 30), 'Initial support for Brewmaster Monk', emallson),
 ];

--- a/src/analysis/classic/monk/brewmaster/Guide.tsx
+++ b/src/analysis/classic/monk/brewmaster/Guide.tsx
@@ -22,10 +22,12 @@ import { WarningIcon } from 'interface/icons';
 import type CombatLogParser from './CombatLogParser';
 import AlertInfo from 'interface/AlertInfo';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import Vengeance from 'parser/classic/modules/Vengeance';
 
 export default function Guide({ events, info }: GuideProps<typeof CombatLogParser>): JSX.Element {
   const { expansion } = useExpansionContext();
   const castEff = useAnalyzer(CastEfficiency);
+  const veng = useAnalyzer(Vengeance);
 
   const parseRotationActive = useMemo(() => {
     if (!castEff) {
@@ -98,6 +100,7 @@ export default function Guide({ events, info }: GuideProps<typeof CombatLogParse
           <SpellLink spell={spells.VENGEANCE_PASSIVE} /> and a good rotation.
         </AlertInfo>
         <TabWrapper tabs={aplTabs} />
+        {veng?.guideSubsection}
       </Section>
       <PreparationSection expansion={expansion} />
     </>

--- a/src/analysis/classic/monk/brewmaster/modules/features/AplCheck.tsx
+++ b/src/analysis/classic/monk/brewmaster/modules/features/AplCheck.tsx
@@ -165,9 +165,7 @@ export default suggestion((events, info) => {
   return undefined;
 });
 
-// the parsing rotation is characterized by:
-// 1. high Tiger Palm casts (> Jab casts, at least 8 cpm)
-// 2. low casts of Expel Harm (<1 cpm)
+// the parsing rotation is characterized by high Tiger Palm casts (> Jab casts, at least 8 cpm)
 // basically prioritizing the raw damage of TP over the Chi generation of Jab/EH.
 export function isUsingParseRotation(
   events: AnyEvent[],
@@ -177,7 +175,6 @@ export function isUsingParseRotation(
   const tpCasts = castEff.getCastEfficiencyForSpell(spells.TIGER_PALM, true);
   const jab1hCasts = castEff.getCastEfficiencyForSpell(SPELLS.JAB_1H, true);
   const jab2hCasts = castEff.getCastEfficiencyForSpell(SPELLS.JAB_2H, true);
-  const ehCasts = castEff.getCastEfficiencyForSpell(spells.EXPEL_HARM);
 
   if (!tpCasts) {
     return false;
@@ -185,10 +182,9 @@ export function isUsingParseRotation(
 
   const jabCondition =
     tpCasts.cpm >= 8 && tpCasts.cpm >= (jab1hCasts?.cpm ?? 0) + (jab2hCasts?.cpm ?? 0);
-  const ehCondition = (ehCasts?.cpm ?? 0) <= 1;
 
   const result = parselordCheck(events, info);
   const accuracy = result.successes.length / (result.successes.length + result.violations.length);
 
-  return accuracy >= 0.7 && jabCondition && ehCondition;
+  return accuracy >= 0.7 && jabCondition;
 }

--- a/src/common/SPELLS/classic/misc.ts
+++ b/src/common/SPELLS/classic/misc.ts
@@ -16,6 +16,11 @@ const spells = {
     name: 'Celerity',
     icon: 'spell_livegivingspeed.jpg',
   },
+  VENGEANCE_BUFF: {
+    id: 132365,
+    name: 'Vengeance',
+    icon: 'spell_shadow_charm.jpg',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/interface/guide/foundation/FoundationDowntimeSectionV2.tsx
+++ b/src/interface/guide/foundation/FoundationDowntimeSectionV2.tsx
@@ -572,7 +572,7 @@ function estimateGlobalMeleeUptime(
 
 const MIN_GLOBAL_GAP = 3000;
 
-function useBossAbilities(
+export function useBossAbilities(
   reportCode: string | undefined,
   startTime: number | undefined,
   endTime: number | undefined,

--- a/src/interface/timeline-diagram/TimelineDiagram.tsx
+++ b/src/interface/timeline-diagram/TimelineDiagram.tsx
@@ -67,7 +67,7 @@ export interface TimelineTrack {
 interface Props {
   info: Info;
   children: TimelineTrack | TimelineTrack[];
-  overlays: React.ReactNode[];
+  overlays?: React.ReactNode[];
 }
 
 export default function TimelineDiagram({ info, children, overlays }: Props): JSX.Element | null {

--- a/src/parser/classic/CombatLogParser.ts
+++ b/src/parser/classic/CombatLogParser.ts
@@ -56,6 +56,7 @@ import GiftOfTheNaaru from 'parser/shared/modules/racials/draenei/GiftOfTheNaaru
 import Stoneform from 'parser/shared/modules/racials/dwarf/Stoneform';
 import { MeleeUptimeAnalyzer } from 'interface/guide/foundation/analyzers/MeleeUptimeAnalyzer';
 import DowntimeDebuffAnalyzer from 'interface/guide/foundation/analyzers/DowntimeDebuffAnalyzer';
+import Vengeance from './modules/Vengeance';
 
 class CombatLogParser extends BaseCombatLogParser {
   static defaultModules: DependenciesDefinition = {
@@ -107,6 +108,8 @@ class CombatLogParser extends BaseCombatLogParser {
     dispels: DispelTracker,
 
     critEffectBonus: CritEffectBonus,
+
+    vengeance: Vengeance,
 
     // Tabs
     raidHealthTab: RaidHealthTab,

--- a/src/parser/classic/modules/Vengeance.tsx
+++ b/src/parser/classic/modules/Vengeance.tsx
@@ -1,0 +1,189 @@
+import ROLES from 'game/ROLES';
+import SpellLink from 'interface/SpellLink';
+import { SubSection } from 'interface/guide';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Events, { AnyEvent, HasSource, HasTarget, ResourceActor } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS/classic';
+import Explanation from 'interface/guide/components/Explanation';
+import { AutoSizer } from 'react-virtualized';
+import BaseChart, { formatTime } from 'parser/ui/BaseChart';
+import { VisualizationSpec } from 'react-vega';
+import MAGIC_SCHOOLS, { color } from 'game/MAGIC_SCHOOLS';
+import { formatNumber } from 'common/format';
+import styled from '@emotion/styled';
+
+interface AttackPowerEvent {
+  attackPower: number;
+  timestamp: number;
+}
+
+const StatList = styled.dl`
+  margin-top: 1em;
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  gap: 0.25em;
+
+  dt {
+    justify-self: end;
+    font-weight: normal;
+  }
+`;
+
+export default class Vengeance extends Analyzer {
+  protected attackPower: AttackPowerEvent[] = [];
+  protected baseAttackPower: number;
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.owner.config.spec.role === ROLES.TANK;
+
+    this.baseAttackPower = this.computeBaseAttackPower();
+
+    this.addEventListener(Events.any, this.recordAttackPower);
+  }
+
+  protected computeBaseAttackPower(): number {
+    // prepull stats could shift this but not by much compared to vengeance
+    const combatantinfo = this.selectedCombatant._combatantInfo;
+    return 2 * Math.max(combatantinfo.strength, combatantinfo.agility);
+  }
+
+  protected recordAttackPower(event: AnyEvent) {
+    if (!('attackPower' in event) || event.attackPower === undefined) {
+      return;
+    }
+
+    if (
+      HasSource(event) &&
+      event.sourceID === this.owner.selectedCombatant.id &&
+      event.resourceActor === ResourceActor.Source
+    ) {
+      this.attackPower.push({
+        timestamp: event.timestamp,
+        attackPower: event.attackPower,
+      });
+    } else if (
+      HasTarget(event) &&
+      event.targetID === this.owner.selectedCombatant.id &&
+      event.resourceActor === ResourceActor.Target
+    ) {
+      this.attackPower.push({
+        timestamp: event.timestamp,
+        attackPower: event.attackPower,
+      });
+    }
+  }
+
+  protected get chartSpec(): VisualizationSpec {
+    return {
+      mark: {
+        type: 'line',
+        interpolate: 'monotone',
+        color: color(MAGIC_SCHOOLS.ids.PHYSICAL),
+      },
+      data: {
+        name: 'attackPower',
+      },
+      transform: [
+        {
+          calculate: `datum.timestamp - ${this.owner.fight.start_time}`,
+          as: 'timestamp',
+        },
+        {
+          calculate: `datum.attackPower / ${this.baseAttackPower}`,
+          as: 'apRatio',
+        },
+      ],
+      encoding: {
+        x: {
+          field: 'timestamp',
+          type: 'quantitative',
+          axis: {
+            labelExpr: formatTime('datum.value'),
+            grid: false,
+          },
+          title: null,
+          scale: { zero: true, nice: false },
+        },
+        y: {
+          field: 'apRatio',
+          type: 'quantitative',
+          axis: {
+            labelExpr: 'if(datum.value == 1, "Base AP", toString(datum.value) + "x")',
+            values: [1, 2.5, 5, 7.5, 10, 12.5],
+          },
+          scale: { domainMin: 1 },
+          title: 'Attack Power',
+        },
+        tooltip: [{ title: 'Attack Power', field: 'attackPower', format: '~s' }],
+      },
+    };
+  }
+
+  avgAttackPower(): number {
+    let previousAp = this.baseAttackPower;
+    let totalAp = 0;
+    let previousTime = this.owner.fight.start_time;
+    for (const event of this.attackPower) {
+      const duration = event.timestamp - previousTime;
+      // go ahead and convert to seconds to help avoid numerical issues from multiplying very large numbers
+      totalAp += (duration / 1000) * previousAp;
+
+      previousTime = event.timestamp;
+      previousAp = event.attackPower;
+    }
+
+    const duration = this.owner.fight.end_time - previousTime;
+    totalAp += (duration / 1000) * previousAp;
+
+    return totalAp / (this.owner.fightDuration / 1000);
+  }
+
+  get guideSubsection(): JSX.Element {
+    const avg = this.avgAttackPower();
+    const max = Math.max.apply(
+      null,
+      this.attackPower.map((event) => event.attackPower),
+    );
+    return (
+      <SubSection title={<SpellLink spell={SPELLS.VENGEANCE_BUFF} />}>
+        <Explanation>
+          <SpellLink spell={SPELLS.VENGEANCE_BUFF} /> is a tank mechanic that <em>massively</em>{' '}
+          increases your <strong>Attack Power</strong> based on damage taken. The amount of AP
+          gained is often <strong>&gt;5x your base AP</strong>.
+        </Explanation>
+        <Explanation>
+          To learn how to safely (or not) optimize <SpellLink spell={SPELLS.VENGEANCE_BUFF} /> on an
+          encounter-by-encounter basis, you should check your{' '}
+          <a href="https://www.wowhead.com/discord-servers">Community Discord</a>.
+        </Explanation>
+        <StatList>
+          <dt>Average Attack Power:</dt>
+          <dd>
+            <strong>{formatNumber(avg)}</strong> ({(avg / this.baseAttackPower).toFixed(1)}x Base
+            AP)
+          </dd>
+          <dt>Max Attack Power:</dt>{' '}
+          <dd>
+            <strong>{formatNumber(max)}</strong> ({(max / this.baseAttackPower).toFixed(1)}x Base
+            AP)
+          </dd>
+        </StatList>
+        <div>
+          <AutoSizer disableHeight>
+            {({ width }) => (
+              <div style={{ width }}>
+                <BaseChart
+                  width={width}
+                  height={200}
+                  spec={this.chartSpec}
+                  data={{ attackPower: this.attackPower }}
+                />
+              </div>
+            )}
+          </AutoSizer>
+        </div>
+      </SubSection>
+    );
+  }
+}


### PR DESCRIPTION
(and other tank specs, in theory)

there is not a lot of *Analysis* here. a ton of stuff about vengeance is apocryphal and I need to get a braindump from a current TC to really understand wtf is going on

### Testing

<img width="2472" height="768" alt="image" src="https://github.com/user-attachments/assets/0ae7356d-e41c-4679-bedf-a7f74edeeff8" />

`/report/NKJLHjgAy4bWMCht/2-Heroic+Feng+the+Accursed+-+Kill+(4:07)/Fleximonk/standard/overview`

I was going to add info about the HP cap, but HP in Classic still logs as 0-100 instead of the actual HP values 💀 

i also experimented a little with adding the boss ability timeline as a header above the chart (for context on what might've led to vengeance gain) but making it line up properly didn't quite work. i'm gonna do some revisions at a later point to make that easier because i want to be able to add timelines more generally