### PR TITLE
Clean VDH tiers and disable Demon Soul

### DIFF
--- a/src/analysis/retail/demonhunter/shared/modules/spells/DemonSoulBuff.tsx
+++ b/src/analysis/retail/demonhunter/shared/modules/spells/DemonSoulBuff.tsx
@@ -13,6 +13,7 @@ export default class DemonSoulBuff extends Analyzer {
   private addedDamage = 0;
   constructor(options: Options) {
     super(options);
+    this.active = false;
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
   }
 

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2025, 11, 20), <>Clean-up VDH tiers and disable Demon Soul.</>, Quaarkz),
   change(date(2025, 11, 15), <>Model VDH tiers and update/add constants.</>, Quaarkz),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2024, 9, 23), <>Clean up <SpellLink spell={SPELLS.FRACTURE} /> analyzer.</>, Topple),

--- a/src/analysis/retail/demonhunter/vengeance/modules/items/MID1Vengeance2P.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/items/MID1Vengeance2P.tsx
@@ -23,10 +23,6 @@ class MID1Vengeance2P extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.has2PieceByTier(TIERS.MID1);
 
-    if (!this.active) {
-      return;
-    }
-
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.FRACTURE_MAIN_HAND),
       this.onDamage,

--- a/src/analysis/retail/demonhunter/vengeance/modules/items/MID1Vengeance2P.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/items/MID1Vengeance2P.tsx
@@ -10,7 +10,7 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
-//import { TIERS } from 'game/TIERS';
+import { TIERS } from 'game/TIERS';
 
 /**
  * (2) Set Vengeance: Fracture damage increased by 30%.
@@ -21,9 +21,7 @@ class MID1Vengeance2P extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = true;
-    //this.active = this.selectedCombatant.has2PieceByTier(TIERS.MIDNIGHT1);
-    //Midnight tiers not implemented yet
+    this.active = this.selectedCombatant.has2PieceByTier(TIERS.MID1);
 
     if (!this.active) {
       return;

--- a/src/analysis/retail/demonhunter/vengeance/modules/items/MID1Vengeance4P.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/items/MID1Vengeance4P.tsx
@@ -2,7 +2,7 @@ import SPELLS from 'common/SPELLS/demonhunter';
 
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
-//import { TIERS } from 'game/TIERS';
+import { TIERS } from 'game/TIERS';
 import React from 'react';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -23,8 +23,11 @@ class MID1Vengeance4P extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this.active = true; //for testing
-    //this.active = this.selectedCombatant.has4PieceByTier(TIERS.MIDNIGHT1);
+    this.active = this.selectedCombatant.has4PieceByTier(TIERS.MID1);
+
+    if (!this.active) {
+      return;
+    }
 
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.MID1_EXPLOSION_OF_THE_SOUL),
@@ -35,22 +38,11 @@ class MID1Vengeance4P extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.FRACTURE),
       this.onFractureCast,
     );
-
-    // If its a cast:
-    // this.addEventListener
-    //   Events.cast.by(SELECTED_PLAYER).spell(SPELLS.MID1_EXPLOSION_OF_THE_SOUL),
-    //   this.onDetonationCast,
-    // );
   }
 
   private onDetonationDamage = (event: DamageEvent) => {
     this.#explosionProcs += 1;
   };
-
-  // Again if its a cast:
-  // private onDetonationCast = (event: CastEvent) => {
-  //  this.explosionProcs++;
-  //};
 
   private onFractureCast = (event: CastEvent) => {
     this.#fractureCount += 1;

--- a/src/analysis/retail/demonhunter/vengeance/modules/items/MID1Vengeance4P.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/items/MID1Vengeance4P.tsx
@@ -25,10 +25,6 @@ class MID1Vengeance4P extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.has4PieceByTier(TIERS.MID1);
 
-    if (!this.active) {
-      return;
-    }
-
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.MID1_EXPLOSION_OF_THE_SOUL),
       this.onDetonationDamage,


### PR DESCRIPTION
### Description

Removed this.active mock-ups for VDH 2 and 4pc, disable demon soul and clean unneccessary comments.

Originally i thought it'd be nice to stop the execution of the class if this.active = false but i found that that's already managed so i removed them both.

Still need to change 4PC percentage colour method to the standard method.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/...`
- Screenshot(s):