### PR TITLE
regenerate talent data for latest live build

### DIFF
--- a/scripts/talents/generate-talents.ts
+++ b/scripts/talents/generate-talents.ts
@@ -22,10 +22,10 @@ import {
   TalentNode,
 } from './talent-tree-types';
 
-const LIVE_WOW_BUILD_NUMBER = '12.0.0.65390';
+const LIVE_WOW_BUILD_NUMBER = '12.0.1.66220';
 const LIVE_TALENT_DATA_URL = `https://www.raidbots.com/static/data/${LIVE_WOW_BUILD_NUMBER}/talents.json`;
 const LIVE_SPELLPOWER_DATA_URL = `https://wago.tools/db2/SpellPower/csv?build=${LIVE_WOW_BUILD_NUMBER}`;
-const PTR_WOW_BUILD_NUMBER = '12.0.1.65337';
+const PTR_WOW_BUILD_NUMBER = '12.0.1.66220';
 const PTR_TALENT_DATA_URL = `https://www.raidbots.com/static/data/${PTR_WOW_BUILD_NUMBER}/talents.json`;
 const PTR_SPELLPOWER_DATA_URL = `https://wago.tools/db2/SpellPower/csv?build=${PTR_WOW_BUILD_NUMBER}`;
 

--- a/src/analysis/retail/hunter/shared/talents/BlackArrow.tsx
+++ b/src/analysis/retail/hunter/shared/talents/BlackArrow.tsx
@@ -11,11 +11,11 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 class BlackArrow extends Analyzer {
   damage = 0;
   private activeBlackArrowTalent = this.selectedCombatant.hasTalent(
-    TALENTS.BLACK_ARROW_1_BEAST_MASTERY_TALENT,
+    TALENTS.BLACK_ARROW_BEAST_MASTERY_TALENT,
   )
-    ? TALENTS.BLACK_ARROW_1_BEAST_MASTERY_TALENT
-    : this.selectedCombatant.hasTalent(TALENTS.BLACK_ARROW_2_BEAST_MASTERY_TALENT)
-      ? TALENTS.BLACK_ARROW_2_BEAST_MASTERY_TALENT
+    ? TALENTS.BLACK_ARROW_BEAST_MASTERY_TALENT
+    : this.selectedCombatant.hasTalent(TALENTS.BLACK_ARROW_MARKSMANSHIP_TALENT)
+      ? TALENTS.BLACK_ARROW_MARKSMANSHIP_TALENT
       : null;
   constructor(options: Options) {
     super(options);

--- a/src/analysis/retail/hunter/shared/talents/KillShot.tsx
+++ b/src/analysis/retail/hunter/shared/talents/KillShot.tsx
@@ -29,7 +29,7 @@ class KillShot extends ExecuteHelper {
 
   constructor(options: Options) {
     super(options);
-    this.active = !this.selectedCombatant.hasTalent(TALENTS.BLACK_ARROW_1_BEAST_MASTERY_TALENT); // Marksman Killshot is replaced by Black Arrow
+    this.active = !this.selectedCombatant.hasTalent(TALENTS.BLACK_ARROW_MARKSMANSHIP_TALENT); // Marksman Killshot is replaced by Black Arrow
     this.selectedCombatant.hasTalent(TALENTS.KILL_SHOT_TALENT);
     const ctor = this.constructor as typeof ExecuteHelper;
     ctor.executeSpells.push(this.activeKillShotSpell);

--- a/src/common/TALENTS/evoker.ts
+++ b/src/common/TALENTS/evoker.ts
@@ -1390,7 +1390,7 @@ const talents = {
     maxRanks: 1,
     entryIds: [115652],
     definitionIds: [{ id: 120664, specId: 1468 }],
-    manaCost: 70000,
+    manaCost: 55000,
   },
   REWIND_TALENT: {
     id: 363534,

--- a/src/common/TALENTS/hunter.ts
+++ b/src/common/TALENTS/hunter.ts
@@ -123,15 +123,7 @@ const talents = {
     entryIds: [135688],
     definitionIds: [{ id: 140444, specId: 255 }],
   },
-  BLACK_ARROW_1_BEAST_MASTERY_TALENT: {
-    id: 466932,
-    name: 'Black Arrow',
-    icon: 'inv_ability_darkrangerhunter_blackarrow',
-    maxRanks: 1,
-    entryIds: [117584],
-    definitionIds: [{ id: 122596, specId: 254 }],
-  },
-  BLACK_ARROW_2_BEAST_MASTERY_TALENT: {
+  BLACK_ARROW_BEAST_MASTERY_TALENT: {
     id: 466930,
     name: 'Black Arrow',
     icon: 'inv_ability_darkrangerhunter_blackarrow',
@@ -139,6 +131,14 @@ const talents = {
     entryIds: [136446],
     definitionIds: [{ id: 141219, specId: 253 }],
     focusCost: 10,
+  },
+  BLACK_ARROW_MARKSMANSHIP_TALENT: {
+    id: 466932,
+    name: 'Black Arrow',
+    icon: 'inv_ability_darkrangerhunter_blackarrow',
+    maxRanks: 1,
+    entryIds: [117584],
+    definitionIds: [{ id: 122596, specId: 254 }],
   },
   BLEAK_ARROWS_TALENT: {
     id: 467749,
@@ -1098,7 +1098,7 @@ const talents = {
   OUTLAND_VENOM_TALENT: {
     id: 459939,
     name: 'Outland Venom',
-    icon: 'ability_creature_disease_04',
+    icon: 'ability_hunter_potentvenom',
     maxRanks: 1,
     entryIds: [135497],
     definitionIds: [{ id: 140254, specId: 255 }],
@@ -1880,7 +1880,7 @@ const talents = {
     maxRanks: 1,
     entryIds: [126324],
     definitionIds: [{ id: 131150, specId: 255 }],
-    focusCost: 20,
+    focusCost: 10,
   },
   WILDFIRE_IMBUEMENT_TALENT: {
     id: 1252943,

--- a/src/common/TALENTS/mage.ts
+++ b/src/common/TALENTS/mage.ts
@@ -760,25 +760,16 @@ const talents = {
     entryIds: [80220],
     definitionIds: [{ id: 85223, specId: 64 }],
   },
-  FROSTFIRE_BOLT_1_FIRE_TALENT: {
+  FROSTFIRE_BOLT_TALENT: {
     id: 431044,
     name: 'Frostfire Bolt',
     icon: 'inv_ability_frostfiremage_frostfirebolt',
     maxRanks: 1,
-    entryIds: [117239, 136441],
+    entryIds: [136441, 117239],
     definitionIds: [
+      { id: 141214, specId: 63 },
       { id: 122251, specId: 64 },
-      { id: 141214, specId: 64 },
     ],
-    manaCost: 50000,
-  },
-  FROSTFIRE_BOLT_2_FIRE_TALENT: {
-    id: 431044,
-    name: 'Frostfire Bolt',
-    icon: 'inv_ability_frostfiremage_frostfirebolt',
-    maxRanks: 1,
-    entryIds: [136441],
-    definitionIds: [{ id: 141214, specId: 63 }],
     manaCost: 50000,
   },
   FROSTFIRE_EMPOWERMENT_TALENT: {

--- a/src/common/TALENTS/monk.ts
+++ b/src/common/TALENTS/monk.ts
@@ -1668,7 +1668,6 @@ const talents = {
     entryIds: [128221],
     definitionIds: [{ id: 133028, specId: 270 }],
     manaCost: 31250,
-    chiCost: 2,
   },
   RUSHING_WIND_KICK_WINDWALKER_TALENT: {
     id: 1250566,
@@ -2399,7 +2398,6 @@ const talents = {
     maxRanks: 1,
     entryIds: [124826],
     definitionIds: [{ id: 129664, specId: 269 }],
-    manaCost: 125000,
   },
   ZEN_PULSE_TALENT: {
     id: 446326,

--- a/src/common/TALENTS/paladin.ts
+++ b/src/common/TALENTS/paladin.ts
@@ -1067,7 +1067,7 @@ const talents = {
     maxRanks: 1,
     entryIds: [102534],
     definitionIds: [{ id: 107539, specId: 65 }],
-    manaCost: 70000,
+    manaCost: 56000,
   },
   ILLUMINE_TALENT: {
     id: 431423,

--- a/src/common/TALENTS/priest.ts
+++ b/src/common/TALENTS/priest.ts
@@ -162,8 +162,8 @@ const talents = {
     name: 'Borrowed Time',
     icon: 'spell_holy_borrowedtime',
     maxRanks: 2,
-    entryIds: [103729],
-    definitionIds: [{ id: 108734, specId: 256 }],
+    entryIds: [103697],
+    definitionIds: [{ id: 108702, specId: 256 }],
   },
   BRIGHT_PUPIL_TALENT: {
     id: 390684,
@@ -690,8 +690,8 @@ const talents = {
     name: 'Harsh Discipline',
     icon: 'ability_paladin_handoflight',
     maxRanks: 2,
-    entryIds: [103697],
-    definitionIds: [{ id: 108702, specId: 256 }],
+    entryIds: [103729],
+    definitionIds: [{ id: 108734, specId: 256 }],
   },
   HAUNTING_SHADOWS_TALENT: {
     id: 1279355,
@@ -1055,7 +1055,7 @@ const talents = {
   MASTER_THE_DARKNESS_1_DISCIPLINE_TALENT: {
     id: 1253590,
     name: 'Master the Darkness',
-    icon: 'inv_nullstone_void',
+    icon: 'inv12_apextalent_priest_voidshield',
     maxRanks: 1,
     entryIds: [136998],
     definitionIds: [{ id: 141761, specId: 256 }],

--- a/src/common/TALENTS/shaman.ts
+++ b/src/common/TALENTS/shaman.ts
@@ -347,7 +347,7 @@ const talents = {
   DOUBLE_DIP_TALENT: {
     id: 1252882,
     name: 'Double Dip',
-    icon: 'spell_shaman_tidalwaves',
+    icon: 'ability_mage_waterjet',
     maxRanks: 1,
     entryIds: [128703],
     definitionIds: [{ id: 133505, specId: 264 }],
@@ -489,10 +489,10 @@ const talents = {
     name: 'Echo of the Elements',
     icon: 'ability_shaman_echooftheelements',
     maxRanks: 1,
-    entryIds: [101850, 101928],
+    entryIds: [101850, 101942],
     definitionIds: [
       { id: 106837, specId: 262 },
-      { id: 106941, specId: 264 },
+      { id: 106939, specId: 264 },
     ],
   },
   ELECTROSHOCK_TALENT: {
@@ -1233,8 +1233,8 @@ const talents = {
     name: 'Primal Tide Core',
     icon: 'ability_shaman_repulsiontotem',
     maxRanks: 1,
-    entryIds: [101942],
-    definitionIds: [{ id: 106939, specId: 264 }],
+    entryIds: [101842],
+    definitionIds: [{ id: 106901, specId: 264 }],
   },
   PRIMORDIAL_BOND_TALENT: {
     id: 1279819,
@@ -1729,6 +1729,14 @@ const talents = {
     entryIds: [135252],
     definitionIds: [{ id: 140020, specId: 263 }],
   },
+  TIDAL_WAVES_TALENT: {
+    id: 51564,
+    name: 'Tidal Waves',
+    icon: 'spell_shaman_tidalwaves',
+    maxRanks: 1,
+    entryIds: [101928],
+    definitionIds: [{ id: 106941, specId: 264 }],
+  },
   TIDEWATERS_TALENT: {
     id: 462424,
     name: 'Tidewaters',
@@ -1891,14 +1899,6 @@ const talents = {
     maxRanks: 1,
     entryIds: [117476],
     definitionIds: [{ id: 122488, specId: 264 }],
-  },
-  WHISPERING_WAVES_TALENT: {
-    id: 1217598,
-    name: 'Whispering Waves',
-    icon: 'shaman_pvp_ripplingwaters',
-    maxRanks: 1,
-    entryIds: [101842],
-    definitionIds: [{ id: 106901, specId: 264 }],
   },
   WHITE_WATER_TALENT: {
     id: 462587,


### PR DESCRIPTION
This fixes the frostfire bolt issue @Sharrq was seeing for mages, as well as a similar issue for hunters with Black Arrow