### PR TITLE
allow disabling checker plugin via env var

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -99,7 +99,9 @@ export default defineConfig((env) => ({
           },
         })
       : null,
-    !process.env.VITEST ? checker({ typescript: true }) : undefined,
+    !process.env.VITEST && !process.env.DISABLE_CHECKER_PLUGIN
+      ? checker({ typescript: true })
+      : undefined,
   ],
   optimizeDeps: {
     include: ['@emotion/styled/base'],


### PR DESCRIPTION
### Description

noticed high runtime from node/tsc on my laptop while working on battery. suspect this does bad things for battery life. 

note that setting this in `.env.local` is insufficient, need to set it via `.envrc` or similar (or we need to make those .env files get loaded early in `vite.config.ts`?)