### PR TITLE
Specify type of event in getDamageEvents and getAppliedDots in TheHuntNormalizer

### DIFF
--- a/src/analysis/retail/demonhunter/shared/normalizers/TheHuntNormalizer.ts
+++ b/src/analysis/retail/demonhunter/shared/normalizers/TheHuntNormalizer.ts
@@ -66,17 +66,17 @@ export function getChargeImpact(event: CastEvent): DamageEvent | undefined {
 }
 
 export function getDamageEvents(event: CastEvent): DamageEvent[] {
-  return GetRelatedEvents(
+  return GetRelatedEvents<DamageEvent>(
     event,
-    THE_HUNT_CHARGE,
+    THE_HUNT_DAMAGE,
     (e): e is DamageEvent => e.type === EventType.Damage,
   );
 }
 
 export function getAppliedDots(event: CastEvent): ApplyDebuffEvent[] {
-  return GetRelatedEvents(
+  return GetRelatedEvents<ApplyDebuffEvent>(
     event,
-    THE_HUNT_CHARGE,
+    THE_HUNT_DOT_APPLICATION,
     (e): e is ApplyDebuffEvent => e.type === EventType.ApplyDebuff,
   );
 }

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2025, 11, 10), <>Specify the types of events in TheHuntNormalizer.</>, Quaarkz),
   change(date(2025, 11, 10), <>Add spells to DemonSoul Allowlist.</>, Quaarkz),
   change(date(2025, 11, 10), <>Fix Demon Soul increased damage calculation.</>, Quaarkz),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),


### PR DESCRIPTION
### Description

getDamageEvents and getAppliedDots had the same implementation that didnt fit them properly, i specified their Event types and input their corresponding EventLink constant so it returns charge + DoT ticks

### Testing

In the same tab as Demon soul, now the damage and dps& checks out with the actual data in warcraftlogs for both HDH and VDH, i checked with different logs from both specs in both raid and dungeon environment

- Test report URL: `/report/...`
- Screenshot(s):
