### PR TITLE
Add Support for Haranir Allied Race

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -31,6 +31,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 3, 14), 'Add Support for Haranir Allied Race.', Vetyst),
   change(date(2026, 3, 13), 'Update EnchantChecker for Midnight.', Vetyst),
   change(date(2026, 3, 10), 'Update GemChecker for Midnight', Vetyst),
   change(date(2026, 3, 10), 'Update Flasks for Midnight.', Vetyst),

--- a/src/common/SPELLS/racials.ts
+++ b/src/common/SPELLS/racials.ts
@@ -337,6 +337,12 @@ const spells = {
     name: 'Azerite Surge',
     icon: 'ability_earthen_azeritesurge',
   },
+  // Haranir
+  THORN_BLOOM: {
+    id: 1237885,
+    name: 'Thorn Bloom',
+    icon: 'inv_12_haranir_ability_thornbloom',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/game/RACES.ts
+++ b/src/game/RACES.ts
@@ -176,6 +176,16 @@ const RACES = {
     name: 'Earthen',
     side: 'alliance',
   },
+  HaranirHorde: {
+    id: 86,
+    name: 'Haranir',
+    side: 'horde',
+  },
+  HaranirAlliance: {
+    id: 91,
+    name: 'Haranir',
+    side: 'alliance',
+  },
 } satisfies Record<string, Race>;
 
 export default RACES;

--- a/src/parser/shared/modules/racials/OtherRacials.ts
+++ b/src/parser/shared/modules/racials/OtherRacials.ts
@@ -185,6 +185,17 @@ class OtherRacials extends Analyzer.withDependencies({
           },
         });
         break;
+      case RACES.HaranirHorde:
+      case RACES.HaranirAlliance:
+        this.deps.abilities.add({
+          spell: SPELLS.THORN_BLOOM.id,
+          cooldown: 180,
+          category: SPELL_CATEGORY.COOLDOWNS,
+          gcd: {
+            base: 500,
+          },
+        });
+        break;
     }
   }
 }


### PR DESCRIPTION
Add Support for Haranir Allied Race and adds its Racial ability `Thorn Boom` to the spellbook


### Testing
Only found a horde log;
/report/34V2WhNLp9jzd1fX/60-Mythic+One-Armed+Bandit+-+Kill+(6:48)/3-Pumps/standard/overview
<img width="1037" height="818" alt="image" src="https://github.com/user-attachments/assets/c082e82e-d4e7-4fa1-8aaa-29cc9a06996a" />

