### PR TITLE
[Enhancement] Quick guide fixes

### DIFF
--- a/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/enhancement/CHANGELOG.tsx
@@ -1,9 +1,10 @@
 import { change, date } from 'common/changelog';
 import { TALENTS_SHAMAN } from 'common/TALENTS';
-import { Seriousnes } from 'CONTRIBUTORS';
+import { Seriousnes, Texleretour } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+    change(date(2026, 2, 12), <>Fix typos and talent check issues.</>, Texleretour),
     change(date(2025, 12, 17), <>Updated for Midnight</>, Seriousnes)
 ];

--- a/src/analysis/retail/shaman/enhancement/modules/Abilities.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/Abilities.tsx
@@ -69,7 +69,7 @@ class Abilities extends ClassAbilities {
         spell: SPELLS.PRIMORDIAL_STORM_CAST.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         gcd: {
-          base: 150,
+          base: 1500,
         },
         enabled: combatant.hasTalent(TALENTS.PRIMORDIAL_STORM_TALENT),
       },

--- a/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/HotHand.tsx
@@ -389,7 +389,7 @@ class HotHand extends MajorCooldown<HotHandProc> {
               <SpellLink spell={TALENTS.SUNDERING_TALENT} /> cast by {ll} will also trigger an{' '}
               <SpellLink spell={TALENTS.EARTHSURGE_TALENT} /> half way along{' '}
               <SpellLink spell={TALENTS.SUNDERING_TALENT} />
-              's path
+              's path.
             </>
           ) : null}
         </p>

--- a/src/analysis/retail/shaman/enhancement/modules/talents/PrimordialStorm.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/PrimordialStorm.tsx
@@ -181,13 +181,13 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
       performance: lotfwActive ? QualitativePerformance.Perfect : QualitativePerformance.Fail,
       summary: (
         <>
-          <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> {lotfwActive ? '' : 'not'}
+          <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> {lotfwActive ? ' ' : 'not '}
           active.
         </>
       ),
       details: (
         <div>
-          <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> {lotfwActive ? '' : 'not'}
+          <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> {lotfwActive ? ' ' : 'not '}
           active.
           {!lotfwActive && (
             <> This is a significant damage increase, aim to have it active for every cast.</>
@@ -226,7 +226,7 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
       ),
       details: (
         <div>
-          <strong>{maelstromUsed}</strong> <SpellLink spell={TALENTS.MAELSTROM_WEAPON_TALENT} />
+          <strong>{maelstromUsed}</strong> <SpellLink spell={TALENTS.MAELSTROM_WEAPON_TALENT} />{' '}
           used.
         </div>
       ),

--- a/src/analysis/retail/shaman/enhancement/modules/talents/PrimordialStorm.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/PrimordialStorm.tsx
@@ -21,7 +21,6 @@ interface PrimordialStormCast extends CooldownTrigger<CastEvent> {
     maelstromUsed: number;
     shouldHaveHadDoomwinds: boolean;
     hadDoomwinds: boolean;
-    legacyOfTheFrostWitch: boolean;
     surgingElementsActive: boolean;
   };
 }
@@ -34,7 +33,6 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
 
   resourceTracker!: MaelstromWeaponTracker;
   doomWindsAlternater = false;
-  lightningStrikesTalented = this.selectedCombatant.hasTalent(TALENTS.LIGHTNING_STRIKES_TALENT);
 
   constructor(options: Options) {
     super({ spell: TALENTS.PRIMORDIAL_STORM_TALENT }, options);
@@ -62,10 +60,6 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
     const details: PrimordialStormCast['details'] = {
       shouldHaveHadDoomwinds: this.doomWindsAlternater,
       hadDoomwinds,
-      legacyOfTheFrostWitch: this.selectedCombatant.hasBuff(
-        SPELLS.LIGHTNING_STRIKES_BUFF,
-        event.timestamp,
-      ),
       maelstromUsed: this.resourceTracker.lastSpenderInfo?.amount ?? 0,
       surgingElementsActive: this.selectedCombatant.hasBuff(
         SPELLS.SURGING_ELEMENTS_BUFF,
@@ -79,14 +73,6 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
       lis.push(
         <>
           <SpellLink spell={TALENTS.DOOM_WINDS_TALENT} /> was missing.
-        </>,
-      );
-    }
-
-    if (this.lightningStrikesTalented && !details.legacyOfTheFrostWitch) {
-      lis.push(
-        <>
-          <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> was missing.
         </>,
       );
     }
@@ -146,15 +132,7 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
         <p>
           Each hit from {pstorm} is considered a Main-Hand attack, and can trigger{' '}
           <SpellLink spell={TALENTS.WINDFURY_WEAPON_TALENT} /> separately and are AoE. Each hit
-          deals combination physical and spell damage
-          {this.lightningStrikesTalented ? (
-            <>
-              , and all hits are amplified by <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} />,
-              and <SpellLink spell={SPELLS.PRIMORDIAL_FROST} /> is buffed twice.
-            </>
-          ) : (
-            '.'
-          )}
+          deals combination physical and spell damage.
         </p>
         <p>
           {pstorm} is currently the <strong>strongest</strong> {msw} spender, and you should always
@@ -171,48 +149,12 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
     const details = cast.details;
 
     const maelstromUsed = details.maelstromUsed ?? 0;
-    const lotfwActive = details.legacyOfTheFrostWitch ?? false;
     const hadDoomwinds = details.hadDoomwinds ?? false;
     const shouldHaveHadDoomwinds = details.shouldHaveHadDoomwinds ?? false;
     const surgingElementsActive = details.surgingElementsActive ?? false;
 
     const issues: ReactNode[] = [];
     const checklistItems: ChecklistUsageInfo[] = [];
-
-    /**
-     * Legacy of the Frost Witch (buff)
-     */
-    if (this.lightningStrikesTalented) {
-      checklistItems.push({
-        check: 'legacy-of-the-frost-witch',
-        timestamp: cast.event.timestamp,
-        performance: lotfwActive ? QualitativePerformance.Perfect : QualitativePerformance.Fail,
-        summary: (
-          <>
-            <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> {lotfwActive ? ' ' : 'not '}
-            active.
-          </>
-        ),
-        details: (
-          <div>
-            <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> {lotfwActive ? ' ' : 'not '}
-            active.
-            {!lotfwActive && (
-              <> This is a significant damage increase, aim to have it active for every cast.</>
-            )}
-          </div>
-        ),
-      });
-      if (!lotfwActive) {
-        issues.push(
-          <>
-            <li key="lotfw">
-              <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> should be active for every cast.
-            </li>
-          </>,
-        );
-      }
-    }
 
     /**
      * Maelstrom Used

--- a/src/analysis/retail/shaman/enhancement/modules/talents/PrimordialStorm.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/PrimordialStorm.tsx
@@ -34,6 +34,7 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
 
   resourceTracker!: MaelstromWeaponTracker;
   doomWindsAlternater = false;
+  lightingStrikesTalented = this.selectedCombatant.hasTalent(TALENTS.LIGHTNING_STRIKES_TALENT);
 
   constructor(options: Options) {
     super({ spell: TALENTS.PRIMORDIAL_STORM_TALENT }, options);
@@ -82,7 +83,7 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
       );
     }
 
-    if (!details.legacyOfTheFrostWitch) {
+    if (this.lightingStrikesTalented && !details.legacyOfTheFrostWitch) {
       lis.push(
         <>
           <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> was missing.
@@ -175,34 +176,36 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
     /**
      * Legacy of the Frost Witch (buff)
      */
-    checklistItems.push({
-      check: 'legacy-of-the-frost-witch',
-      timestamp: cast.event.timestamp,
-      performance: lotfwActive ? QualitativePerformance.Perfect : QualitativePerformance.Fail,
-      summary: (
-        <>
-          <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> {lotfwActive ? ' ' : 'not '}
-          active.
-        </>
-      ),
-      details: (
-        <div>
-          <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> {lotfwActive ? ' ' : 'not '}
-          active.
-          {!lotfwActive && (
-            <> This is a significant damage increase, aim to have it active for every cast.</>
-          )}
-        </div>
-      ),
-    });
-    if (!lotfwActive) {
-      issues.push(
-        <>
-          <li key="lotfw">
-            <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> should be active for every cast.
-          </li>
-        </>,
-      );
+    if (this.lightingStrikesTalented) {
+      checklistItems.push({
+        check: 'legacy-of-the-frost-witch',
+        timestamp: cast.event.timestamp,
+        performance: lotfwActive ? QualitativePerformance.Perfect : QualitativePerformance.Fail,
+        summary: (
+          <>
+            <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> {lotfwActive ? ' ' : 'not '}
+            active.
+          </>
+        ),
+        details: (
+          <div>
+            <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> {lotfwActive ? ' ' : 'not '}
+            active.
+            {!lotfwActive && (
+              <> This is a significant damage increase, aim to have it active for every cast.</>
+            )}
+          </div>
+        ),
+      });
+      if (!lotfwActive) {
+        issues.push(
+          <>
+            <li key="lotfw">
+              <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> should be active for every cast.
+            </li>
+          </>,
+        );
+      }
     }
 
     /**

--- a/src/analysis/retail/shaman/enhancement/modules/talents/PrimordialStorm.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/PrimordialStorm.tsx
@@ -34,7 +34,7 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
 
   resourceTracker!: MaelstromWeaponTracker;
   doomWindsAlternater = false;
-  lightingStrikesTalented = this.selectedCombatant.hasTalent(TALENTS.LIGHTNING_STRIKES_TALENT);
+  lightningStrikesTalented = this.selectedCombatant.hasTalent(TALENTS.LIGHTNING_STRIKES_TALENT);
 
   constructor(options: Options) {
     super({ spell: TALENTS.PRIMORDIAL_STORM_TALENT }, options);
@@ -83,7 +83,7 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
       );
     }
 
-    if (this.lightingStrikesTalented && !details.legacyOfTheFrostWitch) {
+    if (this.lightningStrikesTalented && !details.legacyOfTheFrostWitch) {
       lis.push(
         <>
           <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} /> was missing.
@@ -146,9 +146,15 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
         <p>
           Each hit from {pstorm} is considered a Main-Hand attack, and can trigger{' '}
           <SpellLink spell={TALENTS.WINDFURY_WEAPON_TALENT} /> separately and are AoE. Each hit
-          deals combination physical and spell damage, and all hits are amplified by{' '}
-          <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} />, and{' '}
-          <SpellLink spell={SPELLS.PRIMORDIAL_FROST} /> is buffed twice.
+          deals combination physical and spell damage
+          {this.lightningStrikesTalented ? (
+            <>
+              , and all hits are amplified by <SpellLink spell={SPELLS.LIGHTNING_STRIKES_BUFF} />,
+              and <SpellLink spell={SPELLS.PRIMORDIAL_FROST} /> is buffed twice.
+            </>
+          ) : (
+            '.'
+          )}
         </p>
         <p>
           {pstorm} is currently the <strong>strongest</strong> {msw} spender, and you should always
@@ -176,7 +182,7 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
     /**
      * Legacy of the Frost Witch (buff)
      */
-    if (this.lightingStrikesTalented) {
+    if (this.lightningStrikesTalented) {
       checklistItems.push({
         check: 'legacy-of-the-frost-witch',
         timestamp: cast.event.timestamp,

--- a/src/analysis/retail/shaman/enhancement/modules/talents/PrimordialStorm.tsx
+++ b/src/analysis/retail/shaman/enhancement/modules/talents/PrimordialStorm.tsx
@@ -238,7 +238,7 @@ class PrimordialStorm extends MajorCooldown<PrimordialStormCast> {
       issues.push(
         <>
           <li key="maelstrom-weapon">
-            Aim to use <strong>10</strong> <SpellLink spell={TALENTS.MAELSTROM_WEAPON_TALENT} />
+            Aim to use <strong>10</strong> <SpellLink spell={TALENTS.MAELSTROM_WEAPON_TALENT} />{' '}
             each time you cast <SpellLink spell={TALENTS.PRIMORDIAL_STORM_TALENT} />.
           </li>
         </>,


### PR DESCRIPTION
# Edits
- Fixed a few missing spaces in the guide
- Added some talent checks so that Lightning strikes doesn't fail checks when you aren't talented in it.
- Fixed PStorm GCD

There's still a problem with Thorim's Invocation as it expects all GCDs during the window to be Crash Lightning/Windstrike/Stormstrike, even when playing Totemic.
Thorim's invocation statistic doesn't work either on pre-patch logs, but works on earlier ones. I don't know why.
@Seriousnes 

# Testing
/report/Rzc6xtHmZL1JDGpr/29-Mythic+Fractillus+-+Kill+(1:25)/4-Aman/standard