### PR TITLE
Feature survival boomstick

### DIFF
--- a/src/analysis/retail/hunter/survival/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/survival/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import { Kivlov,
  } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2026, 1, 17), 'Add Boomstick Analyzer', Kivlov),
   change(date(2026, 1, 10), 'Update Survival for 12.0.0 support', Kivlov),
 
 ];

--- a/src/analysis/retail/hunter/survival/CombatLogParser.ts
+++ b/src/analysis/retail/hunter/survival/CombatLogParser.ts
@@ -1,5 +1,6 @@
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 import ArcaneTorrent from 'parser/shared/modules/racials/bloodelf/ArcaneTorrent';
+import Channeling from 'parser/shared/normalizers/Channeling';
 import {
   BindingShot,
   DeathTracker,
@@ -30,6 +31,8 @@ import FocusGraph from './modules/guide/sections/resources/FocusGraph';
 import Guide from './modules/guide/Guide';
 import SurvivalOfTheFittest from '../shared/talents/SurvivalOfTheFittest';
 import ExhilarationTiming from '../shared/guide/defensives/Exhiliration';
+import Boomstick from './modules/talents/Boomstick';
+import BoomstickNormalizer from './normalizers/BoomstickNormalizer';
 // import EventLinkNormalizer from '../shared/normalizers/HunterEventLinkNormalizers'; // This has a pack leader normalizer in it useful to Survival so not deleting yet.
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -57,7 +60,10 @@ class CombatLogParser extends CoreCombatLogParser {
     exhilarationTiming: ExhilarationTiming,
 
     //Normalizers
+    // Channeling must come before BoomstickNormalizer to ensure EndChannel events exist
+    channeling: Channeling,
     tipOfTheSpearNormalizer: TipOfTheSpearNormalizer,
+    boomstickNormalizer: BoomstickNormalizer,
     // EventLinkNormalizers: EventLinkNormalizer,
 
     //DeathTracker
@@ -70,6 +76,7 @@ class CombatLogParser extends CoreCombatLogParser {
     tipOfTheSpear: TipOfTheSpear,
     wildfireBomb: WildfireBomb,
     lunge: Lunge,
+    boomstick: Boomstick,
 
     //Shared Talents
 

--- a/src/analysis/retail/hunter/survival/modules/Abilities.tsx
+++ b/src/analysis/retail/hunter/survival/modules/Abilities.tsx
@@ -53,6 +53,16 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.85,
         },
       },
+      {
+        spell: TALENTS.BOOMSTICK_TALENT.id,
+        category: SPELL_CATEGORY.ROTATIONAL,
+        enabled: combatant.hasTalent(TALENTS.BOOMSTICK_TALENT),
+        gcd: {
+          base: 1500,
+        },
+        cooldown: 45,
+        timelineSortIndex: 1,
+      },
       //endregion
 
       //region Talents

--- a/src/analysis/retail/hunter/survival/modules/guide/sections/rotation/RotationSection.tsx
+++ b/src/analysis/retail/hunter/survival/modules/guide/sections/rotation/RotationSection.tsx
@@ -36,6 +36,7 @@ export default function RotationSection({
           have fit a whole extra use of the cooldown.
         </Trans>
         {modules.wildfireBomb.guideSubsection}
+        {modules.boomstick.guideSubsection}
       </SubSection>
     </Section>
   );

--- a/src/analysis/retail/hunter/survival/modules/talents/Boomstick.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/Boomstick.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/hunter';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
+  BeginCastEvent,
   CastEvent,
   DamageEvent,
   EndChannelEvent,
@@ -77,7 +78,7 @@ class Boomstick extends Analyzer.withDependencies({ haste: Haste }) {
 
     const tipped = this.selectedCombatant.hasBuff(SPELLS.TIP_OF_THE_SPEAR_CAST.id, cast.timestamp);
     const tickResults = this.analyzeTicksForCast(cast);
-    const nextAbility = GetRelatedEvent(event, BOOMSTICK_NEXT_CAST);
+    const nextAbility = GetRelatedEvent<CastEvent | BeginCastEvent>(event, BOOMSTICK_NEXT_CAST);
 
     // Aggregate stats
     const ticksHit = tickResults.filter((t) => t.hit).length;
@@ -169,7 +170,7 @@ class Boomstick extends Analyzer.withDependencies({ haste: Haste }) {
     ticksHit: number,
     wasClipped: boolean,
     missedTicks: number[],
-    nextAbility: ReturnType<typeof GetRelatedEvent>,
+    nextAbility: CastEvent | BeginCastEvent | undefined,
   ): { value: QualitativePerformance; header: JSX.Element; clippingInfo: JSX.Element | null } {
     let value: QualitativePerformance;
     let header: JSX.Element;
@@ -286,6 +287,7 @@ class Boomstick extends Analyzer.withDependencies({ haste: Haste }) {
         <BoringSpellValueText spell={TALENTS.BOOMSTICK_TALENT}>
           <>
             <ItemDamageDone amount={this.totalDamage} />
+            <br />
             {this.totalHits} <small>targets hit</small>
             <br />
             {(this.totalTicks > 0 ? this.totalHits / this.totalTicks : 0).toFixed(1)}{' '}

--- a/src/analysis/retail/hunter/survival/modules/talents/Boomstick.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/Boomstick.tsx
@@ -1,0 +1,249 @@
+import type { JSX } from 'react';
+import { formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS/hunter';
+import TALENTS from 'common/TALENTS/hunter';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  CastEvent,
+  DamageEvent,
+  EndChannelEvent,
+  GetRelatedEvent,
+  GetRelatedEvents,
+  HasAbility,
+} from 'parser/core/Events';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
+import { BadColor, GoodColor, OkColor } from 'interface/guide';
+import {
+  BOOMSTICK_CAST_HIT,
+  BOOMSTICK_CAST_END,
+  BOOMSTICK_NEXT_CAST,
+} from '../../normalizers/BoomstickNormalizer';
+
+/**
+ * Boomstick analyzer
+ *
+ * Boomstick is a 3-second channeled ability that fires a directional cone of damage.
+ * It deals damage in 4 ticks at 1s intervals (hasted).
+ */
+class Boomstick extends Analyzer {
+  private totalDamage = 0;
+  private totalHits = 0;
+  private totalTicks = 0;
+  private useEntries: BoxRowEntry[] = [];
+  private clippedCasts = 0;
+
+  private castTippedStatus = new Map<number, boolean>();
+
+  private static readonly BUCKET_WINDOW_MS = 100;
+  private static readonly EXPECTED_TICKS = 4;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.BOOMSTICK_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.BOOMSTICK_TALENT),
+      this.onCast,
+    );
+
+    this.addEventListener(
+      Events.EndChannel.by(SELECTED_PLAYER).spell(TALENTS.BOOMSTICK_TALENT),
+      this.onEndChannel,
+    );
+  }
+
+  private onCast = (event: CastEvent) => {
+    const tipped = this.selectedCombatant.hasBuff(SPELLS.TIP_OF_THE_SPEAR_CAST.id);
+    this.castTippedStatus.set(event.timestamp, tipped);
+  };
+
+  private onEndChannel = (event: EndChannelEvent) => {
+    const cast = GetRelatedEvent<CastEvent>(event, BOOMSTICK_CAST_END);
+    if (!cast) {
+      return;
+    }
+
+    // Retrieve whether this cast had Tip of the Spear
+    const tipped = this.castTippedStatus.get(cast.timestamp) ?? false;
+
+    const hits = GetRelatedEvents<DamageEvent>(cast, BOOMSTICK_CAST_HIT).sort(
+      (a, b) => a.timestamp - b.timestamp,
+    );
+
+    // Group damage events into ticks based on timestamp proximity
+    const buckets: DamageEvent[][] = [];
+    hits.forEach((hit) => {
+      if (buckets.length === 0) {
+        buckets.push([hit]);
+        return;
+      }
+      const currentBucket = buckets[buckets.length - 1];
+      const bucketStart = currentBucket[0].timestamp;
+
+      // If this hit is within 100ms of the bucket start, it's part of the same tick
+      if (hit.timestamp - bucketStart <= Boomstick.BUCKET_WINDOW_MS) {
+        currentBucket.push(hit);
+      } else {
+        // Otherwise, start a new tick bucket
+        buckets.push([hit]);
+      }
+    });
+
+    const tickCount = buckets.length;
+
+    // Summaries for Guide Tooltip
+    const tickSummaries = buckets.map((bucket) => {
+      const damage = bucket.reduce((sum, hit) => sum + hit.amount + (hit.absorbed ?? 0), 0);
+      return { targetsHit: bucket.length, damage, timestamp: bucket[0].timestamp };
+    });
+
+    const tickTotalDamage = tickSummaries.reduce((sum, tick) => sum + tick.damage, 0);
+    const tickTotalHits = tickSummaries.reduce((sum, tick) => sum + tick.targetsHit, 0);
+    this.totalDamage += tickTotalDamage;
+    this.totalHits += tickTotalHits;
+    this.totalTicks += tickSummaries.length;
+
+    // Check if the channel was clipped
+    // Don't count clipped if 4 ticks (normalizer buffer picked up a quick post-channel cast)
+    const nextAbility = GetRelatedEvent(event, BOOMSTICK_NEXT_CAST);
+    const wasClipped =
+      tickCount < Boomstick.EXPECTED_TICKS && nextAbility !== undefined && HasAbility(nextAbility);
+
+    let value: QualitativePerformance;
+    let header: JSX.Element;
+    let clippingInfo: JSX.Element | null = null;
+
+    if (!tipped) {
+      // No Tip of the Spear = FAIL
+      value = QualitativePerformance.Fail;
+      header = <h5 style={{ color: BadColor }}>Bad cast: no Tip of the Spear.</h5>;
+    } else if (tickCount === Boomstick.EXPECTED_TICKS) {
+      // Perfect: 4 ticks + tipped = GOOD
+      value = QualitativePerformance.Good;
+      header = <h5 style={{ color: GoodColor }}>Good cast: tipped with all ticks.</h5>;
+    } else if (wasClipped) {
+      // Clipped with another ability = FAIL
+      value = QualitativePerformance.Fail;
+      this.clippedCasts += 1;
+      header = <h5 style={{ color: BadColor }}>Bad cast: channel clipped early.</h5>;
+      if (nextAbility && HasAbility(nextAbility)) {
+        clippingInfo = (
+          <div>
+            <strong>Clipped by:</strong> <SpellLink spell={nextAbility.ability.guid} />
+          </div>
+        );
+      }
+    } else if (tickCount === 3) {
+      // 3 ticks + not clipped = OK (likely missed one tick due to aim/target movement)
+      value = QualitativePerformance.Ok;
+      header = <h5 style={{ color: OkColor }}>Acceptable: tipped but missed 1 tick.</h5>;
+    } else {
+      // <3 ticks + not clipped = FAIL (missed multiple ticks, very poor aim)
+      value = QualitativePerformance.Fail;
+      header = (
+        <h5 style={{ color: BadColor }}>
+          Bad cast: missed {Boomstick.EXPECTED_TICKS - tickCount} ticks.
+        </h5>
+      );
+    }
+
+    const tickLines = tickSummaries.map((tick, index) => (
+      <div key={tick.timestamp}>
+        Tick {index + 1}: <strong>{tick.targetsHit}</strong> targets{' '}
+        <small>({formatNumber(tick.damage)} damage)</small>
+      </div>
+    ));
+
+    const tooltip = (
+      <div>
+        {header}
+        <strong>{this.owner.formatTimestamp(cast.timestamp)}</strong>
+        {tickCount !== Boomstick.EXPECTED_TICKS && (
+          <div>
+            Ticks: {tickCount}/{Boomstick.EXPECTED_TICKS}{' '}
+            <small>
+              {wasClipped
+                ? '(clipped channel)'
+                : `(missed ${Boomstick.EXPECTED_TICKS - tickCount} tick${Boomstick.EXPECTED_TICKS - tickCount !== 1 ? 's' : ''})`}
+            </small>
+          </div>
+        )}
+        {tickLines}
+        <div>
+          <strong>Total Damage:</strong> {formatNumber(tickTotalDamage)}
+        </div>
+        {clippingInfo}
+      </div>
+    );
+
+    this.useEntries.push({ value, tooltip });
+  };
+
+  private get averageTargetsHit() {
+    return this.totalTicks > 0 ? this.totalHits / this.totalTicks : 0;
+  }
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <strong>
+          <SpellLink spell={TALENTS.BOOMSTICK_TALENT} />
+        </strong>{' '}
+        should always be cast with <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST.id} /> active.
+        Additionally, avoid interrupting the channel early - let it complete all 4 ticks for maximum
+        damage. Because Boomstick is a directional cone ability, ensure you're facing targets to
+        avoid missing ticks.
+      </p>
+    );
+
+    const data = (
+      <CastSummaryAndBreakdown
+        spell={TALENTS.BOOMSTICK_TALENT}
+        castEntries={this.useEntries}
+        badExtraExplanation={<>missing Tip of the Spear or clipped channel</>}
+        usesInsteadOfCasts
+      />
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE()}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <BoringSpellValueText spell={TALENTS.BOOMSTICK_TALENT}>
+          <>
+            <ItemDamageDone amount={this.totalDamage} />
+            {this.totalHits} <small>targets hit</small>
+            <br />
+            {this.averageTargetsHit.toFixed(1)} <small>avg targets/tick</small>
+            {this.clippedCasts > 0 && (
+              <>
+                <br />
+                {this.clippedCasts} <small>clipped casts</small>
+              </>
+            )}
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default Boomstick;

--- a/src/analysis/retail/hunter/survival/normalizers/BoomstickNormalizer.ts
+++ b/src/analysis/retail/hunter/survival/normalizers/BoomstickNormalizer.ts
@@ -1,0 +1,61 @@
+import SPELLS from 'common/SPELLS/hunter';
+import TALENTS from 'common/TALENTS/hunter';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { EventType } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+import Channeling from 'parser/shared/normalizers/Channeling';
+
+export const BOOMSTICK_CAST_HIT = 'boomstick-cast-hit';
+export const BOOMSTICK_CAST_END = 'boomstick-cast-end';
+export const BOOMSTICK_NEXT_CAST = 'boomstick-next-cast';
+const MAX_CHANNEL_BUFFER_MS = 4000;
+
+const EVENT_LINKS: EventLink[] = [
+  // Link damage to cast
+  {
+    linkRelation: BOOMSTICK_CAST_HIT,
+    reverseLinkRelation: BOOMSTICK_CAST_HIT,
+    linkingEventId: SPELLS.BOOMSTICK_DAMAGE.id,
+    linkingEventType: EventType.Damage,
+    referencedEventId: TALENTS.BOOMSTICK_TALENT.id,
+    referencedEventType: EventType.Cast,
+    backwardBufferMs: MAX_CHANNEL_BUFFER_MS,
+    anyTarget: true,
+  },
+  // Link end channel to cast
+  {
+    linkRelation: BOOMSTICK_CAST_END,
+    reverseLinkRelation: BOOMSTICK_CAST_END,
+    linkingEventId: TALENTS.BOOMSTICK_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: TALENTS.BOOMSTICK_TALENT.id,
+    referencedEventType: EventType.EndChannel,
+    forwardBufferMs: MAX_CHANNEL_BUFFER_MS,
+    anyTarget: true,
+    maximumLinks: 1,
+  },
+  // Link the EndChannel event to potential clipped ability
+  {
+    linkRelation: BOOMSTICK_NEXT_CAST,
+    linkingEventId: TALENTS.BOOMSTICK_TALENT.id,
+    linkingEventType: EventType.EndChannel,
+    referencedEventId: null,
+    referencedEventType: [EventType.Cast, EventType.BeginCast],
+    forwardBufferMs: 100,
+    anyTarget: true,
+    maximumLinks: 1,
+  },
+];
+
+class BoomstickNormalizer extends EventLinkNormalizer {
+  static dependencies = {
+    ...EventLinkNormalizer.dependencies,
+    channeling: Channeling,
+  };
+
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export default BoomstickNormalizer;

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -386,6 +386,11 @@ const spells = {
     name: 'Merciless Blow',
     icon: 'ability_hunter_swiftstrike',
   },
+  BOOMSTICK_DAMAGE: {
+    id: 1261215,
+    name: 'Merciless Blow',
+    icon: 'ability_hunter_swiftstrike',
+  },
   //endregion
 
   //region Shared

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -388,8 +388,8 @@ const spells = {
   },
   BOOMSTICK_DAMAGE: {
     id: 1261215,
-    name: 'Merciless Blow',
-    icon: 'ability_hunter_swiftstrike',
+    name: 'Boomstick',
+    icon: 'inv_musket_04',
   },
   //endregion
 

--- a/src/parser/shared/normalizers/Channeling.ts
+++ b/src/parser/shared/normalizers/Channeling.ts
@@ -2,6 +2,7 @@ import SPELLS from 'common/SPELLS';
 import CLASSIC_SPELLS from 'common/SPELLS/classic';
 import {
   TALENTS_EVOKER,
+  TALENTS_HUNTER,
   TALENTS_MAGE,
   TALENTS_MONK,
   TALENTS_ROGUE,
@@ -105,6 +106,7 @@ class Channeling extends EventsNormalizer {
     // Shaman
     // Hunter
     buffChannelSpec(SPELLS.RAPID_FIRE.id),
+    buffChannelSpec(TALENTS_HUNTER.BOOMSTICK_TALENT.id),
     // Paladin
     // Warrior
     buffChannelSpec(SPELLS.BLADESTORM.id),


### PR DESCRIPTION
### Description

I have another PR after this one that does further cleanup and adds in the missing new ability spellIDs in SPELLS but because Boomstick is integral to the rotation now, and is a complete new addition I'm adding it on it's own.

I used claude opus to plan and base the analyzer off of the windwalker Fist of Fury analyzer using the instructions in the .github. The damage is dealt in 4 ticks over a 3s (hasted) channel so I have it group the damage into the ticks for display & for performance.

In order to capture if it was clipped, I set the normalizer to 100ms buffer but I found there was the odd cast the player would have a very minimal delay after the channel ended and so if it picks up a cast but it makes 4 buckets/ticks of damage then it considers it not-clipped. The ability does a significant amount of damage and so missing a tick of it is really bad.

3f2051a8fe3d8e4f19136b6b962b34f25c78450c
45126d9ee204fbcf294b4af8fb81e23e47a8c0c2
These 2 commits have simple versions of the analyzer. If you look at the haste calculation commit and the analysis is too hard to follow (I leaned on claude to refactor for the hasted ticks rather than just make a plan), I will just get rid of it and fall back to the simpler one for now.


- Test report URL: /report/AZ8jBw1CHx76r9pm/1-Mythic++Pit+of+Saron+-+Kill+(27:27)/5-Giftia/standard)
- Test report with lots of clipped and missed casts: report/Bx96hAMnzVZKyGRq/1-Mythic++Skyreach+-+Kill+(57:02)/8-Giftia/standard
- I have no raid log to test with unfortunately at the moment. I'll take a look and on the PR that will follow this one that does more cleanup, I'll see if I can get a log to replace the example log. I'll have my own pre-patch logs in a week to use if I cant find a good one.


