### PR TITLE
Remove Dimensius mechanic from Eons calculations

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -4,7 +4,8 @@ import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 
-export default [
+export default [  
+  change(date(2025, 9, 20), <>Update filter for <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT}/> to remove a Dimensius mechanic.</>, KYZ),
   change(date(2025, 8, 29), <>Update <SpellLink spell={TALENTS.EBON_MIGHT_TALENT}/> module to be more lenient with pandemic duration.</>, KYZ),
   change(date(2025, 8, 22), "Update example report for 11.2.0", Vollmer),
   change(date(2025, 8, 11), <>Update filter for <SpellLink spell={TALENTS.BREATH_OF_EONS_TALENT}/> to make module more reliably load.</>, KYZ),

--- a/src/analysis/retail/evoker/augmentation/modules/util/abilityFilter.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/util/abilityFilter.ts
@@ -323,6 +323,7 @@ export const ABILITY_NO_EM_SCALING = new Set<number>([
   1246637, // Chaotic Nethergate,
   1247690, // Artisanal Blink Trap,
   1248107, // Nether-warped Seedling
+  1246948, // Shooting Star (Dimensius)
 ]);
 
 /** Class or non-class abilities that don't contribute to Eons
@@ -685,4 +686,5 @@ export const ABILITY_NO_BOE_SCALING = new Set<number>([
   1243069, // Horrific Visions,
   1243105, // Horrific Vision,
   1243106, // Vision of N'Zoth,
+  1246948, // Shooting Star (Dimensius)
 ]);


### PR DESCRIPTION
Short pull request updating the ability filter, as Shooting Star was being included in Eons calculations.