### PR TITLE
Crash fixes

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -29,6 +29,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 1, 24), 'Fix crash in Death Recap view', emallson),
   change(date(2026, 1, 24), 'Fix crash when selecting a phase or pull', emallson),
   change(date(2025, 11, 26), 'Update to React 19.', [Topple, emallson]),
   change(date(2025, 11, 26), 'Add bosses for Midnight S1.', Topple),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -29,6 +29,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 1, 24), 'Fix crash when selecting a phase or pull', emallson),
   change(date(2025, 11, 26), 'Update to React 19.', [Topple, emallson]),
   change(date(2025, 11, 26), 'Add bosses for Midnight S1.', Topple),
   change(date(2025, 11, 9), 'Redesign fight analysis header.', emallson),

--- a/src/interface/report/hooks/useEventParser.ts
+++ b/src/interface/report/hooks/useEventParser.ts
@@ -39,6 +39,10 @@ interface Props {
   parserClass?: new (...args: ConstructorParameters<typeof CombatLogParser>) => CombatLogParser;
   characterProfile: CharacterProfile | null;
   events?: AnyEvent[];
+  /**
+   * Events that have not been filtered to the time range.
+   */
+  allEvents?: AnyEvent[];
   dependenciesLoading?: boolean;
 }
 
@@ -52,6 +56,7 @@ const useEventParser = ({
   parserClass,
   characterProfile,
   events,
+  allEvents,
   dependenciesLoading,
 }: Props) => {
   const [isLoading, setIsLoading] = useState(true);
@@ -60,10 +65,10 @@ const useEventParser = ({
 
   const playerCombatantInfo = useMemo(
     () =>
-      events?.find(
+      allEvents?.find(
         (event) => event.type === EventType.CombatantInfo && event.sourceID === player.id,
       ) as CombatantInfoEvent | undefined,
-    [events, player.id],
+    [allEvents, player.id],
   );
 
   const parser = useMemo(() => {

--- a/src/interface/report/hooks/useEventParser.ts
+++ b/src/interface/report/hooks/useEventParser.ts
@@ -42,7 +42,7 @@ interface Props {
   /**
    * Events that have not been filtered to the time range.
    */
-  allEvents?: AnyEvent[];
+  allEvents?: AnyEvent[] | null;
   dependenciesLoading?: boolean;
 }
 

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -153,6 +153,7 @@ const ResultsLoader = () => {
     parserClass,
     characterProfile,
     events: filteredEvents,
+    allEvents: events,
     dependenciesLoading: isLoadingParser || isLoadingCharacterProfile || isFilteringEvents,
   });
   const parsingState = isParsingEvents ? EVENT_PARSING_STATE.PARSING : EVENT_PARSING_STATE.DONE;

--- a/src/parser/shared/modules/DeathRecap.jsx
+++ b/src/parser/shared/modules/DeathRecap.jsx
@@ -160,14 +160,10 @@ class DeathRecap extends PureComponent {
                     let sourceName =
                       event.source && event.source.type === 'NPC' ? event.source.name : null;
                     if (!sourceName && event.type === EventType.Heal) {
-                      sourceName = this.props.combatants[event.sourceID]
-                        ? this.props.combatants[event.sourceID]._combatantInfo.name
-                        : null;
+                      sourceName = this.props.combatants[event.sourceID]?.name ?? null;
                     }
                     if (!sourceName && event.type === EventType.Damage) {
-                      sourceName = this.props.enemies[event.sourceID]
-                        ? this.props.enemies[event.sourceID]._baseInfo.name
-                        : null;
+                      sourceName = this.props.enemies[event.sourceID]?.name ?? null;
                     }
                     if (!sourceName && event.type !== EventType.Instakill) {
                       sourceName = event.ability.name;


### PR DESCRIPTION
### Description

- throw from missing combatantinfo due to filtering it out based on phase/pull selection
- `_combatantInfo` is undefined but we don't actually need to access it