### PR TITLE
use average instead of median for support stats.

### DIFF
--- a/src/common/server-metrics.ts
+++ b/src/common/server-metrics.ts
@@ -25,7 +25,6 @@ export interface Aggregate {
   min: number;
   max: number;
   avg: number;
-  median: number;
 }
 
 export interface Selection {
@@ -97,7 +96,6 @@ interface RawServerMetricValue {
   metricId: keyof ServerMetrics;
   avgValue: number;
   maxValue: number;
-  medValue: number;
   minValue: number;
 }
 
@@ -117,7 +115,6 @@ function groupRawMetrics(
       min: metric.minValue,
       max: metric.maxValue,
       avg: metric.avgValue,
-      median: metric.medValue,
     };
   }
 

--- a/src/interface/routes/support-stats.tsx
+++ b/src/interface/routes/support-stats.tsx
@@ -209,21 +209,21 @@ function StatsTableEntry({
 
   const perf = evaluateQualitativePerformanceByThreshold({
     ...props.threshold,
-    actual: value.median,
+    actual: value.avg,
   } as QualitativePerformanceThreshold);
 
   return (
     <Tooltip
       content={
         <>
-          The median value. The average is <strong>{formatValue(value.avg)}</strong>, and the data
-          ranges from a min of <strong>{formatValue(value.min)}</strong> to a max of{' '}
+          The average is <strong>{formatValue(value.avg)}</strong>, and the data ranges from a min
+          of <strong>{formatValue(value.min)}</strong> to a max of{' '}
           <strong>{formatValue(value.max)}</strong>
         </>
       }
     >
       <div style={{ cursor: 'pointer', color: qualitativePerformanceToColor(perf) }}>
-        {formatValue(value.median)}
+        {formatValue(value.avg)}
       </div>
     </Tooltip>
   );


### PR DESCRIPTION
tl;dr - the calculation of median on the server is wrong due to the interaction of `GROUP BY` and `OVER (window)` in MariaDB/MySQL. There is no median aggregate function, and switching fully to window functions makes performance *even worse,* so this simply removes the use of the median.

This is why some specs would flip between 0% active time and some high % while having high % average active time (seen in the tooltip) with effectively no CD errors, etc.

There will be a separate backend PR to remove the median calculation.

### Before
<img width="1267" height="506" alt="image" src="https://github.com/user-attachments/assets/b21b4d62-2d11-4882-a2c3-b93a60e8f6b9" />

### After
<img width="1236" height="442" alt="image" src="https://github.com/user-attachments/assets/21e16f1b-950b-4c30-8ef6-82df7c3a84d1" />
