### PR TITLE
Updated Shadow Priest Spellbook

### DIFF
--- a/src/analysis/retail/priest/shadow/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/shadow/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
 //import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/priest';
-import { DoxAshe } from 'CONTRIBUTORS';
+import { DoxAshe, Vetyst } from 'CONTRIBUTORS';
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2026, 3, 14), <>Updated spellbook</>,Vetyst),
   change(date(2026, 2, 24), <>Fix issues in guide view with <SpellLink spell={TALENTS.COLLAPSING_VOID_TALENT}/> </>,DoxAshe),
   change(date(2026, 2, 23), <>Fix issues in guide view with <SpellLink spell={TALENTS.SHADOW_WORD_MADNESS_TALENT}/> and <SpellLink spell={TALENTS.VOIDFORM_TALENT}/></>,DoxAshe),
   change(date(2026, 1, 10), <>Enable spec for Midnight</>,DoxAshe),

--- a/src/analysis/retail/priest/shadow/modules/Abilities.tsx
+++ b/src/analysis/retail/priest/shadow/modules/Abilities.tsx
@@ -126,21 +126,6 @@ class Abilities extends CoreAbilities {
         damageSpellIds: [SPELLS.VOID_VOLLEY_DAMAGE.id],
       },*/
       {
-        spell: TALENTS.MINDBENDER_SHADOW_TALENT.id,
-        category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 60,
-        gcd: {
-          base: 1500,
-        },
-        enabled:
-          combatant.hasTalent(TALENTS.MINDBENDER_SHADOW_TALENT) &&
-          !combatant.hasTalent(TALENTS.VOIDWRAITH_TALENT),
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.9,
-        },
-      },
-      {
         spell: SPELLS.SHADOW_PRIEST_VOIDWEAVER_VOIDWRAITH_CAST.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: 180 - (combatant.hasTalent(TALENTS.MINDBENDER_SHADOW_TALENT) ? 120 : 0), //mindbender reduces the CD of Voidwraith by 2 minutes
@@ -148,23 +133,6 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         enabled: combatant.hasTalent(TALENTS.VOIDWRAITH_TALENT),
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.9,
-        },
-      },
-      {
-        spell: [
-          SPELLS.SHADOWFIEND.id,
-          SPELLS.SHADOWFIEND_WITH_GLYPH_OF_THE_SHA.id,
-          SPELLS.VOIDLING.id,
-        ],
-        category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 180,
-        gcd: {
-          base: 1500,
-        },
-        enabled: !combatant.hasTalent(TALENTS.MINDBENDER_SHADOW_TALENT),
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.9,
@@ -186,24 +154,22 @@ class Abilities extends CoreAbilities {
       },
 
       // Utility
-      /*{
-        spell: TALENTS.DISPERSION_TALENT.id,
+      {
+        spell: SPELLS.DISPERSION.id,
         isDefensive: true,
-        buffSpellId: TALENTS.DISPERSION_TALENT.id,
+        buffSpellId: SPELLS.DISPERSION.id,
         category: SPELL_CATEGORY.DEFENSIVE,
         cooldown: 120 - (combatant.hasTalent(TALENTS.INTANGIBILITY_TALENT) ? 30 : 0),
         gcd: {
           base: 1500,
         },
-        enabled: combatant.hasTalent(TALENTS.DISPERSION_TALENT),
       },
       {
-        spell: TALENTS.SILENCE_TALENT.id,
+        spell: SPELLS.SILENCE.id,
         category: SPELL_CATEGORY.UTILITY,
-        cooldown: 45 - (combatant.hasTalent(TALENTS.LAST_WORD_TALENT) ? 15 : 0),
+        cooldown: 30,
         gcd: null,
-        enabled: combatant.hasTalent(TALENTS.SILENCE_TALENT),
-      },*/
+      },
       {
         spell: SPELLS.POWER_WORD_SHIELD.id,
         isDefensive: true,
@@ -221,10 +187,11 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.DESPERATE_PRAYER.id,
+        spell: TALENTS.DESPERATE_PRAYER_TALENT.id,
         category: SPELL_CATEGORY.DEFENSIVE,
         cooldown: 90 - (combatant.hasTalent(TALENTS.ANGELS_MERCY_TALENT) ? 20 : 0),
         gcd: null,
+        enabled: combatant.hasTalent(TALENTS.DESPERATE_PRAYER_TALENT),
       },
       {
         spell: SPELLS.LEAP_OF_FAITH.id,
@@ -234,9 +201,16 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS.LEAP_OF_FAITH_TALENT),
       },
       {
-        spell: SPELLS.FADE.id,
+        spell: TALENTS.FADE_TALENT.id,
         category: SPELL_CATEGORY.DEFENSIVE,
         cooldown: 30 - combatant.getTalentRank(TALENTS.IMPROVED_FADE_TALENT) * 5,
+        gcd: null,
+        enabled: combatant.hasTalent(TALENTS.FADE_TALENT),
+      },
+      {
+        spell: SPELLS.VAMPIRIC_EMBRACE.id,
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 120,
         gcd: null,
       },
       {
@@ -267,6 +241,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        enabled: combatant.hasTalent(TALENTS.MASS_DISPEL_TALENT),
       },
       {
         spell: TALENTS.DISPEL_MAGIC_TALENT.id,
@@ -274,28 +249,41 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        enabled: combatant.hasTalent(TALENTS.DISPEL_MAGIC_TALENT),
       },
       {
-        spell: SPELLS.MIND_CONTROL.id,
+        spell: TALENTS.MIND_CONTROL_TALENT.id,
         category: SPELL_CATEGORY.UTILITY,
         gcd: {
           base: 1500,
         },
+        enabled: combatant.hasTalent(TALENTS.MIND_CONTROL_TALENT),
       },
       {
-        spell: SPELLS.SHACKLE_UNDEAD.id,
+        spell: TALENTS.DOMINATE_MIND_TALENT.id,
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 30,
+        gcd: {
+          base: 1500,
+        },
+        enabled: combatant.hasTalent(TALENTS.DOMINATE_MIND_TALENT),
+      },
+      {
+        spell: TALENTS.SHACKLE_HORROR_TALENT.id,
         category: SPELL_CATEGORY.UTILITY,
         gcd: {
           base: 1500,
         },
+        enabled: combatant.hasTalent(TALENTS.SHACKLE_HORROR_TALENT),
       },
       {
-        spell: SPELLS.PSYCHIC_SCREAM.id,
+        spell: TALENTS.PSYCHIC_SCREAM_TALENT.id,
         category: SPELL_CATEGORY.UTILITY,
-        cooldown: 60 - (combatant.hasTalent(TALENTS.PSYCHIC_VOICE_TALENT) ? 15 : 0),
+        cooldown: 30 - (combatant.hasTalent(TALENTS.PSYCHIC_VOICE_TALENT) ? 10 : 0),
         gcd: {
           base: 1500,
         },
+        enabled: combatant.hasTalent(TALENTS.PSYCHIC_SCREAM_TALENT),
       },
       {
         spell: SPELLS.MIND_VISION.id,
@@ -311,6 +299,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        enabled: combatant.hasTalent(TALENTS.PURIFY_DISEASE_TALENT),
       },
       {
         spell: TALENTS.ANGELIC_FEATHER_TALENT.id,
@@ -320,6 +309,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
+        enabled: combatant.hasTalent(TALENTS.ANGELIC_FEATHER_TALENT),
       },
       {
         spell: SPELLS.SHADOWFORM.id,

--- a/src/analysis/retail/priest/shadow/modules/spells/ShadowWordDeath.tsx
+++ b/src/analysis/retail/priest/shadow/modules/spells/ShadowWordDeath.tsx
@@ -30,6 +30,9 @@ class ShadowWordDeath extends ExecuteHelper {
   constructor(options: Options) {
     super(options);
     this.active = !this.selectedCombatant.hasTalent(TALENTS.DEATHSPEAKER_TALENT);
+    if (!this.active) {
+      return;
+    }
 
     this.addEventListener(Events.fightend, this.adjustMaxCasts);
     const ctor = this.constructor as typeof ExecuteHelper;

--- a/src/analysis/retail/priest/shadow/modules/spells/ShadowWordDeathSpeaker.tsx
+++ b/src/analysis/retail/priest/shadow/modules/spells/ShadowWordDeathSpeaker.tsx
@@ -30,6 +30,9 @@ class ShadowWordDeathSpeaker extends ExecuteHelper {
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.DEATHSPEAKER_TALENT);
+    if (!this.active) {
+      return;
+    }
 
     this.addEventListener(Events.fightend, this.adjustMaxCasts);
     const ctor = this.constructor as typeof ExecuteHelper;

--- a/src/common/SPELLS/priest.ts
+++ b/src/common/SPELLS/priest.ts
@@ -243,6 +243,11 @@ const spells = {
     icon: 'spell_nature_slow',
     manaCost: 30000,
   },
+  VAMPIRIC_EMBRACE: {
+    id: 15286,
+    name: 'Vampiric Embrace',
+    icon: 'spell_shadow_unsummonbuilding',
+  },
   SHADOWFIEND: {
     id: 34433,
     name: 'Shadowfiend',


### PR DESCRIPTION
Updated the shadow priest spellbook
* Put spells behind talents if this was their source
* Updated cooldown durations
* Added missing spells
  * Dispersion
  * Vampiric Embrace
  * Silence
* De-duplicated Shadow Word: Death


### Testing

/report/YdRCjPN2bTXJ6Maq/1-Heroic+Plexus+Sentinel+-+Kill+(2:03)/16-Doxashe/standard/statistics
/report/CBAkyFWJVR1xXPgQ/34-Mythic+Fallen-King+Salhadaar+-+Kill+(8:09)/9-Nagato/standard

<img width="1197" height="914" alt="image" src="https://github.com/user-attachments/assets/980ffdc1-b93d-4611-8550-9148e88127fe" />
<img width="1197" height="649" alt="image" src="https://github.com/user-attachments/assets/06049900-a30a-472e-bebd-065687a44515" />

