### PR TITLE
update zone and encounter IDs for Midnight S1

### DIFF
--- a/src/game/ZONES.ts
+++ b/src/game/ZONES.ts
@@ -17,32 +17,18 @@ export interface Zone {
 
 const ZONES: Zone[] = [
   {
-    id: 49, // TODO (@emallson): the release zone is 47
+    id: 47,
     name: 'Mythic+ Season 1',
     frozen: false,
     useBetaTooltips: true,
     encounters: Object.values(MythicPlusSeasonOne.bosses),
   },
   {
-    id: 48, // TODO (@emallson): the release zone is 46
+    id: 46,
     name: 'Voidspire / Dreamrift / MQD',
     frozen: false,
     useBetaTooltips: true,
     encounters: Object.values(VSDRMQD.bosses),
-  },
-  {
-    id: 45,
-    name: 'Mythic+ Season 3',
-    frozen: false,
-    encounters: [],
-    partition: 2, // pre-patch
-  },
-  {
-    id: 44,
-    name: 'Manaforge Omega',
-    frozen: false,
-    encounters: [],
-    partition: 3, // pre-patch
   },
 ];
 

--- a/src/game/raids/mythicplusseasonone/index.ts
+++ b/src/game/raids/mythicplusseasonone/index.ts
@@ -7,35 +7,35 @@ export default {
   background,
   bosses: {
     MagistersTerrace: buildBoss({
-      id: 2811,
+      id: 12811,
       name: "Magister's Terrace",
     }),
     MaisaraCaverns: buildBoss({
-      id: 2874,
+      id: 12874,
       name: 'Maisara Caverns',
     }),
     NexusPointXenas: buildBoss({
-      id: 2915,
+      id: 12915,
       name: 'Nexus Point Xenas',
     }),
     WindrunnerSpire: buildBoss({
-      id: 2805,
+      id: 12805,
       name: 'Windrunner Spire',
     }),
     AlgetharAcademy: buildBoss({
-      id: 162526,
+      id: 112526,
       name: "Algeth'ar Academy",
     }),
     SeatOfTheTriumvirate: buildBoss({
-      id: 411753,
+      id: 361753,
       name: 'The Seat of the Triumvirate',
     }),
     Skyreach: buildBoss({
-      id: 111209,
+      id: 61209,
       name: 'Skyreach',
     }),
     PitOfSaron: buildBoss({
-      id: 60658,
+      id: 10658,
       name: 'Pit of Saron',
     }),
   },

--- a/src/game/raids/vs_dr_mqd/Beloren.ts
+++ b/src/game/raids/vs_dr_mqd/Beloren.ts
@@ -1,3 +1,3 @@
 import { buildBoss } from 'game/raids/builders';
 
-export const Beloren = buildBoss({ id: 53182, name: "Belo'ren, Child of Al'ar" });
+export const Beloren = buildBoss({ id: 3182, name: "Belo'ren, Child of Al'ar" });

--- a/src/game/raids/vs_dr_mqd/Chimaerus.ts
+++ b/src/game/raids/vs_dr_mqd/Chimaerus.ts
@@ -1,3 +1,3 @@
 import { buildBoss } from 'game/raids/builders';
 
-export const Chimaerus = buildBoss({ id: 53306, name: 'Chimaerus the Undreamt God' });
+export const Chimaerus = buildBoss({ id: 3306, name: 'Chimaerus the Undreamt God' });

--- a/src/game/raids/vs_dr_mqd/CrownOfTheCosmos.ts
+++ b/src/game/raids/vs_dr_mqd/CrownOfTheCosmos.ts
@@ -1,3 +1,3 @@
 import { buildBoss } from 'game/raids/builders';
 
-export const CrownOfTheCosmos = buildBoss({ id: 53181, name: 'Crown of the Cosmos' });
+export const CrownOfTheCosmos = buildBoss({ id: 3181, name: 'Crown of the Cosmos' });

--- a/src/game/raids/vs_dr_mqd/ImperatorAverzian.ts
+++ b/src/game/raids/vs_dr_mqd/ImperatorAverzian.ts
@@ -1,3 +1,3 @@
 import { buildBoss } from 'game/raids/builders';
 
-export const ImperatorAverzian = buildBoss({ id: 53176, name: 'Imperator Averzian' });
+export const ImperatorAverzian = buildBoss({ id: 3176, name: 'Imperator Averzian' });

--- a/src/game/raids/vs_dr_mqd/LightblindedVanguard.ts
+++ b/src/game/raids/vs_dr_mqd/LightblindedVanguard.ts
@@ -1,3 +1,3 @@
 import { buildBoss } from 'game/raids/builders';
 
-export const LightblindedVanguard = buildBoss({ id: 53180, name: 'Lightblinded Vanguard' });
+export const LightblindedVanguard = buildBoss({ id: 3180, name: 'Lightblinded Vanguard' });

--- a/src/game/raids/vs_dr_mqd/MidnightFalls.ts
+++ b/src/game/raids/vs_dr_mqd/MidnightFalls.ts
@@ -1,3 +1,3 @@
 import { buildBoss } from 'game/raids/builders';
 
-export const MidnightFalls = buildBoss({ id: 53183, name: 'Midnight Falls' });
+export const MidnightFalls = buildBoss({ id: 3183, name: 'Midnight Falls' });

--- a/src/game/raids/vs_dr_mqd/Salhadaar.ts
+++ b/src/game/raids/vs_dr_mqd/Salhadaar.ts
@@ -1,3 +1,3 @@
 import { buildBoss } from 'game/raids/builders';
 
-export const Salhadaar = buildBoss({ id: 53179, name: 'Fallen King Salhadaar' });
+export const Salhadaar = buildBoss({ id: 3179, name: 'Fallen King Salhadaar' });

--- a/src/game/raids/vs_dr_mqd/VaelgorEzzorak.ts
+++ b/src/game/raids/vs_dr_mqd/VaelgorEzzorak.ts
@@ -1,3 +1,3 @@
 import { buildBoss } from 'game/raids/builders';
 
-export const VaelgorEzzorak = buildBoss({ id: 53178, name: 'Vaelgor & Ezzorak' });
+export const VaelgorEzzorak = buildBoss({ id: 3178, name: 'Vaelgor & Ezzorak' });

--- a/src/game/raids/vs_dr_mqd/Vorasius.ts
+++ b/src/game/raids/vs_dr_mqd/Vorasius.ts
@@ -1,3 +1,3 @@
 import { buildBoss } from 'game/raids/builders';
 
-export const Vorasius = buildBoss({ id: 53177, name: 'Vorasius' });
+export const Vorasius = buildBoss({ id: 3177, name: 'Vorasius' });

--- a/src/interface/CharacterParses.scss
+++ b/src/interface/CharacterParses.scss
@@ -124,11 +124,10 @@
   position: relative;
   z-index: 0;
   background: #0e0b0b;
-  min-height: 600px;
+  min-height: 300px;
   margin-bottom: 30px;
   display: flex;
   flex-direction: column;
-  padding-top: 85px;
 
   .background {
     background-position: center 62.5%;

--- a/src/interface/CharacterParses.tsx
+++ b/src/interface/CharacterParses.tsx
@@ -82,6 +82,17 @@ const ERRORS = {
   }),
 };
 
+const DEFAULT_BACKGROUND_OFFSET = '35%';
+const CHARACTER_BACKGROUND_OFFSETS: Record<number, string> = {
+  // Gnome / Mechagnome / Vulpera
+  [7]: '60%',
+  [35]: '60%',
+  [37]: '60%',
+  // Dwarf / Dark Iron Dwarf
+  [3]: '45%',
+  [34]: '45%',
+};
+
 interface CharacterParsesProps {
   region: string;
   realm: string;
@@ -107,6 +118,7 @@ interface CharacterParsesState {
   sortBy: number;
   metric: string;
   characterImage: string | null;
+  characterRace: number | null; // used to determine background image offset
   classImage: string | null;
   avatarImage: string | null;
   parses: Parse[];
@@ -131,6 +143,7 @@ class CharacterParses extends Component<CharacterParsesProps, CharacterParsesSta
       sortBy: ORDER_BY.DATE,
       metric: 'dps',
       characterImage: null,
+      characterRace: null,
       classImage: null,
       avatarImage: null,
       parses: [],
@@ -337,6 +350,7 @@ class CharacterParses extends Component<CharacterParsesProps, CharacterParsesSta
         classImage: classImageUrl,
         avatarImage: avatarUrl,
         metric: metric,
+        characterRace: data.race,
       },
       () => {
         this.load();
@@ -610,7 +624,7 @@ class CharacterParses extends Component<CharacterParsesProps, CharacterParsesSta
     }
 
     return (
-      <div className="results">
+      <div className="container results">
         <header>
           <div
             className="background"
@@ -622,7 +636,7 @@ class CharacterParses extends Component<CharacterParsesProps, CharacterParsesSta
               className="img"
               style={{
                 backgroundImage: `url(${this.state.characterImage})`,
-                backgroundPosition: 'center center',
+                backgroundPosition: `center ${CHARACTER_BACKGROUND_OFFSETS[this.state.characterRace ?? -1] ?? DEFAULT_BACKGROUND_OFFSET}`,
               }}
             />
           </div>

--- a/src/interface/CharacterParses.tsx
+++ b/src/interface/CharacterParses.tsx
@@ -47,7 +47,7 @@ const ORDER_BY = {
   DPS: 1,
   PERCENTILE: 2,
 };
-const DEFAULT_RETAIL_ZONE = 44; // Manaforge Omega
+const DEFAULT_RETAIL_ZONE = 46; // Voidspire / Dreamrift / MQD
 const DEFAULT_CLASSIC_ZONE = 1046; // Throne of Thunder
 const BOSS_DEFAULT_ALL_BOSSES = 0;
 const FALLBACK_PICTURE = '/img/fallback-character.jpg';

--- a/src/interface/report/Results/Results.scss
+++ b/src/interface/report/Results/Results.scss
@@ -25,7 +25,7 @@
   }
 }
 
-.results {
+#fight-results.results {
   display: grid;
   grid-template-columns: 1fr Ad.$side-rail-width;
   gap: 1rem;

--- a/src/interface/report/Results/index.tsx
+++ b/src/interface/report/Results/index.tsx
@@ -199,7 +199,10 @@ const Results = (props: PassedProps) => {
   return (
     <ResultsContext value={providerValue}>
       <CombatLogParserProvider combatLogParser={props.parser}>
-        <div className={`container results boss-${props.fight.boss} ${!showSideAd ? 'no-ad' : ''}`}>
+        <div
+          id="fight-results"
+          className={`container results boss-${props.fight.boss} ${!showSideAd ? 'no-ad' : ''}`}
+        >
           <div className={'no-expand'}>
             <Header
               config={props.config}


### PR DESCRIPTION
### Description

The beta zone/encounter IDs on WCL are not the same as the ones for the live zones. This PR updates the beta IDs to match the live IDs. This should have no meaningful impact on current usage (including dev usage) *except* that I went ahead and removed the prepatch zone data so it is no longer findable on the character rankings page.

This also fixes layout breakage on the character parses page that occurs if you visit a fight results page and then navigate to character parses. (Along with reducing the header height on this page as well). This is another instance of unscoped CSS breaking things due to delayed loading of other page's CSS files. Eventually we'll get through module-ifying / emotion-ifying all of this CSS 💀 

#### Before
<img width="2940" height="1670" alt="image" src="https://github.com/user-attachments/assets/e686182f-11a5-4098-8f22-d2965bd11038" />

#### After
<img width="2940" height="1670" alt="image" src="https://github.com/user-attachments/assets/1067f182-fd86-4307-bd81-72160c427d9f" />