### PR TITLE
[Survival] Sentinel Talent: Moonlight Chakrams

### DIFF
--- a/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
@@ -31,9 +31,10 @@ export default class MoonlightChakram extends Analyzer {
   protected spellUsable!: SpellUsable;
 
   private totalDamage = 0;
-  private totalHits = 0;
   private chakramCasts = 0;
   private missedCasts = 0;
+  private totalWildfireBombCdr = 0;
+  private totalWildfireBombCdrWasted = 0;
   private useEntries: BoxRowEntry[] = [];
   private isSurvival = false;
   private hasStalkAndStrike = false;
@@ -91,7 +92,6 @@ export default class MoonlightChakram extends Analyzer {
     const hits = damageEvents.length;
 
     this.totalDamage += damage;
-    this.totalHits += hits;
 
     let performance = QualitativePerformance.Good;
     let wastedCDR = 0;
@@ -115,6 +115,8 @@ export default class MoonlightChakram extends Analyzer {
             performance = QualitativePerformance.Fail;
           }
         }
+        this.totalWildfireBombCdrWasted += wastedCDR;
+        this.totalWildfireBombCdr += STALK_AND_STRIKE_CDR - wastedCDR;
       } else {
         wastedLockAndLoad = this.selectedCombatant.hasBuff(
           SPELLS.LOCK_AND_LOAD_BUFF.id,
@@ -212,8 +214,6 @@ export default class MoonlightChakram extends Analyzer {
   }
 
   statistic() {
-    const avgHits = this.chakramCasts > 0 ? this.totalHits / this.chakramCasts : 0;
-
     return (
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL(13)}
@@ -222,9 +222,20 @@ export default class MoonlightChakram extends Analyzer {
       >
         <BoringSpellValueText spell={TALENTS.MOONLIGHT_CHAKRAM_TALENT}>
           <ItemDamageDone amount={this.totalDamage} />
-          <div>
-            {avgHits.toFixed(1)} <small>average targets hit</small>
-          </div>
+          {this.hasStalkAndStrike && this.isSurvival && this.chakramCasts > 0 && (
+            <>
+              <div>
+                {(this.totalWildfireBombCdr / 1000).toFixed(1)}s{' '}
+                <small>Wildfire Bomb CDR gained</small>
+              </div>
+              {this.totalWildfireBombCdrWasted > 0 && (
+                <div>
+                  {(this.totalWildfireBombCdrWasted / 1000).toFixed(1)}s{' '}
+                  <small>Wildfire Bomb CDR wasted</small>
+                </div>
+              )}
+            </>
+          )}
           {this.missedCasts > 0 && (
             <div style={{ color: BadColor }}>
               {this.missedCasts} <small>missed {this.missedCasts === 1 ? 'cast' : 'casts'}</small>

--- a/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
@@ -57,11 +57,11 @@ export default class MoonlightChakram extends Analyzer {
   }
 
   private onTriggerCast(event: CastEvent) {
-    const triggerName = event.ability.guid === SPELLS.TRUESHOT.id ? 'Trueshot' : 'Takedown';
     // Chakram is a 15s duration availability after using cooldown.
     const chakramCast = GetRelatedEvents(event, TRIGGER_TO_CHAKRAM_CAST)[0] as
       | CastEvent
       | undefined;
+    const chakramTarget = this.owner.getTargetName(event) || 'unknown';
 
     if (!chakramCast) {
       this.missedCasts += 1;
@@ -72,8 +72,8 @@ export default class MoonlightChakram extends Analyzer {
             <h5 style={{ color: BadColor }}>
               FAIL: No <SpellLink spell={SPELLS.MOONLIGHT_CHAKRAM_CAST} /> cast
             </h5>
-            @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> after{' '}
-            <strong>{triggerName}</strong>
+            Target: <strong>{chakramTarget}</strong>
+            <br />@ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
           </>
         ),
       });
@@ -81,8 +81,10 @@ export default class MoonlightChakram extends Analyzer {
     }
 
     this.chakramCasts += 1;
+    const targetName = this.owner.getTargetName(chakramCast) || chakramTarget;
 
-    //Currently hits 16 times, but will only hit for 7 at level 90 with the extra hero talents.
+    //Currently hits 16 times, but will only hit for 7 at level 90 with the extra hero talents
+    // So analysis is a little weird. The important bit is did they even cast the ability or did they forget
     const damageEvents =
       (GetRelatedEvents(chakramCast, CHAKRAM_CAST_TO_DAMAGE) as DamageEvent[]) || [];
     const damage = damageEvents.reduce((sum, dmg) => sum + dmg.amount + (dmg.absorbed || 0), 0);
@@ -147,6 +149,8 @@ export default class MoonlightChakram extends Analyzer {
             Damage: <strong>{damage.toLocaleString()}</strong> ({hits} {hits === 1 ? 'hit' : 'hits'}
             )
             <br />
+            Target: <strong>{targetName}</strong>
+            <br />
             {this.hasStalkAndStrike && this.isSurvival && wastedCDR > 0 && (
               <>
                 {wastedCDR > STALK_AND_STRIKE_WASTE_THRESHOLD ? 'BAD: ' : ''}Wasted{' '}
@@ -161,8 +165,7 @@ export default class MoonlightChakram extends Analyzer {
               </>
             )}
           </div>
-          @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> after{' '}
-          <strong>{triggerName}</strong>
+          @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
         </>
       ),
     });

--- a/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
@@ -1,0 +1,230 @@
+import type { JSX } from 'react';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent, DamageEvent, GetRelatedEvents } from 'parser/core/Events';
+import TALENTS from 'common/TALENTS/hunter';
+import SPELLS from 'common/SPELLS';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import SpellLink from 'interface/SpellLink';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
+import { BadColor, GoodColor, OkColor } from 'interface/guide';
+import {
+  TRIGGER_TO_CHAKRAM_CAST,
+  CHAKRAM_CAST_TO_DAMAGE,
+} from '../normalizers/MoonlightChakramNormalizer';
+
+const STALK_AND_STRIKE_CDR = 10000;
+const STALK_AND_STRIKE_WASTE_THRESHOLD = 3000;
+
+export default class MoonlightChakram extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+
+  private totalDamage = 0;
+  private totalHits = 0;
+  private chakramCasts = 0;
+  private missedCasts = 0;
+  private useEntries: BoxRowEntry[] = [];
+  private isSurvival = false;
+  private hasStalkAndStrike = false;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS.MOONLIGHT_CHAKRAM_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    //Survival gets bomb CDR, MM gets Lock and Load buff
+    this.isSurvival = this.selectedCombatant.hasTalent(TALENTS.RAPTOR_STRIKE_TALENT);
+    this.hasStalkAndStrike = this.selectedCombatant.hasTalent(TALENTS.STALK_AND_STRIKE_TALENT);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell([SPELLS.TRUESHOT, SPELLS.TAKEDOWN_PLAYER]),
+      this.onTriggerCast,
+    );
+  }
+
+  private onTriggerCast(event: CastEvent) {
+    const triggerName = event.ability.guid === SPELLS.TRUESHOT.id ? 'Trueshot' : 'Takedown';
+    // Chakram is a 15s duration availability after using cooldown.
+    const chakramCast = GetRelatedEvents(event, TRIGGER_TO_CHAKRAM_CAST)[0] as
+      | CastEvent
+      | undefined;
+
+    if (!chakramCast) {
+      this.missedCasts += 1;
+      this.useEntries.push({
+        value: QualitativePerformance.Fail,
+        tooltip: (
+          <>
+            <h5 style={{ color: BadColor }}>
+              FAIL: No <SpellLink spell={SPELLS.MOONLIGHT_CHAKRAM_CAST} /> cast
+            </h5>
+            @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> after{' '}
+            <strong>{triggerName}</strong>
+          </>
+        ),
+      });
+      return;
+    }
+
+    this.chakramCasts += 1;
+
+    //Currently hits 16 times, but will only hit for 7 at level 90 with the extra hero talents.
+    const damageEvents =
+      (GetRelatedEvents(chakramCast, CHAKRAM_CAST_TO_DAMAGE) as DamageEvent[]) || [];
+    const damage = damageEvents.reduce((sum, dmg) => sum + dmg.amount + (dmg.absorbed || 0), 0);
+    const hits = damageEvents.length;
+
+    this.totalDamage += damage;
+    this.totalHits += hits;
+
+    let performance = QualitativePerformance.Good;
+    let wastedCDR = 0;
+    let wastedLockAndLoad = false;
+
+    if (hits < 4) {
+      performance = QualitativePerformance.Fail;
+    } else if (hits < 7) {
+      performance = QualitativePerformance.Ok;
+    }
+
+    if (this.hasStalkAndStrike) {
+      if (this.isSurvival) {
+        const cdRemaining = this.spellUsable.cooldownRemaining(
+          TALENTS.WILDFIRE_BOMB_TALENT.id,
+          chakramCast.timestamp,
+        );
+        if (cdRemaining <= STALK_AND_STRIKE_CDR) {
+          wastedCDR = STALK_AND_STRIKE_CDR - cdRemaining;
+          if (wastedCDR > STALK_AND_STRIKE_WASTE_THRESHOLD) {
+            performance = QualitativePerformance.Fail;
+          }
+        }
+      } else {
+        wastedLockAndLoad = this.selectedCombatant.hasBuff(
+          SPELLS.LOCK_AND_LOAD_BUFF.id,
+          chakramCast.timestamp,
+        );
+        if (wastedLockAndLoad) {
+          performance = QualitativePerformance.Fail;
+        }
+      }
+    }
+
+    // Build tooltip
+    const color =
+      performance === QualitativePerformance.Good
+        ? GoodColor
+        : performance === QualitativePerformance.Ok
+          ? OkColor
+          : BadColor;
+    const perfLabel =
+      performance === QualitativePerformance.Good
+        ? 'GOOD'
+        : performance === QualitativePerformance.Ok
+          ? 'OK'
+          : 'BAD';
+
+    this.useEntries.push({
+      value: performance,
+      tooltip: (
+        <>
+          <h5 style={{ color }}>{perfLabel}</h5>
+          <div>
+            Damage: <strong>{damage.toLocaleString()}</strong> ({hits} {hits === 1 ? 'hit' : 'hits'}
+            )
+            <br />
+            {this.hasStalkAndStrike && this.isSurvival && wastedCDR > 0 && (
+              <>
+                {wastedCDR > STALK_AND_STRIKE_WASTE_THRESHOLD ? 'BAD: ' : ''}Wasted{' '}
+                {(wastedCDR / 1000).toFixed(1)}s Wildfire Bomb CDR
+                <br />
+              </>
+            )}
+            {this.hasStalkAndStrike && !this.isSurvival && wastedLockAndLoad && (
+              <>
+                BAD: Wasted Lock and Load buff
+                <br />
+              </>
+            )}
+          </div>
+          @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> after{' '}
+          <strong>{triggerName}</strong>
+        </>
+      ),
+    });
+  }
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <strong>
+          <SpellLink spell={TALENTS.MOONLIGHT_CHAKRAM_TALENT} />
+        </strong>{' '}
+        should be cast within 15 seconds of becoming available.
+        {this.hasStalkAndStrike && this.isSurvival && (
+          <>
+            {' '}
+            With <SpellLink spell={TALENTS.STALK_AND_STRIKE_TALENT} />, ensure you don't waste{' '}
+            <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} /> cooldown reduction.
+          </>
+        )}
+        {this.hasStalkAndStrike && !this.isSurvival && (
+          <>
+            {' '}
+            With <SpellLink spell={TALENTS.STALK_AND_STRIKE_TALENT} />, avoid casting when you
+            already have <SpellLink spell={SPELLS.LOCK_AND_LOAD_BUFF} /> active to prevent wasting
+            the buff.
+          </>
+        )}
+      </p>
+    );
+
+    const data = (
+      <CastSummaryAndBreakdown
+        spell={TALENTS.MOONLIGHT_CHAKRAM_TALENT}
+        castEntries={this.useEntries}
+        usesInsteadOfCasts
+      />
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+
+  statistic() {
+    const avgHits = this.chakramCasts > 0 ? this.totalHits / this.chakramCasts : 0;
+
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <BoringSpellValueText spell={TALENTS.MOONLIGHT_CHAKRAM_TALENT}>
+          <ItemDamageDone amount={this.totalDamage} />
+          <div>
+            {avgHits.toFixed(1)} <small>average targets hit</small>
+          </div>
+          {this.missedCasts > 0 && (
+            <div style={{ color: BadColor }}>
+              {this.missedCasts} <small>missed {this.missedCasts === 1 ? 'cast' : 'casts'}</small>
+            </div>
+          )}
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
@@ -173,27 +173,31 @@ export default class MoonlightChakram extends Analyzer {
 
   get guideSubsection(): JSX.Element {
     const explanation = (
-      <p>
-        <strong>
-          <SpellLink spell={TALENTS.MOONLIGHT_CHAKRAM_TALENT} />
-        </strong>{' '}
-        should be cast within 15 seconds of becoming available.
-        {this.hasStalkAndStrike && this.isSurvival && (
-          <>
-            {' '}
-            With <SpellLink spell={TALENTS.STALK_AND_STRIKE_TALENT} />, ensure you don't waste{' '}
-            <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} /> cooldown reduction.
-          </>
-        )}
-        {this.hasStalkAndStrike && !this.isSurvival && (
-          <>
-            {' '}
-            With <SpellLink spell={TALENTS.STALK_AND_STRIKE_TALENT} />, avoid casting when you
-            already have <SpellLink spell={SPELLS.LOCK_AND_LOAD_BUFF} /> active to prevent wasting
-            the buff.
-          </>
-        )}
-      </p>
+      <div>
+        <p>
+          <strong>
+            <SpellLink spell={TALENTS.MOONLIGHT_CHAKRAM_TALENT} />
+          </strong>{' '}
+          should be cast within 15 seconds of becoming available.
+        </p>
+        <p>
+          {this.hasStalkAndStrike && this.isSurvival && (
+            <>
+              {' '}
+              With <SpellLink spell={TALENTS.STALK_AND_STRIKE_TALENT} />, ensure you don't waste{' '}
+              <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} /> cooldown reduction.
+            </>
+          )}
+          {this.hasStalkAndStrike && !this.isSurvival && (
+            <>
+              {' '}
+              With <SpellLink spell={TALENTS.STALK_AND_STRIKE_TALENT} />, avoid casting when you
+              already have <SpellLink spell={SPELLS.LOCK_AND_LOAD_BUFF} /> active to prevent wasting
+              the buff.
+            </>
+          )}
+        </p>
+      </div>
     );
 
     const data = (

--- a/src/analysis/retail/hunter/shared/index.ts
+++ b/src/analysis/retail/hunter/shared/index.ts
@@ -15,3 +15,4 @@ export { default as RejuvenatingWind } from './talents/RejuvenatingWind';
 export { default as SpellFocusCost } from './SpellFocusCost';
 export { default as Trailblazer } from './talents/Trailblazer';
 export { default as TranquilizingShot } from './talents/TranquilizingShot';
+export { default as MoonlightChakram } from './herotalents/MoonlightChakram';

--- a/src/analysis/retail/hunter/shared/normalizers/MoonlightChakramNormalizer.ts
+++ b/src/analysis/retail/hunter/shared/normalizers/MoonlightChakramNormalizer.ts
@@ -1,0 +1,39 @@
+import { Options } from 'parser/core/Analyzer';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { EventType } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS';
+import { MOONLIGHT_CHAKRAM_BUFFER } from '../../survival/constants';
+export const TRIGGER_TO_CHAKRAM_CAST = 'trigger_to_chakram_cast';
+export const CHAKRAM_CAST_TO_DAMAGE = 'chakram_cast_to_damage';
+
+const links: EventLink[] = [
+  {
+    linkRelation: TRIGGER_TO_CHAKRAM_CAST,
+    linkingEventType: EventType.Cast,
+    linkingEventId: [SPELLS.TRUESHOT.id, SPELLS.TAKEDOWN_PLAYER.id],
+    referencedEventType: EventType.Cast,
+    referencedEventId: SPELLS.MOONLIGHT_CHAKRAM_CAST.id,
+    anyTarget: true,
+    anySource: false,
+    forwardBufferMs: MOONLIGHT_CHAKRAM_BUFFER,
+    backwardBufferMs: 0,
+    maximumLinks: 1,
+  },
+  {
+    linkRelation: CHAKRAM_CAST_TO_DAMAGE,
+    linkingEventType: EventType.Cast,
+    linkingEventId: SPELLS.MOONLIGHT_CHAKRAM_CAST.id,
+    referencedEventType: EventType.Damage,
+    referencedEventId: SPELLS.MOONLIGHT_CHAKRAM_DAMAGE.id,
+    anyTarget: true,
+    anySource: false,
+    forwardBufferMs: MOONLIGHT_CHAKRAM_BUFFER,
+    backwardBufferMs: 0,
+  },
+];
+
+export default class MoonlightChakramNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, links);
+  }
+}

--- a/src/analysis/retail/hunter/survival/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/survival/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import { Kivlov,
  } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2026, 2, 1), 'Add Moonlight Chakram Analysis', Kivlov),
   change(date(2026, 1, 25), 'Add APL section. Add Tip of the Spear as a Resource', Kivlov),
   change(date(2026, 1, 23), 'Add Midnight abilities and clean up old abilities', Kivlov),
   change(date(2026, 1, 17), 'Add Boomstick Analyzer', Kivlov),

--- a/src/analysis/retail/hunter/survival/CombatLogParser.ts
+++ b/src/analysis/retail/hunter/survival/CombatLogParser.ts
@@ -36,6 +36,8 @@ import LethalCalibration from './modules/talents/LethalCalibration';
 import WildfireBombNormalizer from './normalizers/WildfireBombNormalizer';
 import TipOfTheSpear from './modules/talents/TipOfTheSpear';
 import AplCheck from './modules/apl/AplCheck';
+import MoonlightChakram from '../shared/herotalents/MoonlightChakram';
+import MoonlightChakramNormalizer from '../shared/normalizers/MoonlightChakramNormalizer';
 // import EventLinkNormalizer from '../shared/normalizers/HunterEventLinkNormalizers'; // This has a pack leader normalizer in it useful to Survival so not deleting yet.
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -70,6 +72,7 @@ class CombatLogParser extends CoreCombatLogParser {
     tipOfTheSpearNormalizer: TipOfTheSpearNormalizer,
     boomstickNormalizer: BoomstickNormalizer,
     wildfireBombNormalizer: WildfireBombNormalizer,
+    moonlightChakramNormalizer: MoonlightChakramNormalizer,
     // EventLinkNormalizers: EventLinkNormalizer,
 
     //DeathTracker
@@ -84,7 +87,7 @@ class CombatLogParser extends CoreCombatLogParser {
     tipOfTheSpear: TipOfTheSpear,
 
     //Shared Talents
-
+    moonlightChakram: MoonlightChakram,
     bindingShot: BindingShot,
     naturalMending: NaturalMending,
     rejuvenatingWind: RejuvenatingWind,

--- a/src/analysis/retail/hunter/survival/constants.ts
+++ b/src/analysis/retail/hunter/survival/constants.ts
@@ -49,6 +49,14 @@ export const LETHAL_CALIBRATION_CDR_PER_HIT = 2000;
 // Maximum targets that can grant CDR per Wildfire Bomb cast
 export const LETHAL_CALIBRATION_MAX_TARGETS = 5;
 //endregion
+/** Stalk and Strike */
+// Cooldown reduction granted to Wildfire Bomb for Survival
+export const STALK_AND_STRIKE_CDR = 10000;
+// Maximum wasted CDR threshold before marking as bad cast
+export const STALK_AND_STRIKE_WASTE_THRESHOLD = 3000;
+// Buffer time to look for Moonlight Chakram cast after Trueshot or Takedown
+// And for the damage after Chakram is cast
+export const MOONLIGHT_CHAKRAM_BUFFER = 16000;
 
 //region Resources
 export const LIST_OF_FOCUS_SPENDERS_SV = [

--- a/src/analysis/retail/hunter/survival/modules/guide/Guide.tsx
+++ b/src/analysis/retail/hunter/survival/modules/guide/Guide.tsx
@@ -8,6 +8,7 @@ import Cooldown from './sections/rotation/Cooldown';
 import MajorDefensives from '../../../shared/guide/defensives/DamageTaken';
 import { IntroSection } from './sections/intro/IntroSection';
 import { AplSection } from '../apl/AplCheck';
+import HeroSection from './sections/rotation/HeroTalents';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -17,6 +18,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
       <ResourceUseSection {...modules} />
       <Cooldown modules={modules} events={events} info={info} />
       <RotationSection modules={modules} events={events} info={info} />
+      <HeroSection modules={modules} events={events} info={info} />
       <AplSection />
       <MajorDefensives />
       {modules.exhilarationTiming.guideSubsection}

--- a/src/analysis/retail/hunter/survival/modules/guide/sections/rotation/HeroTalents.tsx
+++ b/src/analysis/retail/hunter/survival/modules/guide/sections/rotation/HeroTalents.tsx
@@ -1,0 +1,20 @@
+import { Trans } from '@lingui/react/macro';
+import { t } from '@lingui/core/macro';
+import { GuideProps, Section } from 'interface/guide';
+import CombatLogParser from 'analysis/retail/hunter/survival/CombatLogParser';
+export default function HeroSection({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
+  return (
+    <Section
+      title={t({
+        id: 'guide.hunter.survival.sections.hero.title',
+        message: 'Hero Talents',
+      })}
+    >
+      <Trans id="guide.hunter.survival.sections.hero.section">
+        <strong>Hero Talents</strong> - This section covers usage of hero talent abilities and
+        mechanics.
+      </Trans>
+      {modules.moonlightChakram.guideSubsection}
+    </Section>
+  );
+}

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -337,11 +337,16 @@ const spells = {
   },
   //endregion
 
-  //region Shared
+  //region Hero Talents
   SENTINELS_MARK_DEBUFF: {
     id: 1253601,
     name: "Sentinel's Mark",
     icon: 'ability_ardenweald_hunter',
+  },
+  MOONLIGHT_CHAKRAM_CAST: {
+    id: 1264949,
+    name: 'Moonlight Chakram',
+    icon: 'inv_ability_hunter_deathchakram',
   },
   MOONLIGHT_CHAKRAM_DAMAGE: {
     id: 1266081,
@@ -358,6 +363,33 @@ const spells = {
     name: 'Howl of the Packleader',
     icon: 'inv_misc_elitewyvern',
   },
+  WAILING_ARROW_DAMAGE: {
+    id: 392058,
+    name: 'Wailing Arrow',
+    icon: 'ability_theblackarrow',
+  },
+  WAILING_ARROW_DAMAGE_FOCUS: {
+    id: 392060,
+    name: 'Wailing Arrow',
+    icon: 'ability_theblackarrow',
+  },
+  BLACK_ARROW_DAMAGE: {
+    id: 466930,
+    name: 'Black Arrow',
+    icon: 'inv_ability_darkrangerhunter_blackarrow',
+  },
+  BLACK_ARROW_DAMAGE_2: {
+    id: 468037,
+    name: 'Black Arrow',
+    icon: 'inv_ability_darkrangerhunter_blackarrow',
+  },
+  BLACK_ARROW_DAMAGE_3: {
+    id: 468572,
+    name: 'Black Arrow',
+    icon: 'inv_ability_darkrangerhunter_blackarrow',
+  },
+  //rendregion
+  //region Shared Talents
   EXPLOSIVE_SHOT_DAMAGE: {
     id: 212680,
     name: 'Explosive Shot',
@@ -492,31 +524,6 @@ const spells = {
     id: 19801,
     name: 'Tranquilizing Shot',
     icon: 'spell_nature_drowsy',
-  },
-  WAILING_ARROW_DAMAGE: {
-    id: 392058,
-    name: 'Wailing Arrow',
-    icon: 'ability_theblackarrow',
-  },
-  WAILING_ARROW_DAMAGE_FOCUS: {
-    id: 392060,
-    name: 'Wailing Arrow',
-    icon: 'ability_theblackarrow',
-  },
-  BLACK_ARROW_DAMAGE: {
-    id: 466930,
-    name: 'Black Arrow',
-    icon: 'inv_ability_darkrangerhunter_blackarrow',
-  },
-  BLACK_ARROW_DAMAGE_2: {
-    id: 468037,
-    name: 'Black Arrow',
-    icon: 'inv_ability_darkrangerhunter_blackarrow',
-  },
-  BLACK_ARROW_DAMAGE_3: {
-    id: 468572,
-    name: 'Black Arrow',
-    icon: 'inv_ability_darkrangerhunter_blackarrow',
   },
   //endregion
 


### PR DESCRIPTION
### Description

Moonlight Chakram for Sentinel Hero talents.
It gives Survival 10s of wildfire bomb, and must be used within 15s of Takedown (Trueshot for MM) cast or it fades.
The goal is to minimise waste, not miss a cast, and try not to cast it on something low hp since it deals it's damage over time (up to 10s with the bug).


This contains analysis for Marksman. They get Lock and Load for free, so if they have the buff when they press Chakram then it's a bad use. Survivals is a sliding  amount of valid waste that will be tuned as sims come out.

Once we're level 90, I can remove all the checks for stalk and strike because right now they are not taken in single target, but they are taken in AoE.

-  `/report/B23zGhvLk1AxKFw4/16-Mythic+Dimensius,+the+All-Devouring+-+Kill+(4:44)/114-Percival/standard` <- Stalkless
- `/report/yMqfrbH9nv6txVRd/33/184` <- Stalk and Strike report
- 

