### PR TITLE
windwalker: zenith initial integration and preface

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -6,6 +6,11 @@ import SpellLink from 'interface/SpellLink';
 
 export default [
   change(
+    date(2026, 3, 10),
+    'Add Zenith talent analysis/guide stats, gate Invoke Xuen, and add a Windwalker guide preface',
+    Durpn,
+  ),
+  change(
     date(2026, 3, 6),
     <>
       Updated Windwalker priority recommendations, improved{' '}

--- a/src/analysis/retail/monk/windwalker/CombatLogParser.ts
+++ b/src/analysis/retail/monk/windwalker/CombatLogParser.ts
@@ -35,6 +35,7 @@ import HitCombo from './modules/talents/HitCombo';
 import HitComboGraph from './modules/talents/HitComboGraph';
 import HitComboTracker from './modules/talents/HitComboTracker';
 import InvokeXuen from './modules/talents/InvokeXuen';
+import Zenith from './modules/talents/Zenith';
 import {
   FistsOfFuryLinkNormalizer,
   FistsOfFuryNormalizer,
@@ -79,6 +80,7 @@ class CombatLogParser extends CoreCombatLogParser {
     chiBurst: ChiBurst,
     heartOfTheJadeSerpent: HeartOfTheJadeSerpent,
     celestialConduit: CelestialConduit,
+    zenith: Zenith,
 
     // Guide helpers
     hitComboTracker: HitComboTracker,

--- a/src/analysis/retail/monk/windwalker/Guide.tsx
+++ b/src/analysis/retail/monk/windwalker/Guide.tsx
@@ -12,19 +12,145 @@ import windwalkerApl from './modules/apl/WindwalkerApl';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
+  const hasStrikeOfTheWindlord = info.combatant.hasTalent(
+    TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT,
+  );
+  const hasCelestialConduit = info.combatant.hasTalent(
+    TALENTS_MONK.CELESTIAL_CONDUIT_WINDWALKER_TALENT,
+  );
+
   return (
     <>
+      <Section title="Preface & Disclaimers">
+        <>
+          The analysis in this guide is provided in collaboration with the{' '}
+          <a href="https://discord.com/invite/peakofserenity">Peak of Serenity</a> Discord. Keep in
+          mind that WoWAnalyzer is limited to what is present in your combat log, and we cannot
+          always detect intentional deviations such as holding cooldowns for a specific strategy.
+          <br />
+          <br />
+          If you notice any issues or errors in this analysis or have feature requests, please reach
+          out to <code>@durpn</code> in the{' '}
+          <a href="https://discord.com/invite/peakofserenity">Peak of Serenity</a> Discord.
+        </>
+      </Section>
       <Section title="Core Spells and Buffs">
+        <>
+          <p>
+            Windwalker is a two-resource spec. <SpellLink spell={RESOURCE_TYPES.ENERGY} /> is the
+            fuel that lets you build <SpellLink spell={RESOURCE_TYPES.CHI} />, and{' '}
+            <SpellLink spell={RESOURCE_TYPES.CHI} /> is what turns into your meaningful damage. Good
+            play is mostly about managing both at the same time: do not overcap either resource, but
+            do not spend so freely that you starve yourself right before an important button becomes
+            available.
+          </p>
+          <p>
+            <SpellLink spell={SPELLS.TIGER_PALM} /> and <SpellLink spell={SPELLS.BLACKOUT_KICK} />{' '}
+            are where this usually goes wrong. <SpellLink spell={SPELLS.TIGER_PALM} /> builds the
+            resources you need, while <SpellLink spell={SPELLS.BLACKOUT_KICK} /> helps keep the spec
+            moving and can be excellent value, but neither is usually the payoff. Their job is to
+            support spells like <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT} />,{' '}
+            <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} />
+            {hasStrikeOfTheWindlord && (
+              <>
+                , <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} />
+              </>
+            )}{' '}
+            and proc-driven casts, not to crowd them out. A common mistake is pressing{' '}
+            <SpellLink spell={SPELLS.BLACKOUT_KICK} /> when you are low on{' '}
+            <SpellLink spell={RESOURCE_TYPES.ENERGY} />, sitting at only enough{' '}
+            <SpellLink spell={RESOURCE_TYPES.CHI} /> for a medium spender, and{' '}
+            <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} /> is about to come up. That often
+            forces extra <SpellLink spell={SPELLS.TIGER_PALM} /> casts and delays your real damage
+            window.
+          </p>
+          <p>
+            This is the downtime trap: sometimes the correct play is to do nothing for a moment. If{' '}
+            <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} />
+            {hasStrikeOfTheWindlord && (
+              <>
+                {' '}
+                or <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} />
+              </>
+            )}{' '}
+            is about to be ready, you are low on <SpellLink spell={RESOURCE_TYPES.ENERGY} />, and
+            spending <SpellLink spell={SPELLS.BLACKOUT_KICK} /> would leave you unable to use the
+            stronger button on time, waiting is better than filling the global. These panels are
+            useful because they show whether you were feeding your priority spells correctly or
+            spending resources in ways that made them late.
+            {hasCelestialConduit && (
+              <>
+                {' '}
+                When playing Conduit of the Celestials,{' '}
+                <SpellLink spell={SPELLS.HEART_OF_THE_JADE_SERPENT_BUFF} /> adds another layer to
+                that planning because it changes the value and timing of several of the spells shown
+                in this section.
+              </>
+            )}
+          </p>
+        </>
         <MasteryGraph modules={modules} events={events} info={info} />
-        {info.combatant.hasTalent(TALENTS_MONK.CELESTIAL_CONDUIT_WINDWALKER_TALENT) &&
+        {hasCelestialConduit &&
           modules.heartOfTheJadeSerpent.guideSubsection(modules.celestialConduit.clipAnalysis)}
         {modules.risingSunKick.guideSubsection}
         {modules.fistsofFury.guideSubsection}
-        {modules.strikeoftheWindlord.guideSubsection}
+        {hasStrikeOfTheWindlord && modules.strikeoftheWindlord.guideSubsection}
         {info.combatant.hasTalent(TALENTS_MONK.SLICING_WINDS_TALENT) &&
           modules.slicingWinds.guideSubsection}
       </Section>
-      <Section title="Major cooldowns">{modules.invokeXuen.guideSubsection}</Section>
+      <Section title="Major cooldowns">
+        <p>
+          In general, use cooldowns as close to cooldown as possible. If you can stack them without
+          losing a cast, that is usually better than desyncing them for no reason.{' '}
+          <SpellLink spell={TALENTS_MONK.ZENITH_TALENT} /> is always part of that plan, so go into
+          each Zenith window with enough resources to spend strong globals immediately instead of
+          fixing chi with multiple <SpellLink spell={SPELLS.TIGER_PALM} /> casts.
+        </p>
+        <p>
+          When playing Conduit of the Celestials, your biggest burst window is still{' '}
+          <SpellLink spell={TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT} /> into{' '}
+          <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_WINDWALKER_TALENT} />. Plan ahead so you
+          are not spending a low-value global summoning Xuen when you want to be channeling Conduit,
+          and keep one <SpellLink spell={TALENTS_MONK.ZENITH_TALENT} /> charge ready for that
+          package. Peak of Serenity currently recommends delaying{' '}
+          {hasStrikeOfTheWindlord ? (
+            <>
+              <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> or{' '}
+              <SpellLink spell={TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT} />
+            </>
+          ) : (
+            <SpellLink spell={TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT} />
+          )}{' '}
+          if that burst starts within about 10 seconds, or delaying Xuen instead if those buttons
+          will be ready in the next 10 seconds.
+        </p>
+        <p>
+          Conduit-specific <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_WINDWALKER_TALENT} />{' '}
+          usage is also about <SpellLink spell={SPELLS.HEART_OF_THE_JADE_SERPENT_BUFF} /> timing.
+          Since that buff can also come from{' '}
+          {hasStrikeOfTheWindlord ? (
+            <>
+              <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> and{' '}
+              <SpellLink spell={TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT} />
+            </>
+          ) : (
+            <SpellLink spell={TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT} />
+          )}
+          , stagger those uses instead of overlapping them blindly so you get more total uptime and
+          value.
+        </p>
+        <p>
+          <SpellLink spell={TALENTS_MONK.ZENITH_TALENT} /> itself is still not just a button to hit
+          mindlessly. Use it where its reduced chi costs and extra{' '}
+          <SpellLink spell={SPELLS.BLACKOUT_KICK} /> cooldown reduction convert into real value, and
+          avoid spending the window on low-impact setup globals. This matters even more with{' '}
+          <SpellLink spell={TALENTS_MONK.OBSIDIAN_SPIRAL_TALENT} />, where reducing{' '}
+          <SpellLink spell={SPELLS.TIGER_PALM} /> usage inside Zenith is part of correct play.
+        </p>
+        {info.combatant.hasTalent(TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT) &&
+          modules.invokeXuen.guideSubsection}
+        {info.combatant.hasTalent(TALENTS_MONK.ZENITH_TALENT) && modules.zenith.guideSubsection}
+      </Section>
       <Section title="Core Rotation">
         <SubSection title="Overview">
           <p>
@@ -38,9 +164,13 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           <p>
             In practice, most of your rotational decisions are about feeding high-value buttons
             cleanly. <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} />,{' '}
-            <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT} />,{' '}
-            <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} />,{' '}
-            <SpellLink spell={TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT} />, and hero-specific
+            <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT} />
+            {hasStrikeOfTheWindlord && (
+              <>
+                , <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} />
+              </>
+            )}
+            , <SpellLink spell={TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT} />, and hero-specific
             payoffs should be given room in the next few globals. That means using{' '}
             <SpellLink spell={SPELLS.TIGER_PALM} /> proactively when you need chi for an upcoming
             spender, but minimizing extra <SpellLink spell={SPELLS.TIGER_PALM} /> casts inside burst
@@ -53,28 +183,6 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
             sitting on high-impact cooldowns for filler globals. The APL should be read as your
             ordered tiebreaker once mastery, resource flow, and proc management are already being
             respected.
-          </p>
-          <p>
-            Your major cooldown windows should be built around{' '}
-            <SpellLink spell={TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT} />. Going into that
-            window, pool enough resources that you can immediately spend globals on your strongest
-            abilities instead of fixing chi with multiple <SpellLink spell={SPELLS.TIGER_PALM} />{' '}
-            casts. Peak of Serenity currently recommends keeping one charge of{' '}
-            <SpellLink spell={TALENTS_MONK.ZENITH_TALENT} /> ready for your{' '}
-            <SpellLink spell={TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT} /> and{' '}
-            <SpellLink spell={TALENTS_MONK.CELESTIAL_CONDUIT_WINDWALKER_TALENT} /> burst, and
-            delaying <SpellLink spell={TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT} /> or{' '}
-            <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} /> briefly if needed so those
-            globals land inside your cooldown package.
-          </p>
-          <p>
-            When playing around <SpellLink spell={TALENTS_MONK.ZENITH_TALENT} />, the goal is not
-            simply to press it on cooldown. Use it with your burst tools, front-load stat buffs and
-            trinkets before activating it, and avoid wasting the window on low-value setup globals.
-            This is especially important with{' '}
-            <SpellLink spell={TALENTS_MONK.OBSIDIAN_SPIRAL_TALENT} />
-            , where reducing <SpellLink spell={SPELLS.TIGER_PALM} /> usage inside Zenith is part of
-            correct play rather than a minor optimization.
           </p>
           <p>
             More complete and up-to-date rotation guidance is available in the{' '}

--- a/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
@@ -76,20 +76,6 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: TALENTS_MONK.CHI_WAVE_TALENT.id,
-        category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 15,
-        gcd: {
-          base: 1000,
-          minimum: 750,
-        },
-        enabled: combatant.hasTalent(TALENTS_MONK.CHI_WAVE_TALENT),
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.65,
-        },
-      },
-      {
         spell: SPELLS.SPINNING_CRANE_KICK.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: {
@@ -151,6 +137,18 @@ class Abilities extends CoreAbilities {
         cooldown: 90,
         gcd: null,
         charges: 2,
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.95,
+        },
+      },
+      {
+        spell: TALENTS_MONK.ZENITH_TALENT.id,
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 90,
+        charges: 2,
+        gcd: null,
+        enabled: combatant.hasTalent(TALENTS_MONK.ZENITH_TALENT),
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.95,

--- a/src/analysis/retail/monk/windwalker/modules/talents/InvokeXuen.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/InvokeXuen.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'react';
 import SpellUsable from 'analysis/retail/monk/windwalker/modules/core/SpellUsable';
 import { SpellLink } from 'interface';
-import Analyzer from 'parser/core/Analyzer';
+import Analyzer, { Options } from 'parser/core/Analyzer';
 
 import { TALENTS_MONK } from 'common/TALENTS';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
@@ -15,6 +15,11 @@ class InvokeXuen extends Analyzer {
   };
 
   protected spellUsable!: SpellUsable;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT);
+  }
 
   get guideSubsection(): JSX.Element {
     const explanation = (

--- a/src/analysis/retail/monk/windwalker/modules/talents/Zenith.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/Zenith.tsx
@@ -1,0 +1,179 @@
+import type { JSX } from 'react';
+import SPELLS from 'common/SPELLS/monk';
+import { formatNumber } from 'common/format';
+import TALENTS_MONK from 'common/TALENTS/monk';
+import { SpellIcon, SpellLink } from 'interface';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+import ChiTracker from 'analysis/retail/monk/windwalker/modules/resources/ChiTracker';
+import SpellUsable from 'analysis/retail/monk/windwalker/modules/core/SpellUsable';
+import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
+import { GapHighlight } from 'parser/ui/CooldownBar';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+
+class Zenith extends Analyzer.withDependencies({
+  chi: ChiTracker,
+  spellUsable: SpellUsable,
+}) {
+  private zenithActiveUntil = 0;
+  private blackoutKicksDuringZenith = 0;
+  private chiGenerated = 0;
+  private chiGeneratedPotential = 0;
+  private readonly hasObsidianSpiral: boolean = false;
+  private readonly zenithDurationMs: number = 15000;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.ZENITH_TALENT);
+    if (!this.active) {
+      return;
+    }
+    this.hasObsidianSpiral = this.selectedCombatant.hasTalent(TALENTS_MONK.OBSIDIAN_SPIRAL_TALENT);
+    this.zenithDurationMs =
+      15000 +
+      (this.selectedCombatant.hasTalent(TALENTS_MONK.DRINKING_HORN_COVER_TALENT) ? 5000 : 0);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.ZENITH_TALENT),
+      this.onZenithCast,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell([SPELLS.BLACKOUT_KICK, SPELLS.BLACKOUT_KICK_TOTM]),
+      this.onBlackoutKick,
+    );
+  }
+
+  private isZenithActive(timestamp: number) {
+    return timestamp <= this.zenithActiveUntil;
+  }
+
+  private onZenithCast(event: CastEvent) {
+    const end = event.timestamp + this.zenithDurationMs;
+    this.zenithActiveUntil = Math.max(this.zenithActiveUntil, end);
+    this.deps.spellUsable.endCooldown(TALENTS_MONK.RISING_SUN_KICK_TALENT.id, event.timestamp);
+  }
+
+  private onBlackoutKick(event: CastEvent) {
+    if (!this.isZenithActive(event.timestamp)) {
+      return;
+    }
+    this.blackoutKicksDuringZenith += 1;
+    this.chiGeneratedPotential += 1;
+    if (this.hasObsidianSpiral) {
+      const current = this.deps.chi.current;
+      const max = this.deps.chi.maxResource;
+      const actualGain = Math.max(0, Math.min(1, max - current));
+      this.chiGenerated += actualGain;
+      this.deps.chi.processInvisibleEnergize(
+        TALENTS_MONK.OBSIDIAN_SPIRAL_TALENT.id,
+        1,
+        event.timestamp,
+      );
+    }
+  }
+
+  get guideSubsection(): JSX.Element {
+    const styleObj = {
+      fontSize: 20,
+    };
+    const styleObjInner = {
+      fontSize: 15,
+    };
+
+    const explanation = (
+      <p>
+        <b>
+          <SpellLink spell={TALENTS_MONK.ZENITH_TALENT} />
+        </b>{' '}
+        resets <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT} />, grants 2 Chi, and for 15
+        seconds reduces Chi costs by 1 while making <SpellLink spell={SPELLS.BLACKOUT_KICK} />{' '}
+        reduce the cooldown of affected abilities by an additional 1 second.
+      </p>
+    );
+
+    const chiLabel = this.hasObsidianSpiral
+      ? 'Chi generated with Obsidian Spiral'
+      : 'Chi that would have been generated with Obsidian Spiral';
+
+    const data = (
+      <div>
+        <RoundedPanel>
+          <strong>
+            <SpellLink spell={TALENTS_MONK.ZENITH_TALENT} /> cast efficiency
+          </strong>
+          {this.guideSubStatistic()}
+          <div style={styleObj}>
+            <small style={styleObjInner}>
+              <SpellLink spell={TALENTS_MONK.OBSIDIAN_SPIRAL_TALENT} /> -{' '}
+            </small>
+            <strong>
+              {formatNumber(
+                this.hasObsidianSpiral ? this.chiGenerated : this.chiGeneratedPotential,
+              )}
+            </strong>{' '}
+            <small>{chiLabel}</small>
+          </div>
+        </RoundedPanel>
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+
+  guideSubStatistic() {
+    return (
+      <CastEfficiencyBar
+        spell={TALENTS_MONK.ZENITH_TALENT}
+        gapHighlightMode={GapHighlight.FullCooldown}
+        minimizeIcons
+        slimLines
+        useThresholds
+      />
+    );
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(6)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <BoringSpellValueText spell={TALENTS_MONK.ZENITH_TALENT}>
+          <span>
+            <SpellIcon
+              spell={SPELLS.BLACKOUT_KICK}
+              style={{
+                height: '1.3em',
+                marginTop: '-1.em',
+              }}
+            />{' '}
+            {formatNumber(this.blackoutKicksDuringZenith)}{' '}
+            <small>Blackout Kicks during Zenith</small>
+            <br />
+            <SpellIcon
+              spell={TALENTS_MONK.OBSIDIAN_SPIRAL_TALENT}
+              style={{
+                height: '1.3em',
+                marginTop: '-1.em',
+              }}
+            />{' '}
+            {formatNumber(this.hasObsidianSpiral ? this.chiGenerated : this.chiGeneratedPotential)}{' '}
+            <small>
+              {this.hasObsidianSpiral
+                ? 'Chi generated during Zenith'
+                : 'Chi that would have been generated during Zenith (requires Obsidian Spiral)'}
+            </small>
+          </span>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default Zenith;


### PR DESCRIPTION
Add Zenith analysis with guide subsection, cast efficiency, and chi/damage stats; register it in the parser and abilities list. Gate Invoke Xuen analysis by talent and add a Windwalker preface/disclaimer section.

### Description
<img width="644" height="918" alt="image" src="https://github.com/user-attachments/assets/2b54ebb9-bbd4-4f78-a91d-3d2b408834fa" />

### Testing

- Test report URL: `http://localhost:3000/report/gMA4yWtDYkdZjhmR/3-Mythic+Dimensius,+the+All-Devouring+-+Kill+(3:43)/13-Lavinath/standard`
- Screenshot(s):
