### PR TITLE
Add Cooldown Grid component

### DIFF
--- a/src/interface/CooldownGrid/CooldownGrid.tsx
+++ b/src/interface/CooldownGrid/CooldownGrid.tsx
@@ -13,6 +13,7 @@ import { JSX, useState } from 'react';
 import * as design from 'interface/design-system';
 import { formatDurationMillisMinSec } from 'common/format';
 import Button from 'interface/controls/Button';
+import React from 'react';
 
 interface CooldownGridProps {
   label: React.ReactNode;
@@ -86,6 +87,8 @@ const ShowMoreButton = styled(Button)`
   align-self: center;
 `;
 
+const CooldownGridElement = React.memo(CooldownGridElementRaw);
+
 /**
  * Show a list of cooldown (or buff/debuff) windows in a grid. A "window" is a (usually short) range of time where a cooldown/buff/debuff is active.
  *
@@ -157,7 +160,7 @@ const CooldownGridTimelineContainer = styled.div`
   background: ${design.level1.background};
 `;
 
-function CooldownGridElement({
+function CooldownGridElementRaw({
   range,
   perf,
   checklistItems,

--- a/src/interface/CooldownGrid/CooldownGrid.tsx
+++ b/src/interface/CooldownGrid/CooldownGrid.tsx
@@ -9,7 +9,7 @@ import EmbeddedTimeline, {
 } from 'interface/report/Results/Timeline/EmbeddedTimeline';
 import ThroughputTable, { ThroughputTableProps } from 'interface/Table/ThroughputTable';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import { JSX, useState } from 'react';
+import { JSX, useRef, useState } from 'react';
 import * as design from 'interface/design-system';
 import { formatDurationMillisMinSec } from 'common/format';
 import Button from 'interface/controls/Button';
@@ -112,13 +112,17 @@ export default function CooldownGrid({
   return (
     <CooldownGridOuterContainer>
       <CooldownGridContainer maximumColumns={maximumColumns}>
-        {items.slice(0, showMore ? Infinity : showMoreCutoff).map((item) => (
+        {items.slice(0, showMore ? Infinity : showMoreCutoff).map((item, ix) => (
           <CooldownGridElement
             key={`${item.range.start}-${item.range.end}`}
             {...item}
             timeline={item.timeline ?? timeline}
             table={item.table ?? table}
             label={label}
+            // render the first row after the "Show More" button by default, as well as those in the initial render.
+            // rows 2+ after the "Show More" button are unlikely to be in the viewport immediately. if they are, it is okay (no breakage, just some pop-in).
+            // if people notice the render jank, we can shadowbox it to reduce the amount of jank
+            defaultRenderContents={ix < showMoreCutoff + maximumColumns}
           />
         ))}
       </CooldownGridContainer>
@@ -141,7 +145,10 @@ const CooldownGridElementContainer = styled.div`
   gap: ${design.gaps.small};
 `;
 
-type CooldownGridItemProps = CooldownGridItem & Pick<CooldownGridProps, 'label'>;
+type CooldownGridItemProps = CooldownGridItem &
+  Pick<CooldownGridProps, 'label'> & {
+    defaultRenderContents?: boolean;
+  };
 
 const CooldownGridElementHeader = styled.header`
   font-weight: bold;
@@ -167,14 +174,40 @@ function CooldownGridElementRaw({
   timeline,
   table,
   label,
+  defaultRenderContents = false,
 }: CooldownGridItemProps) {
   const info = useInfo();
+  // use an intersection observer to prevent interaction jank when rendering lots of cooldowns (mostly an M+ problem)
+  const [renderContents, setRenderContents] = useState(defaultRenderContents);
+  const observer = useRef(
+    new IntersectionObserver(
+      // linter doesn't understand that this *is* an event listener
+      // eslint-disable-next-line react-hooks/refs
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setRenderContents(true); // note: we never un-render
+            observer.current.disconnect();
+            break;
+          }
+        }
+      },
+      {
+        // large value because we want this to get rendered before it comes into view.
+        // a fully-featured window is ~550px tall
+        rootMargin: '250px',
+      },
+    ),
+  );
+
   if (!info) {
     return null;
   }
 
   return (
-    <CooldownGridElementContainer>
+    <CooldownGridElementContainer
+      ref={(el) => (el ? observer.current.observe(el) : observer.current.disconnect())}
+    >
       <CooldownGridElementHeader>
         <div>
           {label} {perf && <PerformanceMark perf={perf} />}
@@ -191,7 +224,7 @@ function CooldownGridElementRaw({
           ))}
         </tbody>
       </table>
-      {timeline && (
+      {renderContents && timeline && (
         <CooldownGridTimelineContainer>
           <EmbeddedTimeline
             cooldownOrder="fixed"
@@ -202,7 +235,7 @@ function CooldownGridElementRaw({
           />
         </CooldownGridTimelineContainer>
       )}
-      {table && <ThroughputTable {...table} range={range} />}
+      {renderContents && table && <ThroughputTable {...table} range={range} />}
     </CooldownGridElementContainer>
   );
 }

--- a/src/interface/CooldownGrid/CooldownGrid.tsx
+++ b/src/interface/CooldownGrid/CooldownGrid.tsx
@@ -1,0 +1,205 @@
+import styled from '@emotion/styled';
+import { PerformanceMark, TimeRange, useInfo } from 'interface/guide';
+import {
+  CooldownExpandableDataItem,
+  CooldownExpandableItem,
+} from 'interface/guide/components/CooldownExpandable';
+import EmbeddedTimeline, {
+  EmbeddedTimelineProps,
+} from 'interface/report/Results/Timeline/EmbeddedTimeline';
+import ThroughputTable, { ThroughputTableProps } from 'interface/Table/ThroughputTable';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { JSX, useState } from 'react';
+import * as design from 'interface/design-system';
+import { formatDurationMillisMinSec } from 'common/format';
+import Button from 'interface/controls/Button';
+
+interface CooldownGridProps {
+  label: React.ReactNode;
+  timeline?: Omit<EmbeddedTimelineProps, 'range'>;
+  table?: Omit<ThroughputTableProps, 'range'>;
+  items: CooldownGridItem[];
+  /**
+   * The number of cooldowns to show in the grid before hiding them behind the "Show More" button.
+   */
+  showMoreCutoff?: number;
+  /**
+   * The desired number of columns. Up to 3 columns are supported. Setting this limits the maximum number of columns used,
+   * it does not guarantee that the component will render that many columns.
+   */
+  maximumColumns?: 1 | 2 | 3;
+}
+
+export interface CooldownGridItem {
+  range: TimeRange;
+  perf?: QualitativePerformance;
+  checklistItems?: CooldownExpandableItem[];
+  /**
+   * Timeline configuration. If unset, defaults to the `CooldownGridProps` timeline configuration (if set).
+   */
+  timeline?: Omit<EmbeddedTimelineProps, 'range'>;
+  /**
+   * Table configuration. If unset, defaults to the `CooldownGridProps` table configuration (if set).
+   */
+  table?: Omit<ThroughputTableProps, 'range'>;
+}
+
+const CooldownGridOuterContainer = styled.div`
+  width: 100%;
+  container: cooldown-grid / inline-size;
+
+  display: flex;
+  flex-direction: column;
+  gap: ${design.gaps.large};
+`;
+
+const CooldownGridContainer = styled.div<{ maximumColumns: 1 | 2 | 3 }>`
+  gap: ${design.gaps.large};
+
+  display: grid;
+  grid-auto-flow: row;
+
+  grid-template-columns: 1fr;
+
+  max-width: 100%;
+
+  ${(props) =>
+    props.maximumColumns >= 2
+      ? `
+      @container cooldown-grid (width >= 700px) {
+        grid-template-columns: 1fr 1fr;
+      }
+    `
+      : ''}
+  ${(props) =>
+    props.maximumColumns >= 3
+      ? `
+      @container cooldown-grid (width >= 1050px) {
+        grid-template-columns: 1fr 1fr 1fr;
+      }
+    `
+      : ''}
+`;
+
+const ShowMoreButton = styled(Button)`
+  padding: ${design.gaps.small} ${design.gaps.large};
+  align-self: center;
+`;
+
+/**
+ * Show a list of cooldown (or buff/debuff) windows in a grid. A "window" is a (usually short) range of time where a cooldown/buff/debuff is active.
+ *
+ * By default, the grid will show the first 6 windows and hide the rest behind a "Show More" button. If you have more than ~1 per minute, you should probably use `CooldownExpandable` instead
+ * to keep this list from taking over the entire page.
+ *
+ * The top-level `timeline` and `table` props provide defaults for all cooldown windows (`items`). Individual windows can override these, or you can provide custom timeline/table configs
+ * for each window. There is no ability to provide fully custom cooldown displays *yet*, but if you want to do that, you can export the container elements and DIY it.
+ */
+export default function CooldownGrid({
+  label,
+  timeline,
+  table,
+  items,
+  showMoreCutoff = 6,
+  maximumColumns = 3,
+}: CooldownGridProps): JSX.Element | null {
+  const [showMore, setShowMore] = useState(false);
+
+  const hasMore = items.length > showMoreCutoff;
+  return (
+    <CooldownGridOuterContainer>
+      <CooldownGridContainer maximumColumns={maximumColumns}>
+        {items.slice(0, showMore ? Infinity : showMoreCutoff).map((item) => (
+          <CooldownGridElement
+            key={`${item.range.start}-${item.range.end}`}
+            {...item}
+            timeline={item.timeline ?? timeline}
+            table={item.table ?? table}
+            label={label}
+          />
+        ))}
+      </CooldownGridContainer>
+      {hasMore && (
+        <ShowMoreButton onClick={() => setShowMore((v) => !v)}>
+          {showMore ? 'Show Less' : 'Show More'}
+        </ShowMoreButton>
+      )}
+    </CooldownGridOuterContainer>
+  );
+}
+
+const CooldownGridElementContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  border: 1px solid ${design.level2.border};
+  background: ${design.level2.background};
+  box-shadow ${design.level2.shadow};
+  padding: ${design.gaps.small};
+  gap: ${design.gaps.small};
+`;
+
+type CooldownGridItemProps = CooldownGridItem & Pick<CooldownGridProps, 'label'>;
+
+const CooldownGridElementHeader = styled.header`
+  font-weight: bold;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 0 ${design.gaps.small};
+
+  & small {
+    font-weight: normal;
+  }
+`;
+
+const CooldownGridTimelineContainer = styled.div`
+  box-shadow: inset ${design.level1.shadow};
+  background: ${design.level1.background};
+`;
+
+function CooldownGridElement({
+  range,
+  perf,
+  checklistItems,
+  timeline,
+  table,
+  label,
+}: CooldownGridItemProps) {
+  const info = useInfo();
+  if (!info) {
+    return null;
+  }
+
+  return (
+    <CooldownGridElementContainer>
+      <CooldownGridElementHeader>
+        <div>
+          {label} {perf && <PerformanceMark perf={perf} />}
+        </div>
+        <small>
+          {formatDurationMillisMinSec(range.start - info.originalFightStart, 0)} &mdash;{' '}
+          {formatDurationMillisMinSec(range.end - info.originalFightStart, 0)}
+        </small>
+      </CooldownGridElementHeader>
+      <table>
+        <tbody>
+          {checklistItems?.map((item, ix) => (
+            <CooldownExpandableDataItem {...item} key={ix} minWidth={0} />
+          ))}
+        </tbody>
+      </table>
+      {timeline && (
+        <CooldownGridTimelineContainer>
+          <EmbeddedTimeline
+            cooldownOrder="fixed"
+            cooldownLegend={false}
+            overlapOffGcds
+            {...timeline}
+            range={range}
+          />
+        </CooldownGridTimelineContainer>
+      )}
+      {table && <ThroughputTable {...table} range={range} />}
+    </CooldownGridElementContainer>
+  );
+}

--- a/src/interface/CooldownGrid/CooldownGrid.tsx
+++ b/src/interface/CooldownGrid/CooldownGrid.tsx
@@ -187,7 +187,7 @@ function CooldownGridElementRaw({
       <table>
         <tbody>
           {checklistItems?.map((item, ix) => (
-            <CooldownExpandableDataItem {...item} key={ix} minWidth={0} />
+            <CooldownExpandableDataItem key={ix} {...item} minWidth={0} />
           ))}
         </tbody>
       </table>

--- a/src/interface/controls/Button.tsx
+++ b/src/interface/controls/Button.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import * as design from 'interface/design-system';
+
+const Button = styled.button`
+  appearance: none;
+  border: none;
+  box-shadow: ${design.level2.shadow};
+  background: ${design.level2.background};
+  border: 1px solid ${design.level2.border};
+  border-radius: 0.5rem;
+  padding: 0 1rem;
+
+  &:hover {
+    filter: brightness(115%);
+  }
+`;
+
+export default Button;

--- a/src/interface/guide/components/CooldownExpandable.tsx
+++ b/src/interface/guide/components/CooldownExpandable.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { JSX, ReactNode, useState } from 'react';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { PerformanceMark, SectionHeader } from 'interface/guide';
 import { ControlledExpandable } from 'interface';
@@ -24,6 +24,19 @@ interface Props {
   table?: Omit<ThroughputTableProps, 'range'>;
 }
 
+export const CooldownExpandableDataItem = ({
+  minWidth,
+  ...item
+}: CooldownExpandableItem & { minWidth?: number | string }): JSX.Element => (
+  <tr>
+    <td style={{ paddingRight: '1em', paddingLeft: '1em', minWidth: minWidth ?? '25em' }}>
+      {item.label}
+    </td>
+    <td style={{ paddingRight: '1em', textAlign: 'right' }}>{item.result ? item.result : ''}</td>
+    {item.details && <td style={{ paddingRight: '1em' }}>{item.details}</td>}
+  </tr>
+);
+
 /**
  * The data list used to display Checklist and Details sections in `CooldownExpandable`
  */
@@ -39,15 +52,7 @@ export const CooldownExpandableDataList = ({
     <table>
       <tbody>
         {items.map((item, ix) => (
-          <tr key={ix}>
-            <td style={{ paddingRight: '1em', paddingLeft: '1em', minWidth: '25em' }}>
-              {item.label}
-            </td>
-            <td style={{ paddingRight: '1em', textAlign: 'right' }}>
-              {item.result ? item.result : ''}
-            </td>
-            {item.details && <td style={{ paddingRight: '1em' }}>{item.details}</td>}
-          </tr>
+          <CooldownExpandableDataItem key={ix} {...item} />
         ))}
       </tbody>
     </table>
@@ -95,7 +100,7 @@ const CooldownExpandable = ({
       // this allows animation transitions to function correctly with auto-height calculations when the timeline is enabled.
       disableDisplayNone={Boolean(timeline)}
     >
-      {/* inert is used to prevent tabbing from getting trapped on the timeline */}
+      {/* inert is used to prevent tabbing from getting trapped on the timeline while hidden */}
       <div inert={!isExpanded}>
         {range && timeline && <EmbeddedTimeline range={range} {...timeline} />}
         {checklistItems && checklistItems.length !== 0 && (

--- a/src/interface/guide/index.tsx
+++ b/src/interface/guide/index.tsx
@@ -236,7 +236,7 @@ export function useInfo(): GuideContextValue['info'] {
   return use(GuideContext).info;
 }
 
-interface TimeRange {
+export interface TimeRange {
   start: number;
   end: number;
 }

--- a/src/interface/guide/index.tsx
+++ b/src/interface/guide/index.tsx
@@ -354,7 +354,10 @@ export const GuideContainer = ({ children }: { children: ReactNode }) => (
 );
 
 const SubSectionContainer = styled.section`
-  margin-top: ${design.gaps.medium};
+  /* including .guide-container here is a specificity hack */
+  .guide-container & {
+    margin-top: ${design.gaps.large};
+  }
 
   & > header {
     font-size: ${design.fontSize.subHeading};

--- a/src/interface/report/Results/Header/FilterButton.tsx
+++ b/src/interface/report/Results/Header/FilterButton.tsx
@@ -12,15 +12,9 @@ import { Filter } from 'interface/report/hooks/useTimeEventFilter';
 import { useFight } from 'interface/report/context/FightContext';
 import Select from 'interface/controls/Select';
 import useClickOutsideHandler from 'interface/hooks/useClickOutsideHandler';
+import Button from 'interface/controls/Button';
 
-const Btn = styled.button`
-  appearance: none;
-  border: none;
-  box-shadow: ${design.level2.shadow};
-  background: ${design.level2.background};
-  border: 1px solid ${design.level2.border};
-  border-radius: 0.5rem;
-  padding: 0 1rem;
+const Btn = styled(Button)`
   grid-area: filter;
 
   align-self: start;
@@ -29,10 +23,6 @@ const Btn = styled.button`
   & .glyphicon {
     padding-right: 0.25rem;
     font-size: 75%;
-  }
-
-  &:hover {
-    filter: brightness(115%);
   }
 `;
 

--- a/src/interface/report/Results/Timeline/Casts.tsx
+++ b/src/interface/report/Results/Timeline/Casts.tsx
@@ -90,6 +90,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   secondWidth?: number;
   events: AnyEvent[];
   movement?: MovementInstance[];
+  overlapOffGcds?: boolean;
 }
 
 const Casts = ({
@@ -98,6 +99,7 @@ const Casts = ({
   secondWidth: explicitSecondWidth,
   events,
   movement,
+  overlapOffGcds,
   ...others
 }: Props) => {
   const timelineSettings = use(TimelineSettingsContext);
@@ -179,7 +181,7 @@ const Casts = ({
     if (lower) {
       className += ' lower';
       // Avoid overlapping icons
-      if (_lastLowered && left - _lastLowered < ICON_WIDTH) {
+      if (_lastLowered && left - _lastLowered < ICON_WIDTH && !overlapOffGcds) {
         _level += 1;
         level = _level;
         _maxLevel = Math.max(_maxLevel, level + 1);

--- a/src/interface/report/Results/Timeline/Cooldowns.tsx
+++ b/src/interface/report/Results/Timeline/Cooldowns.tsx
@@ -26,27 +26,40 @@ interface Props {
    * but is used in embedded timelines.
    */
   castsOmitted?: boolean;
+  /**
+   * Sort in a consistent order, regardless of data. This is used by embedded timelines in the cooldown to make sure
+   * that every cooldown window shows the spells in the same order.
+   */
+  fixedCooldownOrder?: boolean;
+  disableLegend?: boolean;
 }
 
 class Cooldowns extends PureComponent<Props> {
   declare context: React.ContextType<typeof TimelineSettingsContext>;
 
-  getSortIndex([spellId, events]: [number, AnyEvent[]]) {
+  getSortIndex([spellId, events]: [number, AnyEvent[]]): number {
     const ability = this.props.abilities.getAbility(spellId);
-    if (!ability?.timelineSortIndex) {
-      return 1000 - events.length;
-    } else {
+    if (ability?.timelineSortIndex !== null && ability?.timelineSortIndex !== undefined) {
       return ability.timelineSortIndex;
     }
+
+    if (this.props.fixedCooldownOrder) {
+      return ability?.cooldown ?? 0;
+    }
+
+    return 1000 - events.length;
+  }
+
+  private sortEntries(entries: [number, AnyEvent[]][], growUp: boolean): void {
+    entries.sort((a, b) => this.getSortIndex(growUp ? b : a) - this.getSortIndex(growUp ? a : b));
   }
 
   renderLanes(eventsBySpellId: Map<number, AnyEvent[]>, growUp: boolean) {
     const entries: [number, AnyEvent[]][] =
       this.props.exactlySpells?.map((spell) => [spell.id, eventsBySpellId.get(spell.id) ?? []]) ??
       Array.from(eventsBySpellId);
-    return entries
-      .sort((a, b) => this.getSortIndex(growUp ? b : a) - this.getSortIndex(growUp ? a : b))
-      .map((item) => this.renderLane(item));
+    this.sortEntries(entries, growUp);
+    return entries.map((item) => this.renderLane(item));
   }
   renderLane([spellId, events]: [number, AnyEvent[]]) {
     return (
@@ -63,31 +76,34 @@ class Cooldowns extends PureComponent<Props> {
       </Lane>
     );
   }
-  renderLegend(eventsBySpellId: Map<number, AnyEvent[]>) {
+  renderLegend(eventsBySpellId: Map<number, AnyEvent[]>, growUp: boolean) {
     const entries: [number, AnyEvent[]][] =
       this.props.exactlySpells?.map((spell) => [spell.id, eventsBySpellId.get(spell.id) ?? []]) ??
       Array.from(eventsBySpellId);
-    return entries
-      .sort((a, b) => this.getSortIndex(a) - this.getSortIndex(b))
-      .map(([spellId, events]) => {
-        if (events.length === 0) {
-          return null;
-        }
 
-        const ability = maybeGetSpell(spellId);
+    this.sortEntries(entries, growUp);
 
-        return (
-          <div className="legend" key={spellId}>
-            {ability && <Icon icon={ability.icon} alt={ability.name} />}
-          </div>
-        );
-      });
+    return entries.map(([spellId, events]) => {
+      if (events.length === 0) {
+        return null;
+      }
+
+      const ability = maybeGetSpell(spellId);
+
+      return (
+        <div className="legend" key={spellId}>
+          {ability && <Icon icon={ability.icon} alt={ability.name} />}
+        </div>
+      );
+    });
   }
   render() {
     const { eventsBySpellId } = this.props;
     return (
       <div className="cooldowns">
-        <div className={'legend-container'}>{this.renderLegend(eventsBySpellId)}</div>
+        {!this.props.disableLegend && (
+          <div className={'legend-container'}>{this.renderLegend(eventsBySpellId, false)}</div>
+        )}
         {this.renderLanes(eventsBySpellId, false)}
       </div>
     );

--- a/src/interface/report/Results/Timeline/EmbeddedTimeline.tsx
+++ b/src/interface/report/Results/Timeline/EmbeddedTimeline.tsx
@@ -171,6 +171,22 @@ export interface EmbeddedTimelineProps {
    * If set to `true`, show all cooldowns (not recommended for inline use)
    */
   cooldowns?: (number | Spell)[] | true;
+  /**
+   * The method to use to order cooldowns. `dynamic` (default) matches the normal timeline, listing
+   * cooldowns in order of frequency. `fixed` orders them in a consistent order that
+   * depends only on the list of cooldowns (and their properties). It may differ between
+   * fights, but not within a fight.
+   */
+  cooldownOrder?: 'fixed' | 'dynamic';
+  /**
+   * Force off-gcd abilities to overlap rather than stack. Use if you want to guarantee
+   * consistent timeline height.
+   */
+  overlapOffGcds?: boolean;
+  /**
+   * Whether to display the cooldown legend. Defaults to true. In smaller embeds, it can be beneficial to disable it.
+   */
+  cooldownLegend?: boolean;
 }
 
 function toSpellId(value: number | Spell): number {
@@ -181,7 +197,14 @@ function toSpellId(value: number | Spell): number {
   return value.id;
 }
 
-function EmbeddedTimeline({ range, auras, cooldowns }: EmbeddedTimelineProps) {
+function EmbeddedTimelineRaw({
+  range,
+  auras,
+  cooldowns,
+  cooldownOrder,
+  overlapOffGcds,
+  cooldownLegend = true,
+}: EmbeddedTimelineProps) {
   const events = useEvents(range);
   const auraAnalyzer = useAnalyzer(Auras);
   const info = useInfo();
@@ -235,7 +258,7 @@ function EmbeddedTimeline({ range, auras, cooldowns }: EmbeddedTimelineProps) {
           />
         )}
         <TimeIndicators seconds={secondsShown} offset={offset} skipInterval={2}>
-          <Casts start={range.start} events={filteredEvents} />
+          <Casts start={range.start} events={filteredEvents} overlapOffGcds={overlapOffGcds} />
         </TimeIndicators>
         <Cooldowns
           start={range.start}
@@ -243,12 +266,14 @@ function EmbeddedTimeline({ range, auras, cooldowns }: EmbeddedTimelineProps) {
           eventsBySpellId={cooldownEventsBySpellId}
           abilities={abilities}
           castsOmitted
+          fixedCooldownOrder={cooldownOrder === 'fixed'}
+          disableLegend={!cooldownLegend}
         />
       </SpellTimeline>
     </AutoSizerTimelineContainer>
   );
 }
 
-const MemoEmbeddedTimeline = React.memo(EmbeddedTimeline);
+const EmbeddedTimeline = React.memo(EmbeddedTimelineRaw);
 
-export default MemoEmbeddedTimeline;
+export default EmbeddedTimeline;

--- a/src/interface/report/Results/Timeline/EmbeddedTimeline.tsx
+++ b/src/interface/report/Results/Timeline/EmbeddedTimeline.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import isPropValid from '@emotion/is-prop-valid';
 // force this to load if you render EmbeddedTimelineContainer
 import './Timeline.scss';
 import { useMemo, useRef, useState } from 'react';
@@ -22,7 +23,7 @@ import DragScroll from 'interface/DragScroll';
  *
  * Use `SpellTimeline` component for wrapping the `Casts` component.
  */
-export const EmbeddedTimelineContainer = styled(DragScroll)<{
+export const EmbeddedTimelineContainer = styled(DragScroll, { shouldForwardProp: isPropValid })<{
   secondWidth?: number;
   secondsShown?: number;
   castBarCount?: number;
@@ -46,6 +47,9 @@ export const EmbeddedTimelineContainer = styled(DragScroll)<{
   &.drag-scroll-container {
     cursor: default;
   }
+  /* safari doesn't support these, but they improve display in chrome and safari doesn't need the help anyway */
+  scrollbar-color: #75736d transparent;
+  scrollbar-width: thin;
 
   --cast-bars: ${(props) => props.castBarCount ?? 1};
 

--- a/src/interface/report/Results/Timeline/Lane.tsx
+++ b/src/interface/report/Results/Timeline/Lane.tsx
@@ -74,7 +74,10 @@ class Lane extends PureComponent<Props> {
   }
 
   renderCast(event: CastEvent | FilterCooldownInfoEvent | UpdateSpellUsableEvent) {
-    if (event.timestamp > this.props.fightEndTimestamp) {
+    if (
+      event.timestamp > this.props.fightEndTimestamp ||
+      this.props.fightStartTimestamp > event.timestamp + OVERFLOW_BUFFER
+    ) {
       return null;
     }
     //let pre phase events be displayed one second tick before the phase


### PR DESCRIPTION
### Description

This PR adds a `CooldownGrid` component to `interface`. This component renders cooldown information in a "small multiples" style. It is suitable to larger cooldowns that have a relatively small number of instances.

<img width="1253" height="876" alt="image" src="https://github.com/user-attachments/assets/61fc4cb2-6633-4a40-b709-1c6b6f69b7a3" />

https://next.wowanalyzer.com/report/KvHmTR2QCBY1c6yG/1-Mythic++Algeth'ar+Academy+-+Kill+(25:43)/4-Ace/standard/overview

<img width="1269" height="630" alt="image" src="https://github.com/user-attachments/assets/c298881a-b477-4427-8b07-38e8b6052bd2" />

https://next.wowanalyzer.com/report/bg42WrMFkR1Dvn9B/3-Mythic+Nexus-King+Salhadaar+-+Kill+(2:03)/8-Eisenpelz/standard

This builds on the `ThroughputTable` and `EmbeddedTimeline` PRs, using them to construct the grid.

The grid is designed to occupy a fixed number of columns, scaling with screen size from 1-3 (with the maximum controlled by the maintainer, if they want to cap it at fewer columns).

The params of `CooldownGrid` are *mostly* compatible with those of `CooldownExpandable`: the main differences are that the (new in the `EmbeddedTimeline` PR) `range` parameter is required on each item, and that there is only one set of `CooldownExpandableItem[]` values (which I called the `checklistItems`, but it could easily be `details`). This should make transition relatively easy for maintainers that want to use it.

`CooldownExpandable` remains largely un-changed: if you want to continue using it with or without the table/timeline elements, this PR does not alter your ability to do so. 

The sample usage of this element can be seen on [this branch](https://github.com/WoWAnalyzer/WoWAnalyzer/compare/cooldown-grid...emallson:WoWAnalyzer:invoke-niuzao-example)