### PR TITLE
Balance Druid: Eclipse Spender Tracking and Starlord Max-Stack Uptime

### DIFF
--- a/src/analysis/retail/druid/balance/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/balance/CHANGELOG.tsx
@@ -4,6 +4,7 @@ import { SpellLink } from 'interface';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2026, 3, 18), <>Core Rotation Rework: Starlord now tracks Max-stack uptime, Per-eclipse spender performance. Updated example log</>, Rex),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2025, 3, 4), <>Marked as updated for 11.1.0.</>, Sref),
   change(date(2024, 11, 18), <>Fixed an issue where <SpellLink spell={TALENTS_DRUID.CELESTIAL_ALIGNMENT_TALENT} /> wouldn't show in cooldowns tab when <SpellLink spell={TALENTS_DRUID.ORBITAL_STRIKE_TALENT} /> talent is chosen.</>, Sref),

--- a/src/analysis/retail/druid/balance/CONFIG.tsx
+++ b/src/analysis/retail/druid/balance/CONFIG.tsx
@@ -51,7 +51,7 @@ const config: Config = {
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
-    '/report/9KT74WFLZabdph8k/13-Mythic+One-Armed+Bandit+-+Kill+(6:55)/Clecia/standard',
+    '/report/RJ1DCkcbZLmz4FyA/39-Heroic+Imperator+Averzian+-+Kill+(5:25)/15-Gamztres/standard',
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.
   spec: SPECS.BALANCE_DRUID,

--- a/src/analysis/retail/druid/balance/modules/Abilities.tsx
+++ b/src/analysis/retail/druid/balance/modules/Abilities.tsx
@@ -12,6 +12,17 @@ class Abilities extends CoreAbilities {
     return [
       // Rotational Spells
       {
+        spell: [SPELLS.SOLAR_ECLIPSE.id, SPELLS.LUNAR_ECLIPSE.id],
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: 32,
+        charges: combatant.hasTalent(TALENTS_DRUID.IMPROVED_ECLIPSE_TALENT) ? 2 : 1,
+        gcd: {
+          base: 500,
+        },
+        enabled: combatant.hasTalent(TALENTS_DRUID.ECLIPSE_TALENT),
+        timelineSortIndex: 1,
+      },
+      {
         spell: SPELLS.STARSURGE_MOONKIN.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: {

--- a/src/analysis/retail/druid/balance/modules/features/FillerUsage.tsx
+++ b/src/analysis/retail/druid/balance/modules/features/FillerUsage.tsx
@@ -126,8 +126,8 @@ export default class FillerUsage extends Analyzer {
         </p>
         <p>
           Your fillers are greatly buffed by their corresponding{' '}
-          <SpellLink spell={SPELLS.ECLIPSE} /> - aim to enter an Eclipse that matches your current
-          target count.
+          <SpellLink spell={TALENTS_DRUID.ECLIPSE_TALENT} /> - aim to enter an Eclipse that matches
+          your current target count.
         </p>
         {this.hasLunarCalling && (
           <p>

--- a/src/analysis/retail/druid/balance/modules/features/SpenderUsage.tsx
+++ b/src/analysis/retail/druid/balance/modules/features/SpenderUsage.tsx
@@ -1,14 +1,30 @@
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import { SpellLink } from 'interface';
+import { SpellLink, SpellIcon } from 'interface';
 import SPELLS from 'common/SPELLS';
+import { TALENTS_DRUID } from 'common/TALENTS';
 import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import GradiatedPerformanceBar from 'interface/guide/components/GradiatedPerformanceBar';
 import { encodeEventTargetString } from 'parser/shared/modules/Enemies';
-import { currentEclipse } from 'analysis/retail/druid/balance/constants';
+import { currentEclipse, ASTRAL_POWER_SCALE_FACTOR } from 'analysis/retail/druid/balance/constants';
 import { addInefficientCastReason } from 'parser/core/EventMetaLib';
+import { mergeTimePeriods, ClosedTimePeriod } from 'parser/core/mergeTimePeriods';
+import { cdSpell } from 'analysis/retail/druid/balance/constants';
+import UptimeBar, { Uptime } from 'parser/ui/UptimeBar';
+import { Highlight } from 'interface/Highlight';
+import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 const MIN_STARFALL_TARGETS = 3;
+// TODO: placeholder thresholds — tune with Balance Discord
+const NEAR_CAP_AP_THRESHOLD = 80; // Spend AP at or above this threshold to avoid capping
+const GOOD_SPENDERS_PER_ECLIPSE = 4; // 4+ = good (green)
+const OK_SPENDERS_PER_ECLIPSE = 3; // 3 = ok (yellow)
+// below OK = bad (red)
+
+const GOOD_WINDOW_COLOR = '#15b025'; // green
+const OK_WINDOW_COLOR = '#e8bb17'; // yellow
+const BAD_WINDOW_COLOR = '#d32117'; // red
 
 export default class SpenderUsage extends Analyzer {
   totalStarsurges = 0;
@@ -21,6 +37,7 @@ export default class SpenderUsage extends Analyzer {
   // populate with targetIDs recently hit
   lastStarfallCast: CastEvent | undefined = undefined;
   recentlyHitStarfallTargets: Set<string> = new Set<string>();
+  spenderCasts: Array<{ timestamp: number }> = [];
 
   constructor(options: Options) {
     super(options);
@@ -41,19 +58,21 @@ export default class SpenderUsage extends Analyzer {
   }
 
   onStarsurge(event: CastEvent) {
-    if (currentEclipse(this.selectedCombatant) === 'none') {
+    if (currentEclipse(this.selectedCombatant) === 'none' && !this.lastCastNearCap(event)) {
       this.noEclipseStarsurges += 1;
-      addInefficientCastReason(event, `You should only cast Starsurge during Eclipse!`);
+      addInefficientCastReason(event, `Starsurge cast outside eclipse without being near AP cap.`);
     }
     this.totalStarsurges += 1;
+    this.spenderCasts.push({ timestamp: event.timestamp });
   }
 
   onStarfall(event: CastEvent) {
-    if (currentEclipse(this.selectedCombatant) === 'none') {
+    if (currentEclipse(this.selectedCombatant) === 'none' && !this.lastCastNearCap(event)) {
       this.noEclipseStarfalls += 1;
-      addInefficientCastReason(event, `You should only cast Starfall during Eclipse!`);
+      addInefficientCastReason(event, `Starfall cast outside eclipse without being near AP cap.`);
     }
     this.totalStarfalls += 1;
+    this.spenderCasts.push({ timestamp: event.timestamp });
 
     this._tallyLastStarfall();
     this.lastStarfallCast = event;
@@ -81,25 +100,64 @@ export default class SpenderUsage extends Analyzer {
     }
   }
 
-  get goodStarsurges() {
-    return this.totalStarsurges - this.noEclipseStarsurges;
+  /** Returns true if the player's AP before this cast was above spending threshold */
+  lastCastNearCap(event: CastEvent): boolean {
+    const resource = event.classResources?.find((r) => r.type === RESOURCE_TYPES.ASTRAL_POWER.id);
+    if (!resource) {
+      return false; // if we can't tell, assume it was bad
+    }
+    const ap = resource.amount * ASTRAL_POWER_SCALE_FACTOR;
+    return ap >= NEAR_CAP_AP_THRESHOLD;
   }
 
-  get goodStarfalls() {
-    return this.totalStarfalls - this.lowTargetStarfalls - this.noEclipseStarfalls;
+  get eclipseWindows(): ClosedTimePeriod[] {
+    const solarHistory = this.selectedCombatant.getBuffHistory(SPELLS.ECLIPSE_SOLAR.id);
+    const lunarHistory = this.selectedCombatant.getBuffHistory(SPELLS.ECLIPSE_LUNAR.id);
+    const caHistory = this.selectedCombatant.getBuffHistory(cdSpell(this.selectedCombatant).id);
+
+    const allUptimes = [...solarHistory, ...lunarHistory, ...caHistory].map((h) => ({
+      start: h.start,
+      end: h.end ?? this.owner.fight.end_time,
+    }));
+
+    return mergeTimePeriods(allUptimes, this.owner.fight.end_time);
   }
 
-  get percentGoodStarsurges() {
-    return this.totalStarsurges === 0
-      ? 1
-      : (this.totalStarsurges - this.noEclipseStarsurges) / this.totalStarsurges;
+  /** Shared: compute spender count per Eclipse window once */
+  get perWindowResults(): Array<{ start: number; end: number; count: number }> {
+    return this.eclipseWindows.map((window) => ({
+      start: window.start,
+      end: window.end,
+      count: this.spenderCasts.filter(
+        (c) => c.timestamp >= window.start && c.timestamp <= window.end,
+      ).length,
+    }));
   }
 
-  get percentGoodStarfalls() {
-    return this.totalStarfalls === 0
-      ? 1
-      : (this.totalStarfalls - this.lowTargetStarfalls - this.noEclipseStarfalls) /
-          this.totalStarfalls;
+  /** For aggregate GradiatedPerformanceBar */
+  get windowPerformance() {
+    const results = this.perWindowResults;
+    return {
+      GOOD: results.filter((w) => w.count >= GOOD_SPENDERS_PER_ECLIPSE).length,
+      OK: results.filter(
+        (w) => w.count >= OK_SPENDERS_PER_ECLIPSE && w.count < GOOD_SPENDERS_PER_ECLIPSE,
+      ).length,
+      BAD: results.filter((w) => w.count < OK_SPENDERS_PER_ECLIPSE).length,
+    };
+  }
+
+  /** For UptimeBar timeline */
+  get spenderWindowUptimes(): Uptime[] {
+    return this.perWindowResults.map((w) => ({
+      start: w.start,
+      end: w.end,
+      customColor:
+        w.count >= GOOD_SPENDERS_PER_ECLIPSE
+          ? GOOD_WINDOW_COLOR
+          : w.count >= OK_SPENDERS_PER_ECLIPSE
+            ? OK_WINDOW_COLOR
+            : BAD_WINDOW_COLOR,
+    }));
   }
 
   get guideSubsection() {
@@ -117,70 +175,74 @@ export default class SpenderUsage extends Analyzer {
           .
         </p>
         <p>
-          They spend Astral Power to do big damage. Use{' '}
-          <SpellLink spell={SPELLS.STARSURGE_MOONKIN} /> against 1 target, and{' '}
-          <SpellLink spell={SPELLS.STARFALL} /> against multiple targets.
+          Aim to cast as many spenders as possible during each{' '}
+          <SpellLink spell={TALENTS_DRUID.ECLIPSE_TALENT} /> window. Use{' '}
+          <SpellLink spell={SPELLS.STARSURGE_MOONKIN} /> against 1 or 2 targets, and{' '}
+          <SpellLink spell={SPELLS.STARFALL} /> against 3 or more targets.
         </p>
         <p>
-          Never use spenders outside of <SpellLink spell={SPELLS.ECLIPSE} />.
+          Avoid using spenders outside of <SpellLink spell={TALENTS_DRUID.ECLIPSE_TALENT} /> except
+          to prevent overcapping Astral Power.
         </p>
       </>
     );
 
-    const goodStarsurgeData = {
-      count: this.goodStarsurges,
-      label: 'Good Starsurges',
-    };
-    const noEclipseStarsurgeData = {
-      count: this.noEclipseStarsurges,
-      label: 'No-Eclipse Starsurges',
-    };
-
-    const goodStarfallData = {
-      count: this.goodStarfalls,
-      label: 'Good Starfalls',
-    };
-    const lowTargetStarfallData = {
-      count: this.lowTargetStarfalls,
-      label: 'Low Target Starfalls',
-    };
-    const noEclipseStarfallData = {
-      count: this.noEclipseStarsurges,
-      label: 'No-Eclipse Starfalls',
-    };
+    const { GOOD, OK, BAD } = this.windowPerformance;
+    const totalWindows = GOOD + OK + BAD;
+    const noEclipseTotal = this.noEclipseStarsurges + this.noEclipseStarfalls;
 
     const data = (
       <div>
+        {/* Aggregate bar */}
         <div>
-          <strong>Starsurge cast breakdown</strong>
+          <strong>Spenders per Eclipse</strong>
           <small>
             {' '}
-            - Green is a good cast, Red is without Eclipse active. Mouseover for more details.
+            - Green is {GOOD_SPENDERS_PER_ECLIPSE}+, Yellow is {OK_SPENDERS_PER_ECLIPSE}, Red is
+            fewer.
           </small>
-          {this.totalStarsurges === 0 ? (
-            <h4>No Starsurges cast this encounter!</h4>
-          ) : (
-            <GradiatedPerformanceBar good={goodStarsurgeData} bad={noEclipseStarsurgeData} />
-          )}
+          <GradiatedPerformanceBar
+            good={{ count: GOOD, label: `${GOOD_SPENDERS_PER_ECLIPSE}+ spenders` }}
+            ok={{ count: OK, label: `${OK_SPENDERS_PER_ECLIPSE} spenders` }}
+            bad={{ count: BAD, label: `Fewer than ${OK_SPENDERS_PER_ECLIPSE} spenders` }}
+          />
         </div>
-        <br />
-        <div>
-          <strong>Starfall cast breakdown</strong>
-          <small>
-            {' '}
-            - Green is a good cast, Yellow hit too few targets, Red is without Eclipse active.
-            Mouseover for more details.
-          </small>
-          {this.totalStarfalls === 0 ? (
-            <h4>No Starfalls cast this encounter!</h4>
-          ) : (
-            <GradiatedPerformanceBar
-              good={goodStarfallData}
-              ok={lowTargetStarfallData}
-              bad={noEclipseStarfallData}
-            />
-          )}
-        </div>
+
+        <RoundedPanel>
+          <div>
+            <strong>Per-Eclipse Performance</strong> -{' '}
+            <Highlight color={GOOD_WINDOW_COLOR} textColor="black">
+              Good ({GOOD_SPENDERS_PER_ECLIPSE}+)
+            </Highlight>{' '}
+            <Highlight color={OK_WINDOW_COLOR} textColor="black">
+              OK ({OK_SPENDERS_PER_ECLIPSE})
+            </Highlight>{' '}
+            <Highlight color={BAD_WINDOW_COLOR} textColor="white">
+              Bad (&lt;{OK_SPENDERS_PER_ECLIPSE})
+            </Highlight>
+          </div>
+          <div className="flex-main multi-uptime-bar">
+            <div className="flex main-bar">
+              <div className="flex-sub bar-label">
+                <SpellIcon spell={TALENTS_DRUID.ECLIPSE_TALENT} />
+              </div>
+              <div className="flex-main chart">
+                <UptimeBar
+                  uptimeHistory={this.spenderWindowUptimes}
+                  start={this.owner.fight.start_time}
+                  end={this.owner.fight.end_time}
+                />
+              </div>
+            </div>
+          </div>
+        </RoundedPanel>
+
+        {/* Outside-Eclipse warning */}
+        {noEclipseTotal > 0 && (
+          <p>
+            <strong>{noEclipseTotal} spender(s) cast outside Eclipse not near AP cap.</strong>
+          </p>
+        )}
       </div>
     );
 

--- a/src/analysis/retail/druid/balance/modules/features/SpenderUsage.tsx
+++ b/src/analysis/retail/druid/balance/modules/features/SpenderUsage.tsx
@@ -200,13 +200,11 @@ export default class SpenderUsage extends Analyzer {
             - Green is {GOOD_SPENDERS_PER_ECLIPSE}+, Yellow is {OK_SPENDERS_PER_ECLIPSE}, Red is
             fewer.
           </small>
-          <div aria-label={`Spenders per Eclipse performance: ${GOOD} good, ${OK} ok, ${BAD} bad`}>
-            <GradiatedPerformanceBar
-              good={{ count: GOOD, label: `${GOOD_SPENDERS_PER_ECLIPSE}+ spenders` }}
-              ok={{ count: OK, label: `${OK_SPENDERS_PER_ECLIPSE} spenders` }}
-              bad={{ count: BAD, label: `Fewer than ${OK_SPENDERS_PER_ECLIPSE} spenders` }}
-            />
-          </div>
+          <GradiatedPerformanceBar
+            good={{ count: GOOD, label: `${GOOD_SPENDERS_PER_ECLIPSE}+ spenders` }}
+            ok={{ count: OK, label: `${OK_SPENDERS_PER_ECLIPSE} spenders` }}
+            bad={{ count: BAD, label: `Fewer than ${OK_SPENDERS_PER_ECLIPSE} spenders` }}
+          />
         </div>
 
         <RoundedPanel>

--- a/src/analysis/retail/druid/balance/modules/features/SpenderUsage.tsx
+++ b/src/analysis/retail/druid/balance/modules/features/SpenderUsage.tsx
@@ -188,7 +188,6 @@ export default class SpenderUsage extends Analyzer {
     );
 
     const { GOOD, OK, BAD } = this.windowPerformance;
-    const totalWindows = GOOD + OK + BAD;
     const noEclipseTotal = this.noEclipseStarsurges + this.noEclipseStarfalls;
 
     const data = (
@@ -201,11 +200,13 @@ export default class SpenderUsage extends Analyzer {
             - Green is {GOOD_SPENDERS_PER_ECLIPSE}+, Yellow is {OK_SPENDERS_PER_ECLIPSE}, Red is
             fewer.
           </small>
-          <GradiatedPerformanceBar
-            good={{ count: GOOD, label: `${GOOD_SPENDERS_PER_ECLIPSE}+ spenders` }}
-            ok={{ count: OK, label: `${OK_SPENDERS_PER_ECLIPSE} spenders` }}
-            bad={{ count: BAD, label: `Fewer than ${OK_SPENDERS_PER_ECLIPSE} spenders` }}
-          />
+          <div aria-label={`Spenders per Eclipse performance: ${GOOD} good, ${OK} ok, ${BAD} bad`}>
+            <GradiatedPerformanceBar
+              good={{ count: GOOD, label: `${GOOD_SPENDERS_PER_ECLIPSE}+ spenders` }}
+              ok={{ count: OK, label: `${OK_SPENDERS_PER_ECLIPSE} spenders` }}
+              bad={{ count: BAD, label: `Fewer than ${OK_SPENDERS_PER_ECLIPSE} spenders` }}
+            />
+          </div>
         </div>
 
         <RoundedPanel>
@@ -228,6 +229,7 @@ export default class SpenderUsage extends Analyzer {
               </div>
               <div className="flex-main chart">
                 <UptimeBar
+                  aria-label="Spender usage per Eclipse Window (green = good, yellow = ok, red = bad)"
                   uptimeHistory={this.spenderWindowUptimes}
                   start={this.owner.fight.start_time}
                   end={this.owner.fight.end_time}

--- a/src/analysis/retail/druid/balance/modules/spells/Eclipse.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/Eclipse.tsx
@@ -72,6 +72,7 @@ export default class Eclipse extends Analyzer {
           </div>
           <div className="flex-main chart">
             <UptimeBar
+              aria-label={`Eclipse uptime timeline: ${formatPercentage(percentUptime, 0)}% active (solar, lunar, and celestial alignment phases)`}
               uptimeHistory={allUptimes}
               start={this.owner.fight.start_time}
               end={this.owner.fight.end_time}

--- a/src/analysis/retail/druid/balance/modules/spells/Eclipse.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/Eclipse.tsx
@@ -72,7 +72,6 @@ export default class Eclipse extends Analyzer {
           </div>
           <div className="flex-main chart">
             <UptimeBar
-              aria-label={`Eclipse uptime timeline: ${formatPercentage(percentUptime, 0)}% active (solar, lunar, and celestial alignment phases)`}
               uptimeHistory={allUptimes}
               start={this.owner.fight.start_time}
               end={this.owner.fight.end_time}

--- a/src/analysis/retail/druid/balance/modules/spells/Eclipse.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/Eclipse.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 import Analyzer from 'parser/core/Analyzer';
-import { SpellIcon, SpellLink, AlertInfo } from 'interface';
+import { SpellIcon, SpellLink } from 'interface';
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import { TrackedBuffEvent } from 'parser/core/Entity';
@@ -66,7 +66,7 @@ export default class Eclipse extends Analyzer {
         <div className="flex main-bar">
           <div className="flex-sub bar-label">
             <span>
-              <SpellIcon spell={SPELLS.ECLIPSE} />{' '}
+              <SpellIcon spell={TALENTS_DRUID.ECLIPSE_TALENT} />{' '}
             </span>
             {formatPercentage(percentUptime, 0)}% <small>uptime</small>
           </div>
@@ -86,8 +86,8 @@ export default class Eclipse extends Analyzer {
     const explanation = (
       <>
         <p>
-          Cast <SpellLink spell={SPELLS.ECLIPSE} /> on cooldown. It has a 32-second cooldown, lasts
-          15 seconds, and dramatically increases your damage.
+          Cast <SpellLink spell={TALENTS_DRUID.ECLIPSE_TALENT} /> on cooldown. It has a 32-second
+          cooldown, lasts 15 seconds, and dramatically increases your damage.
         </p>
         <p>
           Your last filler cast determines which Eclipse you enter:
@@ -106,19 +106,14 @@ export default class Eclipse extends Analyzer {
           Choose <SpellLink spell={SPELLS.ECLIPSE_LUNAR} /> when hitting 3 or more stacked targets.
           Choose <SpellLink spell={SPELLS.ECLIPSE_SOLAR} /> for 1 to 2 targets.
         </p>
-        <AlertInfo>
+        {this.selectedCombatant.hasTalent(TALENTS_DRUID.LUNAR_CALLING_TALENT) && (
           <p>
             <strong>
-              <SpellLink spell={TALENTS_DRUID.LUNAR_CALLING_TALENT} /> talented{' '}
+              <SpellLink spell={TALENTS_DRUID.LUNAR_CALLING_TALENT} /> talented:{' '}
             </strong>
+            This talent restricts you from casting <SpellLink spell={SPELLS.ECLIPSE_SOLAR} />
           </p>
-          <strong>
-            <SpellLink spell={TALENTS_DRUID.LUNAR_CALLING_TALENT} />:
-          </strong>{' '}
-          <p>
-            Restricts you from casting <SpellLink spell={SPELLS.ECLIPSE_SOLAR} />
-          </p>
-        </AlertInfo>
+        )}
       </>
     );
 

--- a/src/analysis/retail/druid/balance/modules/spells/Starlord.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/Starlord.tsx
@@ -15,7 +15,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
-import { SpellIcon, SpellLink, TooltipElement } from 'interface';
+import { SpellIcon, SpellLink } from 'interface';
 import UptimeStackBar, { getStackUptimesFromBuffHistory } from 'parser/ui/UptimeStackBar';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { getUptimesFromBuffHistory } from 'parser/ui/UptimeBar';
@@ -47,6 +47,11 @@ class Starlord extends Analyzer {
     return this.averageStacks * this.hastePerStack * 100;
   }
 
+  get threeStackUptimePercent() {
+    const threeStackTime = this.buffStacks[MAX_STACKS].reduce((a, b) => a + b, 0);
+    return threeStackTime / this.owner.fightDuration;
+  }
+
   ranks;
   hastePerStack;
 
@@ -59,7 +64,7 @@ class Starlord extends Analyzer {
     this.ranks = this.selectedCombatant.getTalentRank(TALENTS_DRUID.STARLORD_TALENT);
     this.active = this.ranks > 0;
     this.hastePerStack = HASTE_PER_STACK_PER_RANK * this.ranks;
-    this.buffStacks = Array.from({ length: MAX_STACKS + 1 }, (x) => [0]);
+    this.buffStacks = Array.from({ length: MAX_STACKS + 1 }, () => [0]);
 
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.STARLORD),
@@ -87,7 +92,7 @@ class Starlord extends Analyzer {
       | RemoveBuffEvent
       | RemoveBuffStackEvent
       | FightEndEvent,
-    stack = null,
+    _stack = null,
   ) {
     this.buffStacks[this.lastStacks].push(event.timestamp - this.lastUpdate);
     if (event.type === EventType.FightEnd) {
@@ -103,16 +108,17 @@ class Starlord extends Analyzer {
         <strong>
           <SpellLink spell={TALENTS_DRUID.STARLORD_TALENT} />
         </strong>{' '}
-        grants a high amount of haste if uptime is maintained. Adding stacks does <i>not</i> refresh
-        duration, so it's impossible to maintain 100% uptime. Pool Astral Power when Starlord is
-        about to fall so you can get back to 3 stacks as quickly as possible.
+        grants a significant haste bonus that increases with each stack, try to maximize time spent
+        at 3 stacks. Since gaining a stack does <i>not</i> refresh the duration, 100% uptime is
+        impossible. Plan ahead by pooling Astral Power as Starlord is about to expire so you can
+        quickly rebuild to 3 stacks.
       </>
     );
 
     const data = (
       <div>
         <RoundedPanel>
-          <strong>Starlord uptime</strong>
+          <strong>Starlord Uptime</strong>
           {this.subStatistic()}
         </RoundedPanel>
       </div>
@@ -133,18 +139,14 @@ class Starlord extends Analyzer {
       <div className="flex-main multi-uptime-bar">
         <div className="flex main-bar-big">
           <div className="flex-sub bar-label">
-            <SpellIcon spell={TALENTS_DRUID.STARLORD_TALENT} />{' '}
-            <span style={{ color: STARLORD_BG_COLOR }}>
+            <div style={{ color: STARLORD_BG_COLOR }}>
+              <SpellIcon spell={TALENTS_DRUID.STARLORD_TALENT} />{' '}
               {formatPercentage(overallUptimePercent, 0)}% <small>active</small>
-            </span>
-            <br />
-            <TooltipElement
-              content={`This is the average number of stacks you had over the course of the fight, counting periods where you didn't have the buff as zero stacks.`}
-            >
-              <span style={{ color: STARLORD_COLOR }}>
-                {this.averageStacks.toFixed(1)} <small>avg stacks</small>
-              </span>
-            </TooltipElement>
+            </div>
+            <div style={{ color: STARLORD_BG_COLOR }}>
+              {formatPercentage(this.threeStackUptimePercent, 0)}% <small>Max Stacks Uptime</small>
+            </div>
+            {this.averageStacks.toFixed(1)} <small>avg stacks</small>
           </div>
           <div className="flex-main chart">
             <UptimeStackBar

--- a/src/analysis/retail/druid/balance/modules/spells/Starlord.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/Starlord.tsx
@@ -175,9 +175,9 @@ class Starlord extends Analyzer {
             <table className="table table-condensed">
               <thead>
                 <tr>
-                  <th>Haste-Bonus</th>
-                  <th>Time (s)</th>
-                  <th>Time (%)</th>
+                  <th scope="col">Haste-Bonus</th>
+                  <th scope="col">Time (s)</th>
+                  <th scope="col">Time (%)</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/analysis/retail/druid/balance/modules/spells/Starlord.tsx
+++ b/src/analysis/retail/druid/balance/modules/spells/Starlord.tsx
@@ -175,9 +175,9 @@ class Starlord extends Analyzer {
             <table className="table table-condensed">
               <thead>
                 <tr>
-                  <th scope="col">Haste-Bonus</th>
-                  <th scope="col">Time (s)</th>
-                  <th scope="col">Time (%)</th>
+                  <th>Haste-Bonus</th>
+                  <th>Time (s)</th>
+                  <th>Time (%)</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -868,11 +868,20 @@ const spells = {
     name: 'Shooting Stars',
     icon: 'spell_priest_divinestar_shadow2',
   },
-  ECLIPSE: {
-    id: 79577,
-    name: 'Eclipse',
+  // Eclipse Casts
+  SOLAR_ECLIPSE: {
+    id: 1233346,
+    name: 'Solar Eclipse',
     icon: 'ability_druid_eclipseorange',
   },
+  LUNAR_ECLIPSE: {
+    id: 1233272,
+    name: 'Lunar Eclipse',
+    icon: 'ability_druid_eclipse',
+  },
+  // Eclipse Buffs
+  // TODO Rename to ECLIPSE_SOLAR_BUFF & ECLIPSE_LUNAR_BUFF
+  // Used in classic module too
   ECLIPSE_SOLAR: {
     id: 48517,
     name: 'Eclipse (Solar)',


### PR DESCRIPTION
## Description

Continued rotation improvements for Balance Druid (Foundation 12.0.1).

### **Eclipse (`SpenderUsage`)**
- Tracks spenders cast per Eclipse window
- Rates each Eclipse window as Good / OK / Bad based on spender count
- Flags spenders cast outside of Eclipse at < 80 Astral Power

### **Eclipse Spell IDs**
- Split `ECLIPSE` into `SOLAR_ECLIPSE` and `LUNAR_ECLIPSE`
  - old ID didn't match actual cast events in logs        
- Added Eclipse to Abilities with cooldown, charges, and GCD
- Fixed SpellLink in FillerUsage to reference the talent

### **Starlord**
- Now tracks Max Stacks (3-stack) uptime
- Shows percentage of fight spent at max stacks

### **Misc**
- Updated example report to a Midnight log

## Testing

- Test report URL: `/report/RJ1DCkcbZLmz4FyA/39-Heroic+Imperator+Averzian+-+Kill+(5:25)/15-Gamztres/standard`
- Screenshot(s):
<img width="1002" height="386" alt="image" src="https://github.com/user-attachments/assets/0f1e4557-3b1f-43a4-a34b-a06c40dd3aa0" />