### PR TITLE
Disc Priest - Protector of the Frail

### DIFF
--- a/src/analysis/retail/priest/discipline/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/discipline/CHANGELOG.tsx
@@ -1,6 +1,9 @@
 import { change, date } from 'common/changelog';
 import { Vetyst } from 'CONTRIBUTORS';
+import { TALENTS_PRIEST } from 'common/TALENTS';
+import { SpellLink } from 'interface';
 
 export default [
+  change(date(2025, 3, 15), <>Implement statistics for <SpellLink spell={TALENTS_PRIEST.PROTECTOR_OF_THE_FRAIL_TALENT} /> talent.</>, Vetyst),
   change(date(2025, 3, 14), <>Enable spec for Midnight</>, Vetyst),
 ];

--- a/src/analysis/retail/priest/discipline/CombatLogParser.ts
+++ b/src/analysis/retail/priest/discipline/CombatLogParser.ts
@@ -48,6 +48,7 @@ import WealAndWoe from './modules/spells/WealAndWoe';
 import EternalBarrier from './modules/spells/EternalBarrier';
 import Benevolence from '../shared/Benevolence';
 import SurgeOfLight from 'analysis/retail/priest/shared/SurgeOfLight';
+import ProtectorOfTheFrail from 'analysis/retail/priest/discipline/modules/spells/ProtectorOfTheFrail';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -108,6 +109,7 @@ class CombatLogParser extends CoreCombatLogParser {
     SurgeOfLight: SurgeOfLight,
     benevolence: Benevolence,
     translucentImage: TranslucentImage,
+    protectorOfTheFrail: ProtectorOfTheFrail,
   };
   static guide = Guide;
 }

--- a/src/analysis/retail/priest/discipline/modules/Abilities.ts
+++ b/src/analysis/retail/priest/discipline/modules/Abilities.ts
@@ -100,6 +100,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: TALENTS.PAIN_SUPPRESSION_TALENT.id,
+        charges: combatant.hasTalent(TALENTS.PROTECTOR_OF_THE_FRAIL_TALENT) ? 2 : 1,
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: 180,
         enabled: combatant.hasTalent(TALENTS.PAIN_SUPPRESSION_TALENT),

--- a/src/analysis/retail/priest/discipline/modules/spells/ProtectorOfTheFrail.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/ProtectorOfTheFrail.tsx
@@ -1,0 +1,70 @@
+import { TALENTS_PRIEST } from 'common/TALENTS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import SPELLS from 'common/SPELLS';
+import Events, { CastEvent } from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import { SpellIcon } from 'interface';
+
+const PROTECTOR_OF_THE_FRAIL_CR = 3000;
+
+class ProtectorOfTheFrail extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+  };
+
+  protected spellUsable!: SpellUsable;
+
+  effectivePainSupressionReductionMs = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_PRIEST.PROTECTOR_OF_THE_FRAIL_TALENT);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.POWER_WORD_SHIELD),
+      this.reducePainSuppresionCooldown,
+    );
+  }
+
+  reducePainSuppresionCooldown(event: CastEvent): void {
+    if (!this.spellUsable.isOnCooldown(TALENTS_PRIEST.PAIN_SUPPRESSION_TALENT.id)) {
+      return;
+    }
+
+    this.effectivePainSupressionReductionMs += this.spellUsable.reduceCooldown(
+      TALENTS_PRIEST.PAIN_SUPPRESSION_TALENT.id,
+      PROTECTOR_OF_THE_FRAIL_CR,
+      event.timestamp,
+    );
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <>
+          <BoringSpellValueText spell={TALENTS_PRIEST.PROTECTOR_OF_THE_FRAIL_TALENT}>
+            <SpellIcon
+              spell={TALENTS_PRIEST.PAIN_SUPPRESSION_TALENT}
+              style={{
+                height: '1.3em',
+                marginTop: '-1.em',
+              }}
+            />{' '}
+            {(this.effectivePainSupressionReductionMs / 1000).toFixed(1)}{' '}
+            <small>Seconds reduced</small>
+          </BoringSpellValueText>
+        </>
+      </Statistic>
+    );
+  }
+}
+
+export default ProtectorOfTheFrail;

--- a/src/analysis/retail/priest/discipline/modules/spells/ProtectorOfTheFrail.tsx
+++ b/src/analysis/retail/priest/discipline/modules/spells/ProtectorOfTheFrail.tsx
@@ -51,13 +51,7 @@ class ProtectorOfTheFrail extends Analyzer {
       >
         <>
           <BoringSpellValueText spell={TALENTS_PRIEST.PROTECTOR_OF_THE_FRAIL_TALENT}>
-            <SpellIcon
-              spell={TALENTS_PRIEST.PAIN_SUPPRESSION_TALENT}
-              style={{
-                height: '1.3em',
-                marginTop: '-1.em',
-              }}
-            />{' '}
+            <SpellIcon spell={TALENTS_PRIEST.PAIN_SUPPRESSION_TALENT} />{' '}
             {(this.effectivePainSupressionReductionMs / 1000).toFixed(1)}{' '}
             <small>Seconds reduced</small>
           </BoringSpellValueText>


### PR DESCRIPTION
Added damage reduction statistics for disc priest talent `Protector of the Frail`

/report/9fHxMGzXcr18aTKh/6-Mythic+Imperator+Averzian+-+Kill+(6:40)/95-Robpri/standard/statistics
<img width="315" height="121" alt="image" src="https://github.com/user-attachments/assets/05722f70-878b-49f0-9655-cafd5bbbd0a6" />