### PR TITLE
[Evoker] Fix edgecase where fake empowerend events get logged

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/evoker';
 
 export default [
+  change(date(2026, 1, 27), "Improve Empower handling to handle bugged casts", Vollmer),
   change(date(2026, 1, 27), <>Add statistics for <SpellLink spell={TALENTS.ESSENCE_WELL_TALENT}/>, <SpellLink spell={TALENTS.TWIN_FLAME_TALENT}/> and <SpellLink spell={TALENTS.FIRE_TORRENT_TALENT}/>.</>, Vollmer),
   change(date(2026, 1, 25), <>Add statistics for <SpellLink spell={TALENTS.STRAFING_RUN_TALENT}/>, <SpellLink spell={TALENTS.AZURE_SWEEP_TALENT}/>, <SpellLink spell={TALENTS.SHATTERING_STARS_TALENT}/> and <SpellLink spell={TALENTS.STAR_SALVO_TALENT}/>.</>, Vollmer),
   change(date(2026, 1, 17), <>Update <SpellLink spell={TALENTS.IMMINENT_DESTRUCTION_DEVASTATION_TALENT}/> module for Midnight.</>, Vollmer),


### PR DESCRIPTION
### Description

So apparently sometimes an `empowerend` event with an `empowermentLevel` of `0` will get [logged](https://www.warcraftlogs.com/reports/ZJyaVLcRTAWf1g87?fight=16&type=summary&source=222&pins=2%24Off%24%23a04D8A%24expression%24ability.name+in%28%22Eternity+Surge%22%2C%22Fire+Breath%22%2C%22Tip+the+Scales%22%29+and+type+not+in+%28%22damage%22%2C%22applydebuff%22%2C%22removedebuff%22%2C%22refreshdebuff%22%29&view=events&start=3476570&end=3482947).
Since the spell never actually went off/on cooldown in-game, this is not a proper event. You can see in the log how `Eternity Surge` is cast twice within 3 seconds, which is not possible.

This was causing issues with channels/gcd/spellusable, and the plethora of modules that makes use of the `empowerend` event.
Luckily the fix was pretty simple with how empowers already are getting handled. Just had to remove it from the event loop and remove a cast link.

I think that *technically* the GCD triggered in-game by this is not the canceled empower GCD but a full one (pretty sure I know, and loathe, what causes this). But that is such a minor difference for an already rare edgecase, that I don't want to go through the pain and suffering of trying to replicate this bug in a controlled environment just to verify and add special case handling for it :sweat_smile:.

### Testing

- Test report URL: `/report/ZJyaVLcRTAWf1g87/16-Mythic+The+Soul+Hunters+-+Kill+(1:34)/222-Blueprínt/standard/timeline`

Without fix:
<img width="407" height="418" alt="image" src="https://github.com/user-attachments/assets/7fdcc8ee-beb2-462b-8a8d-d170d4957b10" />
<img width="913" height="187" alt="image" src="https://github.com/user-attachments/assets/9988eb32-a24f-4291-9c71-ddc19f4fd280" />
<img width="839" height="348" alt="image" src="https://github.com/user-attachments/assets/27fc36f4-41f9-4a2b-96e6-e8cde8be2903" />

With fix:
<img width="517" height="361" alt="image" src="https://github.com/user-attachments/assets/f4f76e9d-544d-4510-9229-550d266fc62f" />
<img width="924" height="180" alt="image" src="https://github.com/user-attachments/assets/11c268f4-da25-4c9e-82a5-9b52a0dd3922" />
<img width="805" height="311" alt="image" src="https://github.com/user-attachments/assets/52c8d348-3d9e-4a74-836a-326f19f57953" />

