### PR TITLE
fix playwright tests' handling of specs with partial support

### DIFF
--- a/e2e/poms/report-page.ts
+++ b/e2e/poms/report-page.ts
@@ -129,15 +129,13 @@ export class ReportPage {
       await this.continueAnywayLink.click();
     }
 
+    if (handlePartial && (await this.partialSupportHeading.isVisible())) {
+      await this.continueAnywayLink.click();
+    }
+
     if ((await this.loadingLink.isVisible()) && waitForLoadingToFinish) {
       await this.expectBossDifficultyAndNameHeaderToBeVisible();
       await this.loadingLink.waitFor({ state: 'detached' });
-
-      if (handlePartial) {
-        if (await this.partialSupportHeading.isVisible()) {
-          await this.continueAnywayLink.click();
-        }
-      }
     }
   }
 

--- a/e2e/poms/report-page.ts
+++ b/e2e/poms/report-page.ts
@@ -129,7 +129,7 @@ export class ReportPage {
       await this.continueAnywayLink.click();
     }
 
-    if (handlePartial && (await this.partialSupportHeading.isVisible())) {
+    if ((await this.partialSupportHeading.isVisible()) && handlePartial) {
       await this.continueAnywayLink.click();
     }
 

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -30,6 +30,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 2, 1), 'Fix playwright tests for specs with partial support', Vollmer),
   change(date(2026, 1, 29), 'RU: improve localization on key pages (news/about/specs/premium/help-wanted) and make Panel headings fully translatable', SaltyRain),
   change(date(2026, 1, 27), 'Add support for Midnight gems and enchants.', Arlie),
   change(date(2026, 1, 27), 'Add error state for ineligible fights.', Topple),


### PR DESCRIPTION
should fix https://github.com/WoWAnalyzer/WoWAnalyzer/actions/runs/21546359318/job/62088335106

Current (note that it never clicks "Continue anyways") / With earlier partial support handling
<img width="2016" height="811" alt="image" src="https://github.com/user-attachments/assets/fc9ca836-f359-4c4b-aeb5-9eb7a4cb4b22" />

