### PR TITLE
Fix Protectors of the Endless phase header crash

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -44,6 +44,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2025, 10, 1), <>Fix crash in Protectors of the Endless analysis if the Foundation timeline is shown. Also fix a zoom bug on the phase header.</>, emallson),
   change(date(2025, 9, 25), <>Add <SpellLink spell={SPELLS.PHASE_BLINK.id} /> to the ignored spells.</>, Arlie),
   change(date(2025, 9, 14), 'MoP update for Classic Engineering Item, Spell, and Enchant IDs', jazminite),
   change(date(2025, 9, 12), 'Add background images and timeline abilities for Terrace of Endless Spring', emallson),

--- a/src/interface/report/hooks/useBossPhaseEvents.tsx
+++ b/src/interface/report/hooks/useBossPhaseEvents.tsx
@@ -37,7 +37,7 @@ const buildWclPhaseConfigs = (
 
     phaseConfigs[id] = {
       key: String(id),
-      name: bossPhases.phases[id - 1],
+      name: bossPhases.phases[id - 1] ?? 'Unknown Phase',
       difficulties: [fight.difficulty ?? 1],
       intermission: intermissions.has(id),
     };


### PR DESCRIPTION
### Description

<img width="2544" height="616" alt="image" src="https://github.com/user-attachments/assets/09406433-f400-4888-99e8-6bf5a63e028e" />

fixes a crash when WCL reports a phase index beyond the end of the label list. this shouldn't happen, but does on protectors.

the 2nd commit also fixes a bug where zoom didn't work properly with phase header clicks. I probably broke this while refactoring and didn't notice. oops.

### Testing
http://localhost:3000/report/VqRJyj1fx3DCwHnb/2-Heroic+Protectors+of+the+Endless+-+Kill+(4:38)/Caischlong/standard

