### PR TITLE
[Survival] - Launch APL

### DIFF
--- a/src/analysis/retail/hunter/survival/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/survival/CHANGELOG.tsx
@@ -3,13 +3,5 @@ import { Kivlov,
  } from 'CONTRIBUTORS';
 
 export default [
-  change(date(2026,2,16), 'Fix Boomstick Tick and Text for WFB', Kivlov),
-  change(date(2026, 2, 5), 'Add Pack Leader Analysis', Kivlov),
-  change(date(2026, 2, 2), 'Add Sentinels Mark Analysis', Kivlov),
-  change(date(2026, 2, 1), 'Add Moonlight Chakram Analysis', Kivlov),
-  change(date(2026, 1, 25), 'Add APL section. Add Tip of the Spear as a Resource', Kivlov),
-  change(date(2026, 1, 23), 'Add Midnight abilities and clean up old abilities', Kivlov),
-  change(date(2026, 1, 17), 'Add Boomstick Analyzer', Kivlov),
-  change(date(2026, 1, 10), 'Update Survival for 12.0.0 support', Kivlov),
-
+  change(date(2026, 3, 18), 'Update Survival for launch', Kivlov),
 ];

--- a/src/analysis/retail/hunter/survival/CONFIG.tsx
+++ b/src/analysis/retail/hunter/survival/CONFIG.tsx
@@ -15,32 +15,30 @@ const config: Config = {
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      Hello and welcome to the Survival Hunter analyzer! We hope that the suggestions and statistics
-      will be helpful in improving your overall performance. Try and focus on improving only a few
-      things at a time, until those become ingrained in your muscle memory so as to not be
-      concentrating on many different things.
-      <br />
-      <br />
-      If you want to learn more about Survival Hunters, join the Hunter community on the Trueshot
-      Lodge Discord:{' '}
-      <a href="https://www.discord.gg/trueshot" target="_blank" rel="noopener noreferrer">
-        discord.gg/trueshot
-      </a>
-      . The <kbd>#Survival</kbd> channel has a lot of helpful people, and if you post your logs in{' '}
-      <kbd>#log-reviews</kbd>, you can expect to get some good pointers for improvement from the
-      community. The <kbd>#Survival</kbd> channel is also a great place to post feedback for this
-      analyzer, as I'll be very likely to see it there. <br />
-      <br />
-      The best guides available currently are the guides on{' '}
-      <a href="https://www.wowhead.com/guide/classes/hunter/survival/overview-pve-dps">
-        {' '}
-        WoWHead or{' '}
-      </a>{' '}
-      <a href="https://www.icy-veins.com/wow/survival-hunter-pve-dps-guide">Icy-Veins</a>. WoWHead
-      is maintained by Thyminde and Doolb and Icy-Veins by Azortharion, and they are constantly
-      fact-checked by community-members, and improved upon on an almost weekly basis.
-      <br />
-      <br />
+      <p>
+        Hello and welcome to the Survival Hunter analyzer! We hope that the suggestions and
+        statistics will be helpful in improving your overall performance. Try and focus on improving
+        only a few things at a time, until those become ingrained in your muscle memory so as to not
+        be concentrating on many different things.
+      </p>
+      <p>
+        If you want to learn more about Survival Hunters, join the Hunter community on the Trueshot
+        Lodge Discord:{' '}
+        <a href="https://www.discord.gg/trueshot" target="_blank" rel="noopener noreferrer">
+          discord.gg/trueshot
+        </a>
+        . The <kbd>#Survival</kbd> channel has a lot of helpful people, and if you post your logs in{' '}
+        <kbd>#log-reviews</kbd>, you can expect to get some good pointers for improvement from the
+        community. The <kbd>#Survival</kbd> channel is also a great place to post feedback for this
+        analyzer, as I'll be very likely to see it there.
+      </p>
+      <p>
+        The best guides available currently are the guides on{' '}
+        <a href="https://www.wowhead.com/guide/classes/hunter/survival/overview-pve-dps">WoWHead</a>{' '}
+        or <a href="https://www.icy-veins.com/wow/survival-hunter-pve-dps-guide">Icy-Veins</a>.
+        WoWHead is maintained by Thyminde and Doolb and Icy-Veins by Azortharion, and they are
+        constantly fact-checked by community-members, and improved upon on an almost weekly basis.
+      </p>
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.

--- a/src/analysis/retail/hunter/survival/CONFIG.tsx
+++ b/src/analysis/retail/hunter/survival/CONFIG.tsx
@@ -44,7 +44,8 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/GcyfdwP1XTJrR3h7/15-Mythic+Ulgrax+the+Devourer+-+Kill+(9:00)/Spearitual',
+  exampleReport:
+    '/report/kJ1Cz2Rqf3QwTWBG/35-Heroic+Imperator+Averzian+-+Wipe+2+(5:54)/82-Percival/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/hunter/survival/modules/apl/AplCheck.tsx
+++ b/src/analysis/retail/hunter/survival/modules/apl/AplCheck.tsx
@@ -5,19 +5,43 @@ import { AplSectionData } from 'interface/guide/components/Apl';
 import SpellLink from 'interface/SpellLink';
 import Analyzer from 'parser/core/Analyzer';
 import { AnyEvent } from 'parser/core/Events';
-import aplCheck, { Apl, build, CheckResult, PlayerInfo, Rule } from 'parser/shared/metrics/apl';
+import aplCheck, {
+  Apl,
+  build,
+  CheckResult,
+  PlayerInfo,
+  Rule,
+  Violation,
+} from 'parser/shared/metrics/apl';
 import {
+  and,
+  buffPresent,
   buffMissing,
+  buffStacks,
   debuffPresent,
+  debuffMissing,
   or,
   spellFractionalCharges,
 } from 'parser/shared/metrics/apl/conditions';
+import {
+  AplViolationExplainers,
+  defaultExplainers,
+} from 'interface/guide/components/Apl/violations/claims';
 
-// APL Is based on feelycraft APL for prepatch. Will need update when Sim APL is available.
 const sentinelRules: Rule[] = [
   {
     spell: TALENTS.KILL_COMMAND_SURVIVAL_TALENT,
     condition: buffMissing(SPELLS.TIP_OF_THE_SPEAR_CAST),
+  },
+  {
+    spell: TALENTS.BOOMSTICK_TALENT,
+    condition: debuffMissing(SPELLS.SENTINELS_MARK_DEBUFF),
+    description: (
+      <>
+        Cast <SpellLink spell={TALENTS.BOOMSTICK_TALENT} /> if{' '}
+        <SpellLink spell={SPELLS.SENTINELS_MARK_DEBUFF} /> is not present.
+      </>
+    ),
   },
   {
     spell: TALENTS.WILDFIRE_BOMB_TALENT,
@@ -33,9 +57,26 @@ const sentinelRules: Rule[] = [
       </>
     ),
   },
-  TALENTS.TAKEDOWN_TALENT,
-  TALENTS.BOOMSTICK_TALENT,
-  TALENTS.MOONLIGHT_CHAKRAM_TALENT,
+  {
+    spell: TALENTS.TAKEDOWN_TALENT,
+    condition: buffMissing(SPELLS.TIP_OF_THE_SPEAR_CAST),
+    description: (
+      <>
+        Cast <SpellLink spell={TALENTS.TAKEDOWN_TALENT} /> if{' '}
+        <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} /> is not present.
+      </>
+    ),
+  },
+  SPELLS.MOONLIGHT_CHAKRAM_CAST,
+  {
+    spell: SPELLS.RAPTOR_SWIPE_DAMAGE,
+    condition: buffPresent(SPELLS.RAPTOR_SWIPE_BUFF),
+    description: (
+      <>
+        Cast <SpellLink spell={SPELLS.RAPTOR_SWIPE_DAMAGE} />
+      </>
+    ),
+  },
   TALENTS.RAPTOR_STRIKE_TALENT,
   {
     spell: SPELLS.HATCHET_TOSS,
@@ -50,12 +91,54 @@ const sentinelRules: Rule[] = [
 const packLeaderRules: Rule[] = [
   {
     spell: TALENTS.KILL_COMMAND_SURVIVAL_TALENT,
+    condition: or(
+      buffMissing(SPELLS.TIP_OF_THE_SPEAR_CAST),
+      and(
+        buffMissing(SPELLS.HOWL_OF_THE_PACKLEADER_BUFF),
+        buffStacks(SPELLS.TIP_OF_THE_SPEAR_CAST, { atMost: 1 }),
+      ),
+    ),
+    description: (
+      <>
+        Cast <SpellLink spell={TALENTS.KILL_COMMAND_SURVIVAL_TALENT} /> if{' '}
+        <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} /> is missing, or if{' '}
+        <SpellLink spell={SPELLS.HOWL_OF_THE_PACKLEADER_BUFF} /> is ready and Tip is at 0-1 stacks.
+        stacks.
+      </>
+    ),
+  },
+  {
+    spell: TALENTS.TAKEDOWN_TALENT,
     condition: buffMissing(SPELLS.TIP_OF_THE_SPEAR_CAST),
+    description: (
+      <>
+        Cast <SpellLink spell={TALENTS.TAKEDOWN_TALENT} /> if not stacks of{' '}
+        <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} /> to maximise Twin Fangs.
+      </>
+    ),
   },
   TALENTS.BOOMSTICK_TALENT,
-  TALENTS.TAKEDOWN_TALENT,
-  TALENTS.WILDFIRE_BOMB_TALENT,
+  {
+    spell: TALENTS.WILDFIRE_BOMB_TALENT,
+    condition: and(
+      buffPresent(SPELLS.WYVERNS_CRY),
+      spellFractionalCharges(TALENTS.WILDFIRE_BOMB_TALENT, { atLeast: 1 }),
+    ),
+    description: (
+      <>
+        Cast <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} /> if{' '}
+        <SpellLink spell={SPELLS.HOWL_WYVERN_BUFF} /> can be extended.
+      </>
+    ),
+  },
+  {
+    spell: SPELLS.RAPTOR_SWIPE_DAMAGE,
+    condition: buffPresent(SPELLS.RAPTOR_SWIPE_BUFF),
+  },
   TALENTS.RAPTOR_STRIKE_TALENT,
+  TALENTS.KILL_COMMAND_SURVIVAL_TALENT,
+  TALENTS.WILDFIRE_BOMB_TALENT,
+  TALENTS.TAKEDOWN_TALENT,
   {
     spell: SPELLS.HATCHET_TOSS,
     description: (
@@ -79,6 +162,42 @@ export const check = (events: AnyEvent[], info: PlayerInfo): CheckResult => {
   return check(events, info);
 };
 
+function KillCommandTipStackNote({ violation }: { violation: Violation }) {
+  const info = useInfo();
+  if (violation.actualCast.ability.guid !== TALENTS.KILL_COMMAND_SURVIVAL_TALENT.id) {
+    return null;
+  }
+
+  const tipStacksOnCast = info?.combatant?.getBuffStacks(
+    SPELLS.TIP_OF_THE_SPEAR_CAST.id,
+    violation.actualCast.timestamp,
+  );
+  if (tipStacksOnCast === undefined) {
+    return null;
+  }
+
+  return (
+    <p>
+      Tip of the Spear stacks on cast: <strong>{tipStacksOnCast}</strong>
+    </p>
+  );
+}
+
+const droppedRuleWithTip: typeof defaultExplainers.droppedRule = {
+  ...defaultExplainers.droppedRule,
+  describe: (props) => (
+    <>
+      {defaultExplainers.droppedRule.describe(props)}
+      <KillCommandTipStackNote violation={props.violation} />
+    </>
+  ),
+};
+
+const survivalExplainers: AplViolationExplainers = {
+  ...defaultExplainers,
+  droppedRule: droppedRuleWithTip,
+};
+
 export function AplSection() {
   const info = useInfo();
   if (!info) {
@@ -96,7 +215,7 @@ export function AplSection() {
         Boomstick to use during takedown's 20% damage amp for a DPS gain as holding it won't result
         in a lost use like it would in a longer fight.
       </p>
-      <AplSectionData checker={check} apl={apl(info)} />
+      <AplSectionData checker={check} apl={apl(info)} violationExplainers={survivalExplainers} />
     </Section>
   );
 }

--- a/src/analysis/retail/hunter/survival/modules/guide/sections/intro/IntroSection.tsx
+++ b/src/analysis/retail/hunter/survival/modules/guide/sections/intro/IntroSection.tsx
@@ -14,8 +14,8 @@ export function IntroSection() {
         The accuracy and problems pointed out here are <b>guidelines</b> and don't factor in raid
         conditions or edge cases. To find a good measure of success, you should compare your results
         to other top Hunters in the same fight with Warcraft Logs (e.g{' '}
-        <a href="https://www.warcraftlogs.com/zone/rankings/44?boss=3129&class=Hunter&spec=Survival">
-          Mythic Plexus Sentinel Top 100
+        <a href="https://www.warcraftlogs.com/zone/rankings/46?boss=3176&class=Hunter&spec=Survival">
+          Heroic Imperator Averzian Top 100
         </a>
         ).
       </p>

--- a/src/analysis/retail/hunter/survival/modules/guide/sections/resources/ResourceUseSection.tsx
+++ b/src/analysis/retail/hunter/survival/modules/guide/sections/resources/ResourceUseSection.tsx
@@ -56,13 +56,11 @@ export default function ResourceUseSection(modules: ModulesOf<typeof CombatLogPa
         })}
       >
         <p>
-          <ResourceLink id={RESOURCE_TYPES.FOCUS.id} /> in Midnight for Survival Hunters has been
-          relegated to a secondary resource. With proper{' '}
-          <SpellLink spell={TALENTS.TIP_OF_THE_SPEAR_TALENT} /> management, you should not run out
-          of focus and waste will be minimal to non-existant. It will occasionally be impossible to
-          avoid capping <ResourceLink id={RESOURCE_TYPES.FOCUS.id} /> but that is ok with the
-          current design of the spec. You should be fitting 2-3 abilities between each cast of Kill
-          Command which will maintain a health buffer between capping and running out of focus.
+          With proper <SpellLink spell={TALENTS.TIP_OF_THE_SPEAR_TALENT} /> management, you should
+          avoid most issues with focus and waste will be minimal to non-existant. It will
+          occasionally be impossible to avoid capping <ResourceLink id={RESOURCE_TYPES.FOCUS.id} />{' '}
+          but that is ok. You should be fitting 2-3 abilities between each cast of Kill Command
+          which will maintain a healthy buffer between capping and running out of focus.
         </p>
         The chart below shows your <ResourceLink id={RESOURCE_TYPES.FOCUS.id} /> over the course of
         the encounter. You wasted{' '}

--- a/src/analysis/retail/hunter/survival/modules/talents/RaptorStrike.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/RaptorStrike.tsx
@@ -33,8 +33,7 @@ class RaptorStrike extends Analyzer {
         <SpellLink spell={TALENTS.TIP_OF_THE_SPEAR_TALENT} />. There are several abilities that are
         stronger than <SpellLink spell={TALENTS.RAPTOR_STRIKE_TALENT} /> and it is ideal to keep
         them on cooldown and engage with spec mechanics that reduce their cooldown like{' '}
-        <SpellLink spell={TALENTS.LUNGE_TALENT} />, and{' '}
-        <SpellLink spell={TALENTS.GRENADE_JUGGLER_TALENT} />.
+        <SpellLink spell={TALENTS.LETHAL_CALIBRATION_TALENT} />.
       </p>
     );
     return explanation;

--- a/src/analysis/retail/hunter/survival/modules/talents/TipOfTheSpear.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/TipOfTheSpear.tsx
@@ -15,6 +15,14 @@ import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
 import { BadColor, GoodColor, OkColor } from 'interface/guide';
 
 const MAX_STACKS = 3;
+const LOW_FOCUS_THRESHOLD = 30;
+// Focus is resource type 2 (see RESOURCE_TYPES.FOCUS)
+const FOCUS_RESOURCE_TYPE = 2;
+const HOWL_BUFFS = [
+  SPELLS.HOWL_OF_THE_PACKLEADER_WYVERN,
+  SPELLS.HOWL_OF_THE_PACKLEADER_BEAR,
+  SPELLS.HOWL_OF_THE_PACKLEADER_BOAR,
+];
 
 class TipOfTheSpear extends BuffStackTracker {
   static trackedBuff = SPELLS.TIP_OF_THE_SPEAR_CAST;
@@ -47,6 +55,14 @@ class TipOfTheSpear extends BuffStackTracker {
     const stacksGained = hasPrimalSurge ? 2 : 1;
     const potentialStacks = currentStacks + stacksGained;
 
+    const currentFocus =
+      event.classResources?.find((r) => r.type === FOCUS_RESOURCE_TYPE)?.amount ?? Infinity;
+    const isLowFocus = currentFocus < LOW_FOCUS_THRESHOLD;
+
+    const hasHowlBuff = HOWL_BUFFS.some((spell) =>
+      this.selectedCombatant.hasBuff(spell.id, event.timestamp),
+    );
+
     // Track waste
     if (potentialStacks > MAX_STACKS) {
       const waste = potentialStacks - MAX_STACKS;
@@ -61,6 +77,14 @@ class TipOfTheSpear extends BuffStackTracker {
       value = QualitativePerformance.Good;
       header = 'Good: generated at 0 stacks.';
       color = GoodColor;
+    } else if (hasHowlBuff && currentStacks === 1) {
+      value = QualitativePerformance.Good;
+      header = 'Good: generated at 1 stack with Howl of the Pack Leader active.';
+      color = GoodColor;
+    } else if (isLowFocus) {
+      value = QualitativePerformance.Ok;
+      header = `Ok: generated at ${currentStacks} stack${currentStacks !== 1 ? 's' : ''} with low focus (${currentFocus}).`;
+      color = OkColor;
     } else if (currentStacks === 1) {
       value = QualitativePerformance.Ok;
       header = 'Ok: generated at 1 stack.';

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -315,6 +315,11 @@ const spells = {
     name: 'Raptor Swipe',
     icon: 'inv12_apextalent_hunter_raptorswipe',
   },
+  RAPTOR_SWIPE_BUFF: {
+    id: 1273155,
+    name: 'Raptor Swipe',
+    icon: 'inv12_apextalent_hunter_raptorswipe',
+  },
   RAPTOR_SWIPE_AOTE: {
     id: 1262343,
     name: 'Raptor Swipe',


### PR DESCRIPTION
### Description

Adjust APL now that sims are working.
Added some tooltip addition to APLCheck so it shows how many stacks of Tip the player had at that current cast as it is important to our rotation to manage stacks properly.
Compressed the changelog down into a single change to be ready for 12.0.1


- Test report URL: `report/kJ1Cz2Rqf3QwTWBG/35-Heroic+Imperator+Averzian+-+Wipe+2+(5:54)/82-Percival/standard`

