### PR TITLE
Add Throughput Table component

### DIFF
--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -1055,11 +1055,10 @@ const spells = {
     ...talents.FLURRY_STRIKES_TALENT,
     id: 450617,
   },
-  // TODO: verify if this is the new damage ability in all cases
   FLURRY_STRIKES_DAMAGE_MIDNIGHT: {
     id: 451250,
     name: 'Flurry Strikes',
-    icon: 'inv-ability-shadopanmonk-flurrystrikes',
+    icon: 'inv_ability_shadopanmonk_flurrystrikes.jpg',
   },
 } satisfies Record<string, Spell>;
 

--- a/src/interface/ActorLink.tsx
+++ b/src/interface/ActorLink.tsx
@@ -47,7 +47,13 @@ export default function ActorLink({
   }
 
   return (
-    <a href={npcTooltip(actor.guid)} className={`${actor.type} ${className ?? ''}`} {...rest}>
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      href={npcTooltip(actor.guid)}
+      className={`${actor.subType} ${className ?? ''}`}
+      {...rest}
+    >
       <Icon icon={actor.icon} /> {children ?? actor.name}
     </a>
   );

--- a/src/interface/ActorLink.tsx
+++ b/src/interface/ActorLink.tsx
@@ -1,0 +1,54 @@
+import { HTMLAttributes, JSX, useMemo } from 'react';
+import useTooltip from './useTooltip';
+import { useReport } from './report/context/ReportContext';
+import type Unit from 'parser/core/Unit';
+import Icon from './Icon';
+
+type ActorLinkProps = Omit<HTMLAttributes<HTMLAnchorElement>, 'id'> & {
+  id: number;
+};
+
+export default function ActorLink({
+  id,
+  children,
+  className,
+  ...rest
+}: ActorLinkProps): JSX.Element | null {
+  const { npc: npcTooltip } = useTooltip();
+  const { report } = useReport();
+
+  const [actor, isPlayer] = useMemo(() => {
+    const player = report.friendlies.find((actor) => actor.id === id);
+    if (player) {
+      return [player, true];
+    }
+
+    return [
+      (report.enemies as Unit[])
+        .concat(report.enemyPets as Unit[])
+        .concat(report.friendlyPets as Unit[])
+        .find((actor) => actor.id === id),
+      false,
+    ];
+  }, [id, report]);
+
+  if (!actor) {
+    return <>Unknown</>;
+  }
+
+  if (isPlayer) {
+    // we manually set up the icon because we need to use the `/specs/` folder
+    return (
+      <span className={actor.type} {...rest}>
+        <img src={`/specs/${actor.icon}.jpg`} className={'game icon'} alt={actor.icon} />{' '}
+        {children ?? actor.name}
+      </span>
+    );
+  }
+
+  return (
+    <a href={npcTooltip(actor.guid)} className={`${actor.type} ${className ?? ''}`} {...rest}>
+      <Icon icon={actor.icon} /> {children ?? actor.name}
+    </a>
+  );
+}

--- a/src/interface/Game.scss
+++ b/src/interface/Game.scss
@@ -102,16 +102,40 @@
   background-color: #33937f !important;
 }
 
-.Pet,
-.Boss,
+.Boss {
+  color: #b4bdff !important;
+}
+
+.Boss-bg {
+  background-color: #b4bdff !important;
+}
+
+.Boss:hover {
+  color: #ffcdff !important;
+}
+
 .NPC {
+  color: #84bdf8 !important;
+}
+
+.NPC-bg {
+  background-color: #84bdf8 !important;
+}
+
+.NPC:hover {
+  color: #a4ddff !important;
+}
+
+.Pet {
   color: #64bdc8 !important;
 }
 
-.Pet-bg,
-.Boss-bg,
-.NPC-bg {
+.Pet-bg {
   background-color: #64bdc8 !important;
+}
+
+.Other-bg {
+  background-color: #434241;
 }
 
 .poor {
@@ -327,69 +351,6 @@
   background-color: #ffffff !important;
 }
 
-/*https://wow.gamepedia.com/COMBAT_LOG_EVENT*/
-/* Physical */
-.spell-school-1-bg {
-  background-color: #ccb278 !important;
-}
-
-/* Holy */
-.spell-school-2-bg {
-  background-color: #ffe680 !important;
-}
-
-/* Fire */
-.spell-school-4-bg {
-  background-color: #d84141 !important;
-}
-
-/* Nature */
-.spell-school-8-bg {
-  background-color: #4dff4d !important;
-}
-
-/* Frost */
-.spell-school-16-bg {
-  background-color: #80ffff !important;
-}
-
-/* Shadow */
-.spell-school-32-bg {
-  background-color: #8080ff !important;
-}
-
-/* Arcane */
-.spell-school-64-bg {
-  background-color: #ff80ff !important;
-}
-
-/* Double schools */
-/* Spellshadow: Arcane + Shadow */
-.spell-school-96-bg {
-  background-image: linear-gradient(to bottom, #ff80ff 0%, #8080ff 100%) !important;
-}
-
-/* Triple and multi schools */
-/* Elemental: Frost + Nature + Fire */
-.spell-school-28-bg {
-  background-color: #8cc084 !important;
-}
-
-/* Chronomatic: Arcane + Shadow + Frost + Nature + Fire */
-.spell-school-124-bg {
-  background-color: #a1a6b5 !important;
-}
-
-/* Magic: Arcane + Shadow + Frost + Nature + Fire + Holy */
-.spell-school-126-bg {
-  background-color: #b1b1ac !important;
-}
-
-/* Chaos: Arcane + Shadow + Frost + Nature + Fire + Holy + Physical */
-.spell-school-127-bg {
-  background-color: #b4b1a5 !important;
-}
-
 .parse-grey {
   color: #666 !important;
 }
@@ -412,4 +373,127 @@
 
 .parse-artifact {
   color: rgb(229, 204, 128) !important;
+}
+
+/* Physical */
+.spell-school-1 {
+  color: rgb(229, 204, 128) !important;
+}
+
+/* Holy */
+.spell-school-2 {
+  color: rgb(100%, 100%, 56%) !important;
+}
+
+/* Fire */
+
+.spell-school-4 {
+  color: rgb(92%, 27%, 38%) !important;
+}
+
+/* Nature */
+.spell-school-8 {
+  color: rgb(82%, 98%, 60%) !important;
+}
+
+/* Frost */
+
+.spell-school-16 {
+  color: rgb(29%, 50%, 100%) !important;
+}
+
+/* Shadow */
+
+.spell-school-32,
+.spell-school-36 {
+  color: rgb(72%, 66%, 94%) !important;
+}
+
+/* Arcane, Cosmic */
+.spell-school-64,
+.spell-school-80,
+.spell-school-106 {
+  color: rgb(56%, 95%, 100%) !important;
+}
+
+/* Chaos */
+.spell-school-127,
+.spell-school-124,
+.spell-school-126,
+.spell-school-125 {
+  color: rgb(163, 48, 201) !important;
+}
+
+/* Physical */
+.spell-school-1-bg {
+  background-color: rgb(229, 204, 128) !important;
+}
+
+/* Holy */
+.spell-school-2-bg {
+  background-color: rgb(100%, 100%, 56%) !important;
+}
+
+/* Fire */
+
+.spell-school-4-bg {
+  background-color: rgb(92%, 27%, 38%) !important;
+}
+
+/* Nature */
+.spell-school-8-bg {
+  background-color: rgb(82%, 98%, 60%) !important;
+}
+
+/* Frost */
+
+.spell-school-16-bg {
+  background-color: rgb(29%, 50%, 100%) !important;
+}
+
+/* Shadow */
+
+.spell-school-32-bg {
+  background-color: rgb(72%, 66%, 94%) !important;
+}
+
+/* Shadowflame */
+.spell-school-36-bg {
+  background-image: linear-gradient(45deg, rgb(72%, 66%, 94%), rgb(92%, 27%, 38%)) !important;
+}
+
+/* Chromatic, fire -> frost -> arcane -> nature -> shadow */
+.spell-school-62-bg {
+  background-image: linear-gradient(
+    45deg,
+    rgb(92%, 27%, 38%),
+    rgb(29%, 50%, 100%),
+    rgb(56%, 95%, 100%),
+    rgb(82%, 98%, 60%),
+    rgb(72%, 66%, 94%)
+  );
+}
+
+/* Arcane */
+.spell-school-64-bg {
+  background-color: rgb(56%, 95%, 100%) !important;
+}
+
+/* Cosmic */
+.spell-school-106-bg {
+  background-image: linear-gradient(
+    45deg,
+    rgb(56%, 95%, 100%),
+    rgb(72%, 66%, 94%) 33%,
+    rgb(82%, 98%, 60%) 66%,
+    rgb(100%, 100%, 56%)
+  );
+}
+
+/* Chaos */
+.spell-school-127-bg,
+.spell-school-124-bg,
+.spell-school-125-bg,
+.spell-school-126-bg {
+  background-color: #a330c9 !important;
 }

--- a/src/interface/Game.scss
+++ b/src/interface/Game.scss
@@ -1,39 +1,51 @@
 .DeathKnight {
   color: #c41f3b !important;
 }
+
 .Druid {
   color: #ff7d0a !important;
 }
+
 .Hunter {
   color: #abd473 !important;
 }
+
 .Mage {
   color: #69ccf0 !important;
 }
+
 .Monk {
   color: #00ff98 !important;
 }
+
 .Paladin {
   color: #f58cba !important;
 }
+
 .Priest {
   color: #ffffff !important;
 }
+
 .Rogue {
   color: #fff569 !important;
 }
+
 .Shaman {
   color: #2459ff !important;
 }
+
 .Warlock {
   color: #9482c9 !important;
 }
+
 .Warrior {
   color: #c79c6e !important;
 }
+
 .DemonHunter {
   color: #a330c9 !important;
 }
+
 .Evoker {
   color: #33937f !important;
 }
@@ -41,61 +53,91 @@
 .DeathKnight-bg {
   background-color: #c41f3b !important;
 }
+
 .Druid-bg {
   background-color: #ff7d0a !important;
 }
+
 .Hunter-bg {
   background-color: #9ec76b !important;
 }
+
 .Mage-bg {
   background-color: #69ccf0 !important;
 }
+
 .Monk-bg {
   background-color: #00ff98 !important;
 }
+
 .Paladin-bg {
   background-color: #f58cba !important;
 }
+
 .Priest-bg {
   background-color: #ffffff !important;
 }
+
 .Rogue-bg {
   background-color: #fff569 !important;
 }
+
 .Shaman-bg {
   background-color: #2459ff !important;
 }
+
 .Warlock-bg {
   background-color: #9482c9 !important;
 }
+
 .Warrior-bg {
   background-color: #c79c6e !important;
 }
+
 .DemonHunter-bg {
   background-color: #a330c9 !important;
 }
+
 .Evoker-bg {
   background-color: #33937f !important;
+}
+
+.Pet,
+.Boss,
+.NPC {
+  color: #64bdc8 !important;
+}
+
+.Pet-bg,
+.Boss-bg,
+.NPC-bg {
+  background-color: #64bdc8 !important;
 }
 
 .poor {
   color: #9d9d9d !important;
 }
+
 .common {
   color: #fff !important;
 }
+
 .uncommon {
   color: #1eff00 !important;
 }
+
 .rare {
   color: #0070ff !important;
 }
+
 .epic {
   color: #a335ee !important;
 }
+
 .legendary {
   color: #ff8000 !important;
 }
+
 .artifact {
   color: #e5cc80 !important;
 }
@@ -103,63 +145,83 @@
 .stat-health {
   color: #27cc4e !important;
 }
+
 .stat-stamina {
   color: #ff8b2d !important;
 }
+
 .stat-energy {
   color: #cb9501 !important;
 }
+
 .stat-focus {
   color: #d45719 !important;
 }
+
 .stat-fury {
   color: #8400ff !important;
 }
+
 .stat-insanity {
   color: #60f !important;
 }
+
 .stat-maelstrom {
   color: #008fff !important;
 }
+
 .stat-mana {
   color: #1c8aff !important;
 }
+
 .stat-pain {
   color: #d45719 !important;
 }
+
 .stat-rage {
   color: #ab0000 !important;
 }
+
 .stat-runicpower {
   color: #00bcde !important;
 }
+
 .stat-agility {
   color: #ffd955 !important;
 }
+
 .stat-intellect {
   color: #d26cd1 !important;
 }
+
 .stat-strength {
   color: #f33232 !important;
 }
+
 .stat-criticalstrike {
   color: #e01c1c !important;
 }
+
 .stat-haste {
   color: #0ed59b !important;
 }
+
 .stat-mastery {
   color: #9256ff !important;
 }
+
 .stat-versatility {
   color: #bfbfbf !important;
 }
+
 .stat-leech {
   color: #1d9c07 !important;
 }
+
 .stat-avoidance {
   color: #376321 !important;
 }
+
 .stat-speed {
   color: #ffff3d !important;
 }
@@ -168,75 +230,99 @@
 .stat-healing-bg {
   background-color: #27cc4e !important;
 }
+
 .stat-healing-absorbs-bg {
   background-color: #ffd955 !important;
 }
+
 .stat-negative-absorbs-bg {
   background-color: #d45719 !important;
 }
+
 .stat-overhealing-bg {
   background-color: #3e3d3d !important;
 }
+
 .stat-stamina-bg {
   background-color: #ff8b2d !important;
 }
+
 .stat-energy-bg {
   background-color: #cb9501 !important;
 }
+
 .stat-focus-bg {
   background-color: #d45719 !important;
 }
+
 .stat-fury-bg {
   background-color: #8400ff !important;
 }
+
 .stat-insanity-bg {
   background-color: #60f !important;
 }
+
 .stat-maelstrom-bg {
   background-color: #008fff !important;
 }
+
 .stat-mana-bg {
   background-color: #1c8aff !important;
 }
+
 .stat-pain-bg {
   background-color: #d45719 !important;
 }
+
 .stat-rage-bg {
   background-color: #ab0000 !important;
 }
+
 .stat-runicpower-bg {
   background-color: #00bcde !important;
 }
+
 .stat-agility-bg {
   background-color: #ffd955 !important;
 }
+
 .stat-intellect-bg {
   background-color: #d26cd1 !important;
 }
+
 .stat-strength-bg {
   background-color: #f33232 !important;
 }
+
 .stat-criticalstrike-bg {
   background-color: #e01c1c !important;
 }
+
 .stat-haste-bg {
   background-color: #0ed59b !important;
 }
+
 .stat-mastery-bg {
   background-color: #9256ff !important;
 }
+
 .stat-versatility-bg {
   background-color: #bfbfbf !important;
 }
+
 .stat-leech-bg {
   background-color: #1d9c07 !important;
 }
+
 .stat-avoidance-bg {
   background-color: #376321 !important;
 }
+
 .stat-speed-bg {
   background-color: #ffff3d !important;
 }
+
 .stat-essence-bg {
   background-color: #ffffff !important;
 }
@@ -246,48 +332,59 @@
 .spell-school-1-bg {
   background-color: #ccb278 !important;
 }
+
 /* Holy */
 .spell-school-2-bg {
   background-color: #ffe680 !important;
 }
+
 /* Fire */
 .spell-school-4-bg {
   background-color: #d84141 !important;
 }
+
 /* Nature */
 .spell-school-8-bg {
   background-color: #4dff4d !important;
 }
+
 /* Frost */
 .spell-school-16-bg {
   background-color: #80ffff !important;
 }
+
 /* Shadow */
 .spell-school-32-bg {
   background-color: #8080ff !important;
 }
+
 /* Arcane */
 .spell-school-64-bg {
   background-color: #ff80ff !important;
 }
+
 /* Double schools */
 /* Spellshadow: Arcane + Shadow */
 .spell-school-96-bg {
   background-image: linear-gradient(to bottom, #ff80ff 0%, #8080ff 100%) !important;
 }
+
 /* Triple and multi schools */
 /* Elemental: Frost + Nature + Fire */
 .spell-school-28-bg {
   background-color: #8cc084 !important;
 }
+
 /* Chronomatic: Arcane + Shadow + Frost + Nature + Fire */
 .spell-school-124-bg {
   background-color: #a1a6b5 !important;
 }
+
 /* Magic: Arcane + Shadow + Frost + Nature + Fire + Holy */
 .spell-school-126-bg {
   background-color: #b1b1ac !important;
 }
+
 /* Chaos: Arcane + Shadow + Frost + Nature + Fire + Holy + Physical */
 .spell-school-127-bg {
   background-color: #b4b1a5 !important;
@@ -296,18 +393,23 @@
 .parse-grey {
   color: #666 !important;
 }
+
 .parse-green {
   color: rgb(30, 255, 0) !important;
 }
+
 .parse-blue {
   color: rgb(0, 112, 255) !important;
 }
+
 .parse-purple {
   color: rgb(163, 53, 238) !important;
 }
+
 .parse-orange {
   color: rgb(255, 128, 0) !important;
 }
+
 .parse-artifact {
   color: rgb(229, 204, 128) !important;
 }

--- a/src/interface/Icon.tsx
+++ b/src/interface/Icon.tsx
@@ -19,13 +19,18 @@ export type SvgIconProps = Omit<
 >;
 
 export function iconUrl(icon: string): string {
-  icon = icon.replace('.jpg', '');
+  let [folder, name] = icon.split('/');
+  if (name === undefined) {
+    [folder, name] = ['abilities', folder];
+  }
+
+  icon = name.replace('.jpg', '');
 
   if (ICON_RENAME[icon]) {
     icon = ICON_RENAME[icon];
   }
 
-  let baseURL = `https://assets.rpglogs.com/img/warcraft/abilities`;
+  let baseURL = `https://assets.rpglogs.com/img/warcraft/${folder}`;
   if (BAD_ICONS.includes(icon)) {
     baseURL = `/img/Icons`;
   }

--- a/src/interface/Icon.tsx
+++ b/src/interface/Icon.tsx
@@ -24,7 +24,7 @@ export function iconUrl(icon: string): string {
     [folder, name] = ['abilities', folder];
   }
 
-  icon = name.replace('.jpg', '');
+  icon = name.replace('.jpg', '').replace(/^custom-icon-/, '');
 
   if (ICON_RENAME[icon]) {
     icon = ICON_RENAME[icon];

--- a/src/interface/SpellIcon.tsx
+++ b/src/interface/SpellIcon.tsx
@@ -26,7 +26,13 @@ const SpellIcon = ({ spell, noLink, alt, ilvl, ...others }: Props) => {
 
   const iconName = SPELL_ICON_OVERRIDES[spellId] ?? spellWithFallback.icon;
 
-  const icon = <Icon icon={iconName} alt={alt !== '' ? spellWithFallback.name : ''} {...others} />;
+  const icon = (
+    <Icon
+      icon={`abilities/${iconName}`}
+      alt={alt !== '' ? spellWithFallback.name : ''}
+      {...others}
+    />
+  );
 
   if (noLink || spellId <= 1) {
     return icon;

--- a/src/interface/Table/DamageTable.tsx
+++ b/src/interface/Table/DamageTable.tsx
@@ -4,25 +4,16 @@ import SpellLink from 'interface/SpellLink';
 import { JSX, useMemo, useState } from 'react';
 import * as design from 'interface/design-system';
 import type Spell from 'common/SPELLS/Spell';
-import MAGIC_SCHOOLS from 'game/MAGIC_SCHOOLS';
 import { useEvents, useInfo } from 'interface/guide';
-import {
-  AnyEvent,
-  DamageEvent,
-  EventType,
-  HasAbility,
-  HasSource,
-  HasTarget,
-  HealEvent,
-} from 'parser/core/Events';
+import { AnyEvent, DamageEvent, EventType, HealEvent } from 'parser/core/Events';
 import { effectiveDamage } from 'parser/shared/modules/DamageValue';
 import ActorLink from 'interface/ActorLink';
 import { useReport } from 'interface/report/context/ReportContext';
 import { Info } from 'parser/core/metric';
 import { effectiveHealing } from 'parser/shared/modules/HealingValue';
-import { WCLReport } from 'parser/core/Report';
 import Unit from 'parser/core/Unit';
 import Select from 'interface/controls/Select';
+import HIT_TYPES from 'game/HIT_TYPES';
 
 export default function DamageTable(): JSX.Element | null {
   return null;
@@ -31,6 +22,7 @@ export default function DamageTable(): JSX.Element | null {
 const TableContainer = styled.div`
   display: grid;
   grid-auto-flow: column;
+  container-type: inline-size;
 `;
 
 const TableRow = styled.div`
@@ -41,6 +33,7 @@ const TableRow = styled.div`
 
 interface TableCellProps {
   align: React.CSSProperties['justifyContent'];
+  optional?: boolean;
 }
 
 const HeaderSelect = styled(Select)`
@@ -64,8 +57,14 @@ const TableCell = styled.div<TableCellProps>`
   border-right: 1px solid ${design.level1.border};
   width: 100%;
 
+  white-space: nowrap;
+
   &:has(${HeaderSelect}) {
     padding: 0;
+  }
+
+  @container (width < 60rem) {
+    ${(props) => (props.optional ? 'display: none;' : '')}
   }
 `;
 
@@ -98,6 +97,7 @@ interface Column<T, Context = {}> {
   render(row: T, ctx: Context): React.ReactNode;
   align?: 'left' | 'right';
   expand?: boolean;
+  optional?: boolean;
 }
 
 const actorName: Column<{ actorId: number }> = {
@@ -121,17 +121,16 @@ const spellName: Column<{ spell: number | Spell; school?: number }> = {
   },
 };
 
-const amountBar: Column<
-  { amount: number; school?: number; type?: string },
-  { max: number; total: number }
-> = {
-  label: '',
+const amountBar = (
+  type: EventType.Damage | EventType.Heal,
+): Column<{ amount: number; school?: number; type?: string }, { max: number; total: number }> => ({
+  label: type === EventType.Damage ? 'Damage' : 'Healing',
   render({ amount, school, type }, { max, total }) {
     return (
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: '5rem 1fr',
+          gridTemplateColumns: '5rem 1fr 4rem',
           gap: design.gaps.medium,
           width: '100%',
         }}
@@ -143,18 +142,45 @@ const amountBar: Column<
           }
           style={{ height: '75%', alignSelf: 'center', width: `${(amount / max) * 100}%` }}
         />
+        <div style={{ textAlign: 'right' }}>{formatNumber(amount)}</div>
       </div>
     );
   },
   expand: true,
-};
+});
 
-const amount: Column<{ amount: number }> = {
-  label: 'Amount',
-  render({ amount }) {
-    return formatNumber(amount);
+const literalNumberColumn = <K extends string>(
+  label: React.ReactNode,
+  key: K,
+): Column<Record<K, number>> => ({
+  label,
+  render(row) {
+    return row[key];
   },
   align: 'right',
+  optional: true,
+});
+
+const critPct: Column<{ hits: number; crits: number }> = {
+  label: 'Crit %',
+  render(row) {
+    if (row.crits === 0) {
+      return null;
+    }
+
+    return `${formatPercentage(row.crits / row.hits, 1)}%`;
+  },
+  align: 'right',
+  optional: true,
+};
+
+const avgHit: Column<{ hits: number; amount: number }> = {
+  label: 'Avg Hit',
+  render(row) {
+    return formatNumber(row.amount / row.hits);
+  },
+  align: 'right',
+  optional: true,
 };
 
 // we need to use an object for the columns to make TS inferrence play nice
@@ -186,7 +212,7 @@ function Table<T, Context, Cols extends Record<string, Column<unknown, unknown>>
     <TableContainer style={{ gridTemplateColumns: gridColumns }}>
       <TableHeader>
         {Object.values(columns).map((col, colIx) => (
-          <TableCell key={colIx} align={'center'}>
+          <TableCell key={colIx} align={'center'} optional={col.optional}>
             {col.label}
           </TableCell>
         ))}
@@ -194,7 +220,7 @@ function Table<T, Context, Cols extends Record<string, Column<unknown, unknown>>
       {data.map((row, ix) => (
         <TableRow key={ix}>
           {Object.values(columns).map((col, colIx) => (
-            <TableCell align={cellAlignment(col.align)} key={colIx}>
+            <TableCell align={cellAlignment(col.align)} key={colIx} optional={col.optional}>
               {col.render(row, ctx)}
             </TableCell>
           ))}
@@ -212,15 +238,19 @@ interface ThroughputTableProps {
 
 type AggregateBy = 'ability' | 'source' | 'target';
 
-interface ThroughputSpellRow {
-  spell: number | Spell;
+interface ThroughputRowCommon {
   amount: number;
+  hits: number;
+  crits: number;
+}
+
+interface ThroughputSpellRow extends ThroughputRowCommon {
+  spell: number | Spell;
   school: number;
 }
 
-interface ThroughputActorRow {
+interface ThroughputActorRow extends ThroughputRowCommon {
   actorId: number;
-  amount: number;
   type: string | undefined;
 }
 
@@ -278,11 +308,15 @@ function throughputByAbility(
         spell: id,
         school,
         amount: 0,
+        hits: 0,
+        crits: 0,
       });
     }
 
     const row = map.get(id)!;
     row.amount += amount;
+    row.hits += 1;
+    row.crits += Number(event.hitType === HIT_TYPES.CRIT);
   }
 
   return Array.from(map.values());
@@ -324,11 +358,15 @@ function throughputByActor(
         actorId: id,
         type: actorType,
         amount: 0,
+        hits: 0,
+        crits: 0,
       });
     }
 
     const row = map.get(id)!;
     row.amount += amount;
+    row.hits += 1;
+    row.crits += Number(event.hitType === HIT_TYPES.CRIT);
   }
 
   return Array.from(map.values());
@@ -376,7 +414,10 @@ export function ThroughputTable({
     result.sort((a, b) => b.amount - a.amount);
 
     if (result.length > maxRows) {
-      const otherTotal = result.slice(maxRows - 1).reduce((total, row) => total + row.amount, 0);
+      const otherRows = result.slice(maxRows - 1);
+      const otherTotal = otherRows.reduce((total, row) => total + row.amount, 0);
+      const otherHits = otherRows.reduce((total, row) => total + row.hits, 0);
+      const otherCrits = otherRows.reduce((total, row) => total + row.crits, 0);
       return [
         ...result.slice(0, maxRows - 1),
         {
@@ -384,6 +425,8 @@ export function ThroughputTable({
           spell: OTHER_SPECIAL_BY,
           type: 'Other',
           amount: otherTotal,
+          hits: otherHits,
+          crits: otherCrits,
         },
       ];
     }
@@ -418,13 +461,17 @@ export function ThroughputTable({
     };
   }, [aggregateBy]);
 
-  const amountColumn = useMemo(
-    () => ({
-      ...amount,
-      label: type === EventType.Damage ? 'Damage' : 'Healing',
-    }),
-    [type],
+  return (
+    <Table
+      columns={{
+        nameColumn,
+        amountBar: amountBar(type),
+        hits: literalNumberColumn('Hits', 'hits'),
+        avgHit,
+        critPct,
+      }}
+      data={data}
+      ctx={ctx}
+    />
   );
-
-  return <Table columns={{ nameColumn, amountBar, amountColumn }} data={data} ctx={ctx} />;
 }

--- a/src/interface/Table/DamageTable.tsx
+++ b/src/interface/Table/DamageTable.tsx
@@ -6,10 +6,23 @@ import * as design from 'interface/design-system';
 import type Spell from 'common/SPELLS/Spell';
 import MAGIC_SCHOOLS from 'game/MAGIC_SCHOOLS';
 import { useEvents, useInfo } from 'interface/guide';
-import { AnyEvent, HasAbility, HasSource, HasTarget } from 'parser/core/Events';
+import {
+  AnyEvent,
+  DamageEvent,
+  EventType,
+  HasAbility,
+  HasSource,
+  HasTarget,
+  HealEvent,
+} from 'parser/core/Events';
 import { effectiveDamage } from 'parser/shared/modules/DamageValue';
 import ActorLink from 'interface/ActorLink';
 import { useReport } from 'interface/report/context/ReportContext';
+import { Info } from 'parser/core/metric';
+import { effectiveHealing } from 'parser/shared/modules/HealingValue';
+import { WCLReport } from 'parser/core/Report';
+import Unit from 'parser/core/Unit';
+import Select from 'interface/controls/Select';
 
 export default function DamageTable(): JSX.Element | null {
   return null;
@@ -27,8 +40,21 @@ const TableRow = styled.div`
 `;
 
 interface TableCellProps {
-  align: Required<React.CSSProperties>['justifyContent'];
+  align: React.CSSProperties['justifyContent'];
 }
+
+const HeaderSelect = styled(Select)`
+  width: 100%;
+  border: unset;
+  box-shadow: unset;
+  text-align: center;
+  padding: 0.2rem ${design.gaps.medium};
+  border-radius: 0;
+
+  &:hover {
+    background-color: ${design.level2.background_active};
+  }
+`;
 
 const TableCell = styled.div<TableCellProps>`
   display: flex;
@@ -37,6 +63,10 @@ const TableCell = styled.div<TableCellProps>`
   padding: 0.2rem ${design.gaps.medium};
   border-right: 1px solid ${design.level1.border};
   width: 100%;
+
+  &:has(${HeaderSelect}) {
+    padding: 0;
+  }
 `;
 
 const TableHeader = styled.div`
@@ -61,116 +91,101 @@ const TableHeader = styled.div`
   }
 `;
 
-interface ColumnProps<T> {
+const OTHER_SPECIAL_BY = -9999;
+
+interface Column<T, Context = {}> {
   label: React.ReactNode;
-  render: (row: T) => React.ReactNode;
-  align: TableCellProps['align'];
+  render(row: T, ctx: Context): React.ReactNode;
+  align?: 'left' | 'right';
   expand?: boolean;
 }
 
-type Accessor<Object, Type> =
-  | ((obj: Object) => Type)
-  | keyof {
-      [Key in keyof Object as Object[Key] extends Type ? Key : never]: never;
-    };
+const actorName: Column<{ actorId: number }> = {
+  label: 'Actor', // this is getting overridden by the table
+  render(row) {
+    if (row.actorId === OTHER_SPECIAL_BY) {
+      return <em>Other</em>;
+    }
 
-const OTHER_SPECIAL_BY = -9999;
+    return <ActorLink id={row.actorId} />;
+  },
+};
 
-function actorName<T>(accessor: Accessor<T, number>, label: React.ReactNode): ColumnProps<T> {
-  return {
-    label,
-    align: 'start',
-    render: (row: T) => (
-      <ActorLink id={typeof accessor === 'function' ? accessor(row) : (row[accessor] as number)} />
-    ),
-  };
-}
+const spellName: Column<{ spell: number | Spell; school?: number }> = {
+  label: 'Ability',
+  render({ spell, school }) {
+    if (spell === OTHER_SPECIAL_BY) {
+      return <em>Other</em>;
+    }
+    return <SpellLink className={school ? `spell-school-${school}` : ''} spell={spell} />;
+  },
+};
 
-function spellName<T>(
-  accessor: Accessor<T, Spell | number>,
-  school?: Accessor<T, number>,
-): ColumnProps<T> {
-  return {
-    label: <>Ability</>,
-    render: (row: T) => {
-      const id = typeof accessor === 'function' ? accessor(row) : (row[accessor] as Spell | number);
-      if (id === OTHER_SPECIAL_BY) {
-        return 'Other';
-      }
-
-      return (
-        <SpellLink
-          className={
-            school
-              ? `spell-school-${typeof school === 'function' ? school(row) : (row[school] as number)}`
-              : ''
-          }
-          spell={id}
-        />
-      );
-    },
-    align: 'left',
-  };
-}
-
-function amountBar<T>(
-  accessor: Accessor<T, number>,
-  backgroundClass: Accessor<T, string>,
-  max: number,
-): ColumnProps<T> {
-  return {
-    label: <></>,
-    align: 'stretch',
-    expand: true,
-    render: (row: T) => {
-      return (
+const amountBar: Column<
+  { amount: number; school?: number; type?: string },
+  { max: number; total: number }
+> = {
+  label: '',
+  render({ amount, school, type }, { max, total }) {
+    return (
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '5rem 1fr',
+          gap: design.gaps.medium,
+          width: '100%',
+        }}
+      >
+        <div style={{ textAlign: 'right' }}>{formatPercentage(amount / total, 1)}%</div>
         <div
           className={
-            typeof backgroundClass === 'function'
-              ? backgroundClass(row)
-              : (row[backgroundClass] as string)
+            school ? `spell-school-${school}-bg` : type ? `${type}-bg` : 'spell-school-1-bg'
           }
-          style={{
-            height: '75%',
-            alignSelf: 'center',
-            width: `${(((typeof accessor === 'function' ? accessor(row) : row[accessor]) as number) / max) * 100}%`,
-          }}
+          style={{ height: '75%', alignSelf: 'center', width: `${(amount / max) * 100}%` }}
         />
-      );
-    },
-  };
-}
+      </div>
+    );
+  },
+  expand: true,
+};
 
-function amount<T>(accessor: Accessor<T, number>, label: React.ReactNode): ColumnProps<T> {
-  return {
-    label,
-    align: 'right',
-    render: (row: T) =>
-      formatNumber(typeof accessor === 'function' ? accessor(row) : (row[accessor] as number)),
-  };
-}
+const amount: Column<{ amount: number }> = {
+  label: 'Amount',
+  render({ amount }) {
+    return formatNumber(amount);
+  },
+  align: 'right',
+};
 
-function percentage<T>(accessor: Accessor<T, number>, total: number): ColumnProps<T> {
-  return {
-    label: <></>,
-    align: 'right',
-    render: (row: T) =>
-      `${formatPercentage((typeof accessor === 'function' ? accessor(row) : (row[accessor] as number)) / total)}%`,
-  };
-}
-
-interface TableProps<T> {
+// we need to use an object for the columns to make TS inferrence play nice
+interface TableProps<T, Context, Cols extends Record<string, Column<unknown, unknown>>> {
   data: T[];
-  columns: ColumnProps<T>[];
+  columns: Cols;
+  ctx: Context;
 }
 
-function Table<T>({ data, columns }: TableProps<T>): JSX.Element | null {
-  const gridColumns = columns.map((col) => (col.expand ? '1fr' : 'auto')).join(' ');
+function cellAlignment(align: Column<any>['align']): React.CSSProperties['justifyContent'] {
+  switch (align) {
+    case 'right':
+      return 'end';
+    default:
+      return 'start';
+  }
+}
+
+function Table<T, Context, Cols extends Record<string, Column<unknown, unknown>>>({
+  data,
+  columns,
+  ctx,
+}: TableProps<T, Context, Cols>): JSX.Element | null {
+  const gridColumns = Object.values(columns)
+    .map((col) => (col.expand ? '1fr' : 'auto'))
+    .join(' ');
 
   return (
     <TableContainer style={{ gridTemplateColumns: gridColumns }}>
       <TableHeader>
-        {columns.map((col, colIx) => (
+        {Object.values(columns).map((col, colIx) => (
           <TableCell key={colIx} align={'center'}>
             {col.label}
           </TableCell>
@@ -178,9 +193,9 @@ function Table<T>({ data, columns }: TableProps<T>): JSX.Element | null {
       </TableHeader>
       {data.map((row, ix) => (
         <TableRow key={ix}>
-          {columns.map((col, colIx) => (
-            <TableCell align={col.align} key={colIx}>
-              {col.render(row)}
+          {Object.values(columns).map((col, colIx) => (
+            <TableCell align={cellAlignment(col.align)} key={colIx}>
+              {col.render(row, ctx)}
             </TableCell>
           ))}
         </TableRow>
@@ -192,74 +207,172 @@ function Table<T>({ data, columns }: TableProps<T>): JSX.Element | null {
 interface ThroughputTableProps {
   range?: { start: number; end: number };
   maxRows?: number;
+  type: EventType.Damage | EventType.Heal;
 }
 
 type AggregateBy = 'ability' | 'source' | 'target';
 
-interface ThroughputRow {
-  by: number;
+interface ThroughputSpellRow {
+  spell: number | Spell;
   amount: number;
   school: number;
 }
 
-function aggregateByKey(event: AnyEvent, by: AggregateBy): number | null {
-  switch (by) {
-    case 'ability':
-      return HasAbility(event) ? event.ability.guid : null;
-    case 'source':
-      return HasSource(event) ? event.sourceID : null;
-    case 'target':
-      return HasTarget(event) ? event.targetID : null;
+interface ThroughputActorRow {
+  actorId: number;
+  amount: number;
+  type: string | undefined;
+}
+
+type ThroughputRow = ThroughputSpellRow | ThroughputActorRow;
+
+const isRelevantToInfo = (info: Info) => (id?: number) =>
+  id === info?.playerId || info?.pets.some((pet) => pet.id === id);
+
+function eventMatchesType<Ty extends EventType.Damage | EventType.Heal>(
+  event: AnyEvent,
+  type: Ty,
+): event is AnyEvent<Ty> {
+  if (event.type !== type) {
+    return false;
   }
+
+  if (
+    (event.targetIsFriendly && event.type === EventType.Damage) ||
+    (!event.targetIsFriendly && event.type === EventType.Heal)
+  ) {
+    return false;
+  }
+
+  // TODO exclude healing done to pets
+
+  return true;
+}
+
+function throughputByAbility(
+  events: AnyEvent[],
+  info: Info,
+  type: EventType.Damage | EventType.Heal,
+): ThroughputSpellRow[] {
+  const map = new Map<number, ThroughputSpellRow>();
+  const isRelevant = isRelevantToInfo(info);
+
+  for (const event of events) {
+    if (!eventMatchesType(event, type)) {
+      continue;
+    }
+
+    if (!isRelevant(event.sourceID)) {
+      continue;
+    }
+
+    const id = event.ability.guid;
+    const school = event.ability.type;
+    const amount =
+      type === EventType.Damage
+        ? effectiveDamage(event as DamageEvent)
+        : effectiveHealing(event as HealEvent);
+
+    if (!map.has(id)) {
+      map.set(id, {
+        spell: id,
+        school,
+        amount: 0,
+      });
+    }
+
+    const row = map.get(id)!;
+    row.amount += amount;
+  }
+
+  return Array.from(map.values());
+}
+
+function throughputByActor(
+  events: AnyEvent[],
+  info: Info,
+  actors: Map<number, Unit>,
+  type: EventType.Damage | EventType.Heal,
+  by: 'sourceID' | 'targetID',
+): ThroughputActorRow[] {
+  const map = new Map<number, ThroughputActorRow>();
+  const isRelevant = isRelevantToInfo(info);
+
+  for (const event of events) {
+    if (!eventMatchesType(event, type)) {
+      continue;
+    }
+
+    if (!isRelevant(event.sourceID)) {
+      continue;
+    }
+
+    const id = event[by];
+    if (!id) {
+      continue;
+    }
+
+    const actor = actors.get(id);
+    const actorType = actor && actor.subType !== '' ? actor.subType : actor?.type;
+    const amount =
+      type === EventType.Damage
+        ? effectiveDamage(event as DamageEvent)
+        : effectiveHealing(event as HealEvent);
+
+    if (!map.has(id)) {
+      map.set(id, {
+        actorId: id,
+        type: actorType,
+        amount: 0,
+      });
+    }
+
+    const row = map.get(id)!;
+    row.amount += amount;
+  }
+
+  return Array.from(map.values());
 }
 
 export function ThroughputTable({
   range,
-  maxRows = Infinity,
+  maxRows = 11,
+  type,
 }: ThroughputTableProps): JSX.Element | null {
   const { report } = useReport();
   const info = useInfo();
   const events = useEvents(range);
   const [aggregateBy, setAggregateBy] = useState<AggregateBy>('ability');
 
+  const actors = useMemo(() => {
+    const map = new Map<number, Unit>();
+
+    report.friendlies
+      .concat(report.friendlyPets)
+      .concat(report.enemies)
+      .concat(report.enemyPets)
+      .map((unit) => map.set(unit.id, unit));
+
+    return map;
+  }, [report]);
+
   const data = useMemo(() => {
-    const map = new Map<number, ThroughputRow>();
-
-    const isPlayerRelevant = (id?: number) =>
-      id === info?.playerId || info?.pets.some((pet) => pet.id === id);
-
-    for (const event of events) {
-      if (event.type !== 'damage') {
-        continue;
-      }
-
-      if (!isPlayerRelevant(event.sourceID)) {
-        continue;
-      }
-
-      if (event.targetIsFriendly) {
-        continue;
-      }
-
-      const key = aggregateByKey(event, aggregateBy);
-      if (key === null) {
-        continue; // explicitly discard events with no aggregation key
-      }
-
-      if (!map.has(key)) {
-        map.set(key, {
-          by: key,
-          amount: 0,
-          school: MAGIC_SCHOOLS.ids.PHYSICAL,
-        });
-      }
-
-      const row = map.get(key)!;
-      row.amount += effectiveDamage(event);
-      row.school = event.ability.type;
+    if (!info) {
+      return [];
     }
 
-    const result = Array.from(map.values().filter((row) => row.amount > 0));
+    const rows =
+      aggregateBy === 'ability'
+        ? throughputByAbility(events, info, type)
+        : throughputByActor(
+            events,
+            info,
+            actors,
+            type,
+            (aggregateBy + 'ID') as 'sourceID' | 'targetID',
+          );
+
+    const result = Array.from(rows.filter((row) => row.amount > 0));
     result.sort((a, b) => b.amount - a.amount);
 
     if (result.length > maxRows) {
@@ -267,52 +380,51 @@ export function ThroughputTable({
       return [
         ...result.slice(0, maxRows - 1),
         {
-          by: OTHER_SPECIAL_BY,
+          actorId: OTHER_SPECIAL_BY,
+          spell: OTHER_SPECIAL_BY,
+          type: 'Other',
           amount: otherTotal,
-          school: MAGIC_SCHOOLS.ids.PHYSICAL,
         },
       ];
     }
 
-    return result;
+    return result as ThroughputSpellRow[] | ThroughputActorRow[];
   }, [events, aggregateBy, info]);
 
-  const max = data.reduce((a, b) => Math.max(a, b.amount), 0);
+  const ctx = useMemo(() => {
+    const max = data.reduce((max, row) => Math.max(max, row.amount), 0);
+    const total = data.reduce((total, row) => total + row.amount, 0);
 
-  const nameColumn = useMemo(
-    () =>
-      aggregateBy === 'ability'
-        ? spellName<ThroughputRow>('by', 'school')
-        : actorName<ThroughputRow>('by', aggregateBy === 'source' ? 'Source' : 'Target'),
-    [aggregateBy],
+    return { max, total };
+  }, [data]);
+
+  const nameColumn = useMemo(() => {
+    const col = aggregateBy === 'ability' ? spellName : actorName;
+
+    return {
+      ...col,
+      label: (
+        <HeaderSelect
+          onChange={(event) => {
+            setAggregateBy(event.target.value as AggregateBy);
+          }}
+          value={aggregateBy}
+        >
+          <option value={'ability'}>Ability</option>
+          <option value={'source'}>Source</option>
+          <option value={'target'}>Target</option>
+        </HeaderSelect>
+      ),
+    };
+  }, [aggregateBy]);
+
+  const amountColumn = useMemo(
+    () => ({
+      ...amount,
+      label: type === EventType.Damage ? 'Damage' : 'Healing',
+    }),
+    [type],
   );
 
-  const barColumn = useMemo(
-    () =>
-      aggregateBy === 'ability'
-        ? amountBar<ThroughputRow>('amount', (row) => `spell-school-${row.school}-bg`, max)
-        : amountBar<ThroughputRow>(
-            'amount',
-            (row) =>
-              (report.friendlies
-                .concat(report.enemies)
-                .concat(report.friendlyPets)
-                .concat(report.enemyPets)
-                .find((actor) => row.by === actor.id)?.type ?? 'NPC') + '-bg',
-            max,
-          ),
-    [report, aggregateBy],
-  );
-
-  return (
-    <Table
-      data={data}
-      columns={[
-        // ok, maybe this type shenanigan isn't worthwhile...
-        nameColumn,
-        barColumn,
-        amount<(typeof data)[number]>('amount', 'Damage'),
-      ]}
-    />
-  );
+  return <Table columns={{ nameColumn, amountBar, amountColumn }} data={data} ctx={ctx} />;
 }

--- a/src/interface/Table/DamageTable.tsx
+++ b/src/interface/Table/DamageTable.tsx
@@ -1,11 +1,10 @@
 import styled from '@emotion/styled';
 import { formatNumber, formatPercentage } from 'common/format';
-import SPELLS from 'common/SPELLS';
 import SpellLink from 'interface/SpellLink';
 import { JSX, useMemo, useState } from 'react';
 import * as design from 'interface/design-system';
 import type Spell from 'common/SPELLS/Spell';
-import MAGIC_SCHOOLS, { color } from 'game/MAGIC_SCHOOLS';
+import MAGIC_SCHOOLS from 'game/MAGIC_SCHOOLS';
 import { useEvents, useInfo } from 'interface/guide';
 import { AnyEvent, HasAbility, HasSource, HasTarget } from 'parser/core/Events';
 import { effectiveDamage } from 'parser/shared/modules/DamageValue';
@@ -101,11 +100,11 @@ function spellName<T>(
 
       return (
         <SpellLink
-          style={{
-            color: school
-              ? color(typeof school === 'function' ? school(row) : (row[school] as number))
-              : design.colors.bodyText,
-          }}
+          className={
+            school
+              ? `spell-school-${typeof school === 'function' ? school(row) : (row[school] as number)}`
+              : ''
+          }
           spell={id}
         />
       );

--- a/src/interface/Table/DamageTable.tsx
+++ b/src/interface/Table/DamageTable.tsx
@@ -1,0 +1,319 @@
+import styled from '@emotion/styled';
+import { formatNumber, formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import SpellLink from 'interface/SpellLink';
+import { JSX, useMemo, useState } from 'react';
+import * as design from 'interface/design-system';
+import type Spell from 'common/SPELLS/Spell';
+import MAGIC_SCHOOLS, { color } from 'game/MAGIC_SCHOOLS';
+import { useEvents, useInfo } from 'interface/guide';
+import { AnyEvent, HasAbility, HasSource, HasTarget } from 'parser/core/Events';
+import { effectiveDamage } from 'parser/shared/modules/DamageValue';
+import ActorLink from 'interface/ActorLink';
+import { useReport } from 'interface/report/context/ReportContext';
+
+export default function DamageTable(): JSX.Element | null {
+  return null;
+}
+
+const TableContainer = styled.div`
+  display: grid;
+  grid-auto-flow: column;
+`;
+
+const TableRow = styled.div`
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+`;
+
+interface TableCellProps {
+  align: Required<React.CSSProperties>['justifyContent'];
+}
+
+const TableCell = styled.div<TableCellProps>`
+  display: flex;
+  flex-direction: row;
+  justify-content: ${(props) => props.align};
+  padding: 0.2rem ${design.gaps.medium};
+  border-right: 1px solid ${design.level1.border};
+  width: 100%;
+`;
+
+const TableHeader = styled.div`
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+
+  background: ${design.level2.background};
+  border: 1px solid ${design.level2.border};
+  box-shadow: ${design.level2.shadow};
+
+  & ${TableCell} {
+    border-color: ${design.level2.border};
+
+    &:last-of-type {
+      border-right: unset;
+    }
+  }
+
+  & + ${TableRow} {
+    padding-top: 0.3rem;
+  }
+`;
+
+interface ColumnProps<T> {
+  label: React.ReactNode;
+  render: (row: T) => React.ReactNode;
+  align: TableCellProps['align'];
+  expand?: boolean;
+}
+
+type Accessor<Object, Type> =
+  | ((obj: Object) => Type)
+  | keyof {
+      [Key in keyof Object as Object[Key] extends Type ? Key : never]: never;
+    };
+
+const OTHER_SPECIAL_BY = -9999;
+
+function actorName<T>(accessor: Accessor<T, number>, label: React.ReactNode): ColumnProps<T> {
+  return {
+    label,
+    align: 'start',
+    render: (row: T) => (
+      <ActorLink id={typeof accessor === 'function' ? accessor(row) : (row[accessor] as number)} />
+    ),
+  };
+}
+
+function spellName<T>(
+  accessor: Accessor<T, Spell | number>,
+  school?: Accessor<T, number>,
+): ColumnProps<T> {
+  return {
+    label: <>Ability</>,
+    render: (row: T) => {
+      const id = typeof accessor === 'function' ? accessor(row) : (row[accessor] as Spell | number);
+      if (id === OTHER_SPECIAL_BY) {
+        return 'Other';
+      }
+
+      return (
+        <SpellLink
+          style={{
+            color: school
+              ? color(typeof school === 'function' ? school(row) : (row[school] as number))
+              : design.colors.bodyText,
+          }}
+          spell={id}
+        />
+      );
+    },
+    align: 'left',
+  };
+}
+
+function amountBar<T>(
+  accessor: Accessor<T, number>,
+  backgroundClass: Accessor<T, string>,
+  max: number,
+): ColumnProps<T> {
+  return {
+    label: <></>,
+    align: 'stretch',
+    expand: true,
+    render: (row: T) => {
+      return (
+        <div
+          className={
+            typeof backgroundClass === 'function'
+              ? backgroundClass(row)
+              : (row[backgroundClass] as string)
+          }
+          style={{
+            height: '75%',
+            alignSelf: 'center',
+            width: `${(((typeof accessor === 'function' ? accessor(row) : row[accessor]) as number) / max) * 100}%`,
+          }}
+        />
+      );
+    },
+  };
+}
+
+function amount<T>(accessor: Accessor<T, number>, label: React.ReactNode): ColumnProps<T> {
+  return {
+    label,
+    align: 'right',
+    render: (row: T) =>
+      formatNumber(typeof accessor === 'function' ? accessor(row) : (row[accessor] as number)),
+  };
+}
+
+function percentage<T>(accessor: Accessor<T, number>, total: number): ColumnProps<T> {
+  return {
+    label: <></>,
+    align: 'right',
+    render: (row: T) =>
+      `${formatPercentage((typeof accessor === 'function' ? accessor(row) : (row[accessor] as number)) / total)}%`,
+  };
+}
+
+interface TableProps<T> {
+  data: T[];
+  columns: ColumnProps<T>[];
+}
+
+function Table<T>({ data, columns }: TableProps<T>): JSX.Element | null {
+  const gridColumns = columns.map((col) => (col.expand ? '1fr' : 'auto')).join(' ');
+
+  return (
+    <TableContainer style={{ gridTemplateColumns: gridColumns }}>
+      <TableHeader>
+        {columns.map((col, colIx) => (
+          <TableCell key={colIx} align={'center'}>
+            {col.label}
+          </TableCell>
+        ))}
+      </TableHeader>
+      {data.map((row, ix) => (
+        <TableRow key={ix}>
+          {columns.map((col, colIx) => (
+            <TableCell align={col.align} key={colIx}>
+              {col.render(row)}
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </TableContainer>
+  );
+}
+
+interface ThroughputTableProps {
+  range?: { start: number; end: number };
+  maxRows?: number;
+}
+
+type AggregateBy = 'ability' | 'source' | 'target';
+
+interface ThroughputRow {
+  by: number;
+  amount: number;
+  school: number;
+}
+
+function aggregateByKey(event: AnyEvent, by: AggregateBy): number | null {
+  switch (by) {
+    case 'ability':
+      return HasAbility(event) ? event.ability.guid : null;
+    case 'source':
+      return HasSource(event) ? event.sourceID : null;
+    case 'target':
+      return HasTarget(event) ? event.targetID : null;
+  }
+}
+
+export function ThroughputTable({
+  range,
+  maxRows = Infinity,
+}: ThroughputTableProps): JSX.Element | null {
+  const { report } = useReport();
+  const info = useInfo();
+  const events = useEvents(range);
+  const [aggregateBy, setAggregateBy] = useState<AggregateBy>('ability');
+
+  const data = useMemo(() => {
+    const map = new Map<number, ThroughputRow>();
+
+    const isPlayerRelevant = (id?: number) =>
+      id === info?.playerId || info?.pets.some((pet) => pet.id === id);
+
+    for (const event of events) {
+      if (event.type !== 'damage') {
+        continue;
+      }
+
+      if (!isPlayerRelevant(event.sourceID)) {
+        continue;
+      }
+
+      if (event.targetIsFriendly) {
+        continue;
+      }
+
+      const key = aggregateByKey(event, aggregateBy);
+      if (key === null) {
+        continue; // explicitly discard events with no aggregation key
+      }
+
+      if (!map.has(key)) {
+        map.set(key, {
+          by: key,
+          amount: 0,
+          school: MAGIC_SCHOOLS.ids.PHYSICAL,
+        });
+      }
+
+      const row = map.get(key)!;
+      row.amount += effectiveDamage(event);
+      row.school = event.ability.type;
+    }
+
+    const result = Array.from(map.values().filter((row) => row.amount > 0));
+    result.sort((a, b) => b.amount - a.amount);
+
+    if (result.length > maxRows) {
+      const otherTotal = result.slice(maxRows - 1).reduce((total, row) => total + row.amount, 0);
+      return [
+        ...result.slice(0, maxRows - 1),
+        {
+          by: OTHER_SPECIAL_BY,
+          amount: otherTotal,
+          school: MAGIC_SCHOOLS.ids.PHYSICAL,
+        },
+      ];
+    }
+
+    return result;
+  }, [events, aggregateBy, info]);
+
+  const max = data.reduce((a, b) => Math.max(a, b.amount), 0);
+
+  const nameColumn = useMemo(
+    () =>
+      aggregateBy === 'ability'
+        ? spellName<ThroughputRow>('by', 'school')
+        : actorName<ThroughputRow>('by', aggregateBy === 'source' ? 'Source' : 'Target'),
+    [aggregateBy],
+  );
+
+  const barColumn = useMemo(
+    () =>
+      aggregateBy === 'ability'
+        ? amountBar<ThroughputRow>('amount', (row) => `spell-school-${row.school}-bg`, max)
+        : amountBar<ThroughputRow>(
+            'amount',
+            (row) =>
+              (report.friendlies
+                .concat(report.enemies)
+                .concat(report.friendlyPets)
+                .concat(report.enemyPets)
+                .find((actor) => row.by === actor.id)?.type ?? 'NPC') + '-bg',
+            max,
+          ),
+    [report, aggregateBy],
+  );
+
+  return (
+    <Table
+      data={data}
+      columns={[
+        // ok, maybe this type shenanigan isn't worthwhile...
+        nameColumn,
+        barColumn,
+        amount<(typeof data)[number]>('amount', 'Damage'),
+      ]}
+    />
+  );
+}

--- a/src/interface/Table/Table.tsx
+++ b/src/interface/Table/Table.tsx
@@ -81,7 +81,7 @@ interface TableProps<T, Context, Cols extends Record<string, Column<unknown, unk
   ctx: Context;
 }
 
-function cellAlignment(align: Column<any>['align']): React.CSSProperties['justifyContent'] {
+function cellAlignment(align: Column<unknown>['align']): React.CSSProperties['justifyContent'] {
   switch (align) {
     case 'right':
       return 'end';
@@ -121,7 +121,7 @@ export default function Table<T, Context, Cols extends Record<string, Column<unk
   );
 }
 
-export interface Column<T, Context = {}> {
+export interface Column<T, Context = object> {
   label: React.ReactNode;
   render(row: T, ctx: Context): React.ReactNode;
   align?: 'left' | 'right';

--- a/src/interface/Table/Table.tsx
+++ b/src/interface/Table/Table.tsx
@@ -47,7 +47,7 @@ const TableCell = styled.div<TableCellProps>`
     padding: 0;
   }
 
-  @container (width < 60rem) {
+  @container (width < 500px) {
     ${(props) => (props.optional ? 'display: none;' : '')}
   }
 `;

--- a/src/interface/Table/ThroughputTable.tsx
+++ b/src/interface/Table/ThroughputTable.tsx
@@ -101,8 +101,20 @@ const avgHit: Column<{ hits: number; amount: number }> = {
 
 export interface ThroughputTableProps {
   range?: { start: number; end: number };
+  /**
+   * The maximum number of rows to show. The final row is the `Other` row and counts against this limit, unless it is disabled by setting `omitOtherRow`.
+   */
   maxRows?: number;
   type: EventType.Damage | EventType.Heal;
+  /**
+   * The list of abilities to include. All other abilities are moved to the `Other` category, unless `omitOtherRow` is set (in which case all other abilities are omitted).
+   *
+   * By default, all abilities are included. The filter is useful if you're showing a cooldown that affects a specific list of abilities and you want to show only those.
+   *
+   * Filtered abilities are completely hidden from the source/target views when `omitOtherRow` is true. Otherwise, they are included. This causes the total values to add up to the same value.
+   */
+  abilityFilter?: (Spell | number)[];
+  omitOtherRow?: boolean;
 }
 
 type AggregateBy = 'ability' | 'source' | 'target';
@@ -150,6 +162,7 @@ function throughputByAbility(
   events: AnyEvent[],
   info: Info,
   type: EventType.Damage | EventType.Heal,
+  abilityFilter: Set<number> | undefined,
 ): ThroughputSpellRow[] {
   const map = new Map<number, ThroughputSpellRow>();
   const isRelevant = isRelevantToInfo(info);
@@ -163,8 +176,11 @@ function throughputByAbility(
       continue;
     }
 
-    const id = event.ability.guid;
-    const school = event.ability.type;
+    const id =
+      !abilityFilter || abilityFilter?.has(event.ability.guid)
+        ? event.ability.guid
+        : OTHER_SPECIAL_BY;
+    const school = id === OTHER_SPECIAL_BY ? 0 : event.ability.type;
     const amount =
       type === EventType.Damage
         ? effectiveDamage(event as DamageEvent)
@@ -178,6 +194,11 @@ function throughputByAbility(
         hits: 0,
         crits: 0,
       });
+
+      if (id === OTHER_SPECIAL_BY) {
+        // hack for 'Other' background
+        (map.get(id)! as unknown as ThroughputActorRow).type = 'Other';
+      }
     }
 
     const row = map.get(id)!;
@@ -195,6 +216,7 @@ function throughputByActor(
   actors: Map<number, Unit>,
   type: EventType.Damage | EventType.Heal,
   by: 'sourceID' | 'targetID',
+  abilityFilter: Set<number> | undefined,
 ): ThroughputActorRow[] {
   const map = new Map<number, ThroughputActorRow>();
   const isRelevant = isRelevantToInfo(info);
@@ -211,6 +233,10 @@ function throughputByActor(
     const id = event[by];
     if (!id) {
       continue;
+    }
+
+    if (abilityFilter && !abilityFilter.has(event.ability.guid)) {
+      continue; // completely hide these abilities for by-actor views
     }
 
     const actor = actors.get(id);
@@ -239,10 +265,23 @@ function throughputByActor(
   return Array.from(map.values());
 }
 
+function isOther(row: ThroughputActorRow | ThroughputSpellRow): boolean {
+  if ('spell' in row) {
+    return row.spell === OTHER_SPECIAL_BY;
+  }
+  if ('actorId' in row) {
+    return row.actorId === OTHER_SPECIAL_BY;
+  }
+
+  return false;
+}
+
 export default function ThroughputTable({
   range,
   maxRows = 6,
   type,
+  abilityFilter,
+  omitOtherRow,
 }: ThroughputTableProps): JSX.Element | null {
   const { report } = useReport();
   const info = useInfo();
@@ -266,40 +305,58 @@ export default function ThroughputTable({
       return [];
     }
 
+    let filterSet = undefined;
+    if (abilityFilter) {
+      filterSet = new Set(
+        abilityFilter.map((spell) => (typeof spell === 'number' ? spell : spell.id)),
+      );
+    }
+
     const rows =
       aggregateBy === 'ability'
-        ? throughputByAbility(events, info, type)
+        ? throughputByAbility(events, info, type, filterSet)
         : throughputByActor(
             events,
             info,
             actors,
             type,
             (aggregateBy + 'ID') as 'sourceID' | 'targetID',
+            omitOtherRow ? filterSet : undefined,
           );
 
-    const result = Array.from(rows.filter((row) => row.amount > 0));
+    const other = rows.find(isOther);
+    const result = Array.from(rows.filter((row) => row.amount > 0 && !isOther(row)));
     result.sort((a, b) => b.amount - a.amount);
 
-    if (result.length > maxRows) {
-      const otherRows = result.slice(maxRows - 1);
+    if (omitOtherRow) {
+      return result.slice(0, maxRows);
+    }
+
+    const otherOffset = other ? 1 : 0;
+
+    if (result.length + otherOffset > maxRows) {
+      const otherRows = result.slice(maxRows - 1 - otherOffset);
       const otherTotal = otherRows.reduce((total, row) => total + row.amount, 0);
       const otherHits = otherRows.reduce((total, row) => total + row.hits, 0);
       const otherCrits = otherRows.reduce((total, row) => total + row.crits, 0);
+
       return [
         ...result.slice(0, maxRows - 1),
         {
           actorId: OTHER_SPECIAL_BY,
           spell: OTHER_SPECIAL_BY,
           type: 'Other',
-          amount: otherTotal,
-          hits: otherHits,
-          crits: otherCrits,
+          amount: otherTotal + (other?.amount ?? 0),
+          hits: otherHits + (other?.hits ?? 0),
+          crits: otherCrits + (other?.crits ?? 0),
         },
       ];
+    } else if (other) {
+      result.push(other);
     }
 
     return result as ThroughputSpellRow[] | ThroughputActorRow[];
-  }, [events, aggregateBy, info]);
+  }, [events, aggregateBy, info, abilityFilter, omitOtherRow]);
 
   const ctx = useMemo(() => {
     const max = data.reduce((max, row) => Math.max(max, row.amount), 0);

--- a/src/interface/Table/ThroughputTable.tsx
+++ b/src/interface/Table/ThroughputTable.tsx
@@ -4,7 +4,7 @@ import { JSX, useMemo, useState } from 'react';
 import * as design from 'interface/design-system';
 import type Spell from 'common/SPELLS/Spell';
 import { useEvents, useInfo } from 'interface/guide';
-import { AnyEvent, DamageEvent, EventType, HealEvent } from 'parser/core/Events';
+import { AnyEvent, EventType } from 'parser/core/Events';
 import { effectiveDamage } from 'parser/shared/modules/DamageValue';
 import ActorLink from 'interface/ActorLink';
 import { useReport } from 'interface/report/context/ReportContext';
@@ -28,21 +28,29 @@ const actorName: Column<{ actorId: number }> = {
   },
 };
 
-const spellName: Column<{ spell: number | Spell; school?: number }> = {
+const spellName: Column<{ spell: number | Spell; school?: number; isPet?: boolean }> = {
   label: 'Ability',
-  render({ spell, school }) {
+  render({ spell, school, isPet }) {
     if (spell === OTHER_SPECIAL_BY) {
       return <em>Other</em>;
     }
-    return <SpellLink className={school ? `spell-school-${school}` : ''} spell={spell} />;
+    return (
+      <>
+        <SpellLink className={school ? `spell-school-${school}` : ''} spell={spell} />
+        {isPet ? <>&nbsp;(Pet)</> : null}
+      </>
+    );
   },
 };
 
 const amountBar = (
   type: EventType.Damage | EventType.Heal,
-): Column<{ amount: number; school?: number; type?: string }, { max: number; total: number }> => ({
+): Column<
+  { amount: number; school?: number; type?: string; isAbsorb?: boolean },
+  { max: number; total: number }
+> => ({
   label: type === EventType.Damage ? 'Damage' : 'Healing',
-  render({ amount, school, type }, { max, total }) {
+  render({ amount, school, type, isAbsorb }, { max, total }) {
     return (
       <div
         style={{
@@ -57,7 +65,12 @@ const amountBar = (
           className={
             school ? `spell-school-${school}-bg` : type ? `${type}-bg` : 'spell-school-1-bg'
           }
-          style={{ height: '75%', alignSelf: 'center', width: `${(amount / max) * 100}%` }}
+          style={{
+            height: '75%',
+            alignSelf: 'center',
+            width: `${(amount / max) * 100}%`,
+            filter: isAbsorb ? 'brightness(60%)' : undefined,
+          }}
         />
         <div style={{ textAlign: 'right' }}>{formatNumber(amount)}</div>
       </div>
@@ -129,6 +142,8 @@ interface ThroughputRowCommon {
 interface ThroughputSpellRow extends ThroughputRowCommon {
   spell: number | Spell;
   school: number;
+  isAbsorb?: boolean;
+  isPet?: boolean;
 }
 
 interface ThroughputActorRow extends ThroughputRowCommon {
@@ -139,24 +154,32 @@ interface ThroughputActorRow extends ThroughputRowCommon {
 const isRelevantToInfo = (info: Info) => (id?: number) =>
   id === info?.playerId || info?.pets.some((pet) => pet.id === id);
 
+const includedEventTypes = {
+  [EventType.Damage]: new Set([EventType.Damage as const]),
+  [EventType.Heal]: new Set([EventType.Heal as const, EventType.Absorbed as const]),
+};
+
+type IncludedEvents<T extends keyof typeof includedEventTypes> =
+  (typeof includedEventTypes)[T] extends Set<infer E extends EventType> ? AnyEvent<E> : never;
+
 function eventMatchesType<Ty extends EventType.Damage | EventType.Heal>(
   event: AnyEvent,
   type: Ty,
-): event is AnyEvent<Ty> {
-  if (event.type !== type) {
+): event is IncludedEvents<Ty> {
+  const includedTypes = includedEventTypes[type];
+  if (!(includedTypes as Set<EventType>).has(event.type)) {
     return false;
   }
 
-  if (
-    (event.targetIsFriendly && event.type === EventType.Damage) ||
-    (!event.targetIsFriendly && event.type === EventType.Heal)
-  ) {
-    return false;
+  const expectedTargetIsFriendly = type === EventType.Heal;
+
+  if ('targetIsFriendly' in event && expectedTargetIsFriendly === event.targetIsFriendly) {
+    return true;
   }
 
-  // TODO exclude healing done to pets
+  // TODO exclude healing done to pets?
 
-  return true;
+  return false;
 }
 
 function throughputByAbility(
@@ -184,8 +207,8 @@ function throughputByAbility(
     const school = id === OTHER_SPECIAL_BY ? 0 : event.ability.type;
     const amount =
       type === EventType.Damage
-        ? effectiveDamage(event as DamageEvent)
-        : effectiveHealing(event as HealEvent);
+        ? effectiveDamage(event as IncludedEvents<EventType.Damage>)
+        : effectiveHealing(event as IncludedEvents<EventType.Heal>);
 
     if (!map.has(id)) {
       map.set(id, {
@@ -194,6 +217,8 @@ function throughputByAbility(
         amount: 0,
         hits: 0,
         crits: 0,
+        isAbsorb: event.type === EventType.Absorbed,
+        isPet: info.pets.some((pet) => pet.id === event.sourceID),
       });
 
       if (id === OTHER_SPECIAL_BY) {
@@ -203,9 +228,13 @@ function throughputByAbility(
     }
 
     const row = map.get(id)!;
+
+    if (info.pets.every((pet) => pet.id !== event.sourceID)) {
+      row.isPet = false; // if an ability can come from both pet and player, mark as non-pet. we don't do hybrid bars
+    }
     row.amount += amount;
     row.hits += 1;
-    row.crits += Number(event.hitType === HIT_TYPES.CRIT);
+    row.crits += 'hitType' in event ? Number(event.hitType === HIT_TYPES.CRIT) : 0;
   }
 
   return Array.from(map.values());
@@ -244,8 +273,8 @@ function throughputByActor(
     const actorType = actor && actor.subType !== '' ? actor.subType : actor?.type;
     const amount =
       type === EventType.Damage
-        ? effectiveDamage(event as DamageEvent)
-        : effectiveHealing(event as HealEvent);
+        ? effectiveDamage(event as IncludedEvents<EventType.Damage>)
+        : effectiveHealing(event as IncludedEvents<EventType.Heal>);
 
     if (!map.has(id)) {
       map.set(id, {
@@ -260,7 +289,7 @@ function throughputByActor(
     const row = map.get(id)!;
     row.amount += amount;
     row.hits += 1;
-    row.crits += Number(event.hitType === HIT_TYPES.CRIT);
+    row.crits += 'hitType' in event ? Number(event.hitType === HIT_TYPES.CRIT) : 0;
   }
 
   return Array.from(map.values());

--- a/src/interface/Table/ThroughputTable.tsx
+++ b/src/interface/Table/ThroughputTable.tsx
@@ -13,6 +13,7 @@ import { effectiveHealing } from 'parser/shared/modules/HealingValue';
 import Unit from 'parser/core/Unit';
 import HIT_TYPES from 'game/HIT_TYPES';
 import Table, { Column, HeaderSelect } from './Table';
+import React from 'react';
 
 const OTHER_SPECIAL_BY = -9999;
 
@@ -276,7 +277,7 @@ function isOther(row: ThroughputActorRow | ThroughputSpellRow): boolean {
   return false;
 }
 
-export default function ThroughputTable({
+function ThroughputTableRaw({
   range,
   maxRows = 6,
   type,
@@ -399,6 +400,10 @@ export default function ThroughputTable({
     />
   );
 }
+
+const ThroughputTable = React.memo(ThroughputTableRaw);
+
+export default ThroughputTable;
 
 export const DamageTable = (props: Omit<ThroughputTableProps, 'type'>) => (
   <ThroughputTable {...props} type={EventType.Damage} />

--- a/src/interface/Table/ThroughputTable.tsx
+++ b/src/interface/Table/ThroughputTable.tsx
@@ -356,7 +356,7 @@ export default function ThroughputTable({
     }
 
     return result as ThroughputSpellRow[] | ThroughputActorRow[];
-  }, [events, aggregateBy, info, abilityFilter, omitOtherRow]);
+  }, [events, aggregateBy, info, abilityFilter, omitOtherRow, actors, maxRows, type]);
 
   const ctx = useMemo(() => {
     const max = data.reduce((max, row) => Math.max(max, row.amount), 0);

--- a/src/interface/Table/ThroughputTable.tsx
+++ b/src/interface/Table/ThroughputTable.tsx
@@ -14,6 +14,7 @@ import Unit from 'parser/core/Unit';
 import HIT_TYPES from 'game/HIT_TYPES';
 import Table, { Column, HeaderSelect } from './Table';
 import React from 'react';
+import { WCLReport } from 'parser/core/Report';
 
 const OTHER_SPECIAL_BY = -9999;
 
@@ -129,6 +130,10 @@ export interface ThroughputTableProps {
    */
   abilityFilter?: (Spell | number)[];
   omitOtherRow?: boolean;
+  /**
+   * A list of unit/actor ids to include as targets. All other units/actors are omitted from the table. By default, all actors are included for damage and all non-pet actors for healing. When explicitly set to `false`, no default filtering is applied.
+   */
+  targetExclusions?: Set<number> | false;
 }
 
 type AggregateBy = 'ability' | 'source' | 'target';
@@ -177,8 +182,6 @@ function eventMatchesType<Ty extends EventType.Damage | EventType.Heal>(
     return true;
   }
 
-  // TODO exclude healing done to pets?
-
   return false;
 }
 
@@ -187,6 +190,7 @@ function throughputByAbility(
   info: Info,
   type: EventType.Damage | EventType.Heal,
   abilityFilter: Set<number> | undefined,
+  targetFilter?: ThroughputTableProps['targetExclusions'],
 ): ThroughputSpellRow[] {
   const map = new Map<number, ThroughputSpellRow>();
   const isRelevant = isRelevantToInfo(info);
@@ -198,6 +202,10 @@ function throughputByAbility(
 
     if (!isRelevant(event.sourceID)) {
       continue;
+    }
+
+    if (targetFilter && targetFilter.has(event.targetID)) {
+      continue; // unlike `abilityFilter`, `targetFilter` does not move to `other`
     }
 
     const id =
@@ -247,6 +255,7 @@ function throughputByActor(
   type: EventType.Damage | EventType.Heal,
   by: 'sourceID' | 'targetID',
   abilityFilter: Set<number> | undefined,
+  targetFilter?: ThroughputTableProps['targetExclusions'],
 ): ThroughputActorRow[] {
   const map = new Map<number, ThroughputActorRow>();
   const isRelevant = isRelevantToInfo(info);
@@ -267,6 +276,10 @@ function throughputByActor(
 
     if (abilityFilter && !abilityFilter.has(event.ability.guid)) {
       continue; // completely hide these abilities for by-actor views
+    }
+
+    if (targetFilter && targetFilter.has(event.targetID)) {
+      continue; // completely exclude this target
     }
 
     const actor = actors.get(id);
@@ -312,11 +325,23 @@ function ThroughputTableRaw({
   type,
   abilityFilter,
   omitOtherRow,
+  targetExclusions: rawUnitFilter,
 }: ThroughputTableProps): JSX.Element | null {
   const { report } = useReport();
   const info = useInfo();
   const events = useEvents(range);
   const [aggregateBy, setAggregateBy] = useState<AggregateBy>('ability');
+
+  const unitFilter = useMemo(() => {
+    if (rawUnitFilter) {
+      return rawUnitFilter;
+    }
+    if (type === EventType.Heal && rawUnitFilter !== false) {
+      return excludeReportPets(report);
+    }
+
+    return undefined;
+  }, [rawUnitFilter, report, type]);
 
   const actors = useMemo(() => {
     const map = new Map<number, Unit>();
@@ -344,7 +369,7 @@ function ThroughputTableRaw({
 
     const rows =
       aggregateBy === 'ability'
-        ? throughputByAbility(events, info, type, filterSet)
+        ? throughputByAbility(events, info, type, filterSet, unitFilter)
         : throughputByActor(
             events,
             info,
@@ -352,6 +377,7 @@ function ThroughputTableRaw({
             type,
             (aggregateBy + 'ID') as 'sourceID' | 'targetID',
             omitOtherRow ? filterSet : undefined,
+            unitFilter,
           );
 
     const other = rows.find(isOther);
@@ -386,7 +412,7 @@ function ThroughputTableRaw({
     }
 
     return result as ThroughputSpellRow[] | ThroughputActorRow[];
-  }, [events, aggregateBy, info, abilityFilter, omitOtherRow, actors, maxRows, type]);
+  }, [events, aggregateBy, info, abilityFilter, omitOtherRow, actors, maxRows, type, unitFilter]);
 
   const ctx = useMemo(() => {
     const max = data.reduce((max, row) => Math.max(max, row.amount), 0);
@@ -440,3 +466,15 @@ export const DamageTable = (props: Omit<ThroughputTableProps, 'type'>) => (
 export const HealingTable = (props: Omit<ThroughputTableProps, 'type'>) => (
   <ThroughputTable {...props} type={EventType.Heal} />
 );
+
+export function excludeReportPets(report: WCLReport): Set<number> {
+  const pets = new Set<number>();
+  for (const pet of report.friendlyPets) {
+    pets.add(pet.id);
+  }
+  for (const pet of report.enemyPets) {
+    pets.add(pet.id);
+  }
+
+  return pets;
+}

--- a/src/interface/guide/components/CooldownExpandable.tsx
+++ b/src/interface/guide/components/CooldownExpandable.tsx
@@ -14,15 +14,26 @@ export interface CooldownExpandableItem {
   details?: ReactNode;
 }
 
-interface Props {
+type RangeProps =
+  | { range?: undefined; timeline?: undefined; table?: undefined }
+  | {
+      range: { start: number; end: number };
+      /**
+       * Enable the embedded timeline. See `EmbeddedTimeline`. Accepts the props of the `EmbeddedTimeline` component. Use `timeline={true}` if you just want default props.
+       */
+      timeline?: Omit<EmbeddedTimelineProps, 'range'> | true;
+      /**
+       * Enable the embedded throughput table. See `ThroughputTable`. Accepts the props of the `ThroughputTable` component.
+       */
+      table?: Omit<ThroughputTableProps, 'range'>;
+    };
+
+type Props = {
   header: ReactNode;
   checklistItems?: CooldownExpandableItem[];
   detailItems?: CooldownExpandableItem[];
   perf?: QualitativePerformance;
-  range?: { start: number; end: number };
-  timeline?: Omit<EmbeddedTimelineProps, 'range'>;
-  table?: Omit<ThroughputTableProps, 'range'>;
-}
+} & RangeProps;
 
 /**
  * The data list used to display Checklist and Details sections in `CooldownExpandable`
@@ -65,19 +76,6 @@ const CooldownExpandable = ({
 }: Props) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // i don't like the `throw`, but the typing for this is very clunky in practice.
-  if (timeline && !range) {
-    throw new Error(
-      '[CooldownExpandable] you must supply the range parameter to use the embedded timeline',
-    );
-  }
-
-  if (table && !range) {
-    throw new Error(
-      '[CooldownExpandable] you must supply the range parameter to use the embedded table',
-    );
-  }
-
   const combinedHeader =
     perf !== undefined ? (
       <div>
@@ -97,7 +95,9 @@ const CooldownExpandable = ({
     >
       {/* inert is used to prevent tabbing from getting trapped on the timeline */}
       <div inert={!isExpanded}>
-        {range && timeline && <EmbeddedTimeline range={range} {...timeline} />}
+        {range && timeline && (
+          <EmbeddedTimeline range={range} {...(typeof timeline === 'boolean' ? {} : timeline)} />
+        )}
         {checklistItems && checklistItems.length !== 0 && (
           <CooldownExpandableDataList items={checklistItems} title="Checklist" />
         )}

--- a/src/interface/guide/components/CooldownExpandable.tsx
+++ b/src/interface/guide/components/CooldownExpandable.tsx
@@ -5,6 +5,7 @@ import { ControlledExpandable } from 'interface';
 import EmbeddedTimeline, {
   EmbeddedTimelineProps,
 } from 'interface/report/Results/Timeline/EmbeddedTimeline';
+import { ThroughputTable } from 'interface/Table/DamageTable';
 
 export interface CooldownExpandableItem {
   label: ReactNode;
@@ -78,6 +79,7 @@ const CooldownExpandable = ({ header, checklistItems, detailItems, perf, timelin
         {detailItems && detailItems.length !== 0 && (
           <CooldownExpandableDataList items={detailItems} title="Details" />
         )}
+        {timeline && <ThroughputTable range={timeline.range} />}
       </div>
     </ControlledExpandable>
   );

--- a/src/interface/guide/components/CooldownExpandable.tsx
+++ b/src/interface/guide/components/CooldownExpandable.tsx
@@ -6,6 +6,7 @@ import EmbeddedTimeline, {
   EmbeddedTimelineProps,
 } from 'interface/report/Results/Timeline/EmbeddedTimeline';
 import { ThroughputTable } from 'interface/Table/DamageTable';
+import { EventType } from 'parser/core/Events';
 
 export interface CooldownExpandableItem {
   label: ReactNode;
@@ -79,7 +80,8 @@ const CooldownExpandable = ({ header, checklistItems, detailItems, perf, timelin
         {detailItems && detailItems.length !== 0 && (
           <CooldownExpandableDataList items={detailItems} title="Details" />
         )}
-        {timeline && <ThroughputTable range={timeline.range} />}
+        {timeline && <ThroughputTable range={timeline.range} type={EventType.Damage} />}
+        {timeline && <ThroughputTable range={timeline.range} type={EventType.Heal} />}
       </div>
     </ControlledExpandable>
   );


### PR DESCRIPTION
### Description

This PR adds a `ThroughputTable` component to `interface`. This component allows creation of (optionally-whitelisted) Damage/Healing tables, without having to manually build up the tables yourself.

It also exposes the internals as a `Table` component, which allows others to build similarly-styled tables that show custom values. (I will be using this when I revisit my Stagger PR to show a table of Staggered damage, so if it isn't good enough for that yet, it will be soon. I didn't want to bloat this PR with that since it isn't critical-path work)

The table component can be seen on https://next.wowanalyzer.com right now on Brewmaster as part of the `CooldownGrid`:

<img width="2502" height="1474" alt="image" src="https://github.com/user-attachments/assets/741aac1d-4f81-4648-b732-a23cc502f932" />

https://next.wowanalyzer.com/report/KvHmTR2QCBY1c6yG/1-Mythic++Algeth'ar+Academy+-+Kill+(25:43)/4-Ace/standard/overview

<img width="1245" height="665" alt="image" src="https://github.com/user-attachments/assets/0459d595-dfcd-4f21-b2cf-d81feb1f5007" />

https://next.wowanalyzer.com/report/bg42WrMFkR1Dvn9B/11-Mythic+Dimensius,+the+All-Devouring+-+Kill+(4:47)/20-Setthh/standard

The objective of the `ThroughputTable` itself is to enable maintainers to easily add damage/healing tables that cover interesting spans of time (like cooldowns) or interesting effects (like talents).

Of particular note: I left out the DPS/HPS column. My thinking there is that in one of the intended use-cases (short spans of time), the DPS/HPS values will not be particularly useful since they'll be highly inflated by the denominator (time) being small. However, it should be easy to add this in a follow-up if people disagree with me on that.

Another noteworthy change is that I replaced the CSS for spell schools and unit types in `Game.scss` with the values from WCL's CSS. The existing values (and the values in `MAGIC_SCHOOLS`) are taken from the game itself, and are very highly saturated, making them too intense for comfortable display on a table like this. I did not update `MAGIC_SCHOOLS` (yet?) but can.

### TODOs

- [x] Absorb healing (you'd think I'd have remembered this as a monk player)
- [ ] Exclude healing done to pets (maybe? not sure what healers think here)
- [x] ~~Handle support event reattribution~~
   - This turned out to be a much bigger task because we don't load the necessary events right now. It requires either a second query, or a WCL backend change. As a result, I punted it. We don't handle support events elsewhere anyway.