### PR TITLE
[Ret] More guide updates and Statistics fixes

### DIFF
--- a/src/analysis/retail/paladin/retribution/CHANGELOG.tsx
+++ b/src/analysis/retail/paladin/retribution/CHANGELOG.tsx
@@ -1,7 +1,10 @@
 import { change, date } from 'common/changelog';
+import { TALENTS_PALADIN } from 'common/TALENTS';
 import { Texleretour, Vetyst } from 'CONTRIBUTORS';
+import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 8, 22), <>Add {<SpellLink spell={TALENTS_PALADIN.WAKE_OF_ASHES_TALENT} />} cast analysis.</>, Texleretour),
   change(date(2025, 8, 22), 'Add Expurgation uptime bar and add Divine Hammer to the Cooldown Graph', Texleretour),
   change(date(2025, 8, 4), 'Few bugfixes and old modules cleaning', Texleretour),
   change(date(2025, 6, 9), 'Basic 11.1.5 support', Vetyst),

--- a/src/analysis/retail/paladin/retribution/CONFIG.tsx
+++ b/src/analysis/retail/paladin/retribution/CONFIG.tsx
@@ -8,8 +8,8 @@ import { Texleretour } from 'CONTRIBUTORS';
 const config: Config = {
   contributors: [Texleretour],
   branch: GameBranch.Retail,
-  patchCompatibility: '11.1.5',
-  supportLevel: SupportLevel.Foundation,
+  patchCompatibility: '11.2',
+  supportLevel: SupportLevel.MaintainedPartial,
   description: (
     <>
       We hope you get some use out this analyzer we have been working on.

--- a/src/analysis/retail/paladin/retribution/CombatLogParser.ts
+++ b/src/analysis/retail/paladin/retribution/CombatLogParser.ts
@@ -28,6 +28,7 @@ import { MeleeUptimeAnalyzer } from 'interface/guide/foundation/analyzers/MeleeU
 import SPELLS from 'common/SPELLS';
 import DivineHammerNormalizer from './normalizers/DivineHammerNormalizer';
 import Expurgation from './modules/talents/Expurgation';
+import WakeOfAshesNormalizer from './normalizers/WakeOfAshesNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static guide = Guide;
@@ -41,6 +42,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Normalizers
     divineHammerNormalizer: DivineHammerNormalizer,
+    wakeOfAshesNormalizer: WakeOfAshesNormalizer,
 
     // Features
     abilities: Abilities,

--- a/src/analysis/retail/paladin/retribution/CombatLogParser.ts
+++ b/src/analysis/retail/paladin/retribution/CombatLogParser.ts
@@ -13,7 +13,6 @@ import Buffs from './modules/Buffs';
 import ArtOfWar from 'analysis/retail/paladin/retribution/modules/talents/ArtOfWar';
 import ArtOfWarProbability from 'analysis/retail/paladin/retribution/modules/talents/ArtOfWarProbability';
 import BladeOfJustice from 'analysis/retail/paladin/retribution/modules/talents/BladeOfJustice';
-import Consecration from './modules/core/Consecration';
 import CrusaderStrike from './modules/core/CrusaderStrike';
 import HammerofWrathRetribution from 'analysis/retail/paladin/retribution/modules/talents/HammerofWrath';
 import ShieldOfVengeance from 'analysis/retail/paladin/retribution/modules/talents/ShieldOfVengeance';
@@ -57,7 +56,6 @@ class CombatLogParser extends CoreCombatLogParser {
     divinePurpose: DivinePurpose,
     crusade: Crusade,
     wakeofAshes: WakeOfAshes,
-    consecration: Consecration,
     hammerofWrathRetribution: HammerofWrathRetribution,
     empyreanPower: EmpyreanPower,
     duskAndDawn: DuskAndDawn,

--- a/src/analysis/retail/paladin/retribution/Guide.tsx
+++ b/src/analysis/retail/paladin/retribution/Guide.tsx
@@ -14,12 +14,13 @@ import CooldownGraphSubsection, {
   Cooldown,
 } from 'interface/guide/components/CooldownGraphSubSection';
 import SPELLS from 'common/SPELLS';
+import CooldownUsage from 'parser/core/MajorCooldowns/CooldownUsage';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
     <>
       <CoreSection modules={modules} events={events} info={info} />
-      <CooldownSection />
+      <CooldownSection modules={modules} events={events} info={info} />
       <PreparationSection />
     </>
   );
@@ -131,7 +132,7 @@ const cooldowns: Cooldown[] = [
     isActive: (c) => c.hasMainHand(DRAGONFLIGHT_OTHERS_ITEMS.FYRALATH.id),
   },
 ];
-function CooldownSection() {
+function CooldownSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
   return (
     <Section title="Cooldowns">
       <p>
@@ -140,6 +141,7 @@ function CooldownSection() {
         cooldown as soon as it becomes available (as long as it can do damage on target).
       </p>
       <CooldownGraphSubsection cooldowns={cooldowns} />
+      <CooldownUsage analyzer={modules.wakeofAshes} title="Wake of Ashes" />
     </Section>
   );
 }

--- a/src/analysis/retail/paladin/retribution/modules/Abilities.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/Abilities.tsx
@@ -24,6 +24,14 @@ class Abilities extends CoreAbilities {
         },
       },
       {
+        spell: SPELLS.CRUSADING_STRIKES.id,
+        enabled: combatant.hasTalent(TALENTS.CRUSADING_STRIKES_TALENT),
+        category: SPELL_CATEGORY.HIDDEN,
+        castEfficiency: {
+          suggestion: false,
+        },
+      },
+      {
         spell: SPELLS.DIVINE_HAMMER_CAST.id,
         enabled: combatant.hasTalent(TALENTS.DIVINE_HAMMER_TALENT),
         category: SPELL_CATEGORY.COOLDOWNS,

--- a/src/analysis/retail/paladin/retribution/modules/Abilities.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/Abilities.tsx
@@ -116,14 +116,6 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.CRUSADING_STRIKES.id,
-        enabled: combatant.hasTalent(TALENTS.CRUSADING_STRIKES_TALENT),
-        category: SPELL_CATEGORY.ROTATIONAL,
-        castEfficiency: {
-          suggestion: false,
-        },
-      },
-      {
         spell: SPELLS.HAMMER_OF_LIGHT.id,
         enabled: combatant.hasTalent(TALENTS.LIGHTS_GUIDANCE_TALENT),
         category: SPELL_CATEGORY.ROTATIONAL,
@@ -208,26 +200,6 @@ class Abilities extends CoreAbilities {
         spell: TALENTS.DIVINE_STORM_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.DIVINE_STORM_TALENT),
         category: SPELL_CATEGORY.ROTATIONAL,
-        gcd: {
-          base: 1500,
-        },
-      },
-      {
-        spell: TALENTS.EXECUTION_SENTENCE_TALENT.id,
-        category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 30,
-        gcd: {
-          base: 1500,
-        },
-        enabled: combatant.hasTalent(TALENTS.EXECUTION_SENTENCE_TALENT),
-        castEfficiency: {
-          suggestion: true,
-        },
-      },
-      {
-        spell: SPELLS.CONSECRATION_CAST.id,
-        category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 9,
         gcd: {
           base: 1500,
         },

--- a/src/analysis/retail/paladin/retribution/normalizers/WakeOfAshesNormalizer.tsx
+++ b/src/analysis/retail/paladin/retribution/normalizers/WakeOfAshesNormalizer.tsx
@@ -1,0 +1,37 @@
+import SPELLS from 'common/SPELLS';
+import { TALENTS_PALADIN } from 'common/TALENTS';
+import { Options } from 'parser/core/Analyzer';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { CastEvent, EventType, GetRelatedEvents } from 'parser/core/Events';
+
+const CRUSADE_MINIMAL_DURATION = 8000;
+
+const CASTS_DURING_WAKE = 'DivineHammerDuringCrusade';
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: CASTS_DURING_WAKE,
+    referencedEventId: [SPELLS.DIVINE_HAMMER_CAST.id, SPELLS.HAMMER_OF_LIGHT.id],
+    referencedEventType: EventType.Cast,
+    linkingEventId: TALENTS_PALADIN.WAKE_OF_ASHES_TALENT.id,
+    linkingEventType: EventType.Cast,
+    forwardBufferMs: CRUSADE_MINIMAL_DURATION,
+    anyTarget: true,
+  },
+];
+
+class WakeOfAshesNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export function getCastsDuringWake(event: CastEvent): CastEvent[] {
+  return GetRelatedEvents<CastEvent>(
+    event,
+    CASTS_DURING_WAKE,
+    (e): e is CastEvent => e.type === EventType.Cast,
+  );
+}
+
+export default WakeOfAshesNormalizer;

--- a/src/analysis/retail/paladin/shared/DuskAndDawn.tsx
+++ b/src/analysis/retail/paladin/shared/DuskAndDawn.tsx
@@ -96,11 +96,6 @@ export class DuskAndDawn extends Analyzer {
             value={`${formatPercentage(this.duskUptimePct)}%`}
             label="Dusk Uptime"
           />
-          <BoringSpellValue
-            spell={SPELLS.BLESSING_OF_DAWN}
-            value={`${formatPercentage(this.dawnUptimePct)}%`}
-            label="Dawn Uptime"
-          />
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/common/SPELLS/paladin.ts
+++ b/src/common/SPELLS/paladin.ts
@@ -461,12 +461,12 @@ const spells = {
   CRUSADING_STRIKES_ENERGIZE: {
     id: 406834,
     name: 'Crusading Strikes',
-    icon: 'inv_sword_2h_artifactashbringer_d_01',
+    icon: 'inv_sword_08',
   },
   CRUSADING_STRIKES: {
     id: 408385,
     name: 'Crusading Strikes',
-    icon: 'spell_holy_crusaderstrike.jpg',
+    icon: 'inv_sword_08',
   },
   VANGUARDS_MOMENTUM: {
     id: 403081,
@@ -621,7 +621,7 @@ const spells = {
     id: 427453,
     name: 'Hammer of Light',
     icon: 'inv_mace_1h_gryphonrider_d_02_silver.jpg',
-    holyPowerCost: 3,
+    holyPowerCost: 5,
   },
   LIGHTS_DELIVERANCE_FREE_CAST_BUFF: {
     ...talents.LIGHTS_DELIVERANCE_TALENT,


### PR DESCRIPTION
### Description

This is a two part PR.
**Statistics page updates and spec fixes** :
([small fixes to the statistics page](https://github.com/WoWAnalyzer/WoWAnalyzer/commit/91aa724181d87bbd450b93d8789e90681deba61b)
[add crusadin strikes to abilities as Hidden to avoid spellusable warning](https://github.com/WoWAnalyzer/WoWAnalyzer/commit/ffef020f2a26ef485dc1c05167f046c276813bd8))

- Correctly marked Hammer of Light as 5HP instead of 3.
- Remove duplicate Execution Sentence in the abilities sections (now only shows in cooldowns)
- Remove Consecration from Abilities so that is isnt showed in the stats page anymore (it's become 100% passive)
- Change Crusading Strikes icons to stay coherent with the in game icon (in game, the one Crusading Strike that generates HP does not have a different icon like it has on wowhead)
- Remove Crusading Strikes from Abilities so that is isnt showed in the stats page anymore (it's 100% passive)
- Remove Blessing of Dawn stat because uptime does not mean anything anymore since its rework. percentage of spenders affected could be interesting to some people though it has no gameplay interactions.

**Guide update**
Add a Cooldown Usage section similar to Havoc. This tracks every cast of Wake of Ashes (now our most important cooldown thanks to Radiant Glory).
It tracks the following:
- Whether or not Execution Sentence was already on target (should be)
- How many Hammer of Light casts were fit into the window (expecting 1+ and 2+ with 4 piece)
- If Divine Hammer was cast during cooldowns (should be cast before. Only displayed if it happened)

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

`/report/pXdNqrLYG4cwM8tC/16/6` with a lot of mistakes and no 4 piece
`/report/Cxq9LjpZQ2kBdftK/49-Heroic+Loom'ithar+-+Kill+(4:00)/Amenadiell/standard` with less mistakes and 4 piece
`/report/pXdNqrLYG4cwM8tC/16-Heroic+Loom'ithar+-+Kill+(6:25)/Poulpitus/standard` between the two, not full fail or full good
- Screenshot(s):
<img width="1268" height="317" alt="image" src="https://github.com/user-attachments/assets/c5e55b27-60c6-45bb-b7ac-40fdfa688ac6" />
<img width="1275" height="291" alt="image" src="https://github.com/user-attachments/assets/d53d6340-0e26-4e6b-819a-9f684c6168fe" />
<img width="602" height="40" alt="image" src="https://github.com/user-attachments/assets/8cff68d5-309c-409c-8397-b52e606ca205" />
<img width="1150" height="44" alt="image" src="https://github.com/user-attachments/assets/b6668bac-d0a9-4731-89e1-e79b81568a4f" />
<img width="1153" height="493" alt="image" src="https://github.com/user-attachments/assets/42d448cc-af30-4ceb-8425-977a179254b1" />

