### PR TITLE
[BrM] add APL checker + cooldown fixes and general cleanup

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -5,6 +5,8 @@ import SPELLS from './spell-list_Monk_Brewmaster.retail';
 
 // prettier-ignore
 export default [
+  change(date(2026, 3, 16), <>Add several missing sources of <SpellLink spell={SPELLS.KEG_SMASH_TALENT} /> and Brew CDR / resets.</>, emallson),
+  change(date(2026, 3, 16), <>Add rotation support for Midnight S1</>, emallson),
   change(date(2026, 2, 22), <>Add new <SpellLink spell={SPELLS.STAGGER_TALENT} /> implementation and section</>, emallson),
   change(date(2026, 2, 21), <>Add <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT} /> section</>, emallson),
   change(date(2026, 1, 18), <>Add statistic for <SpellLink spell={SPELLS.VITAL_FLAME_TALENT} /></>, emallson),

--- a/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
+++ b/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
@@ -50,6 +50,7 @@ import StaggerClearSourceLinkNormalizer from './normalizers/StaggerClearSourceLi
 import PurifyingBrew from './modules/talents/PurifyingBrew';
 import TouchOfDeathStagger from './modules/spells/TouchOfDeathStagger';
 import InvokeNiuzaoStagger from './modules/talents/InvokeNiuzao/InvokeNiuzaoStagger';
+import Buffs from './modules/core/Buffs';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -61,6 +62,7 @@ class CombatLogParser extends CoreCombatLogParser {
     channeling: Channeling,
     EnergyTracker,
     EnergyGraph,
+    buffs: Buffs,
     // There's no throughput benefit from casting Arcane Torrent on cooldown
     arcaneTorrent: [ArcaneTorrent, { castEfficiency: null }] as const,
     mysticTouch: MysticTouch,

--- a/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
+++ b/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
@@ -51,6 +51,9 @@ import PurifyingBrew from './modules/talents/PurifyingBrew';
 import TouchOfDeathStagger from './modules/spells/TouchOfDeathStagger';
 import InvokeNiuzaoStagger from './modules/talents/InvokeNiuzao/InvokeNiuzaoStagger';
 import Buffs from './modules/core/Buffs';
+import EmptyBarrel from './modules/talents/BringMeAnother/EmptyBarrel';
+import ExplodingKeg from './modules/spells/ExplodingKeg';
+import EmptyTheCellar from './modules/spells/EmptyTheCellar';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -86,6 +89,7 @@ class CombatLogParser extends CoreCombatLogParser {
     defensiveBuffs: DefensiveBuffs,
     defensiveLinks: DefensiveBuffLinkNormalizer,
     stagger: StaggerPool,
+    ExplodingKeg,
 
     // Items
 
@@ -118,6 +122,8 @@ class CombatLogParser extends CoreCombatLogParser {
     VitalFlames,
     InvokeNiuzao,
     InvokeNiuzaoStagger,
+    EmptyBarrel,
+    EmptyTheCellar,
 
     apl: AplCheck,
   };

--- a/src/analysis/retail/monk/brewmaster/Guide.tsx
+++ b/src/analysis/retail/monk/brewmaster/Guide.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 import SPELLS from 'common/SPELLS';
-import { AlertInfo, SpellLink, TooltipElement } from 'interface';
+import { SpellLink, TooltipElement } from 'interface';
 import CombatLogParser from './CombatLogParser';
 import { GuideProps, Section, SubSection, useAnalyzer } from 'interface/guide';
 import talents from 'common/TALENTS/monk';
@@ -17,6 +17,7 @@ import AspectOfHarmony from './modules/talents/AspectOfHarmony';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
 import InvokeNiuzaoSection from './modules/talents/InvokeNiuzao/InvokeNiuzaoSection';
 import StaggerPoolSection from './modules/core/StaggerPool/StaggerPoolSection';
+import AplChoiceDescription from './modules/core/AplCheck/AplChoiceDescription';
 
 export default function Guide({ info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -35,11 +36,10 @@ export default function Guide({ info }: GuideProps<typeof CombatLogParser>) {
         </p>
         <StaggerPoolSection />
       </Section>
-      <Section title="Core Rotation">
-        <AlertInfo>
-          Analysis of the Brewmaster rotation is temporarily disabled due to large changes in
-          Midnight. Cooldown analysis is still available.
-        </AlertInfo>
+      <Section title="Rotation & Cooldowns">
+        <SubSection title="Rotation">
+          <AplChoiceDescription />
+        </SubSection>
         <SubSection title="Major Cooldowns">
           <Explanation>
             <p>

--- a/src/analysis/retail/monk/brewmaster/gen.ts
+++ b/src/analysis/retail/monk/brewmaster/gen.ts
@@ -8,9 +8,8 @@ export const Abilities = genAbilities({
     spells.TIGER_PALM,
     spells.SPINNING_CRANE_KICK,
     spells.KEG_SMASH_TALENT,
-    spells.BREATH_OF_FIRE_TALENT,
   ],
-  cooldowns: [spells.INVOKE_NIUZAO_THE_BLACK_OX_TALENT],
+  cooldowns: [spells.INVOKE_NIUZAO_THE_BLACK_OX_TALENT, spells.EXPLODING_KEG_TALENT],
   defensives: [spells.FORTIFYING_BREW],
   omit: [spells.BREATH_OF_FIRE_TALENT],
 });

--- a/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
@@ -1,7 +1,7 @@
 import SPELLS_COMMON from 'common/SPELLS';
 import SPELLS from '../../spell-list_Monk_Brewmaster.retail';
 import { suggestion } from 'parser/core/Analyzer';
-import aplCheck, { Apl, build, CheckResult, PlayerInfo } from 'parser/shared/metrics/apl';
+import aplCheck, { Apl, build, CheckResult, PlayerInfo, tenseAlt } from 'parser/shared/metrics/apl';
 import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import * as cnd from 'parser/shared/metrics/apl/conditions';
 import talents from 'common/TALENTS/monk';
@@ -50,6 +50,38 @@ const CHP_SETUP = {
 };
 
 const standardApl = build([
+  {
+    spell: SPELLS.BREATH_OF_FIRE_TALENT,
+    condition: cnd.describe(
+      cnd.and(
+        cnd.hasTalent(talents.WISDOM_OF_THE_WALL_TALENT),
+        cnd.buffPresent(SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT),
+      ),
+      (tense) => (
+        <>
+          <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}>Niuzao</SpellLink>{' '}
+          {tenseAlt(tense, 'is', 'was')} active (as{' '}
+          <SpellLink spell={SPELLS.FLURRY_STRIKES_TALENT}>Shado-Pan</SpellLink>)
+        </>
+      ),
+    ),
+  },
+  {
+    spell: SPELLS.KEG_SMASH_TALENT,
+    condition: cnd.describe(
+      cnd.and(
+        cnd.hasTalent(talents.WISDOM_OF_THE_WALL_TALENT),
+        cnd.buffPresent(SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT),
+      ),
+      (tense) => (
+        <>
+          <SpellLink spell={SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}>Niuzao</SpellLink>{' '}
+          {tenseAlt(tense, 'is', 'was')} active (as{' '}
+          <SpellLink spell={SPELLS.FLURRY_STRIKES_TALENT}>Shado-Pan</SpellLink>)
+        </>
+      ),
+    ),
+  },
   CHP_SETUP,
   SPELLS.BLACKOUT_KICK,
   {

--- a/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
@@ -1,23 +1,14 @@
-import SPELLS from 'common/SPELLS';
+import SPELLS_COMMON from 'common/SPELLS';
+import SPELLS from '../../spell-list_Monk_Brewmaster.retail';
 import { suggestion } from 'parser/core/Analyzer';
-import aplCheck, { Apl, build, CheckResult, PlayerInfo, tenseAlt } from 'parser/shared/metrics/apl';
+import aplCheck, { Apl, build, CheckResult, PlayerInfo } from 'parser/shared/metrics/apl';
 import annotateTimeline from 'parser/shared/metrics/apl/annotate';
 import * as cnd from 'parser/shared/metrics/apl/conditions';
 import talents from 'common/TALENTS/monk';
 import { AnyEvent } from 'parser/core/Events';
 import { SpellLink, TooltipElement } from 'interface';
 
-const withCombo = cnd.buffPresent(SPELLS.BLACKOUT_COMBO_BUFF);
-
-const SCK_AOE = {
-  spell: SPELLS.SPINNING_CRANE_KICK_BRM,
-  condition: cnd.targetsHit(
-    { atLeast: 2 },
-    {
-      targetSpell: SPELLS.SPINNING_CRANE_KICK_DAMAGE,
-    },
-  ),
-};
+const withCombo = cnd.buffPresent(SPELLS_COMMON.BLACKOUT_COMBO_BUFF);
 
 const CHP_SETUP = {
   spell: talents.BREATH_OF_FIRE_TALENT,
@@ -25,7 +16,7 @@ const CHP_SETUP = {
     cnd.and(
       cnd.hasTalent(talents.CHARRED_PASSIONS_TALENT),
       cnd.not(withCombo),
-      cnd.buffMissing(SPELLS.CHARRED_PASSIONS_BUFF, {
+      cnd.buffMissing(SPELLS_COMMON.CHARRED_PASSIONS_BUFF, {
         duration: 8000,
         timeRemaining: 2000,
         pandemicCap: 1,
@@ -39,8 +30,8 @@ const CHP_SETUP = {
           <>
             <p>
               Applying <SpellLink spell={talents.CHARRED_PASSIONS_TALENT} /> before using{' '}
-              <SpellLink spell={SPELLS.BLACKOUT_KICK_BRM} /> can be a damage gain, but if you find
-              yourself doing it too often it means you are missing{' '}
+              <SpellLink spell={SPELLS_COMMON.BLACKOUT_KICK_BRM} /> can be a damage gain, but if you
+              find yourself doing it too often it means you are missing{' '}
               <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} /> casts during your normal rotation.
             </p>
             <p>
@@ -53,17 +44,55 @@ const CHP_SETUP = {
         (Optional)
       </TooltipElement>{' '}
       Apply <SpellLink spell={talents.CHARRED_PASSIONS_TALENT} /> when it is missing before using{' '}
-      <SpellLink spell={SPELLS.BLACKOUT_KICK_BRM} />
+      <SpellLink spell={SPELLS_COMMON.BLACKOUT_KICK_BRM} />
     </>
   ),
 };
 
-const standardApl = build([]);
+const standardApl = build([
+  CHP_SETUP,
+  SPELLS.BLACKOUT_KICK,
+  {
+    spell: SPELLS.CHI_BURST_TALENT,
+    condition: cnd.hasTalent(talents.MANIFESTATION_TALENT),
+    description: (
+      <>
+        Cast <SpellLink spell={SPELLS.CHI_BURST_TALENT} /> (as{' '}
+        <SpellLink spell={SPELLS.ASPECT_OF_HARMONY_TALENT}>MoH</SpellLink>)
+      </>
+    ),
+  },
+  {
+    spell: SPELLS.TIGER_PALM,
+    condition: withCombo,
+  },
+  {
+    spell: SPELLS.KEG_SMASH_TALENT,
+    condition: cnd.buffPresent(SPELLS_COMMON.EMPTY_BARREL_BUFF),
+  },
+  {
+    spell: SPELLS.KEG_SMASH_TALENT,
+    condition: cnd.and(
+      cnd.spellFractionalCharges(SPELLS.KEG_SMASH_TALENT, { atLeast: 1.8 }),
+      cnd.hasTalent(talents.FLURRY_STRIKES_TALENT),
+    ),
+    description: (
+      <>
+        Cast <SpellLink spell={SPELLS.KEG_SMASH_TALENT} /> at or near 2 charges (as{' '}
+        <SpellLink spell={SPELLS.FLURRY_STRIKES_TALENT}>Shado-Pan</SpellLink>)
+      </>
+    ),
+  },
+  SPELLS.BREATH_OF_FIRE_TALENT,
+  SPELLS.CHI_BURST_TALENT,
+  SPELLS.KEG_SMASH_TALENT,
+]);
+
 export enum BrewmasterApl {
   Standard,
 }
 
-export const chooseApl = (info: PlayerInfo): BrewmasterApl => {
+export const chooseApl = (_info: PlayerInfo): BrewmasterApl => {
   return BrewmasterApl.Standard;
 };
 

--- a/src/analysis/retail/monk/brewmaster/modules/core/AplCheck/AplChoiceDescription.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/AplCheck/AplChoiceDescription.tsx
@@ -32,9 +32,8 @@ const StandardDescription = () => {
         <p>
           Using <SpellLink spell={talents.BLACKOUT_COMBO_TALENT} /> adds an extra layer to the
           Brewmaster rotation. You <em>almost always</em> want to spend the{' '}
-          <SpellLink spell={talents.BLACKOUT_COMBO_TALENT}>Combo</SpellLink> on either{' '}
-          <SpellLink spell={SPELLS.TIGER_PALM} /> (in single-target) or{' '}
-          <SpellLink spell={talents.BREATH_OF_FIRE_TALENT} /> (with 3+ targets).{' '}
+          <SpellLink spell={talents.BLACKOUT_COMBO_TALENT}>Combo</SpellLink> on
+          <SpellLink spell={SPELLS.TIGER_PALM} />.
         </p>
         <DivP>
           It can help to think of your rotation as small sequences like{' '}
@@ -64,14 +63,14 @@ const StandardDescription = () => {
               SPELLS.BLACKOUT_KICK_BRM,
               SPELLS.TIGER_PALM,
               talents.KEG_SMASH_TALENT,
-              talents.RISING_SUN_KICK_TALENT,
+              talents.EXPLODING_KEG_TALENT,
             ]}
           />{' '}
           and{' '}
           <SpellSeq
             spells={[
               SPELLS.BLACKOUT_KICK_BRM,
-              talents.RISING_SUN_KICK_TALENT,
+              talents.EXPLODING_KEG_TALENT,
               SPELLS.TIGER_PALM,
               talents.KEG_SMASH_TALENT,
             ]}
@@ -81,7 +80,7 @@ const StandardDescription = () => {
             spells={[
               SPELLS.BLACKOUT_KICK_BRM,
               talents.KEG_SMASH_TALENT,
-              talents.RISING_SUN_KICK_TALENT,
+              talents.EXPLODING_KEG_TALENT,
               SPELLS.TIGER_PALM,
             ]}
           />{' '}
@@ -130,8 +129,7 @@ export default function AplChoiceDescription(): JSX.Element {
       <p>
         After pushing <SpellLink spell={SPELLS.BLACKOUT_KICK_BRM} />, you follow a simple priority
         focused on using strong, low-cooldown abilities like{' '}
-        <SpellLink spell={talents.KEG_SMASH_TALENT} /> and{' '}
-        <SpellLink spell={talents.RISING_SUN_KICK_TALENT} /> as often as possible.
+        <SpellLink spell={talents.KEG_SMASH_TALENT} />.
       </p>
       <Description aplChoice={aplChoice} />
       <SubSection>

--- a/src/analysis/retail/monk/brewmaster/modules/core/Buffs.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/Buffs.tsx
@@ -1,0 +1,27 @@
+import { type SpellbookAura } from 'parser/core/modules/Aura';
+import Auras from 'parser/core/modules/Auras';
+import SPELLS from '../../spell-list_Monk_Brewmaster.retail';
+import SPELLS_COMMON from 'common/SPELLS';
+
+export default class Buffs extends Auras {
+  auras() {
+    return [
+      {
+        spellId: SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT.id,
+        timelineHighlight: true,
+        enabled: this.selectedCombatant.hasTalent(SPELLS.INVOKE_NIUZAO_THE_BLACK_OX_TALENT),
+      },
+      {
+        spellId: SPELLS_COMMON.CHARRED_PASSIONS_BUFF.id,
+        timelineHighlight: true,
+        enabled: this.selectedCombatant.hasTalent(SPELLS.CHARRED_PASSIONS_TALENT),
+      },
+      {
+        spellId: SPELLS_COMMON.BLACKOUT_COMBO_BUFF.id,
+        timelineHighlight: true,
+        triggeredBySpellId: SPELLS.BLACKOUT_KICK.id,
+        enabled: this.selectedCombatant.hasTalent(SPELLS.BLACKOUT_COMBO_TALENT),
+      },
+    ] satisfies SpellbookAura[];
+  }
+}

--- a/src/analysis/retail/monk/brewmaster/modules/core/StaggerPool/StaggerPoolSection.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/StaggerPool/StaggerPoolSection.tsx
@@ -22,9 +22,9 @@ import SpellLink from 'interface/SpellLink';
 import Explanation from 'interface/guide/components/Explanation';
 import { formatNumber } from 'common/format';
 import InvokeNiuzaoStagger from '../../talents/InvokeNiuzao/InvokeNiuzaoStagger';
-import AlertWarning from 'interface/AlertWarning';
 import Tooltip from 'interface/Tooltip';
 import { InformationIcon } from 'interface/icons';
+import AlertInfo from 'interface/AlertInfo';
 
 const SideBySide = styled.div`
   margin-top: ${design.gaps.large};
@@ -69,11 +69,11 @@ export default function StaggerPoolSection(): JSX.Element | null {
 
   return (
     <>
-      <AlertWarning>
+      <AlertInfo>
         <SpellLink spell={SPELLS.STAGGER_TALENT} /> tracking has received a major overhaul in
         Midnight to handle all of the new talents that purify or prevent Stagger. If you see errors,
         please contact <code>@emallson</code> on Discord.
-      </AlertWarning>
+      </AlertInfo>
       <SubSection title={<SpellLink spell={SPELLS.STAGGER_TALENT} />}>
         <SummaryDL>
           <dt>

--- a/src/analysis/retail/monk/brewmaster/modules/spells/EmptyTheCellar.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/EmptyTheCellar.tsx
@@ -1,0 +1,66 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SharedBrews from '../core/SharedBrews';
+import { Options } from 'parser/core/Module';
+import SPELLS from '../../spell-list_Monk_Brewmaster.retail';
+import SPELLS_COMMON from 'common/SPELLS';
+import Events from 'parser/core/Events';
+import ExecuteHelper from 'parser/shared/modules/helpers/ExecuteHelper';
+import Spell from 'common/SPELLS/Spell';
+import Abilities from 'parser/core/modules/Abilities';
+import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+
+const EMPTY_THE_CELLAR_CDR = 3000;
+
+export default class EmptyTheCellar extends ExecuteHelper.withDependencies({
+  brew: SharedBrews,
+  abilities: Abilities,
+}) {
+  static executeSources = SELECTED_PLAYER;
+  static lowerThreshold = -1;
+  static executeOutsideRangeEnablers: Spell[] = [SPELLS.EMPTY_THE_CELLAR_TALENT];
+
+  static executeSpells = [SPELLS_COMMON.EMPTY_THE_CELLAR_CAST];
+  static countCooldownAsExecuteTime = true;
+
+  private ekCasts = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(SPELLS.EMPTY_THE_CELLAR_TALENT);
+
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS_COMMON.EMPTY_THE_CELLAR_DAMAGE),
+      this.onDamage,
+    );
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.EXPLODING_KEG_TALENT),
+      this.onEKCast,
+    );
+
+    this.deps.abilities.add({
+      spell: SPELLS_COMMON.EMPTY_THE_CELLAR_CAST.id,
+      category: SPELL_CATEGORY.COOLDOWNS,
+      cooldown: 60,
+      gcd: {
+        static: 1000,
+      },
+      castEfficiency: {
+        maxCasts: () => this.ekCasts,
+      },
+    });
+  }
+
+  onDamage() {
+    this.deps.brew.reduceCooldown(EMPTY_THE_CELLAR_CDR);
+  }
+
+  onEKCast() {
+    this.ekCasts += 1;
+  }
+}

--- a/src/analysis/retail/monk/brewmaster/modules/spells/ExplodingKeg.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/ExplodingKeg.tsx
@@ -1,0 +1,22 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Module';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import SPELLS from '../../spell-list_Monk_Brewmaster.retail';
+import Events from 'parser/core/Events';
+
+export default class ExplodingKeg extends Analyzer.withDependencies({ spellUsable: SpellUsable }) {
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(SPELLS.EXPLODING_KEG_TALENT);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.EXPLODING_KEG_TALENT),
+      this.onCast,
+    );
+  }
+
+  onCast() {
+    this.deps.spellUsable.endCooldown(SPELLS.KEG_SMASH_TALENT.id);
+  }
+}

--- a/src/analysis/retail/monk/brewmaster/modules/talents/AspectOfHarmony.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/AspectOfHarmony.tsx
@@ -248,33 +248,6 @@ export default class AspectOfHarmony extends Analyzer.withDependencies({ stats: 
               },
             )
           : null,
-        createChecklistItem(
-          'aoh_chain',
-          { event: spend.event },
-          {
-            performance: chained ? QualitativePerformance.Ok : QualitativePerformance.Good,
-            summary: chained ? <>Chained spenders</> : <>Did Not Chain Spenders</>,
-            details: (
-              <>
-                {chained ? (
-                  <>
-                    You cast <SpellLink spell={this.activeSpender} /> while the DoT was still
-                    active.
-                  </>
-                ) : (
-                  <>
-                    You did not chain casts of <SpellLink spell={this.activeSpender} />.
-                  </>
-                )}{' '}
-                Casting <SpellLink spell={this.activeSpender} /> while{' '}
-                <SpellLink spell={SPELLS.ASPECT_OF_HARMONY_DOT} /> is still active does not extend
-                the DoT, but <em>does</em> add damage to it. This can reduce the benefit you gain
-                from the <strong>20% damage buff</strong> on{' '}
-                <SpellLink spell={talents.COALESCENCE_TALENT} /> (and may break estimation).
-              </>
-            ),
-          },
-        ),
       ]);
     });
   }
@@ -364,8 +337,8 @@ export default class AspectOfHarmony extends Analyzer.withDependencies({ stats: 
   }
 }
 
-const AOH_VITALITY_DAMAGE_MULTIPLIER = 0.15;
-const AOH_VITALITY_HEALING_MULTIPLIER = 0.07;
+const AOH_VITALITY_DAMAGE_MULTIPLIER = 0.12;
+const AOH_VITALITY_HEALING_MULTIPLIER = 0.06;
 const RESURGENCE_BUFF_MULTIPLIER = 1.25;
 
 export class AspectOfHarmonyLinkNormalizer extends EventLinkNormalizer {

--- a/src/analysis/retail/monk/brewmaster/modules/talents/BringMeAnother/EmptyBarrel.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/BringMeAnother/EmptyBarrel.tsx
@@ -1,0 +1,27 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import SPELLS from '../../../spell-list_Monk_Brewmaster.retail';
+import SPELLS_COMMON from 'common/SPELLS';
+import Events from 'parser/core/Events';
+
+export default class EmptyBarrel extends Analyzer.withDependencies({ spellUsable: SpellUsable }) {
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(SPELLS.BRING_ME_ANOTHER_TALENT_1);
+
+    this.addEventListener(
+      Events.applybuff.spell(SPELLS_COMMON.EMPTY_BARREL_BUFF).to(SELECTED_PLAYER),
+      this.onBuffApply,
+    );
+    this.addEventListener(
+      Events.refreshbuff.spell(SPELLS_COMMON.EMPTY_BARREL_BUFF).to(SELECTED_PLAYER),
+      this.onBuffApply,
+    );
+    // not tracking wasted at this time, just want cdr correct.
+  }
+
+  onBuffApply() {
+    this.deps.spellUsable.endCooldown(SPELLS.KEG_SMASH_TALENT.id);
+  }
+}

--- a/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
@@ -169,8 +169,7 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
     items.push({
       label: (
         <>
-          <SpellLink spell={SPELLS_COMMON.NIUZAO_STOMP_DAMAGE} /> triggers (from{' '}
-          <SpellLink spell={SPELLS.BLACKOUT_KICK}>BoK</SpellLink> casts)
+          <SpellLink spell={SPELLS_COMMON.NIUZAO_STOMP_DAMAGE} /> triggers{' '}
         </>
       ),
       details: (
@@ -198,40 +197,7 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
             <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT}>WotW</SpellLink> triggers
           </>
         ),
-        details: (
-          <>
-            <TooltipElement
-              content={
-                <>
-                  Trigger Sources:
-                  <ul>
-                    <li>
-                      <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> &mdash;{' '}
-                      {
-                        cast.wotwTriggers.filter(
-                          (event) => event.ability.guid === SPELLS.BREATH_OF_FIRE_TALENT.id,
-                        ).length
-                      }
-                    </li>
-                    {this.selectedCombatant.hasTalent(SPELLS.DRAGONFIRE_BREW_TALENT) && (
-                      <li>
-                        <SpellLink spell={SPELLS.DRAGONFIRE_BREW_TALENT} /> &mdash;{' '}
-                        {
-                          cast.wotwTriggers.filter(
-                            (event) =>
-                              event.ability.guid === SPELLS_COMMON.DRAGONFIRE_BREW_DAMAGE.id,
-                          ).length
-                        }
-                      </li>
-                    )}
-                  </ul>
-                </>
-              }
-            >
-              {cast.wotwTriggers.length}
-            </TooltipElement>{' '}
-          </>
-        ),
+        details: <>{cast.wotwTriggers.length}</>,
         result: <PerformanceMark perf={wotwPerf} />,
       });
     }

--- a/src/common/SPELLS/midnight/trinkets.ts
+++ b/src/common/SPELLS/midnight/trinkets.ts
@@ -1,5 +1,11 @@
 import Spell from '../Spell';
 
-const spells = {} satisfies Record<string, Spell>;
+const spells = {
+  EYE_OF_THE_DROWNING_VOID: {
+    id: 1255476,
+    name: 'Eye of the Drowning Void',
+    icon: 'inv_archaeology_70_tauren_moosebonefishhook.jpg',
+  },
+} satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -823,6 +823,16 @@ const spells = {
     name: 'Exploding Keg',
     icon: 'inv12_ability_monk_explodingkeg.jpg',
   },
+  EMPTY_THE_CELLAR_CAST: {
+    id: 1263438,
+    name: 'Empty the Cellar',
+    icon: 'ability_vehicle_liquidpyrite.jpg',
+  },
+  EMPTY_THE_CELLAR_DAMAGE: {
+    id: 1262765,
+    name: 'Empty the Cellar',
+    icon: 'ability_vehicle_liquidpyrite.jpg',
+  },
   // Midnight S1 Tier Set
   EXTRA_KICK_DAMAGE: {
     id: 1272464,

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -790,11 +790,10 @@ const spells = {
     name: 'Charred Passions',
     icon: 'ability_monk_mightyoxkick',
   },
-  // Tier 29 2-set bonus
-  BREWMASTERS_RHYTHM_BUFF: {
-    id: 394797,
-    name: "Brewmaster's Rhythm",
-    icon: 'ability_monk_standingkick',
+  EMPTY_BARREL_BUFF: {
+    id: 1265307,
+    name: 'Empty Barrel',
+    icon: 'inv_achievement_dungeon_cinderbrewmeadery.jpg',
   },
   PRESS_THE_ADVANTAGE_BUFF: {
     ...talents.PRESS_THE_ADVANTAGE_TALENT,

--- a/src/interface/guide/components/Apl/violations/claims.tsx
+++ b/src/interface/guide/components/Apl/violations/claims.tsx
@@ -166,7 +166,7 @@ const overcastFillers: ViolationExplainer<InternalRule> = {
         <ActualCastDescription event={violation.actualCast} />.
       </p>
       <p>
-        This is a low-priority filler spell. You should instead cast a higher-priority spell like{' '}
+        You should instead cast a higher-priority spell like{' '}
         <SpellLink spell={violation.expectedCast[0].id} />.
       </p>
     </>

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -178,6 +178,7 @@ const spells: number[] = [
   //endregion
 
   //region trinket
+  SPELLS.EYE_OF_THE_DROWNING_VOID.id,
   //endregion
   //region Embellishments
   //endregion


### PR DESCRIPTION
### Description

<img width="1253" height="592" alt="image" src="https://github.com/user-attachments/assets/6663110d-0df9-4927-8190-f06c83bb4302" />
<img width="1239" height="566" alt="image" src="https://github.com/user-attachments/assets/b55f00de-7ac7-43b1-969a-9b84a7cc3518" />


<img width="842" height="418" alt="image" src="https://github.com/user-attachments/assets/268ec8d7-9f47-40c5-9a5b-74ccc0616848" />

its beautiful (the yellow dots are Snowdrift from M0 Sentinel of Winter. not an M+ boss this season so I didn't add it to the blacklist)

### Testing

- Shado-Pan: `/report/3RNtdcKFGakDAfZY/9-Mythic+Sentinel+of+Winter+-+Kill+(1:06)/5-Eisenpelz/standard/overview`
- Master of Harmony: `/report/9C8c16AdYarGhvxt/17-Mythic+Lithiel+Cinderfury+-+Kill+(2:36)/5-Dzoogmonk/standard`