### PR TITLE
[BrM] Invoke Niuzao setup

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,7 +295,7 @@ importers:
         version: 3.2.4(@types/node@22.17.0)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@22.1.0)(sass@1.93.2)(tsx@4.20.6)
       wow-dbc:
         specifier: github:RPGLogs/wow-dbc#main
-        version: https://codeload.github.com/RPGLogs/wow-dbc/tar.gz/a9622cedbac874e16ed83e9b7148c21503c93982
+        version: https://codeload.github.com/RPGLogs/wow-dbc/tar.gz/f96cff8d6354247059cbc7d373cdad20add0da7f
 
   packages/eslint-plugin-wowanalyzer:
     dependencies:
@@ -4367,8 +4367,8 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wow-dbc@https://codeload.github.com/RPGLogs/wow-dbc/tar.gz/a9622cedbac874e16ed83e9b7148c21503c93982:
-    resolution: {tarball: https://codeload.github.com/RPGLogs/wow-dbc/tar.gz/a9622cedbac874e16ed83e9b7148c21503c93982}
+  wow-dbc@https://codeload.github.com/RPGLogs/wow-dbc/tar.gz/f96cff8d6354247059cbc7d373cdad20add0da7f:
+    resolution: {tarball: https://codeload.github.com/RPGLogs/wow-dbc/tar.gz/f96cff8d6354247059cbc7d373cdad20add0da7f}
     version: 0.1.0
 
   wrap-ansi@7.0.0:
@@ -8841,7 +8841,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wow-dbc@https://codeload.github.com/RPGLogs/wow-dbc/tar.gz/a9622cedbac874e16ed83e9b7148c21503c93982:
+  wow-dbc@https://codeload.github.com/RPGLogs/wow-dbc/tar.gz/f96cff8d6354247059cbc7d373cdad20add0da7f:
     dependencies:
       udsv: 0.6.0
 

--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from './spell-list_Monk_Brewmaster.retail';
 
 // prettier-ignore
 export default [
+  change(date(2025, 2, 21), <>Add <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT} /> section</>, emallson),
   change(date(2026, 1, 18), <>Add statistic for <SpellLink spell={SPELLS.VITAL_FLAME_TALENT} /></>, emallson),
   change(date(2025, 11, 27), <>Update <SpellLink spell={SPELLS.HIGH_TOLERANCE_TALENT} />, <SpellLink spell={SPELLS.STAGGERING_STRIKES_TALENT} /> and <SpellLink spell={SPELLS.WALK_WITH_THE_OX_TALENT} /> for Midnight</>, emallson),
   change(date(2025, 11, 20), <>Remove Purified Chi in Midnight and do a pass on <SpellLink spell={SPELLS.PURIFYING_BREW_TALENT} /> / <SpellLink spell={SPELLS.CELESTIAL_BREW_TALENT} /> analysis</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
+++ b/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
@@ -48,6 +48,7 @@ import AspectOfHarmony, { AspectOfHarmonyLinkNormalizer } from './modules/talent
 import { Abilities } from './gen';
 import { ExpelOxOrbsNormalizer } from './normalizers/ExpelHarm';
 import VitalFlames, { VitalFlameNormalizer } from './modules/talents/VitalFlames';
+import InvokeNiuzao from './modules/talents/InvokeNiuzao/InvokeNiuzao';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -110,6 +111,7 @@ class CombatLogParser extends CoreCombatLogParser {
     veteransEye: VeteransEye,
     AspectOfHarmony,
     VitalFlames,
+    InvokeNiuzao,
 
     apl: AplCheck,
 

--- a/src/analysis/retail/monk/brewmaster/Guide.tsx
+++ b/src/analysis/retail/monk/brewmaster/Guide.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 import SPELLS from 'common/SPELLS';
-import { AlertInfo, AlertWarning, SpellLink, TooltipElement } from 'interface';
+import { AlertInfo, SpellLink, TooltipElement } from 'interface';
 import CombatLogParser from './CombatLogParser';
 import { GuideProps, Section, SubSection, useAnalyzer } from 'interface/guide';
 import { PurifySection } from './modules/problems/PurifyingBrew';
@@ -8,16 +8,15 @@ import talents from 'common/TALENTS/monk';
 import spells from './spell-list_Monk_Brewmaster.retail';
 
 import MajorDefensivesSection from './modules/core/MajorDefensives';
-import AplChoiceDescription from './modules/core/AplCheck/AplChoiceDescription';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import Explanation from 'interface/guide/components/Explanation';
 import { Highlight } from 'interface/Highlight';
-import BlackoutComboSection from './modules/spells/BlackoutCombo/BlackoutComboSection';
 import { FoundationDowntimeSection } from 'interface/guide/foundation/FoundationDowntimeSection';
 import SpellUsageSubSection from 'parser/core/SpellUsage/SpellUsageSubSection';
 import AspectOfHarmony from './modules/talents/AspectOfHarmony';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
+import InvokeNiuzaoSection from './modules/talents/InvokeNiuzao/InvokeNiuzaoSection';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -61,11 +60,13 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
             </p>
           </Explanation>
           {info.combatant.hasTalent(talents.INVOKE_NIUZAO_THE_BLACK_OX_TALENT) && (
-            <CastEfficiencyBar
-              spell={talents.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}
-              gapHighlightMode={GapHighlight.FullCooldown}
-              useThresholds
-            />
+            <>
+              <CastEfficiencyBar
+                spell={talents.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}
+                gapHighlightMode={GapHighlight.FullCooldown}
+                useThresholds
+              />
+            </>
           )}
           {info.combatant.hasTalent(talents.EXPLODING_KEG_TALENT) && (
             <CastEfficiencyBar
@@ -75,6 +76,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
             />
           )}
         </SubSection>
+        <InvokeNiuzaoSection />
       </Section>
       <MasterOfHarmonySection />
       <MajorDefensivesSection />

--- a/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
@@ -1,0 +1,280 @@
+import { PerformanceMark } from 'interface/guide';
+import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import SPELLS from '../../../spell-list_Monk_Brewmaster.retail';
+import Events, {
+  AbilityEvent,
+  DamageEvent,
+  DeathEvent,
+  EventType,
+  SummonEvent,
+} from 'parser/core/Events';
+import SPELLS_COMMON from 'common/SPELLS';
+import { CooldownExpandableItem } from 'interface/guide/components/CooldownExpandable';
+import SpellLink from 'interface/SpellLink';
+import {
+  evaluateQualitativePerformanceByThreshold,
+  QualitativePerformance,
+} from 'parser/ui/QualitativePerformance';
+import { TooltipElement } from 'interface/Tooltip';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import { formatDuration, formatDurationMillisMinSec } from 'common/format';
+
+/**
+ * @internal
+ */
+export interface NiuzaoCast {
+  summonEvent: SummonEvent;
+  deathEvent?: DeathEvent;
+  stompCount: number;
+  wotwTriggers: AbilityEvent<EventType>[];
+  /**
+   * The number of BoF/DFB instances that could have triggered WotW but didn't.
+   */
+  wotwClipCount: number;
+  cooldowns: Map<number, number>;
+}
+
+const EXPECTED_STOMP_COUNT = 6;
+const WOTW_ICD_MS = 1000;
+
+export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsable: SpellUsable }) {
+  private hasWotW = this.selectedCombatant.hasTalent(SPELLS.WISDOM_OF_THE_WALL_TALENT);
+
+  private lastWotWTrigger?: AbilityEvent<EventType>;
+
+  readonly niuzaoCasts: NiuzaoCast[] = [];
+
+  private get currentCast() {
+    const cast = this.niuzaoCasts.at(-1);
+    if (cast && !cast.deathEvent) {
+      return cast;
+    }
+
+    return undefined;
+  }
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT);
+
+    this.addEventListener(
+      Events.summon.by(SELECTED_PLAYER).spell(SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT),
+      this.onSummon,
+    );
+    // there is no stomp cast, so we look for BoK casts
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.BLACKOUT_KICK),
+      this.onStomp,
+    );
+    this.addEventListener(Events.death.to(SELECTED_PLAYER_PET), this.onDeath);
+
+    if (this.hasWotW) {
+      this.addEventListener(
+        Events.damage
+          .by(SELECTED_PLAYER)
+          .spell([SPELLS.BREATH_OF_FIRE_TALENT, SPELLS_COMMON.DRAGONFIRE_BREW_DAMAGE]),
+        this.triggerWotW,
+      );
+    }
+  }
+
+  private triggerWotW(event: DamageEvent): void {
+    if (
+      !this.selectedCombatant.hasBuff(SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT) ||
+      !this.currentCast
+    ) {
+      return; // WotW only triggers during Invoke Niuzao
+    }
+
+    if (this.lastWotWTrigger && event.timestamp - this.lastWotWTrigger.timestamp < WOTW_ICD_MS) {
+      if (
+        event.timestamp - this.lastWotWTrigger.timestamp > 100 ||
+        event.ability.guid !== this.lastWotWTrigger.ability.guid
+      ) {
+        // treat this as a distinct potential trigger and count it as a clip
+        this.currentCast.wotwClipCount += 1;
+      }
+
+      return;
+    }
+
+    this.currentCast.wotwTriggers.push(event);
+  }
+
+  private onSummon(event: SummonEvent) {
+    const cooldowns = new Map();
+
+    cooldowns.set(
+      SPELLS.BLACKOUT_KICK.id,
+      this.deps.spellUsable.cooldownRemaining(SPELLS.BLACKOUT_KICK.id),
+    );
+    cooldowns.set(
+      SPELLS.BREATH_OF_FIRE_TALENT.id,
+      this.deps.spellUsable.fractionalChargesAvailable(SPELLS.BREATH_OF_FIRE_TALENT.id),
+    );
+    cooldowns.set(
+      SPELLS.KEG_SMASH_TALENT.id,
+      this.deps.spellUsable.fractionalChargesAvailable(SPELLS.KEG_SMASH_TALENT.id),
+    );
+
+    this.niuzaoCasts.push({
+      summonEvent: event,
+      stompCount: 0,
+      wotwTriggers: [],
+      wotwClipCount: 0,
+      cooldowns,
+    });
+  }
+
+  private onDeath(event: DeathEvent) {
+    if (!this.currentCast) {
+      return;
+    }
+
+    if (event.targetID === this.currentCast.summonEvent.targetID) {
+      this.currentCast.deathEvent = event;
+    }
+  }
+
+  private onStomp() {
+    if (!this.currentCast) {
+      return;
+    }
+
+    this.currentCast.stompCount += 1;
+  }
+
+  checklist(cast: NiuzaoCast) {
+    const items: CooldownExpandableItem[] = [];
+
+    const extraBokCasts = this.selectedCombatant.hasTalent(SPELLS.FLUIDITY_OF_MOTION_TALENT)
+      ? 2
+      : 0;
+
+    const initialBoKCooldown = cast.cooldowns.get(SPELLS.BLACKOUT_KICK.id) ?? 0;
+    items.push({
+      label: (
+        <>
+          <SpellLink spell={SPELLS.BLACKOUT_KICK} /> available immediately
+        </>
+      ),
+      result: (
+        <PerformanceMark
+          perf={
+            initialBoKCooldown < 1000 ? QualitativePerformance.Good : QualitativePerformance.Fail
+          }
+        />
+      ),
+      details:
+        initialBoKCooldown > 1000 ? (
+          <>{formatDurationMillisMinSec(initialBoKCooldown, 1)} remaining on cooldown</>
+        ) : null,
+    });
+
+    items.push({
+      label: (
+        <>
+          <SpellLink spell={SPELLS_COMMON.NIUZAO_STOMP_DAMAGE} /> triggers (from{' '}
+          <SpellLink spell={SPELLS.BLACKOUT_KICK}>BoK</SpellLink> casts)
+        </>
+      ),
+      details: (
+        <>
+          {cast.stompCount} / {EXPECTED_STOMP_COUNT + extraBokCasts}
+        </>
+      ),
+      result: (
+        <PerformanceMark
+          perf={evaluateQualitativePerformanceByThreshold({
+            isGreaterThanOrEqual: {
+              perfect: 7 + extraBokCasts,
+              good: 6 + extraBokCasts,
+              ok: 5 + extraBokCasts,
+              fail: 4 + extraBokCasts,
+            },
+            actual: cast.stompCount,
+          })}
+        />
+      ),
+    });
+
+    if (this.selectedCombatant.hasTalent(SPELLS.WISDOM_OF_THE_WALL_TALENT)) {
+      // multiply by 3 with DFB because of the extra hits. in the future, probably need a separate threshold for ChP but nobody is really playing it right now
+      const thresholdScale = this.selectedCombatant.hasTalent(SPELLS.DRAGONFIRE_BREW_TALENT)
+        ? 3
+        : 1;
+      items.push({
+        label: (
+          <>
+            <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT} /> triggers (from{' '}
+            <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT}>BoF</SpellLink> /{' '}
+            <SpellLink spell={SPELLS.DRAGONFIRE_BREW_TALENT}>DFB</SpellLink>)
+          </>
+        ),
+        details: (
+          <>
+            <TooltipElement
+              content={
+                <>
+                  Trigger Sources:
+                  <ul>
+                    <li>
+                      <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> &mdash;{' '}
+                      {
+                        cast.wotwTriggers.filter(
+                          (event) => event.ability.guid === SPELLS.BREATH_OF_FIRE_TALENT.id,
+                        ).length
+                      }
+                    </li>
+                    {this.selectedCombatant.hasTalent(SPELLS.DRAGONFIRE_BREW_TALENT) && (
+                      <li>
+                        <SpellLink spell={SPELLS.DRAGONFIRE_BREW_TALENT} /> &mdash;{' '}
+                        {
+                          cast.wotwTriggers.filter(
+                            (event) =>
+                              event.ability.guid === SPELLS_COMMON.DRAGONFIRE_BREW_DAMAGE.id,
+                          ).length
+                        }
+                      </li>
+                    )}
+                  </ul>
+                </>
+              }
+            >
+              {cast.wotwTriggers.length}
+            </TooltipElement>{' '}
+            ({cast.wotwClipCount}{' '}
+            <TooltipElement
+              content={
+                <>
+                  <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT} /> has a{' '}
+                  <strong>1 second</strong> cooldown, which can prevent repeated casts from
+                  triggering <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT}>WotW</SpellLink>{' '}
+                  when using <SpellLink spell={SPELLS.DRAGONFIRE_BREW_TALENT} />.
+                </>
+              }
+            >
+              clipped
+            </TooltipElement>
+            )
+          </>
+        ),
+        result: (
+          <PerformanceMark
+            perf={evaluateQualitativePerformanceByThreshold({
+              actual: cast.wotwTriggers.length,
+              isGreaterThanOrEqual: {
+                perfect: 6 * thresholdScale,
+                good: 5 * thresholdScale,
+                ok: 4 * thresholdScale,
+              },
+            })}
+          />
+        ),
+      });
+    }
+
+    return items;
+  }
+}

--- a/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
@@ -97,6 +97,8 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
       }
 
       return;
+    } else {
+      this.lastWotWTrigger = event;
     }
 
     this.currentCast.wotwTriggers.push(event);

--- a/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
@@ -32,7 +32,7 @@ export interface NiuzaoCast {
 
 const EXPECTED_STOMP_COUNT = Math.floor(25 / 4);
 const EXPECTED_STOMP_COUNT_FOM = Math.floor(25 / 3);
-const EXPECTED_BOF_COUNT = 6; // made up in pre-patch. TODO this probably changes with apex talent resets
+const EXPECTED_BOF_COUNT = 8; // made up in pre-patch. TODO this probably changes with apex talent resets
 
 export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsable: SpellUsable }) {
   private hasWotW = this.selectedCombatant.hasTalent(SPELLS.WISDOM_OF_THE_WALL_TALENT);
@@ -125,13 +125,17 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
     this.currentCast.stompCount += 1;
   }
 
-  checklist(cast: NiuzaoCast) {
+  checklist(cast: NiuzaoCast): {
+    checklist: CooldownExpandableItem[];
+    perf: QualitativePerformance;
+  } {
     const items: CooldownExpandableItem[] = [];
 
     const expectedStomps = this.selectedCombatant.hasTalent(SPELLS.FLUIDITY_OF_MOTION_TALENT)
       ? EXPECTED_STOMP_COUNT_FOM
       : EXPECTED_STOMP_COUNT;
 
+    let overallPerf = QualitativePerformance.Fail;
     const initialBoKCooldown = cast.cooldowns.get(SPELLS.BLACKOUT_KICK.id) ?? 0;
     items.push({
       label: (
@@ -152,6 +156,16 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
         ) : null,
     });
 
+    const stompPerf = evaluateQualitativePerformanceByThreshold({
+      isGreaterThanOrEqual: {
+        perfect: expectedStomps + 1,
+        good: expectedStomps,
+        ok: expectedStomps - 2,
+        fail: expectedStomps - 3,
+      },
+      actual: cast.stompCount,
+    });
+    overallPerf = stompPerf;
     items.push({
       label: (
         <>
@@ -164,28 +178,24 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
           {cast.stompCount} / {expectedStomps}
         </>
       ),
-      result: (
-        <PerformanceMark
-          perf={evaluateQualitativePerformanceByThreshold({
-            isGreaterThanOrEqual: {
-              perfect: expectedStomps + 1,
-              good: expectedStomps,
-              ok: expectedStomps - 2,
-              fail: expectedStomps - 3,
-            },
-            actual: cast.stompCount,
-          })}
-        />
-      ),
+      result: <PerformanceMark perf={overallPerf} />,
     });
 
     if (this.selectedCombatant.hasTalent(SPELLS.WISDOM_OF_THE_WALL_TALENT)) {
+      const wotwPerf = evaluateQualitativePerformanceByThreshold({
+        actual: cast.wotwTriggers.length,
+        isGreaterThanOrEqual: {
+          perfect: EXPECTED_BOF_COUNT + 1,
+          good: EXPECTED_BOF_COUNT,
+          ok: EXPECTED_BOF_COUNT - 2,
+        },
+      });
+
+      overallPerf = wotwPerf; // WotW is more important than Stomp, overwrite the overall value.
       items.push({
         label: (
           <>
-            <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT} /> triggers (from{' '}
-            <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT}>BoF</SpellLink> /{' '}
-            <SpellLink spell={SPELLS.DRAGONFIRE_BREW_TALENT}>DFB</SpellLink>)
+            <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT}>WotW</SpellLink> triggers
           </>
         ),
         details: (
@@ -222,21 +232,10 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
             </TooltipElement>{' '}
           </>
         ),
-        result: (
-          <PerformanceMark
-            perf={evaluateQualitativePerformanceByThreshold({
-              actual: cast.wotwTriggers.length,
-              isGreaterThanOrEqual: {
-                perfect: EXPECTED_BOF_COUNT + 1,
-                good: EXPECTED_BOF_COUNT,
-                ok: EXPECTED_BOF_COUNT - 1,
-              },
-            })}
-          />
-        ),
+        result: <PerformanceMark perf={wotwPerf} />,
       });
     }
 
-    return items;
+    return { checklist: items, perf: overallPerf };
   }
 }

--- a/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
@@ -3,7 +3,7 @@ import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/
 import SPELLS from '../../../spell-list_Monk_Brewmaster.retail';
 import Events, {
   AbilityEvent,
-  DamageEvent,
+  CastEvent,
   DeathEvent,
   EventType,
   SummonEvent,
@@ -17,7 +17,7 @@ import {
 } from 'parser/ui/QualitativePerformance';
 import { TooltipElement } from 'interface/Tooltip';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
-import { formatDuration, formatDurationMillisMinSec } from 'common/format';
+import { formatDurationMillisMinSec } from 'common/format';
 
 /**
  * @internal
@@ -27,20 +27,15 @@ export interface NiuzaoCast {
   deathEvent?: DeathEvent;
   stompCount: number;
   wotwTriggers: AbilityEvent<EventType>[];
-  /**
-   * The number of BoF/DFB instances that could have triggered WotW but didn't.
-   */
-  wotwClipCount: number;
   cooldowns: Map<number, number>;
 }
 
-const EXPECTED_STOMP_COUNT = 6;
-const WOTW_ICD_MS = 1000;
+const EXPECTED_STOMP_COUNT = Math.floor(25 / 4);
+const EXPECTED_STOMP_COUNT_FOM = Math.floor(25 / 3);
+const EXPECTED_BOF_COUNT = 6; // made up in pre-patch. TODO this probably changes with apex talent resets
 
 export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsable: SpellUsable }) {
   private hasWotW = this.selectedCombatant.hasTalent(SPELLS.WISDOM_OF_THE_WALL_TALENT);
-
-  private lastWotWTrigger?: AbilityEvent<EventType>;
 
   readonly niuzaoCasts: NiuzaoCast[] = [];
 
@@ -71,34 +66,18 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
 
     if (this.hasWotW) {
       this.addEventListener(
-        Events.damage
-          .by(SELECTED_PLAYER)
-          .spell([SPELLS.BREATH_OF_FIRE_TALENT, SPELLS_COMMON.DRAGONFIRE_BREW_DAMAGE]),
+        Events.cast.by(SELECTED_PLAYER).spell([SPELLS.BREATH_OF_FIRE_TALENT]),
         this.triggerWotW,
       );
     }
   }
 
-  private triggerWotW(event: DamageEvent): void {
+  private triggerWotW(event: CastEvent): void {
     if (
       !this.selectedCombatant.hasBuff(SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT) ||
       !this.currentCast
     ) {
       return; // WotW only triggers during Invoke Niuzao
-    }
-
-    if (this.lastWotWTrigger && event.timestamp - this.lastWotWTrigger.timestamp < WOTW_ICD_MS) {
-      if (
-        event.timestamp - this.lastWotWTrigger.timestamp > 100 ||
-        event.ability.guid !== this.lastWotWTrigger.ability.guid
-      ) {
-        // treat this as a distinct potential trigger and count it as a clip
-        this.currentCast.wotwClipCount += 1;
-      }
-
-      return;
-    } else {
-      this.lastWotWTrigger = event;
     }
 
     this.currentCast.wotwTriggers.push(event);
@@ -124,7 +103,6 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
       summonEvent: event,
       stompCount: 0,
       wotwTriggers: [],
-      wotwClipCount: 0,
       cooldowns,
     });
   }
@@ -150,9 +128,9 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
   checklist(cast: NiuzaoCast) {
     const items: CooldownExpandableItem[] = [];
 
-    const extraBokCasts = this.selectedCombatant.hasTalent(SPELLS.FLUIDITY_OF_MOTION_TALENT)
-      ? 2
-      : 0;
+    const expectedStomps = this.selectedCombatant.hasTalent(SPELLS.FLUIDITY_OF_MOTION_TALENT)
+      ? EXPECTED_STOMP_COUNT_FOM
+      : EXPECTED_STOMP_COUNT;
 
     const initialBoKCooldown = cast.cooldowns.get(SPELLS.BLACKOUT_KICK.id) ?? 0;
     items.push({
@@ -183,17 +161,17 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
       ),
       details: (
         <>
-          {cast.stompCount} / {EXPECTED_STOMP_COUNT + extraBokCasts}
+          {cast.stompCount} / {expectedStomps}
         </>
       ),
       result: (
         <PerformanceMark
           perf={evaluateQualitativePerformanceByThreshold({
             isGreaterThanOrEqual: {
-              perfect: 7 + extraBokCasts,
-              good: 6 + extraBokCasts,
-              ok: 5 + extraBokCasts,
-              fail: 4 + extraBokCasts,
+              perfect: expectedStomps + 1,
+              good: expectedStomps,
+              ok: expectedStomps - 2,
+              fail: expectedStomps - 3,
             },
             actual: cast.stompCount,
           })}
@@ -202,10 +180,6 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
     });
 
     if (this.selectedCombatant.hasTalent(SPELLS.WISDOM_OF_THE_WALL_TALENT)) {
-      // multiply by 3 with DFB because of the extra hits. in the future, probably need a separate threshold for ChP but nobody is really playing it right now
-      const thresholdScale = this.selectedCombatant.hasTalent(SPELLS.DRAGONFIRE_BREW_TALENT)
-        ? 3
-        : 1;
       items.push({
         label: (
           <>
@@ -246,20 +220,6 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
             >
               {cast.wotwTriggers.length}
             </TooltipElement>{' '}
-            ({cast.wotwClipCount}{' '}
-            <TooltipElement
-              content={
-                <>
-                  <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT} /> has a{' '}
-                  <strong>1 second</strong> cooldown, which can prevent repeated casts from
-                  triggering <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT}>WotW</SpellLink>{' '}
-                  when using <SpellLink spell={SPELLS.DRAGONFIRE_BREW_TALENT} />.
-                </>
-              }
-            >
-              clipped
-            </TooltipElement>
-            )
           </>
         ),
         result: (
@@ -267,9 +227,9 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
             perf={evaluateQualitativePerformanceByThreshold({
               actual: cast.wotwTriggers.length,
               isGreaterThanOrEqual: {
-                perfect: 6 * thresholdScale,
-                good: 5 * thresholdScale,
-                ok: 4 * thresholdScale,
+                perfect: EXPECTED_BOF_COUNT + 1,
+                good: EXPECTED_BOF_COUNT,
+                ok: EXPECTED_BOF_COUNT - 1,
               },
             })}
           />

--- a/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzaoSection.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzaoSection.tsx
@@ -1,0 +1,85 @@
+import { PerformanceMark, Section, useAnalyzer, useInfo } from 'interface/guide';
+import { JSX } from 'react';
+import InvokeNiuzao, { NiuzaoCast } from './InvokeNiuzao';
+import SpellLink from 'interface/SpellLink';
+import SPELLS from '../../../spell-list_Monk_Brewmaster.retail';
+import SPELLS_COMMON from 'common/SPELLS';
+import CooldownExpandable, {
+  CooldownExpandableItem,
+} from 'interface/guide/components/CooldownExpandable';
+import { formatDuration } from 'common/format';
+import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
+import { evaluateQualitativePerformanceByThreshold } from 'parser/ui/QualitativePerformance';
+
+export default function InvokeNiuzaoSection(): JSX.Element | null {
+  const invoke = useAnalyzer(InvokeNiuzao);
+  const info = useInfo();
+
+  if (!invoke || !info) {
+    return null;
+  }
+
+  if (!invoke.active) {
+    return null;
+  }
+
+  return (
+    <ExplanationAndDataSubSection
+      title={<SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT} />}
+      explanation={
+        <>
+          <p>
+            <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}>Invoke Niuzao</SpellLink> is
+            Brewmaster's major damage cooldown. Most of the direct damage from Niuzao comes from
+            triggering <SpellLink spell={SPELLS_COMMON.NIUZAO_STOMP_DAMAGE} /> by casting{' '}
+            <SpellLink spell={SPELLS.BLACKOUT_KICK} />.
+          </p>
+          {info.combatant.hasTalent(SPELLS.WISDOM_OF_THE_WALL_TALENT) ? (
+            <p>
+              <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT}>Shado-Pan</SpellLink> Brewmasters
+              additionally trigger <SpellLink spell={SPELLS.FLURRY_STRIKES_TALENT} /> from{' '}
+              <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> <em>and</em>{' '}
+              <SpellLink spell={SPELLS.DRAGONFIRE_BREW_TALENT} /> while Niuzao is active.
+            </p>
+          ) : (
+            <small>
+              Note: the ability priority during Niuzao differs significantly between{' '}
+              <SpellLink spell={SPELLS.FLURRY_STRIKES_TALENT}>Shado-Pan</SpellLink> and{' '}
+              <SpellLink spell={SPELLS.ASPECT_OF_HARMONY_TALENT}>Master of Harmony</SpellLink>
+            </small>
+          )}
+        </>
+      }
+      data={
+        <div>
+          {invoke.niuzaoCasts.map((cast) => (
+            <CooldownExpandable
+              key={cast.summonEvent.timestamp}
+              header={
+                <>
+                  @ {formatDuration(cast.summonEvent.timestamp - info.originalFightStart)} -{' '}
+                  <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}>
+                    Invoke Niuzao
+                  </SpellLink>
+                </>
+              }
+              timeline={{
+                range: {
+                  start: cast.summonEvent.timestamp,
+                  end: cast.deathEvent?.timestamp ?? info.fightEnd,
+                },
+                cooldowns: [
+                  SPELLS.BLACKOUT_KICK,
+                  SPELLS.BREATH_OF_FIRE_TALENT,
+                  SPELLS.KEG_SMASH_TALENT,
+                  SPELLS.BLACK_OX_BREW_TALENT,
+                ],
+              }}
+              checklistItems={invoke.checklist(cast)}
+            />
+          ))}
+        </div>
+      }
+    />
+  );
+}

--- a/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzaoSection.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzaoSection.tsx
@@ -1,15 +1,13 @@
-import { PerformanceMark, Section, useAnalyzer, useInfo } from 'interface/guide';
+import { useAnalyzer, useInfo } from 'interface/guide';
 import { JSX } from 'react';
-import InvokeNiuzao, { NiuzaoCast } from './InvokeNiuzao';
+import InvokeNiuzao from './InvokeNiuzao';
 import SpellLink from 'interface/SpellLink';
 import SPELLS from '../../../spell-list_Monk_Brewmaster.retail';
 import SPELLS_COMMON from 'common/SPELLS';
-import CooldownExpandable, {
-  CooldownExpandableItem,
-} from 'interface/guide/components/CooldownExpandable';
+import CooldownExpandable from 'interface/guide/components/CooldownExpandable';
 import { formatDuration } from 'common/format';
 import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
-import { evaluateQualitativePerformanceByThreshold } from 'parser/ui/QualitativePerformance';
+import { EventType } from 'parser/core/Events';
 
 export default function InvokeNiuzaoSection(): JSX.Element | null {
   const invoke = useAnalyzer(InvokeNiuzao);
@@ -38,8 +36,7 @@ export default function InvokeNiuzaoSection(): JSX.Element | null {
             <p>
               <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT}>Shado-Pan</SpellLink> Brewmasters
               additionally trigger <SpellLink spell={SPELLS.FLURRY_STRIKES_TALENT} /> from{' '}
-              <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> <em>and</em>{' '}
-              <SpellLink spell={SPELLS.DRAGONFIRE_BREW_TALENT} /> while Niuzao is active.
+              <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> while Niuzao is active.
             </p>
           ) : (
             <small>
@@ -63,17 +60,20 @@ export default function InvokeNiuzaoSection(): JSX.Element | null {
                   </SpellLink>
                 </>
               }
+              range={{
+                start: cast.summonEvent.timestamp,
+                end: cast.deathEvent?.timestamp ?? info.fightEnd,
+              }}
               timeline={{
-                range: {
-                  start: cast.summonEvent.timestamp,
-                  end: cast.deathEvent?.timestamp ?? info.fightEnd,
-                },
                 cooldowns: [
                   SPELLS.BLACKOUT_KICK,
                   SPELLS.BREATH_OF_FIRE_TALENT,
                   SPELLS.KEG_SMASH_TALENT,
                   SPELLS.BLACK_OX_BREW_TALENT,
                 ],
+              }}
+              table={{
+                type: EventType.Damage,
               }}
               checklistItems={invoke.checklist(cast)}
             />

--- a/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzaoSection.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzaoSection.tsx
@@ -1,4 +1,4 @@
-import { useAnalyzer, useInfo } from 'interface/guide';
+import { Section, SubSection, useAnalyzer, useInfo } from 'interface/guide';
 import { JSX } from 'react';
 import InvokeNiuzao from './InvokeNiuzao';
 import SpellLink from 'interface/SpellLink';
@@ -8,6 +8,8 @@ import CooldownExpandable from 'interface/guide/components/CooldownExpandable';
 import { formatDuration } from 'common/format';
 import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
 import { EventType } from 'parser/core/Events';
+import Explanation from 'interface/guide/components/Explanation';
+import CooldownGrid from 'interface/CooldownGrid/CooldownGrid';
 
 export default function InvokeNiuzaoSection(): JSX.Element | null {
   const invoke = useAnalyzer(InvokeNiuzao);
@@ -22,64 +24,56 @@ export default function InvokeNiuzaoSection(): JSX.Element | null {
   }
 
   return (
-    <ExplanationAndDataSubSection
-      title={<SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT} />}
-      explanation={
-        <>
+    <SubSection title={<SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT} />}>
+      <Explanation>
+        <p>
+          <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}>Invoke Niuzao</SpellLink> is
+          Brewmaster's major damage cooldown. Most of the direct damage from Niuzao comes from
+          triggering <SpellLink spell={SPELLS_COMMON.NIUZAO_STOMP_DAMAGE} /> by casting{' '}
+          <SpellLink spell={SPELLS.BLACKOUT_KICK} />. However, at this time{' '}
+          <strong>Niuzao's direct damage is low</strong>. You should play normally during{' '}
+          <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}>Invoke Niuzao</SpellLink>{' '}
+          unless playing <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT}>Shado-Pan</SpellLink>.
+        </p>
+        {info.combatant.hasTalent(SPELLS.WISDOM_OF_THE_WALL_TALENT) && (
           <p>
-            <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}>Invoke Niuzao</SpellLink> is
-            Brewmaster's major damage cooldown. Most of the direct damage from Niuzao comes from
-            triggering <SpellLink spell={SPELLS_COMMON.NIUZAO_STOMP_DAMAGE} /> by casting{' '}
-            <SpellLink spell={SPELLS.BLACKOUT_KICK} />.
+            <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT}>Shado-Pan</SpellLink> Brewmasters
+            additionally trigger <SpellLink spell={SPELLS.FLURRY_STRIKES_TALENT} /> from{' '}
+            <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> while Niuzao is active. This{' '}
+            <strong>greatly buffs</strong>{' '}
+            <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}>Invoke Niuzao</SpellLink>{' '}
+            but changes your priority: use <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> as
+            much as possible while Niuzao is active.
           </p>
-          {info.combatant.hasTalent(SPELLS.WISDOM_OF_THE_WALL_TALENT) ? (
-            <p>
-              <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT}>Shado-Pan</SpellLink> Brewmasters
-              additionally trigger <SpellLink spell={SPELLS.FLURRY_STRIKES_TALENT} /> from{' '}
-              <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> while Niuzao is active.
-            </p>
-          ) : (
-            <small>
-              Note: the ability priority during Niuzao differs significantly between{' '}
-              <SpellLink spell={SPELLS.FLURRY_STRIKES_TALENT}>Shado-Pan</SpellLink> and{' '}
-              <SpellLink spell={SPELLS.ASPECT_OF_HARMONY_TALENT}>Master of Harmony</SpellLink>
-            </small>
-          )}
-        </>
-      }
-      data={
-        <div>
-          {invoke.niuzaoCasts.map((cast) => (
-            <CooldownExpandable
-              key={cast.summonEvent.timestamp}
-              header={
-                <>
-                  @ {formatDuration(cast.summonEvent.timestamp - info.originalFightStart)} -{' '}
-                  <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}>
-                    Invoke Niuzao
-                  </SpellLink>
-                </>
-              }
-              range={{
-                start: cast.summonEvent.timestamp,
-                end: cast.deathEvent?.timestamp ?? info.fightEnd,
-              }}
-              timeline={{
-                cooldowns: [
-                  SPELLS.BLACKOUT_KICK,
-                  SPELLS.BREATH_OF_FIRE_TALENT,
-                  SPELLS.KEG_SMASH_TALENT,
-                  SPELLS.BLACK_OX_BREW_TALENT,
-                ],
-              }}
-              table={{
-                type: EventType.Damage,
-              }}
-              checklistItems={invoke.checklist(cast)}
-            />
-          ))}
-        </div>
-      }
-    />
+        )}
+      </Explanation>
+      <CooldownGrid
+        label={
+          <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}>Invoke Niuzao</SpellLink>
+        }
+        timeline={{
+          cooldowns: [
+            SPELLS.BLACKOUT_KICK,
+            SPELLS.BREATH_OF_FIRE_TALENT,
+            SPELLS.KEG_SMASH_TALENT,
+            SPELLS.BLACK_OX_BREW_TALENT,
+          ],
+        }}
+        table={{
+          type: EventType.Damage,
+        }}
+        items={invoke.niuzaoCasts.map((cast) => {
+          const { perf, checklist } = invoke.checklist(cast);
+          return {
+            perf,
+            checklistItems: checklist,
+            range: {
+              start: cast.summonEvent.timestamp,
+              end: cast.deathEvent?.timestamp ?? info.fightEnd,
+            },
+          };
+        })}
+      />
+    </SubSection>
   );
 }

--- a/src/analysis/retail/monk/brewmaster/spell-list_Monk_Brewmaster.retail.ts
+++ b/src/analysis/retail/monk/brewmaster/spell-list_Monk_Brewmaster.retail.ts
@@ -61,6 +61,12 @@ const SPELLS = {
     cooldown: {
       duration: 4000,
       hasted: false,
+      modifiers: [
+        {
+          duration: -1000,
+          requiredSpells: [387230],
+        },
+      ],
     },
     icon: 'ability_monk_roundhousekick.jpg',
   },
@@ -170,6 +176,14 @@ const SPELLS = {
       hasted: false,
       modifiers: [
         {
+          duration: 2000,
+          requiredSpells: [449582],
+        },
+        {
+          duration: -5000,
+          requiredSpells: [115173],
+        },
+        {
           duration: -2000,
           requiredSpells: [1272844],
         },
@@ -199,6 +213,14 @@ const SPELLS = {
       duration: 20000,
       hasted: false,
       modifiers: [
+        {
+          duration: 2000,
+          requiredSpells: [449582],
+        },
+        {
+          duration: -5000,
+          requiredSpells: [115173],
+        },
         {
           duration: -2000,
           requiredSpells: [1272844],


### PR DESCRIPTION
### Description

<img width="1252" height="692" alt="image" src="https://github.com/user-attachments/assets/f7b45b8d-3021-48dc-906a-75dd1e45cd00" />

this adds support for Invoke Niuzao to the Brewmaster analyzer, using the new `CooldownGrid` component.

it also bumps the version of `wow-dbc` to pick up a fix to cooldown modifiers on charge-based spells (which technically Blackout Kick is due to an old tier set)

### Testing

`/report/KvHmTR2QCBY1c6yG/1-Mythic++Algeth'ar+Academy+-+Kill+(25:43)/4-Ace/standard` shown above

some prepatch logs:
<img width="1249" height="604" alt="image" src="https://github.com/user-attachments/assets/39cc53a6-2ebd-480a-9b34-308af4d138e2" />

`/report/bg42WrMFkR1Dvn9B/3-Mythic+Nexus-King+Salhadaar+-+Kill+(2:03)/8-Eisenpelz/standard`