### PR TITLE
[Survival] Boomstick Analyzer Fix & WFB text

### DIFF
--- a/src/analysis/retail/hunter/survival/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/survival/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import { Kivlov,
  } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2026,2,16), 'Fix Boomstick Tick and Text for WFB', Kivlov),
   change(date(2026, 2, 5), 'Add Pack Leader Analysis', Kivlov),
   change(date(2026, 2, 2), 'Add Sentinels Mark Analysis', Kivlov),
   change(date(2026, 2, 1), 'Add Moonlight Chakram Analysis', Kivlov),

--- a/src/analysis/retail/hunter/survival/modules/talents/Boomstick.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/Boomstick.tsx
@@ -55,7 +55,7 @@ class Boomstick extends Analyzer.withDependencies({ haste: Haste }) {
   private static readonly BUCKET_WINDOW_MS = 100;
   private static readonly EXPECTED_TICKS = 4;
   private static readonly BASE_TICK_INTERVAL_MS = 800;
-  private static readonly TICK_MATCH_TOLERANCE_MS = 200;
+  private static readonly TICK_MATCH_TOLERANCE_MS = 400; // Haste issue with live, return to 200 and tick interval to 1000 on midnight release
 
   constructor(options: Options) {
     super(options);

--- a/src/analysis/retail/hunter/survival/modules/talents/WildfireBomb.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/WildfireBomb.tsx
@@ -133,8 +133,14 @@ class WildfireBomb extends Analyzer.withDependencies({
         <strong>
           <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} />
         </strong>{' '}
-        should always be cast with <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST.id} />. Bombs that
-        hit a target with <SpellLink spell={SPELLS.SENTINELS_MARK_DEBUFF} /> are perfect casts.
+        should always be cast with <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST.id} />.
+        {this.selectedCombatant.hasTalent(TALENTS.SENTINEL_TALENT) && (
+          <>
+            {' '}
+            Bombs that hit a target with <SpellLink spell={SPELLS.SENTINELS_MARK_DEBUFF} /> are
+            perfect casts.
+          </>
+        )}
       </p>
     );
 


### PR DESCRIPTION
### Description

Haste value for TWW is messing with expected tick. Upped the tolerance for finding the tick to 400 ms.
The tolerance can stay at 400 without any real harm but probably best once Midnight launches to go back to 1000ms tick + 200ms window but I don't expect this will cause any issues if we leave it after.

- Test report URL: `/report/rxJmhQ2pDjZb8ytM/43-Mythic++The+Dawnbreaker+-+Kill+(24:45)/667-Wantlove/standard` This log was clipping 1-2 ticks from every single boomstick cast.
- `/report/R3MatwYcbCGTVDyz/7-Mythic++The+Dawnbreaker+-+Kill+(27:27)/1-뽕야/standard` example of a log where it wasn't and this log also works with the higher tolerance.

