### PR TITLE
Coalescence now correctly amps Ancient Teachings and Awakened Jadefire

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { ortemis, emallson, swirl, Trevor, Vetyst, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 9, 12), <><SpellLink spell={TALENTS_MONK.COALESCENCE_TALENT}/> now correctly amps <SpellLink spell={SPELLS.ANCIENT_TEACHINGS}/> and <SpellLink spell={TALENTS_MONK.AWAKENED_JADEFIRE_TALENT}/> healing.</>, swirl),
   change(date(2025, 8, 19), <>Add haste buffs for 11.2 tier set</>, Trevor),
   change(date(2025, 8, 17), <>Update <SpellLink spell={TALENTS_MONK.VIVACIOUS_VIVIFICATION_TALENT}/> descriptions</>, Trevor),
   change(date(2025, 8, 16), <>Bump support to 11.2</>, Trevor),

--- a/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/Coalesence.tsx
+++ b/src/analysis/retail/monk/shared/hero/MasterOfHarmony/talents/Coalesence.tsx
@@ -15,14 +15,6 @@ import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from 'analysis/retail/monk/mistweaver/constants';
 
-// These abilities are affected by healing amps but not Coalescence
-const coalescenceAmpExceptions = [
-  SPELLS.AT_CRIT_HEAL.id,
-  SPELLS.AT_HEAL.id,
-  SPELLS.AJ_HEAL.id,
-  SPELLS.AJ_CRIT_HEAL.id,
-];
-
 class Coalesence extends Analyzer {
   static dependencies = {
     combatants: Combatants,
@@ -46,10 +38,7 @@ class Coalesence extends Analyzer {
       return;
     }
 
-    if (
-      !ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(event.ability.guid) ||
-      coalescenceAmpExceptions.includes(event.ability.guid)
-    ) {
+    if (!ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(event.ability.guid)) {
       return;
     }
 


### PR DESCRIPTION
### Description

A bugfix made on 09/09 correctly fixes Ancient Teachings and (not mentioned in bugfix, but is part of it) Awakened Jadefire being increased by Coalescence's 20% heal amp.

<img width="1410" height="884" alt="image" src="https://github.com/user-attachments/assets/a26b1e13-d1b4-4ceb-9d88-1f589df99437" />

### Testing

`/report/4ZF3bWfvnPQgK8ch/3-Mythic++Operation:+Floodgate+-+Kill+(31:32)/Swirl/standard/overview`
Post-fix:
<img width="392" height="197" alt="image" src="https://github.com/user-attachments/assets/4264c9e7-b810-427d-b1f0-2ec2c85e4d12" />

Pre-fix:
<img width="413" height="207" alt="image" src="https://github.com/user-attachments/assets/746c4c58-aca1-47e4-b53e-980a5c4893ae" />
