### PR TITLE
Created Demonic Tyrant Analyzer

### DIFF
--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
-// import SPELLS from 'common/SPELLS';
+import SPELLS from 'common/SPELLS';
 // import { TALENTS_WARLOCK } from 'common/TALENTS';
 import { Katorri} from 'CONTRIBUTORS';
-// import { SpellLink } from 'interface';
+import SpellLink from 'interface/SpellLink';
 
 export default [
   change(date(2026, 3, 6), "Add tracking for Grimoire: Imp Lord and Grimoire: Fel Ravager. Removed Demonic Tyrant Cooldown subsection as it was out of date.", Katorri),
+  change(date(20226, 3, 7), <>Create <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT}></SpellLink> Analyzer to detail Demonic Tyrant windows.</>, Katorri),
   change(date(2026, 2, 28), "Initial pass to enable Midnight Demonology. In a very rough state, and some info is out of date.", Katorri)
 ];

--- a/src/analysis/retail/warlock/demonology/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/demonology/CombatLogParser.ts
@@ -34,6 +34,9 @@ import TWW3SoulHarvesterTierSet from './modules/tier/TWW3SoulHarvesterTierSet';
 import { UnendingResolve, DarkPact, DemonicCircle } from '../shared';
 import ImpLordNormalizer from './modules/pets/normalizers/ImpLordNormalizer';
 import FelRavagerNormalizer from './modules/pets/normalizers/FelRavagerNormalizer';
+import DemonicTyrant from './modules/features/DemonicTyrant';
+import DemonicTyrantGuide from './modules/guide/DemonicTyrantGuide';
+
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -42,6 +45,10 @@ class CombatLogParser extends CoreCombatLogParser {
     alwaysBeCasting: AlwaysBeCasting,
     cooldownThroughputTracker: CooldownThroughputTracker,
     legionStrike: LegionStrike,
+    DemonicTyrant: DemonicTyrant,
+
+    // Guide
+    DemonicTyrantGuide: DemonicTyrantGuide,
 
     // Core
     soulShardTracker: SoulShardTracker,

--- a/src/analysis/retail/warlock/demonology/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/demonology/CombatLogParser.ts
@@ -6,36 +6,30 @@ import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import LegionStrike from './modules/features/LegionStrike';
 import DemoPets from './modules/pets/DemoPets';
-import DemonicTyrantHandler from './modules/pets/DemoPets/DemonicTyrantHandler';
-import ImplosionHandler from './modules/pets/DemoPets/ImplosionHandler';
+import DemonicTyrant from './modules/features/DemonicTyrant';
 import PetDamageHandler from './modules/pets/DemoPets/PetDamageHandler';
 import PetSummonHandler from './modules/pets/DemoPets/PetSummonHandler';
 import PowerSiphonHandler from './modules/pets/DemoPets/PowerSiphonHandler';
-import PrepullPetNormalizer from './modules/pets/normalizers/PrepullPetNormalizer';
+import DemonicTyrantHandler from './modules/pets/DemoPets/DemonicTyrantHandler';
+import ImplosionHandler from './modules/pets/DemoPets/ImplosionHandler';
 import SummonOrderNormalizer from './modules/pets/normalizers/SummonOrderNormalizer';
-import SoulShardDetails from './modules/resources/SoulShardDetails';
-import SoulShardTracker from './modules/resources/SoulShardTracker';
-import SoulShardGraph from './modules/resources/SoulShardGraph';
+import PrepullPetNormalizer from './modules/pets/normalizers/PrepullPetNormalizer';
+import ImpLordNormalizer from './modules/pets/normalizers/ImpLordNormalizer';
+import FelRavagerNormalizer from './modules/pets/normalizers/FelRavagerNormalizer';
 import DemonicCalling from './modules/talents/DemonicCalling';
 import Doom from './modules/talents/Doom';
 import Dreadlash from './modules/talents/Dreadlash';
 import InnerDemons from './modules/talents/InnerDemons';
-import PowerSiphonNormalizer from './modules/talents/normalizers/PowerSiphonNormalizer';
-import PowerSiphonBuffCastNormalizer from './modules/talents/normalizers/PowerSiphonBuffCastNormalizer';
 import PowerSiphon from './modules/talents/PowerSiphon';
 import SacrificedSouls from './modules/talents/SacrificedSouls';
 import SummonVilefiend from './modules/talents/SummonVilefiend';
 import DiabolicRitual from './modules/talents/DiabolicRitual';
 import DiabolicRitualEmpowers from './modules/talents/DiabolicRitualEmpowers';
-import Guide from './Guide';
-import TWW2TierSet from './modules/thewarwithin/tier/TWW2TierSet';
-import TWW3DiabolistTierSet from './modules/tier/TWW3DiabolistTierSet';
-import TWW3SoulHarvesterTierSet from './modules/tier/TWW3SoulHarvesterTierSet';
+import SoulShardDetails from './modules/resources/SoulShardDetails';
+import SoulShardTracker from './modules/resources/SoulShardTracker';
+import SoulShardGraph from './modules/resources/SoulShardGraph';
 import { UnendingResolve, DarkPact, DemonicCircle } from '../shared';
-import ImpLordNormalizer from './modules/pets/normalizers/ImpLordNormalizer';
-import FelRavagerNormalizer from './modules/pets/normalizers/FelRavagerNormalizer';
-import DemonicTyrant from './modules/features/DemonicTyrant';
-import DemonicTyrantGuide from './modules/guide/DemonicTyrantGuide';
+import Guide from './Guide';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -46,13 +40,10 @@ class CombatLogParser extends CoreCombatLogParser {
     legionStrike: LegionStrike,
     DemonicTyrant: DemonicTyrant,
 
-    // Guide
-    DemonicTyrantGuide: DemonicTyrantGuide,
-
     // Core
     soulShardTracker: SoulShardTracker,
     soulShardDetails: SoulShardDetails,
-    soulshardGraph: SoulShardGraph,
+    soulShardGraph: SoulShardGraph,
 
     // Pets
     demoPets: DemoPets,
@@ -66,10 +57,6 @@ class CombatLogParser extends CoreCombatLogParser {
     ImpLordNormalizer: ImpLordNormalizer,
     FelRavagerNormalizer: FelRavagerNormalizer,
 
-    // Normalizers
-    powerSiphonNormalizer: PowerSiphonNormalizer,
-    PowerSiphonBuffCastNormalizer: PowerSiphonBuffCastNormalizer,
-
     // Talents
     dreadlash: Dreadlash,
     demonicCalling: DemonicCalling,
@@ -77,7 +64,6 @@ class CombatLogParser extends CoreCombatLogParser {
     summonVilefiend: SummonVilefiend,
     powerSiphon: PowerSiphon,
     doom: Doom,
-
     sacrificedSouls: SacrificedSouls,
     DiabolicRitual: DiabolicRitual,
     DiabolicRitualEmpowers: DiabolicRitualEmpowers,
@@ -87,12 +73,7 @@ class CombatLogParser extends CoreCombatLogParser {
     darkPact: DarkPact,
     demonicCircle: DemonicCircle,
 
-    // Tier
-    tww2TierSet: TWW2TierSet,
-    tww3DiabolistTierSet: TWW3DiabolistTierSet,
-    tww3SoulHarvesterTierSet: TWW3SoulHarvesterTierSet,
-
-    // There's no throughput benefit from casting Arcane Torrent on cooldown
+    // Tier / Racial
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
   };
 

--- a/src/analysis/retail/warlock/demonology/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/demonology/CombatLogParser.ts
@@ -37,7 +37,6 @@ import FelRavagerNormalizer from './modules/pets/normalizers/FelRavagerNormalize
 import DemonicTyrant from './modules/features/DemonicTyrant';
 import DemonicTyrantGuide from './modules/guide/DemonicTyrantGuide';
 
-
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Features

--- a/src/analysis/retail/warlock/demonology/Guide.tsx
+++ b/src/analysis/retail/warlock/demonology/Guide.tsx
@@ -25,6 +25,7 @@ function CooldownSection({ modules }: GuideProps<typeof CombatLogParser>) {
   return (
     <Section title="Cooldowns">
       <CooldownSubsection />
+      {modules.DemonicTyrantGuide.guideSubsection}
     </Section>
   );
 }

--- a/src/analysis/retail/warlock/demonology/Guide.tsx
+++ b/src/analysis/retail/warlock/demonology/Guide.tsx
@@ -4,6 +4,7 @@ import PreparationSection from 'interface/guide/components/Preparation/Preparati
 import CooldownSubsection from './modules/guide/CooldownsSubsection';
 import ResourceUsage from './modules/guide/ResourceUsage';
 import DefensivesGuide from '../shared/Defensives';
+import DemonicTyrantGuide from './modules/guide/DemonicTyrantGuide';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -25,7 +26,7 @@ function CooldownSection({ modules }: GuideProps<typeof CombatLogParser>) {
   return (
     <Section title="Cooldowns">
       <CooldownSubsection />
-      {modules.DemonicTyrantGuide.guideSubsection}
+      <DemonicTyrantGuide />
     </Section>
   );
 }

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -40,9 +40,9 @@ export default class DemonicTyrant extends Analyzer {
   onTyrantCast = (event: CastEvent) => {
     const timeSinceDreadstalkers = event.timestamp - this.lastDreadstalkersCast;
 
-    const dreadstalkersActive = timeSinceDreadstalkers <= 12000;
+    const dreadstalkersActive = timeSinceDreadstalkers <= DREADSTALKERS_DURATION;
 
-    const dreadstalkersTooEarly = dreadstalkersActive && timeSinceDreadstalkers > 7000;
+    const dreadstalkersTooEarly = dreadstalkersActive && timeSinceDreadstalkers > DREADSTALKERS_EARLY_CUTOFF_MS;
 
     const tyrant: TyrantCastData = {
       cast: event.timestamp,

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -2,7 +2,6 @@ import SPELLS from 'common/SPELLS';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Analyzer from 'parser/core/Analyzer';
 import Events, { CastEvent, SummonEvent } from 'parser/core/Events';
-import TALENTS from 'common/TALENTS/warlock';
 
 const DREADSTALKERS_DURATION = 12000;
 const TYRANT_WINDOW_MS = 20000;
@@ -19,7 +18,7 @@ export default class DemonicTyrant extends Analyzer {
     // Tyrant cast
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SUMMON_DEMONIC_TYRANT),
-      (event) => this.onTyrantCast(event),
+      this.onTyrantCast,
     );
 
     // Hand of Gul'dan cast
@@ -31,24 +30,13 @@ export default class DemonicTyrant extends Analyzer {
     // Wild imp summons
     this.addEventListener(
       Events.summon.by(SELECTED_PLAYER).spell(SPELLS.WILD_IMP_HOG_SUMMON),
-      (event) => this.onImpSummon(event),
+      this.onImpSummon,
     );
 
     // Dreadstalkers cast
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.CALL_DREADSTALKERS),
-      (event) => this.onDreadstalkersCast(event),
-    );
-
-    // Implosion cast
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.IMPLOSION_CAST), (event) =>
-      this.onImplosionCast(event),
-    );
-
-    // Power Siphon cast
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.POWER_SIPHON_TALENT),
-      (event) => this.onPowerSiphonCast(event),
+      this.onDreadstalkersCast,
     );
   }
 
@@ -65,8 +53,6 @@ export default class DemonicTyrant extends Analyzer {
       impsSummoned: 0,
       dreadstalkersActive,
       dreadstalkersTooEarly,
-      castedImplosion: false,
-      castedPowerSiphon: false,
     };
 
     this.tyrantData.push(tyrant);
@@ -98,16 +84,6 @@ export default class DemonicTyrant extends Analyzer {
   onDreadstalkersCast(event: CastEvent) {
     this.lastDreadstalkersCast = event.timestamp;
   }
-
-  onImplosionCast(event: CastEvent) {
-    if (!this.currentTyrant) return;
-    this.currentTyrant.castedImplosion = true;
-  }
-
-  onPowerSiphonCast(event: CastEvent) {
-    if (!this.currentTyrant) return;
-    this.currentTyrant.castedPowerSiphon = true;
-  }
 }
 
 export interface TyrantCastData {
@@ -116,6 +92,4 @@ export interface TyrantCastData {
   impsSummoned: number;
   dreadstalkersActive: boolean;
   dreadstalkersTooEarly: boolean;
-  castedImplosion?: boolean;
-  castedPowerSiphon?: boolean;
 }

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -7,6 +7,8 @@ export default class DemonicTyrant extends Analyzer {
   tyrantData: TyrantCastData[] = [];
   currentTyrant: TyrantCastData | null = null;
 
+  lastDreadstalkersCast = 0;
+
   constructor(options: Options) {
     super(options);
 
@@ -28,13 +30,26 @@ export default class DemonicTyrant extends Analyzer {
       Events.summon.by(SELECTED_PLAYER).spell(SPELLS.WILD_IMP_HOG_SUMMON),
       (event) => this.onImpSummon(event),
     );
+    // Dreadstalkers cast
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.CALL_DREADSTALKERS),
+      (event) => this.onDreadstalkersCast(event),
+    );
   }
 
   onTyrantCast = (event: CastEvent) => {
+    const timeSinceDreadstalkers = event.timestamp - this.lastDreadstalkersCast;
+
+    const dreadstalkersActive = timeSinceDreadstalkers <= 12000;
+
+    const dreadstalkersTooEarly = dreadstalkersActive && timeSinceDreadstalkers > 7000;
+
     const tyrant: TyrantCastData = {
       cast: event.timestamp,
       handOfGuldanCasts: 0,
       impsSummoned: 0,
+      dreadstalkersActive,
+      dreadstalkersTooEarly,
     };
 
     this.tyrantData.push(tyrant);
@@ -66,10 +81,15 @@ export default class DemonicTyrant extends Analyzer {
 
     this.currentTyrant.impsSummoned += 1;
   };
+  onDreadstalkersCast = (event: CastEvent) => {
+    this.lastDreadstalkersCast = event.timestamp;
+  };
 }
 
 export interface TyrantCastData {
   cast: number;
   handOfGuldanCasts: number;
   impsSummoned: number;
+  dreadstalkersActive: boolean;
+  dreadstalkersTooEarly: boolean;
 }

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -25,7 +25,7 @@ export default class DemonicTyrant extends Analyzer {
     // Hand of Gul'dan cast
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.HAND_OF_GULDAN_CAST),
-      (event) => this.onHandOfGuldanCast(event),
+      this.onHandOfGuldanCast,
     );
 
     // Wild imp summons

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -1,27 +1,75 @@
 import SPELLS from 'common/SPELLS';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Analyzer from 'parser/core/Analyzer';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, { CastEvent, SummonEvent } from 'parser/core/Events';
 
 export default class DemonicTyrant extends Analyzer {
   tyrantData: TyrantCastData[] = [];
+  currentTyrant: TyrantCastData | null = null;
 
   constructor(options: Options) {
     super(options);
 
+    // Tyrant cast
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SUMMON_DEMONIC_TYRANT),
-      this.onTyrantCast,
+      (event) => this.onTyrantCast(event),
+    );
+
+    // Hand of Gul'dan cast
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.HAND_OF_GULDAN_CAST),
+      (event) => this.onHandOfGuldanCast(event),
+    );
+
+    // Wild imp summons (spell name may vary in the repo)
+    // If this errors later we will fix the spell constant
+    this.addEventListener(
+      Events.summon.by(SELECTED_PLAYER).spell(SPELLS.WILD_IMP_HOG_SUMMON),
+      (event) => this.onImpSummon(event),
     );
   }
 
-  onTyrantCast(event: CastEvent) {
-    this.tyrantData.push({
+  onTyrantCast = (event: CastEvent) => {
+    const tyrant: TyrantCastData = {
       cast: event.timestamp,
-    });
-  }
+      handOfGuldanCasts: 0,
+      impsSummoned: 0,
+    };
+
+    this.tyrantData.push(tyrant);
+    this.currentTyrant = tyrant;
+  };
+
+  onHandOfGuldanCast = (event: CastEvent) => {
+    if (!this.currentTyrant) {
+      return;
+    }
+
+    if (event.timestamp > this.currentTyrant.cast + 20000) {
+      this.currentTyrant = null;
+      return;
+    }
+
+    this.currentTyrant.handOfGuldanCasts += 1;
+  };
+
+  onImpSummon = (event: SummonEvent) => {
+    if (!this.currentTyrant) {
+      return;
+    }
+
+    if (event.timestamp > this.currentTyrant.cast + 20000) {
+      this.currentTyrant = null;
+      return;
+    }
+
+    this.currentTyrant.impsSummoned += 1;
+  };
 }
 
 export interface TyrantCastData {
   cast: number;
+  handOfGuldanCasts: number;
+  impsSummoned: number;
 }

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -1,0 +1,27 @@
+import SPELLS from 'common/SPELLS';
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Analyzer from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+
+export default class DemonicTyrant extends Analyzer {
+  tyrantData: TyrantCastData[] = [];
+
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SUMMON_DEMONIC_TYRANT),
+      this.onTyrantCast,
+    );
+  }
+
+  onTyrantCast(event: CastEvent) {
+    this.tyrantData.push({
+      cast: event.timestamp,
+    });
+  }
+}
+
+export interface TyrantCastData {
+  cast: number;
+}

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -2,6 +2,10 @@ import SPELLS from 'common/SPELLS';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Analyzer from 'parser/core/Analyzer';
 import Events, { CastEvent, SummonEvent } from 'parser/core/Events';
+import TALENTS from 'common/TALENTS/warlock';
+
+const DREADSTALKERS_DURATION = 12000;
+const TYRANT_WINDOW_MS = 20000;
 
 export default class DemonicTyrant extends Analyzer {
   tyrantData: TyrantCastData[] = [];
@@ -24,16 +28,27 @@ export default class DemonicTyrant extends Analyzer {
       (event) => this.onHandOfGuldanCast(event),
     );
 
-    // Wild imp summons (spell name may vary in the repo)
-    // If this errors later we will fix the spell constant
+    // Wild imp summons
     this.addEventListener(
       Events.summon.by(SELECTED_PLAYER).spell(SPELLS.WILD_IMP_HOG_SUMMON),
       (event) => this.onImpSummon(event),
     );
+
     // Dreadstalkers cast
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.CALL_DREADSTALKERS),
       (event) => this.onDreadstalkersCast(event),
+    );
+
+    // Implosion cast
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.IMPLOSION_CAST), (event) =>
+      this.onImplosionCast(event),
+    );
+
+    // Power Siphon cast
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.POWER_SIPHON_TALENT),
+      (event) => this.onPowerSiphonCast(event),
     );
   }
 
@@ -41,8 +56,8 @@ export default class DemonicTyrant extends Analyzer {
     const timeSinceDreadstalkers = event.timestamp - this.lastDreadstalkersCast;
 
     const dreadstalkersActive = timeSinceDreadstalkers <= DREADSTALKERS_DURATION;
-
-    const dreadstalkersTooEarly = dreadstalkersActive && timeSinceDreadstalkers > DREADSTALKERS_EARLY_CUTOFF_MS;
+    const dreadstalkersTooEarly =
+      dreadstalkersActive && timeSinceDreadstalkers > DREADSTALKERS_DURATION / 2;
 
     const tyrant: TyrantCastData = {
       cast: event.timestamp,
@@ -50,40 +65,49 @@ export default class DemonicTyrant extends Analyzer {
       impsSummoned: 0,
       dreadstalkersActive,
       dreadstalkersTooEarly,
+      castedImplosion: false,
+      castedPowerSiphon: false,
     };
 
     this.tyrantData.push(tyrant);
     this.currentTyrant = tyrant;
-  };
+  }
 
-  onHandOfGuldanCast = (event: CastEvent) => {
-    if (!this.currentTyrant) {
-      return;
-    }
+  onHandOfGuldanCast(event: CastEvent) {
+    if (!this.currentTyrant) return;
 
-    if (event.timestamp > this.currentTyrant.cast + 20000) {
+    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) {
       this.currentTyrant = null;
       return;
     }
 
     this.currentTyrant.handOfGuldanCasts += 1;
-  };
+  }
 
-  onImpSummon = (event: SummonEvent) => {
-    if (!this.currentTyrant) {
-      return;
-    }
+  onImpSummon(event: SummonEvent) {
+    if (!this.currentTyrant) return;
 
-    if (event.timestamp > this.currentTyrant.cast + 20000) {
+    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) {
       this.currentTyrant = null;
       return;
     }
 
     this.currentTyrant.impsSummoned += 1;
-  };
-  onDreadstalkersCast = (event: CastEvent) => {
+  }
+
+  onDreadstalkersCast(event: CastEvent) {
     this.lastDreadstalkersCast = event.timestamp;
-  };
+  }
+
+  onImplosionCast(event: CastEvent) {
+    if (!this.currentTyrant) return;
+    this.currentTyrant.castedImplosion = true;
+  }
+
+  onPowerSiphonCast(event: CastEvent) {
+    if (!this.currentTyrant) return;
+    this.currentTyrant.castedPowerSiphon = true;
+  }
 }
 
 export interface TyrantCastData {
@@ -92,4 +116,6 @@ export interface TyrantCastData {
   impsSummoned: number;
   dreadstalkersActive: boolean;
   dreadstalkersTooEarly: boolean;
+  castedImplosion?: boolean;
+  castedPowerSiphon?: boolean;
 }

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -37,7 +37,7 @@ export default class DemonicTyrant extends Analyzer {
     );
   }
 
-  onTyrantCast = (event: CastEvent) => {
+  onTyrantCast(event: CastEvent) {
     const timeSinceDreadstalkers = event.timestamp - this.lastDreadstalkersCast;
 
     const dreadstalkersActive = timeSinceDreadstalkers <= DREADSTALKERS_DURATION;

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -1,0 +1,91 @@
+import type { JSX } from 'react';
+import SPELLS from 'common/SPELLS';
+import { SpellLink } from 'interface';
+import Analyzer from 'parser/core/Analyzer';
+import { EventType } from 'parser/core/Events';
+import GuideSection from 'interface/guide/components/GuideSection';
+import CastDetail, { type PerCastData } from 'interface/guide/components/CastDetail';
+import EventHistory from 'parser/shared/modules/EventHistory';
+import {
+  SpellSequence,
+  type CastSequenceEntry,
+  type CastInSequence,
+} from 'interface/guide/components/CastSequence';
+import DemonicTyrant, { TyrantCastData } from '../features/DemonicTyrant';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+
+const TYRANT_PRE_WINDOW = 8000;
+const TYRANT_POST_WINDOW = 12000;
+
+class DemonicTyrantGuide extends Analyzer {
+  static dependencies = {
+    demonicTyrant: DemonicTyrant,
+    eventHistory: EventHistory,
+  };
+
+  protected demonicTyrant!: DemonicTyrant;
+  protected eventHistory!: EventHistory;
+
+  get guideSubsection(): JSX.Element {
+    const tyrant = <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT} />;
+
+    const explanation = (
+      <>
+        <b>{tyrant}</b> is Demonology's primary cooldown. The goal is to build a strong demon setup
+        before casting it and then spend globals efficiently during the window.
+      </>
+    );
+
+    const tyrantSequenceEvents: CastSequenceEntry<TyrantCastData>[] =
+      this.demonicTyrant.tyrantData.map((cast) => {
+        const windowStart = cast.cast - TYRANT_PRE_WINDOW;
+        const windowEnd = cast.cast + TYRANT_POST_WINDOW;
+
+        const castEvents = this.eventHistory.getEvents([EventType.Cast], {
+          searchBackwards: false,
+          startTimestamp: windowStart,
+          duration: windowEnd - windowStart,
+        });
+
+        const casts: CastInSequence[] = castEvents.map((event) => ({
+          timestamp: event.timestamp,
+          spellId: event.ability.guid,
+          spellName: event.ability.name,
+          icon: event.ability.abilityIcon.replace('.jpg', ''),
+          performance: QualitativePerformance.Ok,
+        }));
+
+        return {
+          data: cast,
+          start: windowStart,
+          end: windowEnd,
+          casts,
+        };
+      });
+
+    const perCastData: PerCastData[] = this.demonicTyrant.tyrantData.map((cast, index) => {
+      const sequenceEntry = tyrantSequenceEvents[index];
+
+      return {
+        performance: QualitativePerformance.Ok,
+        timestamp: this.owner.formatTimestamp(cast.cast),
+        stats: [],
+        details: 'Spell sequence around Demonic Tyrant.',
+        additionalContent: sequenceEntry
+          ? {
+              title: 'Cast Sequence',
+              content: <SpellSequence casts={sequenceEntry.casts} iconSize={40} />,
+            }
+          : undefined,
+      };
+    });
+
+    return (
+      <GuideSection spell={SPELLS.SUMMON_DEMONIC_TYRANT} explanation={explanation}>
+        <CastDetail title="Demonic Tyrant Casts" casts={perCastData} />
+      </GuideSection>
+    );
+  }
+}
+
+export default DemonicTyrantGuide;

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'react';
+import { useMemo } from 'react';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 import { SpellLink } from 'interface';
@@ -19,16 +20,9 @@ const TYRANT_PRE_WINDOW = 7000;
 const TYRANT_POST_WINDOW = 20000;
 
 function rateTyrantWindow(handOfGuldanCasts: number): QualitativePerformance {
-  if (handOfGuldanCasts >= 6) {
-    return QualitativePerformance.Perfect;
-  }
-  if (handOfGuldanCasts === 5) {
-    return QualitativePerformance.Good;
-  }
-  if (handOfGuldanCasts >= 3) {
-    return QualitativePerformance.Ok;
-  }
-
+  if (handOfGuldanCasts >= 6) return QualitativePerformance.Perfect;
+  if (handOfGuldanCasts === 5) return QualitativePerformance.Good;
+  if (handOfGuldanCasts >= 3) return QualitativePerformance.Ok;
   return QualitativePerformance.Fail;
 }
 
@@ -62,7 +56,6 @@ function getTyrantFeedback(
   }
 
   const castedImplosion = preTyrantCasts.some((cast) => cast.spellId === SPELLS.IMPLOSION_CAST.id);
-
   const castedPowerSiphon = preTyrantCasts.some(
     (cast) => cast.spellId === TALENTS.POWER_SIPHON_TALENT.id,
   );
@@ -77,21 +70,17 @@ function getTyrantFeedback(
     );
   }
 
-  if (castedImplosion) {
+  if (castedImplosion)
     feedback.push(
       'Avoid casting Implosion before Tyrant, as it removes imps that Tyrant could extend.',
     );
-  }
-
-  if (castedPowerSiphon) {
+  if (castedPowerSiphon)
     feedback.push('Power Siphon before Tyrant sacrifices imps that could increase Tyrant damage.');
-  }
-
-  if (impsSummoned < 8) {
+  if (impsSummoned < 8)
     feedback.push(
       'Entering Tyrant with more imps already active will significantly increase its damage.',
     );
-  }
+
   return (
     <ul>
       {feedback.map((line, i) => (
@@ -105,51 +94,10 @@ function DemonicTyrantGuide(): JSX.Element | null {
   const demonicTyrant = useAnalyzer(DemonicTyrant);
   const eventHistory = useAnalyzer(EventHistory);
 
-  if (!demonicTyrant || !eventHistory) {
-    return null;
-  }
+  const tyrantSequenceEvents = useMemo((): CastSequenceEntry<TyrantCastData>[] => {
+    if (!demonicTyrant || !eventHistory) return [];
 
-  function formatTimestampMs(ms: number) {
-    const totalSec = Math.floor(ms / 1000);
-    const min = Math.floor(totalSec / 60);
-    const sec = totalSec % 60;
-    return `${min}:${sec.toString().padStart(2, '0')}`;
-  }
-
-  const tyrant = <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT} />;
-
-  const explanation = (
-    <>
-      <p>
-        <b>{tyrant}</b> deals increased damage based on the number of active demons during its
-        duration. To maximize its effectiveness, summon as many pets as possible before and during
-        the Tyrant window.
-      </p>
-
-      <p>The primary demons contributing to Tyrant damage are:</p>
-      <ul>
-        <li>
-          <SpellLink spell={SPELLS.CALL_DREADSTALKERS} /> — summons two Dreadstalkers
-        </li>
-        <li>
-          Wild Imps summoned from <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} />
-        </li>
-        <li>
-          Imp Gang Bosses summoned by <SpellLink spell={SPELLS.IMPLOSION_CAST} /> or{' '}
-          <SpellLink spell={TALENTS.POWER_SIPHON_TALENT} /> with the talent{' '}
-          <SpellLink spell={TALENTS.TO_HELL_AND_BACK_TALENT} />
-        </li>
-      </ul>
-
-      <p>
-        During the Tyrant window, aim to cast as many{' '}
-        <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} /> as possible to summon additional imps and
-        increase Tyrant's damage.
-      </p>
-    </>
-  );
-  const tyrantSequenceEvents: CastSequenceEntry<TyrantCastData>[] = demonicTyrant.tyrantData.map(
-    (cast) => {
+    return demonicTyrant.tyrantData.map((cast) => {
       const windowStart = cast.cast - TYRANT_PRE_WINDOW;
       const windowEnd = cast.cast + TYRANT_POST_WINDOW;
 
@@ -166,49 +114,61 @@ function DemonicTyrantGuide(): JSX.Element | null {
         icon: event.ability.abilityIcon.replace('.jpg', ''),
       }));
 
-      return {
-        data: cast,
-        start: windowStart,
-        end: windowEnd,
-        casts,
-      };
-    },
-  );
+      return { data: cast, start: windowStart, end: windowEnd, casts };
+    });
+  }, [demonicTyrant, eventHistory]);
 
-  const perCastData: PerCastData[] = demonicTyrant.tyrantData.map((cast, index) => {
-    const sequenceEntry = tyrantSequenceEvents[index];
+  const perCastData: PerCastData[] = useMemo(() => {
+    if (!demonicTyrant) return [];
 
-    return {
-      performance: rateTyrantWindow(cast.handOfGuldanCasts),
-      timestamp: formatTimestampMs(cast.cast),
-      stats: [
-        {
-          label: "Hand of Gul'dan Casts",
-          value: cast.handOfGuldanCasts,
-          tooltip: "Number of Hand of Gul'dan casts during the Tyrant window",
-        },
-        {
-          label: 'Imps Summoned',
-          value: cast.impsSummoned,
-          tooltip: 'Wild Imps generated during the Tyrant window',
-        },
-      ],
-      details: getTyrantFeedback(
-        cast.handOfGuldanCasts,
-        cast.impsSummoned,
-        cast.dreadstalkersActive,
-        cast.dreadstalkersTooEarly,
-        sequenceEntry?.casts ?? [],
-        cast.cast,
-      ),
-      additionalContent: sequenceEntry
-        ? {
-            title: 'Cast Sequence',
-            content: <SpellSequence casts={sequenceEntry.casts} iconSize={40} />,
-          }
-        : undefined,
+    const formatTimestampMs = (ms: number) => {
+      const totalSec = Math.floor(ms / 1000);
+      const min = Math.floor(totalSec / 60);
+      const sec = totalSec % 60;
+      return `${min}:${sec.toString().padStart(2, '0')}`;
     };
-  });
+
+    return demonicTyrant.tyrantData.map((cast, index) => {
+      const sequenceEntry = tyrantSequenceEvents[index];
+
+      return {
+        performance: rateTyrantWindow(cast.handOfGuldanCasts),
+        timestamp: formatTimestampMs(cast.cast),
+        stats: [
+          { label: "Hand of Gul'dan Casts", value: cast.handOfGuldanCasts, tooltip: '...' },
+          { label: 'Imps Summoned', value: cast.impsSummoned, tooltip: '...' },
+        ],
+        details: getTyrantFeedback(
+          cast.handOfGuldanCasts,
+          cast.impsSummoned,
+          cast.dreadstalkersActive,
+          cast.dreadstalkersTooEarly,
+          sequenceEntry?.casts ?? [],
+          cast.cast,
+        ),
+        additionalContent: sequenceEntry
+          ? {
+              title: 'Cast Sequence',
+              content: <SpellSequence casts={sequenceEntry.casts} iconSize={40} />,
+            }
+          : undefined,
+      };
+    });
+  }, [demonicTyrant, tyrantSequenceEvents]);
+
+  // If analyzers are missing, just render nothing
+  if (!demonicTyrant || !eventHistory) return null;
+
+  const tyrant = <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT} />;
+  const explanation = (
+    <>
+      <p>
+        <b>{tyrant}</b> deals increased damage based on the number of active demons during its
+        duration.
+      </p>
+      {/* ... rest of your explanation ... */}
+    </>
+  );
 
   return (
     <GuideSection spell={SPELLS.SUMMON_DEMONIC_TYRANT} explanation={explanation}>

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from 'react';
 import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
 import { SpellLink } from 'interface';
 import Analyzer from 'parser/core/Analyzer';
 import { EventType } from 'parser/core/Events';
@@ -14,8 +15,8 @@ import {
 import DemonicTyrant, { TyrantCastData } from '../features/DemonicTyrant';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
-const TYRANT_PRE_WINDOW = 8000;
-const TYRANT_POST_WINDOW = 12000;
+const TYRANT_PRE_WINDOW = 7000;
+const TYRANT_POST_WINDOW = 20000;
 
 class DemonicTyrantGuide extends Analyzer {
   static dependencies = {
@@ -31,11 +32,31 @@ class DemonicTyrantGuide extends Analyzer {
 
     const explanation = (
       <>
-        <b>{tyrant}</b> is Demonology's primary cooldown. The goal is to build a strong demon setup
-        before casting it and then spend globals efficiently during the window.
+        <b>{tyrant}</b> deals increased damage based on the number of active demons during its
+        duration. To maximize its effectiveness, summon as many pets as possible before and during
+        the Tyrant window.
+        <br />
+        <br />
+        The primary demons contributing to Tyrant damage are:
+        <ul>
+          <li>
+            <SpellLink spell={SPELLS.CALL_DREADSTALKERS} /> — summons two Dreadstalkers
+          </li>
+          <li>
+            Wild Imps summoned from <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} />
+          </li>
+          <li>
+            Imp Gang Bosses summoned by <SpellLink spell={SPELLS.IMPLOSION_CAST} /> or{' '}
+            <SpellLink spell={TALENTS.POWER_SIPHON_TALENT} /> with the talent{' '}
+            <SpellLink spell={TALENTS.TO_HELL_AND_BACK_TALENT} />
+          </li>
+        </ul>
+        <br />
+        During the Tyrant window, aim to cast as many{' '}
+        <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} /> as possible to summon additional imps and
+        increase Tyrant's damage.
       </>
     );
-
     const tyrantSequenceEvents: CastSequenceEntry<TyrantCastData>[] =
       this.demonicTyrant.tyrantData.map((cast) => {
         const windowStart = cast.cast - TYRANT_PRE_WINDOW;
@@ -63,14 +84,115 @@ class DemonicTyrantGuide extends Analyzer {
         };
       });
 
+    function rateTyrantWindow(handOfGuldanCasts: number): QualitativePerformance {
+      if (handOfGuldanCasts >= 6) {
+        return QualitativePerformance.Perfect;
+      }
+      if (handOfGuldanCasts === 5) {
+        return QualitativePerformance.Good;
+      }
+      if (handOfGuldanCasts >= 3) {
+        return QualitativePerformance.Ok;
+      }
+
+      return QualitativePerformance.Fail;
+    }
+
+    function getTyrantFeedback(
+      handOfGuldanCasts: number,
+      impsSummoned: number,
+      casts: CastInSequence[],
+      tyrantTimestamp: number,
+    ): JSX.Element {
+      const feedback: string[] = [];
+      const preTyrantCasts = casts.filter((cast) => cast.timestamp < tyrantTimestamp);
+
+      if (handOfGuldanCasts >= 6) {
+        feedback.push(
+          "Perfect Tyrant window. You maximized Hand of Gul'dan casts during the Tyrant duration.",
+        );
+      } else if (handOfGuldanCasts === 5) {
+        feedback.push(
+          "Great Tyrant window. One additional Hand of Gul'dan cast would make this perfect.",
+        );
+      } else if (handOfGuldanCasts >= 3) {
+        feedback.push(
+          "Try to cast Hand of Gul'dan more often during Tyrant by saving Demonic Cores for your Tyrant window.",
+        );
+      } else {
+        feedback.push(
+          "Too few Hand of Gul'dan casts. Either try pooling Soul Shards or Demonic Core charges before casting Tyrant.",
+        );
+      }
+
+      const castedDreadstalkers = preTyrantCasts.some(
+        (cast) => cast.spellId === SPELLS.CALL_DREADSTALKERS.id,
+      );
+
+      const castedImplosion = preTyrantCasts.some(
+        (cast) => cast.spellId === SPELLS.IMPLOSION_CAST.id,
+      );
+
+      const castedPowerSiphon = preTyrantCasts.some(
+        (cast) => cast.spellId === TALENTS.POWER_SIPHON_TALENT.id,
+      );
+
+      if (!castedDreadstalkers) {
+        feedback.push(
+          'Cast Call Dreadstalkers before summoning Demonic Tyrant so they benefit from the damage bonus.',
+        );
+      }
+
+      if (castedImplosion) {
+        feedback.push(
+          'Avoid casting Implosion before Tyrant, as it removes imps that Tyrant could extend.',
+        );
+      }
+
+      if (castedPowerSiphon) {
+        feedback.push(
+          'Power Siphon before Tyrant sacrifices imps that could increase Tyrant damage.',
+        );
+      }
+
+      if (impsSummoned < 8) {
+        feedback.push(
+          'Entering Tyrant with more imps already active will significantly increase its damage.',
+        );
+      }
+      return (
+        <>
+          {feedback.map((line, i) => (
+            <div key={i}>{line}</div>
+          ))}
+        </>
+      );
+    }
+
     const perCastData: PerCastData[] = this.demonicTyrant.tyrantData.map((cast, index) => {
       const sequenceEntry = tyrantSequenceEvents[index];
 
       return {
-        performance: QualitativePerformance.Ok,
+        performance: rateTyrantWindow(cast.handOfGuldanCasts),
         timestamp: this.owner.formatTimestamp(cast.cast),
-        stats: [],
-        details: 'Spell sequence around Demonic Tyrant.',
+        stats: [
+          {
+            label: "Hand of Gul'dan Casts",
+            value: cast.handOfGuldanCasts,
+            tooltip: "Number of Hand of Gul'dan casts during the Tyrant window",
+          },
+          {
+            label: 'Imps Summoned',
+            value: cast.impsSummoned,
+            tooltip: 'Wild Imps generated during the Tyrant window',
+          },
+        ],
+        details: getTyrantFeedback(
+          cast.handOfGuldanCasts,
+          cast.impsSummoned,
+          sequenceEntry?.casts ?? [],
+          cast.cast,
+        ),
         additionalContent: sequenceEntry
           ? {
               title: 'Cast Sequence',

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -73,7 +73,6 @@ class DemonicTyrantGuide extends Analyzer {
           spellId: event.ability.guid,
           spellName: event.ability.name,
           icon: event.ability.abilityIcon.replace('.jpg', ''),
-          performance: QualitativePerformance.Ok,
         }));
 
         return {

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -101,6 +101,8 @@ class DemonicTyrantGuide extends Analyzer {
     function getTyrantFeedback(
       handOfGuldanCasts: number,
       impsSummoned: number,
+      dreadstalkersActive: boolean,
+      dreadstalkersTooEarly: boolean,
       casts: CastInSequence[],
       tyrantTimestamp: number,
     ): JSX.Element {
@@ -125,10 +127,6 @@ class DemonicTyrantGuide extends Analyzer {
         );
       }
 
-      const castedDreadstalkers = preTyrantCasts.some(
-        (cast) => cast.spellId === SPELLS.CALL_DREADSTALKERS.id,
-      );
-
       const castedImplosion = preTyrantCasts.some(
         (cast) => cast.spellId === SPELLS.IMPLOSION_CAST.id,
       );
@@ -137,9 +135,13 @@ class DemonicTyrantGuide extends Analyzer {
         (cast) => cast.spellId === TALENTS.POWER_SIPHON_TALENT.id,
       );
 
-      if (!castedDreadstalkers) {
+      if (!dreadstalkersActive) {
         feedback.push(
           'Cast Call Dreadstalkers before summoning Demonic Tyrant so they benefit from the damage bonus.',
+        );
+      } else if (dreadstalkersTooEarly) {
+        feedback.push(
+          'Call Dreadstalkers was cast too early before Tyrant. Try casting it closer to your Summon Demonic Tyrant window.',
         );
       }
 
@@ -190,6 +192,8 @@ class DemonicTyrantGuide extends Analyzer {
         details: getTyrantFeedback(
           cast.handOfGuldanCasts,
           cast.impsSummoned,
+          cast.dreadstalkersActive,
+          cast.dreadstalkersTooEarly,
           sequenceEntry?.casts ?? [],
           cast.cast,
         ),

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -2,7 +2,6 @@ import type { JSX } from 'react';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 import { SpellLink } from 'interface';
-import Analyzer from 'parser/core/Analyzer';
 import { EventType } from 'parser/core/Events';
 import GuideSection from 'interface/guide/components/GuideSection';
 import CastDetail, { type PerCastData } from 'interface/guide/components/CastDetail';
@@ -14,203 +13,208 @@ import {
 } from 'interface/guide/components/CastSequence';
 import DemonicTyrant, { TyrantCastData } from '../features/DemonicTyrant';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { useAnalyzer } from 'interface/guide';
 
 const TYRANT_PRE_WINDOW = 7000;
 const TYRANT_POST_WINDOW = 20000;
 
-class DemonicTyrantGuide extends Analyzer {
-  static dependencies = {
-    demonicTyrant: DemonicTyrant,
-    eventHistory: EventHistory,
-  };
+function rateTyrantWindow(handOfGuldanCasts: number): QualitativePerformance {
+  if (handOfGuldanCasts >= 6) {
+    return QualitativePerformance.Perfect;
+  }
+  if (handOfGuldanCasts === 5) {
+    return QualitativePerformance.Good;
+  }
+  if (handOfGuldanCasts >= 3) {
+    return QualitativePerformance.Ok;
+  }
 
-  protected demonicTyrant!: DemonicTyrant;
-  protected eventHistory!: EventHistory;
+  return QualitativePerformance.Fail;
+}
 
-  get guideSubsection(): JSX.Element {
-    const tyrant = <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT} />;
+function getTyrantFeedback(
+  handOfGuldanCasts: number,
+  impsSummoned: number,
+  dreadstalkersActive: boolean,
+  dreadstalkersTooEarly: boolean,
+  casts: CastInSequence[],
+  tyrantTimestamp: number,
+): JSX.Element {
+  const feedback: string[] = [];
+  const preTyrantCasts = casts.filter((cast) => cast.timestamp < tyrantTimestamp);
 
-    const explanation = (
-      <>
+  if (handOfGuldanCasts >= 6) {
+    feedback.push(
+      "Perfect Tyrant window. You maximized Hand of Gul'dan casts during the Tyrant duration.",
+    );
+  } else if (handOfGuldanCasts === 5) {
+    feedback.push(
+      "Great Tyrant window. One additional Hand of Gul'dan cast would make this perfect.",
+    );
+  } else if (handOfGuldanCasts >= 3) {
+    feedback.push(
+      "Try to cast Hand of Gul'dan more often during Tyrant by saving Demonic Cores for your Tyrant window.",
+    );
+  } else {
+    feedback.push(
+      "Too few Hand of Gul'dan casts. Either try pooling Soul Shards or Demonic Core charges before casting Tyrant.",
+    );
+  }
+
+  const castedImplosion = preTyrantCasts.some((cast) => cast.spellId === SPELLS.IMPLOSION_CAST.id);
+
+  const castedPowerSiphon = preTyrantCasts.some(
+    (cast) => cast.spellId === TALENTS.POWER_SIPHON_TALENT.id,
+  );
+
+  if (!dreadstalkersActive) {
+    feedback.push(
+      'Cast Call Dreadstalkers before summoning Demonic Tyrant so they benefit from the damage bonus.',
+    );
+  } else if (dreadstalkersTooEarly) {
+    feedback.push(
+      'Call Dreadstalkers was cast too early before Tyrant. Try casting it closer to your Summon Demonic Tyrant window.',
+    );
+  }
+
+  if (castedImplosion) {
+    feedback.push(
+      'Avoid casting Implosion before Tyrant, as it removes imps that Tyrant could extend.',
+    );
+  }
+
+  if (castedPowerSiphon) {
+    feedback.push('Power Siphon before Tyrant sacrifices imps that could increase Tyrant damage.');
+  }
+
+  if (impsSummoned < 8) {
+    feedback.push(
+      'Entering Tyrant with more imps already active will significantly increase its damage.',
+    );
+  }
+  return (
+    <ul>
+      {feedback.map((line, i) => (
+        <li key={i}>{line}</li>
+      ))}
+    </ul>
+  );
+}
+
+function DemonicTyrantGuide(): JSX.Element | null {
+  const demonicTyrant = useAnalyzer(DemonicTyrant);
+  const eventHistory = useAnalyzer(EventHistory);
+
+  if (!demonicTyrant || !eventHistory) {
+    return null;
+  }
+
+  function formatTimestampMs(ms: number) {
+    const totalSec = Math.floor(ms / 1000);
+    const min = Math.floor(totalSec / 60);
+    const sec = totalSec % 60;
+    return `${min}:${sec.toString().padStart(2, '0')}`;
+  }
+
+  const tyrant = <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT} />;
+
+  const explanation = (
+    <>
+      <p>
         <b>{tyrant}</b> deals increased damage based on the number of active demons during its
         duration. To maximize its effectiveness, summon as many pets as possible before and during
         the Tyrant window.
-        <br />
-        <br />
-        The primary demons contributing to Tyrant damage are:
-        <ul>
-          <li>
-            <SpellLink spell={SPELLS.CALL_DREADSTALKERS} /> — summons two Dreadstalkers
-          </li>
-          <li>
-            Wild Imps summoned from <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} />
-          </li>
-          <li>
-            Imp Gang Bosses summoned by <SpellLink spell={SPELLS.IMPLOSION_CAST} /> or{' '}
-            <SpellLink spell={TALENTS.POWER_SIPHON_TALENT} /> with the talent{' '}
-            <SpellLink spell={TALENTS.TO_HELL_AND_BACK_TALENT} />
-          </li>
-        </ul>
-        <br />
+      </p>
+
+      <p>The primary demons contributing to Tyrant damage are:</p>
+      <ul>
+        <li>
+          <SpellLink spell={SPELLS.CALL_DREADSTALKERS} /> — summons two Dreadstalkers
+        </li>
+        <li>
+          Wild Imps summoned from <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} />
+        </li>
+        <li>
+          Imp Gang Bosses summoned by <SpellLink spell={SPELLS.IMPLOSION_CAST} /> or{' '}
+          <SpellLink spell={TALENTS.POWER_SIPHON_TALENT} /> with the talent{' '}
+          <SpellLink spell={TALENTS.TO_HELL_AND_BACK_TALENT} />
+        </li>
+      </ul>
+
+      <p>
         During the Tyrant window, aim to cast as many{' '}
         <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} /> as possible to summon additional imps and
         increase Tyrant's damage.
-      </>
-    );
-    const tyrantSequenceEvents: CastSequenceEntry<TyrantCastData>[] =
-      this.demonicTyrant.tyrantData.map((cast) => {
-        const windowStart = cast.cast - TYRANT_PRE_WINDOW;
-        const windowEnd = cast.cast + TYRANT_POST_WINDOW;
+      </p>
+    </>
+  );
+  const tyrantSequenceEvents: CastSequenceEntry<TyrantCastData>[] = demonicTyrant.tyrantData.map(
+    (cast) => {
+      const windowStart = cast.cast - TYRANT_PRE_WINDOW;
+      const windowEnd = cast.cast + TYRANT_POST_WINDOW;
 
-        const castEvents = this.eventHistory.getEvents([EventType.Cast], {
-          searchBackwards: false,
-          startTimestamp: windowStart,
-          duration: windowEnd - windowStart,
-        });
-
-        const casts: CastInSequence[] = castEvents.map((event) => ({
-          timestamp: event.timestamp,
-          spellId: event.ability.guid,
-          spellName: event.ability.name,
-          icon: event.ability.abilityIcon.replace('.jpg', ''),
-        }));
-
-        return {
-          data: cast,
-          start: windowStart,
-          end: windowEnd,
-          casts,
-        };
+      const castEvents = eventHistory.getEvents([EventType.Cast], {
+        searchBackwards: false,
+        startTimestamp: windowStart,
+        duration: windowEnd - windowStart,
       });
 
-    function rateTyrantWindow(handOfGuldanCasts: number): QualitativePerformance {
-      if (handOfGuldanCasts >= 6) {
-        return QualitativePerformance.Perfect;
-      }
-      if (handOfGuldanCasts === 5) {
-        return QualitativePerformance.Good;
-      }
-      if (handOfGuldanCasts >= 3) {
-        return QualitativePerformance.Ok;
-      }
-
-      return QualitativePerformance.Fail;
-    }
-
-    function getTyrantFeedback(
-      handOfGuldanCasts: number,
-      impsSummoned: number,
-      dreadstalkersActive: boolean,
-      dreadstalkersTooEarly: boolean,
-      casts: CastInSequence[],
-      tyrantTimestamp: number,
-    ): JSX.Element {
-      const feedback: string[] = [];
-      const preTyrantCasts = casts.filter((cast) => cast.timestamp < tyrantTimestamp);
-
-      if (handOfGuldanCasts >= 6) {
-        feedback.push(
-          "Perfect Tyrant window. You maximized Hand of Gul'dan casts during the Tyrant duration.",
-        );
-      } else if (handOfGuldanCasts === 5) {
-        feedback.push(
-          "Great Tyrant window. One additional Hand of Gul'dan cast would make this perfect.",
-        );
-      } else if (handOfGuldanCasts >= 3) {
-        feedback.push(
-          "Try to cast Hand of Gul'dan more often during Tyrant by saving Demonic Cores for your Tyrant window.",
-        );
-      } else {
-        feedback.push(
-          "Too few Hand of Gul'dan casts. Either try pooling Soul Shards or Demonic Core charges before casting Tyrant.",
-        );
-      }
-
-      const castedImplosion = preTyrantCasts.some(
-        (cast) => cast.spellId === SPELLS.IMPLOSION_CAST.id,
-      );
-
-      const castedPowerSiphon = preTyrantCasts.some(
-        (cast) => cast.spellId === TALENTS.POWER_SIPHON_TALENT.id,
-      );
-
-      if (!dreadstalkersActive) {
-        feedback.push(
-          'Cast Call Dreadstalkers before summoning Demonic Tyrant so they benefit from the damage bonus.',
-        );
-      } else if (dreadstalkersTooEarly) {
-        feedback.push(
-          'Call Dreadstalkers was cast too early before Tyrant. Try casting it closer to your Summon Demonic Tyrant window.',
-        );
-      }
-
-      if (castedImplosion) {
-        feedback.push(
-          'Avoid casting Implosion before Tyrant, as it removes imps that Tyrant could extend.',
-        );
-      }
-
-      if (castedPowerSiphon) {
-        feedback.push(
-          'Power Siphon before Tyrant sacrifices imps that could increase Tyrant damage.',
-        );
-      }
-
-      if (impsSummoned < 8) {
-        feedback.push(
-          'Entering Tyrant with more imps already active will significantly increase its damage.',
-        );
-      }
-      return (
-        <>
-          {feedback.map((line, i) => (
-            <div key={i}>{line}</div>
-          ))}
-        </>
-      );
-    }
-
-    const perCastData: PerCastData[] = this.demonicTyrant.tyrantData.map((cast, index) => {
-      const sequenceEntry = tyrantSequenceEvents[index];
+      const casts: CastInSequence[] = castEvents.map((event) => ({
+        timestamp: event.timestamp,
+        spellId: event.ability.guid,
+        spellName: event.ability.name,
+        icon: event.ability.abilityIcon.replace('.jpg', ''),
+      }));
 
       return {
-        performance: rateTyrantWindow(cast.handOfGuldanCasts),
-        timestamp: this.owner.formatTimestamp(cast.cast),
-        stats: [
-          {
-            label: "Hand of Gul'dan Casts",
-            value: cast.handOfGuldanCasts,
-            tooltip: "Number of Hand of Gul'dan casts during the Tyrant window",
-          },
-          {
-            label: 'Imps Summoned',
-            value: cast.impsSummoned,
-            tooltip: 'Wild Imps generated during the Tyrant window',
-          },
-        ],
-        details: getTyrantFeedback(
-          cast.handOfGuldanCasts,
-          cast.impsSummoned,
-          cast.dreadstalkersActive,
-          cast.dreadstalkersTooEarly,
-          sequenceEntry?.casts ?? [],
-          cast.cast,
-        ),
-        additionalContent: sequenceEntry
-          ? {
-              title: 'Cast Sequence',
-              content: <SpellSequence casts={sequenceEntry.casts} iconSize={40} />,
-            }
-          : undefined,
+        data: cast,
+        start: windowStart,
+        end: windowEnd,
+        casts,
       };
-    });
+    },
+  );
 
-    return (
-      <GuideSection spell={SPELLS.SUMMON_DEMONIC_TYRANT} explanation={explanation}>
-        <CastDetail title="Demonic Tyrant Casts" casts={perCastData} />
-      </GuideSection>
-    );
-  }
+  const perCastData: PerCastData[] = demonicTyrant.tyrantData.map((cast, index) => {
+    const sequenceEntry = tyrantSequenceEvents[index];
+
+    return {
+      performance: rateTyrantWindow(cast.handOfGuldanCasts),
+      timestamp: formatTimestampMs(cast.cast),
+      stats: [
+        {
+          label: "Hand of Gul'dan Casts",
+          value: cast.handOfGuldanCasts,
+          tooltip: "Number of Hand of Gul'dan casts during the Tyrant window",
+        },
+        {
+          label: 'Imps Summoned',
+          value: cast.impsSummoned,
+          tooltip: 'Wild Imps generated during the Tyrant window',
+        },
+      ],
+      details: getTyrantFeedback(
+        cast.handOfGuldanCasts,
+        cast.impsSummoned,
+        cast.dreadstalkersActive,
+        cast.dreadstalkersTooEarly,
+        sequenceEntry?.casts ?? [],
+        cast.cast,
+      ),
+      additionalContent: sequenceEntry
+        ? {
+            title: 'Cast Sequence',
+            content: <SpellSequence casts={sequenceEntry.casts} iconSize={40} />,
+          }
+        : undefined,
+    };
+  });
+
+  return (
+    <GuideSection spell={SPELLS.SUMMON_DEMONIC_TYRANT} explanation={explanation}>
+      <CastDetail title="Demonic Tyrant Casts" casts={perCastData} />
+    </GuideSection>
+  );
 }
 
 export default DemonicTyrantGuide;

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -26,6 +26,13 @@ function rateTyrantWindow(handOfGuldanCasts: number): QualitativePerformance {
   return QualitativePerformance.Fail;
 }
 
+function formatTimestampMs(ms: number) {
+  const totalSec = Math.floor(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}:${sec.toString().padStart(2, '0')}`;
+}
+
 function getTyrantFeedback(
   handOfGuldanCasts: number,
   impsSummoned: number,
@@ -74,8 +81,10 @@ function getTyrantFeedback(
     feedback.push(
       'Avoid casting Implosion before Tyrant, as it removes imps that Tyrant could extend.',
     );
+
   if (castedPowerSiphon)
     feedback.push('Power Siphon before Tyrant sacrifices imps that could increase Tyrant damage.');
+
   if (impsSummoned < 8)
     feedback.push(
       'Entering Tyrant with more imps already active will significantly increase its damage.',
@@ -84,7 +93,7 @@ function getTyrantFeedback(
   return (
     <ul>
       {feedback.map((line, i) => (
-        <li key={i}>{line}</li>
+        <p key={i}>{line}</p>
       ))}
     </ul>
   );
@@ -114,19 +123,17 @@ function DemonicTyrantGuide(): JSX.Element | null {
         icon: event.ability.abilityIcon.replace('.jpg', ''),
       }));
 
-      return { data: cast, start: windowStart, end: windowEnd, casts };
+      return {
+        data: cast,
+        start: windowStart,
+        end: windowEnd,
+        casts,
+      };
     });
   }, [demonicTyrant, eventHistory]);
 
   const perCastData: PerCastData[] = useMemo(() => {
     if (!demonicTyrant) return [];
-
-    const formatTimestampMs = (ms: number) => {
-      const totalSec = Math.floor(ms / 1000);
-      const min = Math.floor(totalSec / 60);
-      const sec = totalSec % 60;
-      return `${min}:${sec.toString().padStart(2, '0')}`;
-    };
 
     return demonicTyrant.tyrantData.map((cast, index) => {
       const sequenceEntry = tyrantSequenceEvents[index];
@@ -135,8 +142,16 @@ function DemonicTyrantGuide(): JSX.Element | null {
         performance: rateTyrantWindow(cast.handOfGuldanCasts),
         timestamp: formatTimestampMs(cast.cast),
         stats: [
-          { label: "Hand of Gul'dan Casts", value: cast.handOfGuldanCasts, tooltip: '...' },
-          { label: 'Imps Summoned', value: cast.impsSummoned, tooltip: '...' },
+          {
+            label: "Hand of Gul'dan Casts",
+            value: cast.handOfGuldanCasts,
+            tooltip: "Number of Hand of Gul'dan casts during the Tyrant window",
+          },
+          {
+            label: 'Imps Summoned',
+            value: cast.impsSummoned,
+            tooltip: 'Wild Imps generated during the Tyrant window',
+          },
         ],
         details: getTyrantFeedback(
           cast.handOfGuldanCasts,
@@ -156,17 +171,39 @@ function DemonicTyrantGuide(): JSX.Element | null {
     });
   }, [demonicTyrant, tyrantSequenceEvents]);
 
-  // If analyzers are missing, just render nothing
   if (!demonicTyrant || !eventHistory) return null;
 
   const tyrant = <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT} />;
+
   const explanation = (
     <>
       <p>
         <b>{tyrant}</b> deals increased damage based on the number of active demons during its
-        duration.
+        duration. To maximize its effectiveness, summon as many pets as possible before and during
+        the Tyrant window.
       </p>
-      {/* ... rest of your explanation ... */}
+
+      <p>The primary demons contributing to Tyrant damage are:</p>
+
+      <ul>
+        <li>
+          <SpellLink spell={SPELLS.CALL_DREADSTALKERS} /> — summons two Dreadstalkers
+        </li>
+        <li>
+          Wild Imps summoned from <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} />
+        </li>
+        <li>
+          Imp Gang Bosses summoned by <SpellLink spell={SPELLS.IMPLOSION_CAST} /> or{' '}
+          <SpellLink spell={TALENTS.POWER_SIPHON_TALENT} /> with the talent{' '}
+          <SpellLink spell={TALENTS.TO_HELL_AND_BACK_TALENT} />
+        </li>
+      </ul>
+
+      <p>
+        During the Tyrant window, aim to cast as many{' '}
+        <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} /> as possible to summon additional imps and
+        increase Tyrant's damage.
+      </p>
     </>
   );
 

--- a/src/analysis/retail/warlock/demonology/modules/guide/ResourceUsage.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/ResourceUsage.tsx
@@ -1,16 +1,20 @@
 import { GuideProps, Section, SubSection } from 'interface/guide';
 import CombatLogParser from '../../CombatLogParser';
+import SoulShardGraph from '../resources/SoulShardGraph';
 
 function ResourceUsage({ modules }: GuideProps<typeof CombatLogParser>) {
+  // cast the module to the correct type
+  const soulShardGraph = modules.soulshardGraph as SoulShardGraph | undefined;
+
   return (
     <Section title="Resource Use">
       <SubSection title="Soul Shards">
-        <>
+        <p>
           These are your primary spending resource as a Warlock. Instead of spells having cooldowns,
           you'll be gated by the amount of Soul Shards you have available. Outside of combat you
           passively regenerate up to 3 shards.
-          {modules.soulshardGraph.plot}
-        </>
+        </p>
+        {soulShardGraph?.plot}
       </SubSection>
     </Section>
   );


### PR DESCRIPTION
### Description

Adds a <b>Demonic Tyrant guide analyzer</b> for Demo Warlock.

This analyzer evaluates each <b>Summon Demonic Tyrant</b> window and provides feedback on how effectively the setup was executed.

The guide currently evaluates:
<ul>
<li> Number of <b>Hand of Gul'dan</b> casts </li>
<li> Number of <b>Wild Imps</b> summoned</li>
<li>Whether <b>Call Dreadstalkers</b> was active when Tyrant was cast</li>
<li>Whether <b>Call Dreadstalkers was cast too early</b> before Tyrant</li>
<li>Whether <b>Implosion</b> or <b>Power Siphon</b> were cast before Tyrant (which reduces demon count)</li>
</ul>

Each Tyrant cast is rated based on the number of <b>Hand of Gul'dan</b> casts during the Tyrant window, and a
<b>cast sequence view</b> shows the spells used around the Tyrant setup.

Also added logic to detect if <b>Call Dreadstalkers</b> was cast too far in advance before Tyrant and therefore expired too soon


### Testing

- Test report URL: 
`report/gnxHv1YBbTdzP3aC/9-Mythic+Gemellus+-+Kill+(2:04)/4-Katorrí/standard`
`report/gnxHv1YBbTdzP3aC/14-Mythic+Degentrius+-+Kill+(1:44)/4-Katorrí/standard`
- Screenshot(s):
<img width="1287" height="566" alt="image" src="https://github.com/user-attachments/assets/5400128f-ff77-4c37-b243-a7128c2452e0" />
<img width="1264" height="538" alt="image" src="https://github.com/user-attachments/assets/8f775afd-e766-4474-b633-86527eda258b" />
