### PR TITLE
[Classic] MoP Engi Items

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -44,6 +44,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 9, 14), 'MoP update for Classic Engineering Item, Spell, and Enchant IDs', jazminite),
   change(date(2025, 9, 12), 'Add background images and timeline abilities for Terrace of Endless Spring', emallson),
   change(date(2025, 9, 5), 'Add page to show analysis errors across all supported specs.', emallson),
   change(date(2025, 8, 25), 'Add option to disable movement warnings on timeline tab.', ToppleTheNun),

--- a/src/common/SPELLS/classic/engineering.ts
+++ b/src/common/SPELLS/classic/engineering.ts
@@ -29,22 +29,17 @@ const spells = {
     icon: 'spell_fire_burningspeed.jpg',
     enchantId: 4223,
   },
-  SARONITE_BOMB: {
-    id: 56350,
-    name: 'Saronite Bomb',
-    icon: 'inv_misc_enggizmos_32.jpg',
-  },
   SYNAPSE_SPRINGS: {
-    id: 82174,
+    id: 126734,
     name: 'Synapse Springs',
     icon: 'spell_shaman_elementaloath.jpg',
-    enchantId: 4179,
+    enchantId: 4898,
   },
   SYNAPSE_SPRINGS_INTEL_BUFF: {
     id: 96230,
     name: 'Synapse Springs',
     icon: 'spell_shaman_elementaloath.jpg',
-    enchantId: 4179,
+    enchantId: 4898,
   },
 } satisfies Record<string, Spell>;
 

--- a/src/parser/classic/modules/items/engineering/Bombs.tsx
+++ b/src/parser/classic/modules/items/engineering/Bombs.tsx
@@ -29,11 +29,6 @@ export default class Bombs extends Analyzer.withDependencies({ abilities: Abilit
         category: SPELL_CATEGORY.ITEMS,
         gcd: null,
       });
-      this.deps.abilities.add({
-        spell: SPELLS.SARONITE_BOMB.id,
-        category: SPELL_CATEGORY.ITEMS,
-        gcd: null,
-      });
     }
   }
 }


### PR DESCRIPTION
### Description

- Update Synapse Springs Spell ID and Enchant ID
- Remove Saronite Bombs (never used anymore)

### Testing

Discovered while working on the Warlock and Mage spec updates
