### PR TITLE
[Mistweaver] Update Restore Balance for MW/WW

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import { Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
-  change(date(2025, 12, 2), <>Updated <SpellLink spell={TALENTS_MONK.RESTORE_BALANCE_TALENT}/> for Midnight.</>, Vohrr),
+  change(date(2025, 12, 2), <>Updated <SpellLink spell={TALENTS_MONK.RESTORE_BALANCE_TALENT}/> for Midnight and re-enabled <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_1_WINDWALKER_TALENT}/> for Mistweaver.</>, Vohrr),
   change(date(2025, 11, 25), <>Added Season 1 Tier Set analysis for Mistweaver</>, Vohrr),
   change(date(2025, 11, 23), <>Minor bug fixes and typos. Added <SpellLink spell={TALENTS_MONK.MISTY_COALESCENCE_TALENT}/> module.</>, Vohrr),
   change(date(2025, 11, 23), <>Updated <SpellLink spell={TALENTS_MONK.YULONS_WHISPER_TALENT}/>, <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> bug fixes,  <SpellLink spell={TALENTS_MONK.JADE_EMPOWERMENT_TALENT}/>, and <SpellLink spell={SPELLS.ANCIENT_TEACHINGS}/> for Midnight.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 12, 2), <>Updated <SpellLink spell={TALENTS_MONK.RESTORE_BALANCE_TALENT}/> for Midnight.</>, Vohrr),
   change(date(2025, 11, 25), <>Added Season 1 Tier Set analysis for Mistweaver</>, Vohrr),
   change(date(2025, 11, 23), <>Minor bug fixes and typos. Added <SpellLink spell={TALENTS_MONK.MISTY_COALESCENCE_TALENT}/> module.</>, Vohrr),
   change(date(2025, 11, 23), <>Updated <SpellLink spell={TALENTS_MONK.YULONS_WHISPER_TALENT}/>, <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> bug fixes,  <SpellLink spell={TALENTS_MONK.JADE_EMPOWERMENT_TALENT}/>, and <SpellLink spell={SPELLS.ANCIENT_TEACHINGS}/> for Midnight.</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -4,6 +4,7 @@ import {
   TouchOfDeath,
   SaveThemAll,
   TeachingsOfTheMonestary,
+  CelestialHooks,
 } from 'analysis/retail/monk/shared';
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import ManaTracker from 'parser/core/healingEfficiency/ManaTracker';
@@ -106,6 +107,7 @@ class CombatLogParser extends CoreCombatLogParser {
     hotTrackerMW: HotTrackerMW,
     hotAttributor: HotAttributor,
     mysticTouch: MysticTouch,
+    celestialHooks: CelestialHooks,
 
     // Generic healer things
     manaLevelChart: ManaLevelChart,

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -13,7 +13,7 @@ import AplChoiceDescription from './modules/core/apl/AplChoiceDescription';
 import { AplSectionData } from 'interface/guide/components/Apl';
 import { defaultExplainers } from 'interface/guide/components/Apl/violations/claims';
 import { filterCelestial } from './modules/core/apl/ExplainCelestial';
-import { getCurrentRSKTalent } from './constants';
+import { getCurrentCelestialTalent, getCurrentRSKTalent } from './constants';
 
 const explainers = {
   overcast: filterCelestial(defaultExplainers.overcastFillers),
@@ -60,7 +60,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
         <p>
           <strong>
             It is important to note that using abilites like{' '}
-            <SpellLink spell={modules.invokeChiJi.getCelestialTalent()} /> have their own priority
+            <SpellLink spell={getCurrentCelestialTalent(info.combatant)} /> have their own priority
             that supercedes the priority list below. This section omits all casts in those windows.
           </strong>
         </p>

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -154,9 +154,14 @@ export function getCurrentRSKTalent(player: Combatant): Talent {
     ? TALENTS_MONK.RUSHING_WIND_KICK_MISTWEAVER_TALENT
     : TALENTS_MONK.RISING_SUN_KICK_TALENT;
 }
-
 export function getCurrentRSKTalentDamage(player: Combatant): Spell {
   return player.hasTalent(TALENTS_MONK.RUSHING_WIND_KICK_MISTWEAVER_TALENT)
     ? SPELLS.RUSHING_WIND_KICK_DAMAGE
     : SPELLS.RISING_SUN_KICK_DAMAGE;
+}
+
+export function getCurrentCelestialTalent(player: Combatant): Talent {
+  return player.hasTalent(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT)
+    ? TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT
+    : TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT;
 }

--- a/src/analysis/retail/monk/mistweaver/modules/core/SpellManaCost.ts
+++ b/src/analysis/retail/monk/mistweaver/modules/core/SpellManaCost.ts
@@ -4,14 +4,14 @@ import { TALENTS_MONK } from 'common/TALENTS';
 import { CHIJI_REDUCTION, YULON_REDUCTION } from '../../constants';
 import SpellManaCost from 'parser/shared/modules/SpellManaCost';
 import { CastEvent } from 'parser/core/Events';
-import BaseCelestialAnalyzer from '../spells/BaseCelestialAnalyzer';
+import { CelestialHooks } from 'analysis/retail/monk/shared';
 
 class MWSpellManaCost extends SpellManaCost {
   static dependencies = {
     ...SpellManaCost.dependencies,
-    celestial: BaseCelestialAnalyzer,
+    celestialHooks: CelestialHooks,
   };
-  celestial!: BaseCelestialAnalyzer;
+  celestialHooks!: CelestialHooks;
   currentBuffs = new Set<number>();
   hasChiji = false;
   constructor(options: Options) {
@@ -39,7 +39,7 @@ class MWSpellManaCost extends SpellManaCost {
       return 0;
     }
     let celestialMultiplier = 1;
-    if (spellID === TALENTS_MONK.ENVELOPING_MIST_TALENT.id && this.celestial.celestialActive) {
+    if (spellID === TALENTS_MONK.ENVELOPING_MIST_TALENT.id && this.celestialHooks.celestialActive) {
       celestialMultiplier -= this.hasChiji ? CHIJI_REDUCTION : YULON_REDUCTION;
     }
     return celestialMultiplier;

--- a/src/analysis/retail/monk/mistweaver/modules/features/HotCountGraph.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/HotCountGraph.tsx
@@ -2,8 +2,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { SpellLink } from 'interface';
 import BuffCountGraph, { GraphedSpellSpec } from 'parser/shared/modules/BuffCountGraph';
-import { SPELL_COLORS } from '../../constants';
-import BaseCelestialAnalyzer from '../spells/BaseCelestialAnalyzer';
+import { getCurrentCelestialTalent, SPELL_COLORS } from '../../constants';
 import Revival from '../spells/Revival';
 import Panel from 'parser/ui/Panel';
 import { Options } from 'parser/core/Module';
@@ -11,11 +10,9 @@ import { Options } from 'parser/core/Module';
 class HotCountGraph extends BuffCountGraph {
   static dependencies = {
     ...BuffCountGraph.dependencies,
-    celestial: BaseCelestialAnalyzer,
     revival: Revival,
   };
   protected revival!: Revival;
-  protected celestial!: BaseCelestialAnalyzer;
 
   constructor(options: Options) {
     super(options);
@@ -34,7 +31,7 @@ class HotCountGraph extends BuffCountGraph {
     const castSpecs: GraphedSpellSpec[] = [];
     castSpecs.push({ spells: this.revival.getRevivalTalent(), color: SPELL_COLORS.REVIVAL });
     castSpecs.push({
-      spells: this.celestial.getCelestialTalent(),
+      spells: getCurrentCelestialTalent(this.selectedCombatant),
       color: SPELL_COLORS.GUSTS_OF_MISTS,
     });
     return castSpecs;
@@ -51,8 +48,8 @@ class HotCountGraph extends BuffCountGraph {
             course of the encounter. It can help you evaluate how effective you were at prepping and
             executing your cooldowns. For example, the number of{' '}
             <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT} />s that go out during{' '}
-            <SpellLink spell={this.celestial.getCelestialTalent()} /> directly correlates to your
-            hps during.
+            <SpellLink spell={getCurrentCelestialTalent(this.selectedCombatant)} /> directly
+            correlates to your hps during.
           </>
         }
       >

--- a/src/analysis/retail/monk/mistweaver/modules/heroTalents/StrengthOfTheBlackOx.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/heroTalents/StrengthOfTheBlackOx.tsx
@@ -9,15 +9,16 @@ import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
 import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import BaseCelestialAnalyzer from '../spells/BaseCelestialAnalyzer';
+import { CelestialHooks } from 'analysis/retail/monk/shared';
+import { getCurrentCelestialTalent } from '../../constants';
 
 class StrengthOfTheBlackOx extends Analyzer {
   static dependencies = {
-    celestial: BaseCelestialAnalyzer,
+    celestial: CelestialHooks,
   };
   wastedBuffs = 0;
   entries: BoxRowEntry[] = [];
-  protected celestial!: BaseCelestialAnalyzer;
+  protected celestial!: CelestialHooks;
 
   constructor(options: Options) {
     super(options);
@@ -71,7 +72,7 @@ class StrengthOfTheBlackOx extends Analyzer {
           {isConsumed && (
             <div>
               <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT} /> or{' '}
-              <SpellLink spell={this.celestial.getCelestialTalent()} /> active:{' '}
+              <SpellLink spell={getCurrentCelestialTalent(this.selectedCombatant)} /> active:{' '}
               <strong>{hasBuff ? 'Yes' : 'No'}</strong>
             </div>
           )}
@@ -90,7 +91,7 @@ class StrengthOfTheBlackOx extends Analyzer {
         have a reduced cast time and apply a shield to 5 nearby allies. It is very important to
         never let this buff refresh or expire as it is a considerable amount of shielding. Try to
         have <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT} /> or{' '}
-        <SpellLink spell={this.celestial.getCelestialTalent()} /> active when casting{' '}
+        <SpellLink spell={getCurrentCelestialTalent(this.selectedCombatant)} /> active when casting{' '}
         <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT} /> as it is very expensive.
       </p>
     );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
@@ -163,12 +163,6 @@ class BaseCelestialAnalyzer extends Analyzer {
     return this.idealEnvmCastsUnhasted * (1 + avgHaste * ENVM_HASTE_FACTOR);
   }
 
-  getCelestialTalent() {
-    return this.selectedCombatant.hasTalent(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT)
-      ? TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT
-      : TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT;
-  }
-
   getCooldownExpandableItems(
     cast: BaseCelestialTracker,
   ): [QualitativePerformance[], CooldownExpandableItem[]] {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
@@ -19,6 +19,7 @@ import Haste from 'parser/shared/modules/Haste';
 import Pets from 'parser/shared/modules/Pets';
 import InformationIcon from 'interface/icons/Information';
 import { Talent } from 'common/TALENTS/types';
+import { CelestialHooks } from 'analysis/retail/monk/shared';
 
 const siDebug = false;
 
@@ -37,14 +38,15 @@ const YULON_GIFT_ENVMS = 4;
 
 class BaseCelestialAnalyzer extends Analyzer {
   static dependencies = {
+    celestialHooks: CelestialHooks,
     haste: Haste,
     pets: Pets,
   };
+  protected celestialHooks!: CelestialHooks;
   protected haste!: Haste;
   protected pets!: Pets;
 
   //celestial vars
-  celestialActive = false;
   currentCelestialStart = -1;
   lastCelestialEnd = -1;
   celestialWindows: Map<number, number> = new Map<number, number>();
@@ -96,8 +98,11 @@ class BaseCelestialAnalyzer extends Analyzer {
       (1 + this.selectedCombatant.getTalentRank(TALENTS_MONK.JADE_BOND_TALENT));
   }
 
+  get celestialActive() {
+    return this.celestialHooks.celestialActive;
+  }
+
   onSummon(event: CastEvent) {
-    this.celestialActive = true;
     this.currentCelestialStart = event.timestamp;
     this.hasteDataPoints = [];
   }
@@ -118,7 +123,6 @@ class BaseCelestialAnalyzer extends Analyzer {
       }
     }
     siDebug && console.log('Celestial Death: ', this.owner.formatTimestamp(event.timestamp));
-    this.celestialActive = false;
     this.celestialWindows.set(this.currentCelestialStart, event.timestamp);
     this.currentCelestialStart = -1;
     this.lastCelestialEnd = event.timestamp;
@@ -224,7 +228,7 @@ class BaseCelestialAnalyzer extends Analyzer {
   }
 
   private getSiBuffType(cast: BaseCelestialTracker): string {
-    console.log(cast);
+    siDebug && console.log(cast);
     if (cast.siBuffId === SPELLS.SECRET_INFUSION_CRIT_BUFF.id) {
       return 'Crit';
     }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
@@ -94,7 +94,6 @@ class InvokeChiJi extends BaseCelestialAnalyzer {
 
   //missed gcd mangement
   handleChijiStart(event: CastEvent) {
-    this.celestialActive = true;
     this.chijiStart = this.lastGlobal = event.timestamp;
     this.chijiGlobals += 1;
     this.chijiUses += 1;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
@@ -11,7 +11,6 @@ import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   AbsorbedEvent,
   CastEvent,
-  DamageEvent,
   GlobalCooldownEvent,
   HealEvent,
   RefreshBuffEvent,
@@ -23,7 +22,7 @@ import Statistic from 'parser/ui/Statistic';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import { getCurrentRSKTalent, getCurrentRSKTalentDamage, MAX_CHIJI_STACKS } from '../../constants';
+import { getCurrentRSKTalent } from '../../constants';
 import BaseCelestialAnalyzer, { BaseCelestialTracker } from './BaseCelestialAnalyzer';
 import InformationIcon from 'interface/icons/Information';
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VivaciousVivify.tsx
@@ -16,23 +16,16 @@ import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
 import RenewingMist from './RenewingMist';
 import Vivify from './Vivify';
 import uptimeBarSubStatistic from 'parser/ui/UptimeBarSubStatistic';
-import BaseCelestialAnalyzer from './BaseCelestialAnalyzer';
-import { formatPercentage } from 'common/format';
 import { isVivaciousVivification } from '../../normalizers/CastLinkNormalizer';
-import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
-import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import Statistic from 'parser/ui/Statistic';
-import TalentSpellText from 'parser/ui/TalentSpellText';
-import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import { CelestialHooks } from 'analysis/retail/monk/shared';
 
 class VivaciousVivification extends Analyzer {
   static dependencies = {
     vivify: Vivify,
     renewingMist: RenewingMist,
-    baseCelestial: BaseCelestialAnalyzer,
+    celestialHooks: CelestialHooks,
   };
-  protected baseCelestial!: BaseCelestialAnalyzer;
+  protected celestialHooks!: CelestialHooks;
   protected renewingMist!: RenewingMist;
   protected vivify!: Vivify;
   currentRenewingMists = 0;
@@ -74,7 +67,7 @@ class VivaciousVivification extends Analyzer {
     return (
       this.renewingMist.currentRenewingMists >= this.vivify.estimatedAverageReMs &&
       this.selectedCombatant.hasBuff(SPELLS.VIVIFICATION_BUFF.id) &&
-      !this.baseCelestial.celestialActive
+      !this.celestialHooks.celestialActive
     );
   }
 

--- a/src/analysis/retail/monk/shared/CelestialHooks.ts
+++ b/src/analysis/retail/monk/shared/CelestialHooks.ts
@@ -1,0 +1,33 @@
+import SPELLS from 'common/SPELLS';
+import { TALENTS_MONK } from 'common/TALENTS';
+import Analyzer, { SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import Events, { CastEvent, DeathEvent, RemoveBuffEvent } from 'parser/core/Events';
+import { Options } from 'parser/core/EventSubscriber';
+
+const TRIGGER_SPELLS = [
+  SPELLS.INVOKE_XUEN_BUFF,
+  TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT,
+  TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT,
+];
+const END_SPELLS = [SPELLS.INVOKE_YULON_BUFF, SPELLS.INVOKE_XUEN_BUFF];
+class CelestialHooks extends Analyzer {
+  celestialActive = false;
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(TRIGGER_SPELLS), this.summon);
+    this.addEventListener(Events.death.to(SELECTED_PLAYER), this.end);
+    this.addEventListener(Events.death.to(SELECTED_PLAYER_PET), this.end);
+    this.addEventListener(Events.removebuff.by(SELECTED_PLAYER).spell(END_SPELLS), this.end);
+  }
+
+  summon(event: CastEvent) {
+    this.celestialActive = true;
+  }
+
+  end(event: DeathEvent | RemoveBuffEvent) {
+    this.celestialActive = false;
+  }
+}
+
+export default CelestialHooks;

--- a/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/constants.ts
+++ b/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/constants.ts
@@ -4,6 +4,7 @@ import { TALENTS_MONK } from 'common/TALENTS/monk';
 export const CELESTIAL_CONDUIT_MAX_DURATION = 4000;
 export const CELESTIAL_CONDUIT_INCREASE_PER_TARGET = 0.06;
 export const CELESTIAL_CONDUIT_MAX_TARGETS = 5;
+export const RESTORE_BALANCE_BOOST = 0.05;
 export const MISTWEAVER_HEART_SPELLS = (hasRWK: boolean): number[] => [
   SPELLS.RENEWING_MIST_CAST.id,
   hasRWK

--- a/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/normalizers/ConduitOfTheCelestialsEventLinks.ts
+++ b/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/normalizers/ConduitOfTheCelestialsEventLinks.ts
@@ -11,13 +11,11 @@ import { CAST_BUFFER_MS } from 'analysis/retail/monk/mistweaver/normalizers/Even
 import SPELLS from 'common/SPELLS';
 import { Options } from 'parser/core/Module';
 import SPECS from 'game/SPECS';
-import { RJW_MAX_DURATION } from 'analysis/retail/monk/mistweaver/constants';
 import { CELESTIAL_CONDUIT_MAX_DURATION, CELESTIAL_CONDUIT_MAX_TARGETS } from '../constants';
 
 export const CELESTIAL_CONDUIT_CAST = 'CelestialConduitCast';
 export const CELESTIAL_CONDUIT = 'CelestialConduit';
 export const RESTORE_BALANCE_APPLY = 'restoreBalanceApply';
-export const RESTORE_BALANCE = 'restoreBalance';
 export const UNITY_FOTRC = 'UnityFlightOfTheRedCrane';
 export const UNITY_COTWT = 'UnityCourageOfTheWhiteTiger';
 export const UNITY_SOTBO = 'UnityStrengthOfTheBlackOx';
@@ -61,58 +59,6 @@ const CELESTIAL_CONDUIT_LINKS: EventLink[] = [
   },
 ];
 
-const RESTORE_BALANCE_EVENT_LINKS: EventLink[] = [
-  //windwalker
-  /* {
-    linkRelation: RESTORE_BALANCE_APPLY,
-    reverseLinkRelation: RESTORE_BALANCE_APPLY,
-    linkingEventId: talents.RUSHING_JADE_WIND_WINDWALKER_TALENT.id,
-    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
-    referencedEventId: talents.INVOKE_XUEN_THE_WHITE_TIGER_TALENT.id,
-    referencedEventType: EventType.Cast,
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
-    isActive(c) {
-      return c.hasTalent(talents.RESTORE_BALANCE_TALENT) && c.specId === SPECS.WINDWALKER_MONK.id;
-    },
-  }, */
-  //mistweaver
-  {
-    linkRelation: RESTORE_BALANCE_APPLY,
-    reverseLinkRelation: RESTORE_BALANCE_APPLY,
-    linkingEventId: -1,
-    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
-    referencedEventId: [
-      talents.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id,
-      talents.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id,
-    ],
-    referencedEventType: EventType.Cast,
-    anyTarget: true,
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
-    isActive(c) {
-      return c.hasTalent(talents.RESTORE_BALANCE_TALENT) && c.specId === SPECS.MISTWEAVER_MONK.id;
-    },
-  },
-  {
-    linkRelation: RESTORE_BALANCE,
-    reverseLinkRelation: RESTORE_BALANCE,
-    linkingEventId: -1, //either delete for fix later, just removing dead reference to deleted spell for now
-    linkingEventType: EventType.Heal,
-    referencedEventId: [
-      talents.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id,
-      talents.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id,
-    ],
-    referencedEventType: EventType.Cast,
-    anyTarget: true,
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: RJW_MAX_DURATION,
-    isActive(c) {
-      return c.hasTalent(talents.RESTORE_BALANCE_TALENT) && c.specId === SPECS.MISTWEAVER_MONK.id;
-    },
-  },
-];
-
 const UNITY_WITHIN_EVENT_LINKS: EventLink[] = [
   //flight of the red crane unity
   {
@@ -137,18 +83,10 @@ const UNITY_WITHIN_EVENT_LINKS: EventLink[] = [
 
 class ConduitOfTheCelestialsEventLinks extends EventLinkNormalizer {
   constructor(options: Options) {
-    const EVENT_LINKS: EventLink[] = [
-      ...CELESTIAL_CONDUIT_LINKS,
-      ...UNITY_WITHIN_EVENT_LINKS,
-      ...RESTORE_BALANCE_EVENT_LINKS,
-    ];
+    const EVENT_LINKS: EventLink[] = [...CELESTIAL_CONDUIT_LINKS, ...UNITY_WITHIN_EVENT_LINKS];
 
     super(options, EVENT_LINKS);
   }
-}
-
-export function isFromRestoreBalance(event: HealEvent | DamageEvent): boolean {
-  return HasRelatedEvent(event, RESTORE_BALANCE);
 }
 
 export function getConduitEventGrouping(event: HealEvent | DamageEvent) {

--- a/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/talents/CelestialConduit.tsx
+++ b/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/talents/CelestialConduit.tsx
@@ -72,25 +72,27 @@ class CelestialConduit extends Analyzer {
 
   constructor(options: Options) {
     super(options);
+    //CONDUIT_2_ is the spellId for the cast/channel buff for mw and ww
+    //CONDUIT_1 is the WW specific buff for when Conduit is available to cast
     this.active = this.selectedCombatant.hasTalent(
-      TALENTS_MONK.CELESTIAL_CONDUIT_1_WINDWALKER_TALENT,
+      TALENTS_MONK.CELESTIAL_CONDUIT_2_WINDWALKER_TALENT,
     );
 
     this.addEventListener(
       Events.applybuff
         .by(SELECTED_PLAYER)
-        .spell(TALENTS_MONK.CELESTIAL_CONDUIT_1_WINDWALKER_TALENT),
+        .spell(TALENTS_MONK.CELESTIAL_CONDUIT_2_WINDWALKER_TALENT),
       this.onChannelStart,
     );
     this.addEventListener(
       Events.EndChannel.by(SELECTED_PLAYER).spell(
-        TALENTS_MONK.CELESTIAL_CONDUIT_1_WINDWALKER_TALENT,
+        TALENTS_MONK.CELESTIAL_CONDUIT_2_WINDWALKER_TALENT,
       ),
       this.onChannelEnd,
     );
     this.addEventListener(
       Events.EndChannel.by(SELECTED_PLAYER).spell(
-        TALENTS_MONK.CELESTIAL_CONDUIT_1_WINDWALKER_TALENT,
+        TALENTS_MONK.CELESTIAL_CONDUIT_2_WINDWALKER_TALENT,
       ),
       this.onUnityWithin,
     );

--- a/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/talents/RestoreBalance.tsx
+++ b/src/analysis/retail/monk/shared/hero/ConduitOfTheCelestials/talents/RestoreBalance.tsx
@@ -1,21 +1,22 @@
 import { TALENTS_MONK } from 'common/TALENTS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent, DamageEvent, HealEvent } from 'parser/core/Events';
-import { isFromRestoreBalance } from '../normalizers/ConduitOfTheCelestialsEventLinks';
+import Events, { DamageEvent, HealEvent } from 'parser/core/Events';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import Statistic from 'parser/ui/Statistic';
 import TalentSpellText from 'parser/ui/TalentSpellText';
+import SPECS from 'game/SPECS';
+import { calculateEffectiveDamage, calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
+import { RESTORE_BALANCE_BOOST } from '../constants';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import CelestialHooks from '../../../CelestialHooks';
 
-//xuen trigger for ww -- yulon/chiji trigger for mw
-const TRIGGER_SPELLS = [
-  TALENTS_MONK.CELESTIAL_CONDUIT_2_WINDWALKER_TALENT,
-  TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT,
-  TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT,
-];
-//TODO: Update for Midnight rework (5% damage during celestial)
 class RestoreBalance extends Analyzer {
+  static dependencies = {
+    celestialHooks: CelestialHooks,
+  };
+  protected celestialHooks!: CelestialHooks;
   casts = 0;
   healing = 0;
   overheal = 0;
@@ -24,26 +25,24 @@ class RestoreBalance extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-
     this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.RESTORE_BALANCE_TALENT);
-
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(TRIGGER_SPELLS), this.onCast);
-  }
-
-  private onCast(event: CastEvent) {
-    this.casts += 1;
+    if (this.selectedCombatant.specId === SPECS.WINDWALKER_MONK.id) {
+      this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
+    }
+    if (this.selectedCombatant.specId === SPECS.MISTWEAVER_MONK.id) {
+      this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
+    }
   }
 
   private onDamage(event: DamageEvent) {
-    if (isFromRestoreBalance(event)) {
-      this.damage += event.amount + (event.absorbed || 0);
+    if (this.celestialHooks.celestialActive) {
+      this.damage += calculateEffectiveDamage(event, RESTORE_BALANCE_BOOST);
     }
   }
 
   private onHeal(event: HealEvent) {
-    if (isFromRestoreBalance(event)) {
-      this.healing += event.amount + (event.absorbed || 0);
-      this.overheal += event.overheal || 0;
+    if (this.celestialHooks.celestialActive) {
+      this.healing += calculateEffectiveHealing(event, RESTORE_BALANCE_BOOST);
     }
   }
 
@@ -55,7 +54,12 @@ class RestoreBalance extends Analyzer {
         size="flexible"
       >
         <TalentSpellText talent={TALENTS_MONK.RESTORE_BALANCE_TALENT}>
-          <ItemHealingDone amount={this.healing} />
+          {this.selectedCombatant.spec === SPECS.MISTWEAVER_MONK && (
+            <ItemHealingDone amount={this.healing} />
+          )}
+          {this.selectedCombatant.spec === SPECS.WINDWALKER_MONK && (
+            <ItemDamageDone amount={this.damage} />
+          )}
         </TalentSpellText>
       </Statistic>
     );

--- a/src/analysis/retail/monk/shared/index.ts
+++ b/src/analysis/retail/monk/shared/index.ts
@@ -3,3 +3,4 @@ export { default as TouchOfDeath } from './TouchOfDeath';
 export { default as MysticTouch } from './MysticTouch';
 export { default as SaveThemAll } from './SaveThemAll';
 export { default as TeachingsOfTheMonestary } from './TeachingsOfTheMonestary';
+export { default as CelestialHooks } from './CelestialHooks';

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -253,6 +253,11 @@ const spells = {
     name: "Invoker's Delight",
     icon: 'inv_inscription_80_warscroll_battleshout',
   },
+  INVOKE_XUEN_BUFF: {
+    id: 123904,
+    name: 'Invoke Xuen, the White Tiger',
+    icon: 'ability_monk_prideofthetiger',
+  },
   FURY_OF_XUEN_BUFF: {
     id: 396168,
     name: 'Fury of Xuen',


### PR DESCRIPTION
### Description

Restore Balance was redesign to increase healing by 5% (for MW) and damage by 5% (for WW) when their respective celestials are active. 

Refactored some common event listeners for the various starting/ending events of celestials (cast, applybuff, player death, pet death, remove debuff) into a shared module CelestialHooks

Re-enabled celestial conduit for mw by pointing to the correct talent

