### PR TITLE
[BrM] miscellaneous updates

### DIFF
--- a/scripts/lint-baseline/baseline.json
+++ b/scripts/lint-baseline/baseline.json
@@ -190,8 +190,6 @@
   "src/interface/guide/components/Apl/index.tsx:133:25__@typescript-eslint/no-explicit-any",
   "src/interface/guide/components/Apl/violations/claims.tsx:47:72__@typescript-eslint/no-explicit-any",
   "src/interface/guide/components/Apl/violations/index.tsx:52:35__@typescript-eslint/no-explicit-any",
-  "src/interface/guide/components/DamageTakenPointChart.tsx:121:23__@typescript-eslint/no-explicit-any",
-  "src/interface/guide/components/DamageTakenPointChart.tsx:121:51__@typescript-eslint/no-explicit-any",
   "src/interface/guide/components/MajorDefensives/AllCooldownUsagesList.tsx:248:28__@typescript-eslint/no-explicit-any",
   "src/interface/guide/components/MajorDefensives/MajorDefensiveAnalyzer.tsx:36:41__@typescript-eslint/no-explicit-any",
   "src/interface/guide/components/MajorDefensives/MajorDefensiveAnalyzer.tsx:88:55__@typescript-eslint/no-explicit-any",

--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,8 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 9, 21), <>Correct handling of pre-pull <SpellLink spell={talents.CHI_BURST_SHARED_TALENT} /> in rotation checker.</>, emallson),
+  change(date(2025, 9, 21), <>Add support for <SpellLink spell={talents.IRONSHELL_BREW_TALENT} /> and <SpellLink spell={talents.CELESTIAL_INFUSION_TALENT} /> to major defensive analysis.</>, emallson),
   change(date(2025, 9, 12), <>Fix purify rate on <SpellLink spell={talents.QUICK_SIP_TALENT} />.</>, emallson),
   change(date(2025, 9, 11), <>Fix cooldown reduction effects not applying to <SpellLink spell={talents.CELESTIAL_INFUSION_TALENT} />.</>, emallson),
   change(date(2025, 8, 21), <>Update priority of <SpellLink spell={talents.KEG_SMASH_TALENT} /> in breathless builds.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
+++ b/src/analysis/retail/monk/brewmaster/modules/Abilities.ts
@@ -73,6 +73,8 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.ROTATIONAL,
         cooldown: 30,
         enabled: combatant.hasTalent(talents.CHI_BURST_SHARED_TALENT),
+        damageSpellIds: [SPELLS.CHI_BURST_TALENT_DAMAGE.id],
+        healSpellIds: [SPELLS.CHI_BURST_HEAL.id],
         castEfficiency: {
           suggestion: false,
         },

--- a/src/interface/guide/components/DamageTakenPointChart.tsx
+++ b/src/interface/guide/components/DamageTakenPointChart.tsx
@@ -66,7 +66,7 @@ interface DamageTakenPointChartProps {
   /**
    * By default, small hits (<10% hp) are hidden. This helps eliminate junk like passive ticking damage.
    */
-  showSmallHits: boolean;
+  showSmallHits?: boolean;
 }
 
 type Props = DamageTakenPointChartProps;

--- a/src/interface/guide/components/DamageTakenPointChart.tsx
+++ b/src/interface/guide/components/DamageTakenPointChart.tsx
@@ -63,6 +63,10 @@ export function damageBreakdown<T>(
 interface DamageTakenPointChartProps {
   hits: TrackedHit[];
   tooltip: React.FC<{ hit: TrackedHit }>;
+  /**
+   * By default, small hits (<10% hp) are hidden. This helps eliminate junk like passive ticking damage.
+   */
+  showSmallHits: boolean;
 }
 
 type Props = DamageTakenPointChartProps;
@@ -118,6 +122,8 @@ export function DamageSourceLink({
   event,
   showSourceName,
 }: {
+  // annoying type issues with non-any type params here
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   event: AbilityEvent<any> & Partial<SourcedEvent<any>>;
   showSourceName?: boolean;
 }): JSX.Element | null {
@@ -150,7 +156,7 @@ function HitTimeline({
   hits,
   showSourceName,
   tooltip: TooltipContent,
-}: Props & { showSourceName?: boolean }) {
+}: Omit<Props, 'showSmallHits'> & { showSourceName?: boolean }) {
   const info = useInfo()!;
   const enemies = useAnalyzer(Enemies);
 
@@ -181,6 +187,23 @@ function HitTimeline({
   );
 }
 
+function hiddenByDefault(data: Map<string, TrackedHit[]>): boolean {
+  let maxHit = 0;
+  for (const hits of data.values()) {
+    maxHit = Math.max(
+      maxHit,
+      Math.max.apply(
+        null,
+        hits
+          .filter((hit) => hit.event.maxHitPoints !== undefined)
+          .map((hit) => hit.event.amount / hit.event.maxHitPoints!),
+      ),
+    );
+  }
+
+  return maxHit < 0.1;
+}
+
 /**
  * Damage Taken chart shown as a single point for each hit. See the Brewmaster Shuffle section
  * for an example of what this looks like.
@@ -191,7 +214,11 @@ function HitTimeline({
  *
  * Note that the `tooltip` component is *required* and that this is intentional.
  */
-export default function DamageTakenPointChart({ hits, tooltip }: Props): JSX.Element {
+export default function DamageTakenPointChart({
+  hits,
+  tooltip,
+  showSmallHits,
+}: Props): JSX.Element {
   const hitsBySpellRaw = damageBreakdown(
     hits,
     (hit: TrackedHit) => hit.event.ability.guid,
@@ -212,6 +239,7 @@ export default function DamageTakenPointChart({ hits, tooltip }: Props): JSX.Ele
       ))}
       {Array.from(hitsBySpellRaw.entries())
         .filter(([id]) => id !== 1)
+        .filter(([, hits]) => showSmallHits || !hiddenByDefault(hits))
         .map(([id, hits]) => (
           <HitTimeline hits={Array.from(hits.values()).flat()} key={id} tooltip={tooltip} />
         ))}


### PR DESCRIPTION
### Description

- fix pre-pull Chi Burst use in rotation checker
- add support for Ironshell Brew & Celestial Infusion in major defensives
- hide spells that only have small hits from damage taken chart by default

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/tW4jYybMd1APQakH/50-Mythic+Nexus-King+Salhadaar+-+Wipe+46+(5:55)/Eisenpelz/standard`
- Screenshot(s):
<img width="2500" height="1118" alt="image" src="https://github.com/user-attachments/assets/1f13746d-3846-4fe2-95a6-a9c8fbc55632" />
<img width="2460" height="414" alt="image" src="https://github.com/user-attachments/assets/197d7298-755a-4263-b3ed-4ed7f405b6e3" />
<img width="2452" height="398" alt="image" src="https://github.com/user-attachments/assets/c1d005e0-b678-4c82-bc1a-3b1c8c33570f" />

