### PR TITLE
[Survival] Hero Talent Pack Leader - Stampede and Howl

### DIFF
--- a/src/analysis/retail/hunter/shared/herotalents/HowlBoar.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/HowlBoar.tsx
@@ -1,0 +1,149 @@
+import type { JSX } from 'react';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  CastEvent,
+  DamageEvent,
+  RemoveBuffEvent,
+  GetRelatedEvent,
+  GetRelatedEvents,
+} from 'parser/core/Events';
+import TALENTS from 'common/TALENTS/hunter';
+import { formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import SpellLink from 'interface/SpellLink';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
+import { PerfectColor, BadColor } from 'interface/guide';
+import {
+  BOAR_TO_HOGSTRIDER_DAMAGE,
+  BOAR_TO_KILL_COMMAND,
+} from '../normalizers/HunterEventLinkNormalizers';
+
+/* Howl of the Pack Leader spawns a Hogstrider boar that charges through the target.
+ * Boar can hit walls, and miss due to the Z-axis so the only pass/fail is did it hit anything
+ */
+
+export default class HowlBoar extends Analyzer {
+  private totalCharges = 0;
+  private totalDamage = 0;
+  private totalTargetsHit = 0;
+  private useEntries: BoxRowEntry[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.HOWL_OF_THE_PACK_LEADER_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    // Howl of the Pack Leader is 4 spell IDs. The only one we care about is when
+    // boar is removed as it can miss entirely and it does significant damage so
+    // missing the boar is a critical oopsie.
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.HOWL_OF_THE_PACKLEADER_BOAR),
+      this.onBoarConsumed,
+    );
+  }
+
+  private onBoarConsumed = (event: RemoveBuffEvent) => {
+    const damages = GetRelatedEvents<DamageEvent>(event, BOAR_TO_HOGSTRIDER_DAMAGE);
+    // Kill command spawns it, it's aoe so get the target from what you KC'd
+    const killCommand = GetRelatedEvent<CastEvent>(event, BOAR_TO_KILL_COMMAND);
+
+    const targetsHit = new Set(damages.map((d) => d.targetID)).size;
+    const chargeDamage = damages.reduce((sum, d) => sum + d.amount + (d.absorbed ?? 0), 0);
+
+    this.totalCharges += 1;
+    this.totalDamage += chargeDamage;
+    this.totalTargetsHit += targetsHit;
+
+    const targetName = killCommand ? this.owner.getTargetName(killCommand) : undefined;
+    const primaryHit = damages.find((d) => d.ability.guid === SPELLS.PL_HOGSTRIDER_DAMAGE_2.id);
+    const targetHpPercent =
+      primaryHit?.hitPoints !== undefined && primaryHit?.maxHitPoints
+        ? Math.round((primaryHit.hitPoints / primaryHit.maxHitPoints) * 100)
+        : undefined;
+
+    const perf = chargeDamage > 0 ? QualitativePerformance.Perfect : QualitativePerformance.Fail;
+    const color = chargeDamage > 0 ? PerfectColor : BadColor;
+    const header = chargeDamage > 0 ? 'Hit' : 'Hogstrider failed to hit any targets!';
+
+    const tooltip = (
+      <div>
+        <h5 style={{ color }}>{header}</h5>
+        <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
+        {targetName && (
+          <>
+            {' '}
+            targeting <strong>{targetName}</strong>
+            {targetHpPercent !== undefined && (
+              <>
+                {' '}
+                at <strong>{targetHpPercent}%</strong> HP
+              </>
+            )}
+          </>
+        )}
+        <div>
+          <strong>{targetsHit}</strong> targets hit{' '}
+          <small>({formatNumber(chargeDamage)} damage)</small>
+        </div>
+        <div>
+          <strong>Total Damage:</strong> {formatNumber(chargeDamage)}
+        </div>
+      </div>
+    );
+
+    this.useEntries.push({ value: perf, tooltip });
+  };
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <BoringSpellValueText spell={SPELLS.PL_HOGSTRIDER_DAMAGE_1}>
+          <>
+            <ItemDamageDone amount={this.totalDamage} />
+            <div>
+              <strong>Charges:</strong> {this.totalCharges}
+            </div>
+            <div>
+              <strong>Total targets hit:</strong> {this.totalTargetsHit}
+            </div>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+
+  get guideSubsection(): JSX.Element {
+    const explanation = (
+      <p>
+        <strong>
+          <SpellLink spell={SPELLS.PL_HOGSTRIDER_DAMAGE_1} />
+        </strong>{' '}
+        charges through, dealing damage to all enemies around your target.
+      </p>
+    );
+
+    const data = (
+      <CastSummaryAndBreakdown
+        spell={SPELLS.PL_HOGSTRIDER_DAMAGE_1}
+        castEntries={this.useEntries}
+        usesInsteadOfCasts
+      />
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+}

--- a/src/analysis/retail/hunter/shared/herotalents/SentinelsMark.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/SentinelsMark.tsx
@@ -164,20 +164,13 @@ export default class SentinelsMark extends Analyzer.withDependencies({
     const gcdsBetweenApplyAndRemove = Math.max(mark.gcdCount - 1, 0);
 
     const baseTooltip = (
-      <>
+      <div>
         <div>
           Target: <strong>{mark.targetName}</strong>
-          {mark.hpPercent !== null && (
-            <>
-              <br />
-              HP: {mark.hpPercent.toFixed(1)}%
-            </>
-          )}
-          <br />
-          Duration: {(duration / 1000).toFixed(1)}s
-          <br />
-          GCDs Between Apply and Remove: {gcdsBetweenApplyAndRemove}
         </div>
+        {mark.hpPercent !== null && <div>HP: {mark.hpPercent.toFixed(1)}%</div>}
+        <div>Duration: {(duration / 1000).toFixed(1)}s</div>
+        <div>GCDs Between Apply and Remove: {gcdsBetweenApplyAndRemove}</div>
         {this.hasMoonsBlessing && mark.wastedCdr > 0 && (
           <div>
             Wasted {(mark.wastedCdr / 1000).toFixed(1)}s{' '}
@@ -189,8 +182,10 @@ export default class SentinelsMark extends Analyzer.withDependencies({
             CDR
           </div>
         )}
-        Applied @ <strong>{this.owner.formatTimestamp(mark.applyTimestamp)}</strong>
-      </>
+        <div>
+          Applied @ <strong>{this.owner.formatTimestamp(mark.applyTimestamp)}</strong>
+        </div>
+      </div>
     );
 
     // GOOD: Mark was consumed
@@ -202,8 +197,9 @@ export default class SentinelsMark extends Analyzer.withDependencies({
           <>
             <h5 style={{ color: GoodColor }}>GOOD: Consumed Mark</h5>
             {baseTooltip}
-            <br />
-            Consumed @ <strong>{this.owner.formatTimestamp(outcome.timestamp)}</strong>
+            <div>
+              Consumed @ <strong>{this.owner.formatTimestamp(outcome.timestamp)}</strong>
+            </div>
           </>
         ),
       };
@@ -222,8 +218,9 @@ export default class SentinelsMark extends Analyzer.withDependencies({
           <>
             <h5 style={{ color: OkColor }}>{header}</h5>
             {baseTooltip}
-            <br />
-            Removed @ <strong>{this.owner.formatTimestamp(outcome.timestamp)}</strong>
+            <div>
+              Removed @ <strong>{this.owner.formatTimestamp(outcome.timestamp)}</strong>
+            </div>
           </>
         ),
       };
@@ -238,8 +235,9 @@ export default class SentinelsMark extends Analyzer.withDependencies({
           <>
             <h5 style={{ color: BadColor }}>FAIL: Target Died with Mark</h5>
             {baseTooltip}
-            <br />
-            Removed @ <strong>{this.owner.formatTimestamp(outcome.timestamp)}</strong>
+            <div>
+              Removed @ <strong>{this.owner.formatTimestamp(outcome.timestamp)}</strong>
+            </div>
           </>
         ),
       };
@@ -254,8 +252,9 @@ export default class SentinelsMark extends Analyzer.withDependencies({
           <>
             <h5 style={{ color: BadColor }}>FAIL: Mark Expired Without Consumption</h5>
             {baseTooltip}
-            <br />
-            Expired @ <strong>{this.owner.formatTimestamp(outcome.timestamp)}</strong>
+            <div>
+              Expired @ <strong>{this.owner.formatTimestamp(outcome.timestamp)}</strong>
+            </div>
           </>
         ),
       };
@@ -284,8 +283,9 @@ export default class SentinelsMark extends Analyzer.withDependencies({
           <>
             <h5 style={{ color: BadColor }}>FAIL: Refreshed Before Consumption</h5>
             {baseTooltip}
-            <br />
-            Refreshed @ <strong>{this.owner.formatTimestamp(outcome.timestamp)}</strong>
+            <div>
+              Refreshed @ <strong>{this.owner.formatTimestamp(outcome.timestamp)}</strong>
+            </div>
           </>
         ),
       };

--- a/src/analysis/retail/hunter/shared/herotalents/Stampede.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/Stampede.tsx
@@ -1,8 +1,8 @@
 import type { JSX } from 'react';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, RemoveBuffEvent } from 'parser/core/Events';
-import { GetRelatedEvents } from 'parser/core/Events';
+import Events, { DamageEvent, RemoveBuffEvent, GetRelatedEvents } from 'parser/core/Events';
 import TALENTS from 'common/TALENTS/hunter';
+import { formatNumber } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -25,22 +25,7 @@ import { STAMPEDE_READY_TO_DAMAGE } from '../normalizers/HunterEventLinkNormaliz
  * tick coverage per stampede to evaluate positioning and target uptime.
  */
 
-interface WindowSummary {
-  start: number;
-  uniqueTargets: number;
-  totalDamage: number;
-  actualTicks: number;
-  expectedTicks: number;
-  hitPercent: number;
-}
-
-const format_compact = (n: number) =>
-  Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 }).format(n);
-
-const TICKS_PER_STAMPEDE_PER_TARGET = 9;
-
 export default class StampedeAnalyzer extends Analyzer {
-  private windows: WindowSummary[] = [];
   private totalStampedeCount = 0;
   private totalStampedeDamage = 0;
   private useEntries: BoxRowEntry[] = [];
@@ -57,6 +42,7 @@ export default class StampedeAnalyzer extends Analyzer {
       this.onStampedeConsumed,
     );
   }
+
   private triggerAbility = this.selectedCombatant.hasTalent(TALENTS.RAPTOR_STRIKE_TALENT)
     ? TALENTS.TAKEDOWN_TALENT
     : TALENTS.BESTIAL_WRATH_TALENT;
@@ -77,33 +63,14 @@ export default class StampedeAnalyzer extends Analyzer {
   }
 
   private onStampedeConsumed = (event: RemoveBuffEvent) => {
-    const damages =
-      (GetRelatedEvents(event, STAMPEDE_READY_TO_DAMAGE) as DamageEvent[] | undefined) ?? [];
+    const damages = GetRelatedEvents<DamageEvent>(event, STAMPEDE_READY_TO_DAMAGE);
 
-    type DamageEventWithInstance = DamageEvent & { targetInstance?: number };
-    let totalDamage = 0;
-    const targetKeys = new Set<string>();
-    for (const d of damages) {
-      totalDamage += d.amount + (d.absorbed ?? 0);
-      const inst = (d as DamageEventWithInstance).targetInstance ?? 0;
-      targetKeys.add(`${d.targetID}:${inst}`);
-    }
-
-    const uniqueTargets = targetKeys.size;
-    const expectedTicks = uniqueTargets * TICKS_PER_STAMPEDE_PER_TARGET;
+    const uniqueTargets = new Set(damages.map((d) => d.targetID)).size;
+    const totalDamage = damages.reduce((sum, d) => sum + d.amount + (d.absorbed ?? 0), 0);
     const actualTicks = damages.length;
+    const expectedTicks = uniqueTargets * 9;
     const hitPercent = expectedTicks > 0 ? Math.min(actualTicks / expectedTicks, 1) : 0;
 
-    const summary: WindowSummary = {
-      start: event.timestamp,
-      uniqueTargets,
-      totalDamage,
-      actualTicks,
-      expectedTicks,
-      hitPercent,
-    };
-
-    this.windows.push(summary);
     this.totalStampedeCount += 1;
     this.totalStampedeDamage += totalDamage;
 
@@ -123,23 +90,20 @@ export default class StampedeAnalyzer extends Analyzer {
     const tooltip = (
       <div>
         {header}
-        <p>
-          Targets: <strong>{uniqueTargets}</strong>
-          <br />
-          Damage: <strong>{format_compact(totalDamage)}</strong>
-        </p>
+        <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
+        <div>
+          <strong>{uniqueTargets}</strong> targets hit{' '}
+          <small>({formatNumber(totalDamage)} damage)</small>
+        </div>
         {expectedTicks > 0 && (
-          <p>
+          <div>
             Ticks:{' '}
             <strong>
               {actualTicks}/{expectedTicks}
             </strong>{' '}
             (<strong>{Math.round(hitPercent * 100)}%</strong>)
-          </p>
+          </div>
         )}
-        <p>
-          At: <strong>{this.owner.formatTimestamp(summary.start)}</strong>
-        </p>
       </div>
     );
 

--- a/src/analysis/retail/hunter/shared/herotalents/Stampede.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/Stampede.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, AnyEvent } from 'parser/core/Events';
+import Events, { DamageEvent, RemoveBuffEvent } from 'parser/core/Events';
 import { GetRelatedEvents } from 'parser/core/Events';
 import TALENTS from 'common/TALENTS/hunter';
 import SPELLS from 'common/SPELLS';
@@ -13,55 +13,36 @@ import SpellLink from 'interface/SpellLink';
 import {
   QualitativePerformance,
   evaluateQualitativePerformanceByThreshold,
-  getLowestPerf,
 } from 'parser/ui/QualitativePerformance';
 import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
 import { PerfectColor, BadColor, GoodColor, OkColor } from 'interface/guide';
-import {
-  LFTF_TO_STAMPEDE_DAMAGE,
-  LFTF_TO_STAMPEDE_BUFF_APPLY,
-  LFTF_TO_STAMPEDE_BUFF_REFRESH,
-} from '../normalizers/HunterEventLinkNormalizers';
+import { STAMPEDE_READY_TO_DAMAGE } from '../normalizers/HunterEventLinkNormalizers';
 
-/* Stampede is a damaging ability that is spawned from the Pack Leader TWW S3 4piece bonus.
- * When a Howl beast is spawned during Lead From The Front, a 12s buff that is applied when
- * you use Coordinated Assault or Bestial Wrath, a stampede is spawned between your target
- * and the player. It is possible to spawn 2 stampedes in a single window by delaying your CA
- * or BW and is a damage gain in nearly every situation.
- * This analyzer monitors the Lead from the Front windows to gather the stampede damage.
- *
- * As lead from the front has no other considerations to play, this analyzer is relevent only during TWW s3
- * and can be retired after the set bonus is disabled in Midnight.
+/* Stampede is a Pack Leader damaging ability that fires when the Stampede! buff
+ * is consumed by the next Kill Command. Each stampede ticks 9 times per target hit. This analyzer tracks
+ * tick coverage per stampede to evaluate positioning and target uptime.
  */
 
 interface WindowSummary {
   start: number;
-  end: number;
-  stampedeCount: number;
   uniqueTargets: number;
   totalDamage: number;
   actualTicks: number;
   expectedTicks: number;
   hitPercent: number;
-  missedTicks: number;
 }
 
 const format_compact = (n: number) =>
   Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 }).format(n);
 
 const TICKS_PER_STAMPEDE_PER_TARGET = 9;
-// We attribute Stampede damage to a short window starting at each apply/refresh.
-// This covers the 4s base duration + approximate travel time from summon to first impact.
-const INSTANCE_WINDOW_MS = 7000;
-const GRACE_MS = 1500;
 
 export default class StampedeAnalyzer extends Analyzer {
   private windows: WindowSummary[] = [];
   private totalStampedeCount = 0;
   private totalStampedeDamage = 0;
-  private encounterUniqueTargets = new Set<string>();
   private useEntries: BoxRowEntry[] = [];
 
   constructor(options: Options) {
@@ -72,167 +53,92 @@ export default class StampedeAnalyzer extends Analyzer {
     }
 
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.LEAD_FROM_THE_FRONT),
-      this.on_lftf_apply,
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.STAMPEDE_READY_BUFF),
+      this.onStampedeConsumed,
     );
   }
+  private triggerAbility = this.selectedCombatant.hasTalent(TALENTS.RAPTOR_STRIKE_TALENT)
+    ? TALENTS.TAKEDOWN_TALENT
+    : TALENTS.BESTIAL_WRATH_TALENT;
 
-  // Usage score for an LFtF window: expect 2 Stampedes, 1 is "ok", 0 is fail.
-  private grade_usage(stampede_count: number): QualitativePerformance {
-    return evaluateQualitativePerformanceByThreshold({
-      actual: stampede_count,
-      isGreaterThanOrEqual: {
-        perfect: 2,
-        ok: 1,
-      },
-    });
-  }
-
-  private grade_coverage(
-    unique_targets: number,
-    stampede_count: number,
-    actual_ticks: number,
-  ): QualitativePerformance {
-    const expected = unique_targets * TICKS_PER_STAMPEDE_PER_TARGET * stampede_count;
-
-    if (expected <= 0) {
+  private gradeTicks(uniqueTargets: number, actualTicks: number): QualitativePerformance {
+    if (uniqueTargets <= 0) {
       return QualitativePerformance.Fail;
     }
 
-    if (unique_targets === 1) {
-      return evaluateQualitativePerformanceByThreshold({
-        actual: actual_ticks,
-        isGreaterThanOrEqual: {
-          perfect: expected,
-          ok: expected - stampede_count,
-        },
-      });
-    }
-
-    const perfect_ticks = expected;
-    const good_ticks = Math.ceil(expected * 0.75);
-    const ok_ticks = Math.floor(expected * 0.5) + 1;
-
     return evaluateQualitativePerformanceByThreshold({
-      actual: actual_ticks,
+      actual: actualTicks,
       isGreaterThanOrEqual: {
-        perfect: perfect_ticks,
-        good: good_ticks,
-        ok: ok_ticks,
+        perfect: uniqueTargets * 9,
+        good: uniqueTargets * 7,
+        ok: uniqueTargets * 5,
       },
     });
   }
 
-  // Stampede triggers a buff, which can refresh if we double stampede early
-  // or provide it's own buff. The damage ticks overlap and so it is impossible
-  // to parse what damage belongs to which on a refresh
-  // Normalizer helps to count stampedes.
-  private on_lftf_apply = (event: AnyEvent) => {
-    const lftfStart = event.timestamp;
-    const lftfEnd = lftfStart + 12000;
-    // Upper bound for including late Stampede impacts tied to this LFtF.
-    const link_end = lftfStart + 20000;
-
+  private onStampedeConsumed = (event: RemoveBuffEvent) => {
     const damages =
-      (GetRelatedEvents(event, LFTF_TO_STAMPEDE_DAMAGE) as DamageEvent[] | undefined) ?? [];
-    const applies = (GetRelatedEvents(event, LFTF_TO_STAMPEDE_BUFF_APPLY) ?? []).sort(
-      (a, b) => a.timestamp - b.timestamp,
-    );
-    const refreshes = (GetRelatedEvents(event, LFTF_TO_STAMPEDE_BUFF_REFRESH) ?? []).sort(
-      (a, b) => a.timestamp - b.timestamp,
-    );
-
-    const stamp_starts = [...applies, ...refreshes]
-      .filter((e) => e.timestamp <= lftfStart + 12000)
-      .sort((a, b) => a.timestamp - b.timestamp);
-
-    const stampede_count = stamp_starts.length;
-
-    const raw_intervals = stamp_starts.map((s) => {
-      const s_ts = s.timestamp;
-      const e_ts = Math.min(s_ts + INSTANCE_WINDOW_MS + GRACE_MS, link_end);
-      return [s_ts, e_ts] as [number, number];
-    });
-
-    const intervals = raw_intervals;
-
-    const dmg_in_intervals: DamageEvent[] =
-      intervals.length === 0
-        ? []
-        : damages.filter((d) => intervals.some(([a, b]) => d.timestamp >= a && d.timestamp <= b));
+      (GetRelatedEvents(event, STAMPEDE_READY_TO_DAMAGE) as DamageEvent[] | undefined) ?? [];
 
     type DamageEventWithInstance = DamageEvent & { targetInstance?: number };
-    let window_damage = 0;
+    let totalDamage = 0;
     const targetKeys = new Set<string>();
-    for (const d of dmg_in_intervals) {
-      window_damage += d.amount + (d.absorbed ?? 0);
+    for (const d of damages) {
+      totalDamage += d.amount + (d.absorbed ?? 0);
       const inst = (d as DamageEventWithInstance).targetInstance ?? 0;
       targetKeys.add(`${d.targetID}:${inst}`);
     }
 
     const uniqueTargets = targetKeys.size;
-    const expectedTicks = uniqueTargets * TICKS_PER_STAMPEDE_PER_TARGET * stampede_count;
-    const actualTicks = dmg_in_intervals.length;
-    const hitPercentage = expectedTicks > 0 ? Math.min(actualTicks / expectedTicks, 1) : 0;
-    const missedTicks = Math.max(expectedTicks - actualTicks, 0);
+    const expectedTicks = uniqueTargets * TICKS_PER_STAMPEDE_PER_TARGET;
+    const actualTicks = damages.length;
+    const hitPercent = expectedTicks > 0 ? Math.min(actualTicks / expectedTicks, 1) : 0;
 
     const summary: WindowSummary = {
-      start: lftfStart,
-      end: lftfEnd,
-      stampedeCount: stampede_count,
-      uniqueTargets: uniqueTargets,
-      totalDamage: window_damage,
-      actualTicks: actualTicks,
-      expectedTicks: expectedTicks,
-      hitPercent: hitPercentage,
-      missedTicks: missedTicks,
+      start: event.timestamp,
+      uniqueTargets,
+      totalDamage,
+      actualTicks,
+      expectedTicks,
+      hitPercent,
     };
 
     this.windows.push(summary);
-    this.totalStampedeCount += stampede_count;
-    this.totalStampedeDamage += window_damage;
-    for (const k of targetKeys) {
-      this.encounterUniqueTargets.add(k);
-    }
+    this.totalStampedeCount += 1;
+    this.totalStampedeDamage += totalDamage;
 
-    const usage_grade = this.grade_usage(stampede_count);
-    const coverage_grade = this.grade_coverage(uniqueTargets, stampede_count, actualTicks);
-    const perf = getLowestPerf([usage_grade, coverage_grade]);
+    const perf = this.gradeTicks(uniqueTargets, actualTicks);
 
     const header =
       perf === QualitativePerformance.Perfect ? (
-        <h5 style={{ color: PerfectColor }}>Perfect window</h5>
+        <h5 style={{ color: PerfectColor }}>Perfect</h5>
       ) : perf === QualitativePerformance.Good ? (
-        <h5 style={{ color: GoodColor }}>Good window</h5>
+        <h5 style={{ color: GoodColor }}>Good</h5>
       ) : perf === QualitativePerformance.Ok ? (
-        <h5 style={{ color: OkColor }}>Okay window</h5>
+        <h5 style={{ color: OkColor }}>Okay</h5>
       ) : (
-        <h5 style={{ color: BadColor }}>
-          {usage_grade === QualitativePerformance.Ok ? 'Bad window' : 'Fail window'}
-        </h5>
+        <h5 style={{ color: BadColor }}>Fail</h5>
       );
 
     const tooltip = (
       <div>
         {header}
         <p>
-          Stampedes: <strong>{stampede_count}</strong> | Targets: <strong>{uniqueTargets}</strong>
+          Targets: <strong>{uniqueTargets}</strong>
           <br />
-          Damage (window): <strong>{format_compact(window_damage)}</strong>
+          Damage: <strong>{format_compact(totalDamage)}</strong>
         </p>
         {expectedTicks > 0 && (
           <p>
-            Ticks hit:{' '}
+            Ticks:{' '}
             <strong>
               {actualTicks}/{expectedTicks}
             </strong>{' '}
-            (<strong>{Math.round(hitPercentage * 100)}%</strong> hit,&nbsp;
-            <strong>{Math.max(0, 100 - Math.round(hitPercentage * 100))}%</strong> missed)
+            (<strong>{Math.round(hitPercent * 100)}%</strong>)
           </p>
         )}
         <p>
-          Window: <strong>{this.owner.formatTimestamp(summary.start)}</strong> →{' '}
-          <strong>{this.owner.formatTimestamp(summary.end)}</strong>
+          At: <strong>{this.owner.formatTimestamp(summary.start)}</strong>
         </p>
       </div>
     );
@@ -247,38 +153,33 @@ export default class StampedeAnalyzer extends Analyzer {
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
       >
-        <BoringSpellValueText spell={SPELLS.LEAD_FROM_THE_FRONT}>
+        <BoringSpellValueText spell={SPELLS.STAMPEDE_DAMAGE}>
           <>
             <div>
-              <strong>Total Stampedes in LFtF:</strong> {this.totalStampedeCount}
+              <strong>Stampedes:</strong> {this.totalStampedeCount}
             </div>
             <ItemDamageDone amount={this.totalStampedeDamage} />
-            <div>
-              <strong>Unique targets (encounter):</strong> {this.encounterUniqueTargets.size}
-            </div>
           </>
         </BoringSpellValueText>
       </Statistic>
     );
   }
 
-  get guideSubsectionStampede(): JSX.Element {
+  get guideSubsection(): JSX.Element {
     const explanation = (
       <p>
         <strong>
-          <SpellLink spell={SPELLS.TWW_STAMPEDE_DAMAGE} />
-        </strong>
-        's occur from beast spawns during
-        <strong>
-          <SpellLink spell={SPELLS.LEAD_FROM_THE_FRONT} />
+          <SpellLink spell={SPELLS.STAMPEDE_DAMAGE} />
         </strong>{' '}
-        windows should contain <strong>2 Stampedes</strong>.
+        fires when a beast is spawned after using <SpellLink spell={this.triggerAbility} />. Each
+        stampede ticks <strong>9 times per target</strong>. Ensure your stampede path crosses
+        through enemies to maximize ticks.
       </p>
     );
 
     const data = (
       <CastSummaryAndBreakdown
-        spell={SPELLS.TWW_STAMPEDE_DAMAGE}
+        spell={SPELLS.STAMPEDE_DAMAGE}
         castEntries={this.useEntries}
         usesInsteadOfCasts
       />

--- a/src/analysis/retail/hunter/shared/normalizers/HunterEventLinkNormalizers.ts
+++ b/src/analysis/retail/hunter/shared/normalizers/HunterEventLinkNormalizers.ts
@@ -6,11 +6,11 @@ import SPELLS from 'common/SPELLS';
 
 export const EXS_CAST_TO_DAMAGE = 'explosive_cast_to_damage';
 export const SV_MB_CLEAVE = 'mb_cleave';
-export const LFTF_TO_STAMPEDE_DAMAGE = 'lftf_to_stampede_damage';
-export const LFTF_TO_STAMPEDE_BUFF_APPLY = 'lftf_to_stampede_buff_apply';
-export const LFTF_TO_STAMPEDE_BUFF_REFRESH = 'lftf_to_stampede_buff_refresh';
-const stampedeDamageBuffer = 20_000;
-const stampedeBuffer = 12_000;
+export const STAMPEDE_READY_TO_DAMAGE = 'stampede_ready_to_damage';
+export const BOAR_TO_HOGSTRIDER_DAMAGE = 'boar_to_hogstrider_damage';
+export const BOAR_TO_KILL_COMMAND = 'boar_to_kill_command';
+const stampedeDamageBuffer = 10_000;
+const boarDamageBuffer = 5_000;
 const links: EventLink[] = [
   {
     linkRelation: SV_MB_CLEAVE,
@@ -25,11 +25,11 @@ const links: EventLink[] = [
     maximumLinks: 5,
   },
   {
-    linkRelation: LFTF_TO_STAMPEDE_DAMAGE,
-    linkingEventType: EventType.ApplyBuff,
-    linkingEventId: SPELLS.LEAD_FROM_THE_FRONT.id,
+    linkRelation: STAMPEDE_READY_TO_DAMAGE,
+    linkingEventType: EventType.RemoveBuff,
+    linkingEventId: SPELLS.STAMPEDE_READY_BUFF.id,
     referencedEventType: EventType.Damage,
-    referencedEventId: SPELLS.TWW_STAMPEDE_DAMAGE.id,
+    referencedEventId: SPELLS.STAMPEDE_DAMAGE.id,
     anyTarget: true,
     anySource: false,
     forwardBufferMs: stampedeDamageBuffer,
@@ -37,28 +37,31 @@ const links: EventLink[] = [
     maximumLinks: 200,
   },
   {
-    linkRelation: LFTF_TO_STAMPEDE_BUFF_APPLY,
-    linkingEventType: EventType.ApplyBuff,
-    linkingEventId: SPELLS.LEAD_FROM_THE_FRONT.id,
-    referencedEventType: EventType.ApplyBuff,
-    referencedEventId: SPELLS.TWW_STAMPEDE_BUFF.id,
-    anyTarget: false,
+    linkRelation: BOAR_TO_HOGSTRIDER_DAMAGE,
+    linkingEventType: EventType.RemoveBuff,
+    linkingEventId: SPELLS.HOWL_OF_THE_PACKLEADER_BOAR.id,
+    referencedEventType: EventType.Damage,
+    referencedEventId: [SPELLS.PL_HOGSTRIDER_DAMAGE_1.id, SPELLS.PL_HOGSTRIDER_DAMAGE_2.id],
+    anyTarget: true,
     anySource: false,
-    forwardBufferMs: stampedeBuffer,
-    backwardBufferMs: 100,
-    maximumLinks: 2,
+    forwardBufferMs: boarDamageBuffer,
+    backwardBufferMs: 0,
+    maximumLinks: 50,
   },
   {
-    linkRelation: LFTF_TO_STAMPEDE_BUFF_REFRESH,
-    linkingEventType: EventType.ApplyBuff,
-    linkingEventId: SPELLS.LEAD_FROM_THE_FRONT.id,
-    referencedEventType: EventType.RefreshBuff,
-    referencedEventId: SPELLS.TWW_STAMPEDE_BUFF.id,
-    anyTarget: false,
+    linkRelation: BOAR_TO_KILL_COMMAND,
+    linkingEventType: EventType.RemoveBuff,
+    linkingEventId: SPELLS.HOWL_OF_THE_PACKLEADER_BOAR.id,
+    referencedEventType: EventType.Cast,
+    referencedEventId: [
+      TALENTS.KILL_COMMAND_SURVIVAL_TALENT.id,
+      TALENTS.KILL_COMMAND_BEAST_MASTERY_TALENT.id,
+    ],
+    anyTarget: true,
     anySource: false,
-    forwardBufferMs: stampedeBuffer,
+    forwardBufferMs: 100,
     backwardBufferMs: 100,
-    maximumLinks: 2,
+    maximumLinks: 1,
   },
 ];
 

--- a/src/analysis/retail/hunter/survival/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/survival/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import { Kivlov,
  } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2026, 2, 5), 'Add Pack Leader Analysis', Kivlov),
   change(date(2026, 2, 2), 'Add Sentinels Mark Analysis', Kivlov),
   change(date(2026, 2, 1), 'Add Moonlight Chakram Analysis', Kivlov),
   change(date(2026, 1, 25), 'Add APL section. Add Tip of the Spear as a Resource', Kivlov),

--- a/src/analysis/retail/hunter/survival/CombatLogParser.ts
+++ b/src/analysis/retail/hunter/survival/CombatLogParser.ts
@@ -40,8 +40,9 @@ import MoonlightChakram from '../shared/herotalents/MoonlightChakram';
 import MoonlightChakramNormalizer from '../shared/normalizers/MoonlightChakramNormalizer';
 import SentinelsMark from '../shared/herotalents/SentinelsMark';
 import SentinelsMarkNormalizer from '../shared/normalizers/SentinelsMarkNormalizer';
-// import EventLinkNormalizer from '../shared/normalizers/HunterEventLinkNormalizers'; // This has a pack leader normalizer in it useful to Survival so not deleting yet.
-
+import EventLinkNormalizer from '../shared/normalizers/HunterEventLinkNormalizers'; // This has a pack leader normalizer in it useful to Survival so not deleting yet.
+import StampedeAnalyzer from '../shared/herotalents/Stampede';
+import HowlBoar from '../shared/herotalents/HowlBoar';
 class CombatLogParser extends CoreCombatLogParser {
   static guide = Guide;
   static specModules = {
@@ -76,7 +77,7 @@ class CombatLogParser extends CoreCombatLogParser {
     wildfireBombNormalizer: WildfireBombNormalizer,
     moonlightChakramNormalizer: MoonlightChakramNormalizer,
     sentinelsMarkNormalizer: SentinelsMarkNormalizer,
-    // EventLinkNormalizers: EventLinkNormalizer,
+    EventLinkNormalizers: EventLinkNormalizer,
 
     //DeathTracker
     deathTracker: DeathTracker,
@@ -97,7 +98,9 @@ class CombatLogParser extends CoreCombatLogParser {
     rejuvenatingWind: RejuvenatingWind,
     trailblazer: Trailblazer,
     tranquilizingShot: TranquilizingShot,
-    SurvivalOfTheFittest: SurvivalOfTheFittest,
+    survivalOfTheFittest: SurvivalOfTheFittest,
+    stampedeAnalyzer: StampedeAnalyzer,
+    howlBoar: HowlBoar,
 
     // Survival's throughput benefit isn't as big as for other classes
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: 0.5 }] as const,

--- a/src/analysis/retail/hunter/survival/modules/apl/AplCheck.tsx
+++ b/src/analysis/retail/hunter/survival/modules/apl/AplCheck.tsx
@@ -8,7 +8,6 @@ import { AnyEvent } from 'parser/core/Events';
 import aplCheck, { Apl, build, CheckResult, PlayerInfo, Rule } from 'parser/shared/metrics/apl';
 import {
   buffMissing,
-  buffPresent,
   debuffPresent,
   or,
   spellFractionalCharges,
@@ -45,15 +44,9 @@ const packLeaderRules: Rule[] = [
     spell: TALENTS.KILL_COMMAND_SURVIVAL_TALENT,
     condition: buffMissing(SPELLS.TIP_OF_THE_SPEAR_CAST),
   },
-  TALENTS.WILDFIRE_BOMB_TALENT,
-
-  {
-    spell: SPELLS.HATCHET_TOSS,
-    condition: buffPresent(SPELLS.HOGSTRIDER_BUFF),
-  },
-  TALENTS.TAKEDOWN_TALENT,
   TALENTS.BOOMSTICK_TALENT,
-  TALENTS.MOONLIGHT_CHAKRAM_TALENT,
+  TALENTS.TAKEDOWN_TALENT,
+  TALENTS.WILDFIRE_BOMB_TALENT,
   TALENTS.RAPTOR_STRIKE_TALENT,
 ];
 

--- a/src/analysis/retail/hunter/survival/modules/apl/AplCheck.tsx
+++ b/src/analysis/retail/hunter/survival/modules/apl/AplCheck.tsx
@@ -37,6 +37,14 @@ const sentinelRules: Rule[] = [
   TALENTS.BOOMSTICK_TALENT,
   TALENTS.MOONLIGHT_CHAKRAM_TALENT,
   TALENTS.RAPTOR_STRIKE_TALENT,
+  {
+    spell: SPELLS.HATCHET_TOSS,
+    description: (
+      <>
+        Never cast <SpellLink spell={SPELLS.HATCHET_TOSS} />.
+      </>
+    ),
+  },
 ];
 
 const packLeaderRules: Rule[] = [
@@ -48,6 +56,14 @@ const packLeaderRules: Rule[] = [
   TALENTS.TAKEDOWN_TALENT,
   TALENTS.WILDFIRE_BOMB_TALENT,
   TALENTS.RAPTOR_STRIKE_TALENT,
+  {
+    spell: SPELLS.HATCHET_TOSS,
+    description: (
+      <>
+        Never cast <SpellLink spell={SPELLS.HATCHET_TOSS} />.
+      </>
+    ),
+  },
 ];
 
 export const apl = (info: PlayerInfo): Apl => {

--- a/src/analysis/retail/hunter/survival/modules/guide/sections/rotation/HeroTalents.tsx
+++ b/src/analysis/retail/hunter/survival/modules/guide/sections/rotation/HeroTalents.tsx
@@ -1,7 +1,10 @@
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { GuideProps, Section } from 'interface/guide';
+import TALENTS from 'common/TALENTS/hunter';
 import CombatLogParser from 'analysis/retail/hunter/survival/CombatLogParser';
+import { SpellLink } from 'interface';
+import SPELLS from 'common/SPELLS';
 export default function HeroSection({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
     <Section
@@ -11,11 +14,35 @@ export default function HeroSection({ modules, events, info }: GuideProps<typeof
       })}
     >
       <Trans id="guide.hunter.survival.sections.hero.section">
-        <strong>Hero Talents</strong> - This section covers usage of hero talent abilities and
-        mechanics.
+        <strong>Hero Talents</strong>
       </Trans>
-      {modules.sentinelsMark.guideSubsection}
-      {modules.moonlightChakram.guideSubsection}
+      {info.combatant.hasTalent(TALENTS.SENTINEL_TALENT) ? (
+        <>
+          <p>
+            Sentinel: It is important for Survival Hunters to ensure proper management of Sentinel's
+            Mark in order to maximise damage. Each time you consume{' '}
+            <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} /> you have a chance to mark a target
+            you're in combat with. It is important to always have a charge of bomb ready to consume
+            the mark so that you do not waste applications.
+          </p>
+          {modules.sentinelsMark.guideSubsection}
+          {modules.moonlightChakram.guideSubsection}
+        </>
+      ) : (
+        <>
+          <p>
+            Pack Leader: The core loop of pack leader revolves around{' '}
+            <SpellLink spell={SPELLS.HOWL_OF_THE_PACKLEADER_BUFF} /> and cycling the beasts as
+            rapidly as possible. It is important that you do not waste the charge from{' '}
+            <SpellLink spell={SPELLS.HOWL_OF_THE_PACKLEADER_BOAR} /> as it is a significant amount
+            of damage. Positioning for both the boar spawn, and{' '}
+            <SpellLink spell={SPELLS.STAMPEDE_READY_BUFF} /> is key to maximizing your damage output
+            to ensure the boar and the stampede do not miss on the vertical axis.
+          </p>
+          {modules.stampedeAnalyzer.guideSubsection}
+          {modules.howlBoar.guideSubsection}
+        </>
+      )}
     </Section>
   );
 }

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -388,6 +388,21 @@ const spells = {
     name: 'Black Arrow',
     icon: 'inv_ability_darkrangerhunter_blackarrow',
   },
+  STAMPEDE_READY_BUFF: {
+    id: 1258338,
+    name: 'Stampede',
+    icon: 'ability_hunter_bestialdiscipline',
+  },
+  STAMPEDE_DAMAGE: {
+    id: 201594,
+    name: 'Stampede',
+    icon: 'inv_pet_babymurlocs_blue',
+  },
+  STAMPEDE_ACTIVE_BUFF: {
+    id: 1258345,
+    name: 'Stampede',
+    icon: 'ability_hunter_bestialdiscipline',
+  },
   //rendregion
   //region Shared Talents
   EXPLOSIVE_SHOT_DAMAGE: {
@@ -746,43 +761,6 @@ const spells = {
     id: 394384,
     name: 'Focusing Aim',
     icon: 'ability_impalingbolt',
-  },
-  //T30 2P
-  T30_2P_BONUS_BEAST_MASTERY: {
-    id: 405524,
-    name: 'T30 2P',
-    icon: 'ability_hunter_killcommand',
-  },
-  //T30 4P
-
-  T30_4P_BONUS_BEAST_MASTERY: {
-    id: 405525,
-    name: 'T30 4P',
-    icon: 'ability_druid_ferociousbite',
-  },
-
-  //TWW Lightless 2p
-  TWW_LIGHTLESS_2P_MM: {
-    id: 453648,
-    name: 'Hunter MM Lightless 2 Piece Set',
-    icon: 'trade_engineering',
-  },
-
-  //TWW Lightless 4p
-  TWW_LIGHTLESS_4P_MM: {
-    id: 453650,
-    name: 'Hunter MM Lightless 4 Piece Set',
-    icon: 'trade_engineering',
-  },
-  TWW_STAMPEDE_BUFF: {
-    id: 1250068,
-    name: 'Stampede Buff Duration',
-    icon: 'ability_hunter_bestialdiscipline',
-  },
-  TWW_STAMPEDE_DAMAGE: {
-    id: 201594,
-    name: 'Stampede',
-    icon: 'inv_pet_babymurlocs_blue',
   },
 
   //endregion


### PR DESCRIPTION
### Description

Adjusted Pack Leader APL now that sims are functional: Hatchet Toss is bad! So any cast of it is bad even with hogstrider. I've placed it below Raptor Strike, and it shouldn't show up if they dont cast it but it should show up as a 'never cast this ability' reminder if they do cast it.

Stampede is back, no longer a tier set unfortunately. It luckily can no longer double stampede, and is triggered from a new Stampede! buff that is applied when you use Takedown or Bestial Wrath and then Kill Command after. Simplified the analyser as well.

Howl of the Pack Leader - Boar Charge. This is currently the only useful or interesting Howl spawn to track. Wyvern is a damage buff for some time, and bear just spawns, deals a bleed, and then autos whatever you're attacking, there isn't any gameplay usage to it. Boar though, they recently buffed it by 200% and it hits like a truck and so making sure it actually hit something and didnt hit a wall, and making sure it actually hits a good amount of targets in aoe since it charges at whatever you target with the Kill Command that spawns it.

Boar also grants Hogstrider buff, which makes Hatchet Toss do more damage, and aoe and same for cobra shot for BM. However, they nerfed it from 700% down to 200% and it sucks now so we don't press it. If they ever buff it, this analyser will be extended to track the usage of hog strider since for survival you can sit on it for 20s to use it at the optimal moment. BM can also hold it for a little while but not as long.


and per last PR, cleaned up the sentinel mark <br /> tags.


- Test report URL: `/report/cN7DPVYJyHv6n1LB/26-Mythic+Fractillus+-+Kill+(1:24)/29-Samfar/standard`

