### PR TITLE
Demon soul DPS increase for Fel Scarred

### DIFF
--- a/src/analysis/retail/demonhunter/shared/modules/spells/DemonSoulBuff.tsx
+++ b/src/analysis/retail/demonhunter/shared/modules/spells/DemonSoulBuff.tsx
@@ -27,10 +27,14 @@ export default class DemonSoulBuff extends Analyzer {
   }
 
   private onDamage(event: DamageEvent) {
-    if (
-      !this.selectedCombatant.hasBuff(SPELLS.DEMON_SOUL_BUFF_NON_FODDER.id) ||
-      !DEMON_SOUL_BUFF_ALLOWLIST.includes(event.ability.guid)
-    ) {
+    const hasDemonSoul =
+      this.selectedCombatant.hasBuff(SPELLS.DEMON_SOUL_BUFF_FEL_SCARRED_VDH.id) ||
+      this.selectedCombatant.hasBuff(SPELLS.DEMON_SOUL_BUFF_FEL_SCARRED_HDH.id) ||
+      this.selectedCombatant.hasBuff(SPELLS.DEMON_SOUL_BUFF_NON_FODDER.id);
+
+    const allowedSpell = DEMON_SOUL_BUFF_ALLOWLIST.includes(event.ability.guid);
+
+    if (!hasDemonSoul || !allowedSpell) {
       return;
     }
     this.addedDamage += calculateEffectiveDamage(event, 0.2);

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2025, 11, 10), <>Fix Demon Soul increased damage calculation.</>, Quaarkz),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2024, 9, 23), <>Clean up <SpellLink spell={TALENTS.FRACTURE_TALENT} /> analyzer.</>, ToppleTheNun),
   change(date(2024, 10, 17), 'Untethered Fury talent taken into consideration for Fracture analysis.', Quaarkz),

--- a/src/common/SPELLS/demonhunter.ts
+++ b/src/common/SPELLS/demonhunter.ts
@@ -190,6 +190,16 @@ const spells = {
     name: 'Demon Soul',
     icon: 'spell_shadow_soulleech_3',
   },
+  DEMON_SOUL_BUFF_FEL_SCARRED_VDH: {
+    id: 1238675,
+    name: 'Demon Soul',
+    icon: 'ability_warlock_improvedsoulleech',
+  },
+  DEMON_SOUL_BUFF_FEL_SCARRED_HDH: {
+    id: 1238676,
+    name: 'Demon Soul',
+    icon: 'ability_warlock_improvedsoulleech',
+  },
   //endregion
 
   //region Vengeance


### PR DESCRIPTION
### Description
Included the Demon Soul ID for FS and updated it in DemonSoulBuff.tsx, might aswell check how the added damage is calculated because my numbers doesnt add up, 4-5% of damage amp in ~50% uptime and obviously lined with cooldowns sounds bad to me but i dont know

### Testing
Input any log from Fel Scarred and go to the statistics tab to see the Demon Soul card, should mark 0 for AR and work for FS

