### PR TITLE
[Mistweaver] Update reworked Tear of Morning

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
-import { Vohrr } from 'CONTRIBUTORS';
+import { swirl, Vohrr } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2025, 12, 12), <>Updated <SpellLink spell={TALENTS_MONK.TEAR_OF_MORNING_TALENT}/> for Midnight.</>, swirl),
   change(date(2025, 12, 5), <>Added <SpellLink spell={TALENTS_MONK.AMPLIFIED_RUSH_TALENT}/> statistic, removed Unison.</>, Vohrr),
   change(date(2025, 12, 2), <>Updated <SpellLink spell={TALENTS_MONK.RESTORE_BALANCE_TALENT}/> for Midnight and re-enabled <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_1_WINDWALKER_TALENT}/> for Mistweaver.</>, Vohrr),
   change(date(2025, 11, 25), <>Added Season 1 Tier Set analysis for Mistweaver</>, Vohrr),

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -104,6 +104,7 @@ export const ATTRIBUTION_STRINGS = {
   JADE_BOND_ENVELOPING_MIST: 'Jade Bond Enveloping Mist',
   HARDCAST_ENVELOPING_MIST: 'Enveloping Mist Hardcast',
   MISTY_PEAKS_ENVELOPING_MIST: 'Enveloping Mist Misty Peaks Proc',
+  DURING_CELESTIAL_ENVELOPING_MIST: 'During Celestial Enveloping Mist',
   HARDCAST_RENEWING_MIST: 'Renewing Mist Hardcast',
   RAPID_DIFFUSION_RENEWING_MIST: 'Renewing Mist Rapid Diffusion',
   DANCING_MIST_RENEWING_MIST: 'Renewing Mist Dancing Mist',

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotAttributor.ts
@@ -24,6 +24,7 @@ import {
 import HotTrackerMW from '../core/HotTrackerMW';
 import { isFromTFT } from '../../normalizers/EventLinks/TierEventLinks';
 import { hasConditionalFieldOrDatumDef } from 'vega-lite/build/src/channeldef';
+import { CelestialHooks } from 'analysis/retail/monk/shared';
 
 const debug = false;
 const remDebug = false;
@@ -34,10 +35,13 @@ class HotAttributor extends Analyzer {
   static dependencies = {
     hotTracker: HotTrackerMW,
     combatants: Combatants,
+    celestialHooks: CelestialHooks,
   };
 
   protected combatants!: Combatants;
   protected hotTracker!: HotTrackerMW;
+  protected celestialHooks!: CelestialHooks;
+
   bouncedAttrib = HotTracker.getNewAttribution(ATTRIBUTION_STRINGS.BOUNCED);
   jadeBondAttrib = HotTracker.getNewAttribution(ATTRIBUTION_STRINGS.JADE_BOND_ENVELOPING_MIST);
   envMistHardcastAttrib = HotTracker.getNewAttribution(
@@ -45,6 +49,9 @@ class HotAttributor extends Analyzer {
   );
   envMistMistyPeaksAttrib = HotTracker.getNewAttribution(
     ATTRIBUTION_STRINGS.MISTY_PEAKS_ENVELOPING_MIST,
+  );
+  envMistDuringCelestialAttrib = HotTracker.getNewAttribution(
+    ATTRIBUTION_STRINGS.DURING_CELESTIAL_ENVELOPING_MIST,
   );
   rapidDiffusionAttrib = HotTracker.getNewAttribution(
     ATTRIBUTION_STRINGS.RAPID_DIFFUSION_RENEWING_MIST,
@@ -170,6 +177,15 @@ class HotAttributor extends Analyzer {
             this.owner.formatTimestamp(event.timestamp, 3),
           'on ' + this.combatants.getEntity(event)?.name,
         );
+      if (this.celestialHooks.celestialActive) {
+        this.hotTracker.addAttributionFromApply(this.envMistDuringCelestialAttrib, event);
+        debug &&
+          console.log(
+            'Attributed Enveloping Mist hardcast during Celestial at ' +
+              this.owner.formatTimestamp(event.timestamp, 3),
+            'on ' + this.combatants.getEntity(event)?.name,
+          );
+      }
     } else if (isFromMistyPeaks(event)) {
       this.hotTracker.addAttributionFromApply(this.envMistMistyPeaksAttrib, event);
       hot.maxDuration = this.hotTracker._getMistyPeaksMaxDuration(this.selectedCombatant);

--- a/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/HotTrackerMW.tsx
@@ -165,6 +165,12 @@ class HotTrackerMW extends HotTracker {
     return hot.attributions.some((a) => a.name === ATTRIBUTION_STRINGS.THUNDER_FOCUS_TEA);
   }
 
+  duringCelestial(hot: Tracker): boolean {
+    return hot.attributions.some(
+      (a) => a.name === ATTRIBUTION_STRINGS.DURING_CELESTIAL_ENVELOPING_MIST,
+    );
+  }
+
   // Decide which extension is responsible for allowing this extra vivify cleave
   getRemExtensionForTimestamp(hot: Tracker, timestamp: number): Extension | null {
     if (timestamp <= hot.originalEnd) {


### PR DESCRIPTION
### Description

modified invigorating mists to swap to sheilun's gift, if talented
added `during celestial` attribution to easier identify envs within that window - logic applied onto those envs to calc on the extra duration of direct and amped healing

note: cleave healing is agnostic of the actual cleaved % since the event is direct instead of ticking from the hot so values will be the same on live vs midnight

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: 
  - `/report/rGqTxmtvPjW1pknQ/13-Mythic++Magisters'+Terrace+-+Wipe+1+(22:21)/1-Swirlanir/standard`
  - `/report/RJ6wpn8CAMNhqBjY/25-Normal+Lightblinded+Vanguard+-+Kill+(8:51)/Jeypii/standard/statistics`

Live:
<img width="391" height="197" alt="image" src="https://github.com/user-attachments/assets/e3e7990f-3470-47bb-aae3-450617db44d1" />
<img width="581" height="110" alt="image" src="https://github.com/user-attachments/assets/1d35dd02-c64f-4e08-8813-485f5c7eaac2" />

Post change:
SG/Chi-Ji
<img width="382" height="206" alt="image" src="https://github.com/user-attachments/assets/3bfa119e-a7dc-407e-aa94-f148783bef6e" />
<img width="698" height="196" alt="image" src="https://github.com/user-attachments/assets/394dce35-66b3-4282-94a9-46caf606b6fd" />

Vivify/Yu'lon
<img width="729" height="171" alt="image" src="https://github.com/user-attachments/assets/d88f98f4-4d51-4d23-b9fc-147acb0bbf8e" />

