### PR TITLE
Quick fix for Soul Shard graph

### DIFF
--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Katorri} from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date( 2026, 3, 11), "Fix to show Soul Shard Graph again", Katorri),
   change(date(2026, 3, 6), "Add tracking for Grimoire: Imp Lord and Grimoire: Fel Ravager. Removed Demonic Tyrant Cooldown subsection as it was out of date.", Katorri),
   change(date(20226, 3, 7), <>Create <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT}></SpellLink> Analyzer to detail Demonic Tyrant windows.</>, Katorri),
   change(date(2026, 2, 28), "Initial pass to enable Midnight Demonology. In a very rough state, and some info is out of date.", Katorri)

--- a/src/analysis/retail/warlock/demonology/modules/guide/ResourceUsage.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/ResourceUsage.tsx
@@ -4,7 +4,7 @@ import SoulShardGraph from '../resources/SoulShardGraph';
 
 function ResourceUsage({ modules }: GuideProps<typeof CombatLogParser>) {
   // cast the module to the correct type
-  const soulShardGraph = modules.soulshardGraph as SoulShardGraph | undefined;
+  const soulShardGraph = modules.soulShardGraph as SoulShardGraph | undefined;
 
   return (
     <Section title="Resource Use">


### PR DESCRIPTION
### Description

Fix the const to show the soul shard graph in demo resources
from
`soulshardGraph`

to
`soulShardGraph`

### Testing

- Test report URL: `/report/gnxHv1YBbTdzP3aC/6-Mythic+Seranel+Sunlash+-+Kill+(2:01)/4-Katorrí/standard`
- Screenshot(s):
<img width="1313" height="188" alt="image" src="https://github.com/user-attachments/assets/0cbf6dc4-3b20-4ef0-97ed-5ebc973255f0" />
<img width="1312" height="392" alt="image" src="https://github.com/user-attachments/assets/3d8a8dcb-98c3-4ef2-a40a-0d5784ce4c97" />

