### PR TITLE
[Restoration Shaman] 12.0.1 guide updates

### DIFF
--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -1,7 +1,8 @@
 import { change, date } from 'common/changelog';
-import { Harrek } from 'CONTRIBUTORS';
+import { Harrek, Texleretour } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2026, 3, 20), "Updates for raid launch", Texleretour),
   change(date(2026, 1, 11), <>Initial support for 12.0</>, Harrek)
 ];

--- a/src/analysis/retail/shaman/restoration/constants.ts
+++ b/src/analysis/retail/shaman/restoration/constants.ts
@@ -60,6 +60,7 @@ export const WHIRLINGWATER_HEAL = 'WhirlingWaterHeal';
 export const RESTORATION_COLORS = {
   CHAIN_HEAL: '#203755',
   HEALING_WAVE: '#146585',
+  HEALING_SURGE: '#40b3bf',
   HEALING_STREAM_TOTEM: '#40b3bf',
   HEALING_TIDE_TOTEM: '#041dffff',
   STORMSTREAM_TOTEM: '#fbff00ff',

--- a/src/analysis/retail/shaman/restoration/constants.ts
+++ b/src/analysis/retail/shaman/restoration/constants.ts
@@ -35,8 +35,7 @@ export const SURGING_TOTEM_BUFFER_MS = 85;
 export const PWAVE_TRAVEL_MS = 1100;
 export const UNLEASH_LIFE_REMOVE_MS = 400;
 //healing increases
-export const UNLEASH_LIFE_HEALING_INCREASE = 0.35;
-export const UNLEASH_LIFE_CHAIN_HEAL_INCREASE = 0.15;
+export const UNLEASH_LIFE_HEALING_INCREASE = 0.25;
 export const FLOW_OF_THE_TIDES_INCREASE = 0.3;
 export const ANCESTRAL_REACH_INCREASE = 0.08;
 //max HP increases
@@ -44,7 +43,6 @@ export const ANCESTRAL_VIGOR_INCREASED_MAX_HEALTH = 0.1;
 export const DOWNPOUR_INCREASED_MAX_HEALTH = 0.1;
 
 //base targets & target increases
-export const UNLEASH_LIFE_EXTRA_TARGETS = 2;
 export const HEALING_RAIN_TARGETS = 5;
 export const DOWNPOUR_TARGETS = 5;
 export const CHAIN_HEAL_TARGETS = 4;

--- a/src/analysis/retail/shaman/restoration/constants.ts
+++ b/src/analysis/retail/shaman/restoration/constants.ts
@@ -60,7 +60,6 @@ export const WHIRLINGWATER_HEAL = 'WhirlingWaterHeal';
 export const RESTORATION_COLORS = {
   CHAIN_HEAL: '#203755',
   HEALING_WAVE: '#146585',
-  HEALING_SURGE: '#40b3bf',
   HEALING_STREAM_TOTEM: '#40b3bf',
   HEALING_TIDE_TOTEM: '#041dffff',
   STORMSTREAM_TOTEM: '#fbff00ff',
@@ -80,20 +79,16 @@ export const HIGH_TIDE_COEFFICIENT = 2.541;
 // TODO: Check all these lists again, maybe restructure to remove repeats
 // TODO: Create list for Ancestral Guidance (should be all BASE + Ascendance + CBT)
 const SHAMAN_BASE_ABILITIES = [
-  SPELLS.HEALING_SURGE,
   SPELLS.PRIMORDIAL_WAVE_HEAL,
   SPELLS.HEALING_WAVE,
   TALENTS.CHAIN_HEAL_TALENT,
-  SPELLS.HEALING_SURGE,
   TALENTS.RIPTIDE_TALENT,
   SPELLS.HEALING_RAIN_HEAL,
-  SPELLS.WELLSPRING_HEAL,
   TALENTS.UNLEASH_LIFE_TALENT,
   SPELLS.EARTH_SHIELD_HEAL,
   TALENTS.DOWNPOUR_TALENT,
   SPELLS.ASCENDANCE_INITIAL_HEAL,
   SPELLS.NATURES_GUARDIAN_HEAL, // double check
-  SPELLS.WELLSPRING_HEAL,
   SPELLS.OVERFLOWING_SHORES_HEAL,
   SPELLS.EARTHLIVING_WEAPON_HEAL,
 ];
@@ -107,7 +102,6 @@ export const ABILITIES_AFFECTED_BY_HEALING_INCREASES = [
 
   // While the following spells don't double dip in healing increases, they gain the same percentual bonus from the transfer
   SPELLS.ANCESTRAL_AWAKENING_HEAL, // double check interactions
-  SPELLS.CLOUDBURST_TOTEM_HEAL,
   SPELLS.ASCENDANCE_HEAL,
   SPELLS.LEECH,
 ];
@@ -121,14 +115,13 @@ export const ABILITIES_AFFECTED_BY_MASTERY = [
   ...BASE_ABILITIES_AFFECTED_BY_MASTERY,
   // While the following spells don't double dip in healing increases, they gain the same percentual bonus from the transfer
   SPELLS.ANCESTRAL_AWAKENING_HEAL,
-  SPELLS.CLOUDBURST_TOTEM_HEAL,
   SPELLS.ASCENDANCE_HEAL,
   SPELLS.LEECH,
 ];
 
 export const FLASH_FLOOD_CAST_SPEED_MODIFIER = 0.1; // per rank
 
-export const HEALING_RAIN_DURATION = 10000;
+export const HEALING_RAIN_DURATION = 18000;
 export const RIPTIDE_BASE_DURATION = 18000;
 export const WAVESPEAKERS_BLESSING = 3000;
 export const SURGING_TOTEM_DURATION = 24000;

--- a/src/analysis/retail/shaman/restoration/modules/Abilities.ts
+++ b/src/analysis/retail/shaman/restoration/modules/Abilities.ts
@@ -32,7 +32,7 @@ class Abilities extends CoreAbilities {
           1 +
           combatant.getTalentRank(TALENTS.ECHO_OF_THE_ELEMENTS_TALENT) +
           combatant.getTalentRank(TALENTS.ELEMENTAL_REVERB_TALENT),
-        cooldown: 6,
+        cooldown: 6 - combatant.getTalentRank(TALENTS.RIP_CURRENT_TALENT),
         timelineSortIndex: 11,
         gcd: {
           base: 1500,

--- a/src/analysis/retail/shaman/restoration/modules/Abilities.ts
+++ b/src/analysis/retail/shaman/restoration/modules/Abilities.ts
@@ -99,7 +99,7 @@ class Abilities extends CoreAbilities {
           combatant.hasTalent(TALENTS.HEALING_RAIN_TALENT) &&
           !combatant.hasTalent(TALENTS.SURGING_TOTEM_TALENT),
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 10,
+        cooldown: 18,
         timelineSortIndex: 17,
         gcd: {
           base: 1500,

--- a/src/analysis/retail/shaman/restoration/modules/Abilities.ts
+++ b/src/analysis/retail/shaman/restoration/modules/Abilities.ts
@@ -132,7 +132,7 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS.UNLEASH_LIFE_TALENT),
         buffSpellId: TALENTS.UNLEASH_LIFE_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 15,
+        cooldown: 17,
         timelineSortIndex: 5,
         gcd: {
           base: 1500,

--- a/src/analysis/retail/shaman/restoration/modules/spells/HealingRain.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/spells/HealingRain.tsx
@@ -18,7 +18,6 @@ import { HEALING_RAIN_TARGETS } from '../../constants';
 // 50 was too low, 100 was too high
 // had no issues with 85ms
 const BUFFER_MS = 85;
-const UNLEASH_LIFE_DURATION = 100;
 interface HealingRainTickInfo {
   timestamp: number;
   hits: number;
@@ -34,18 +33,7 @@ class HealingRain extends Analyzer {
   healingRainTicks: HealingRainTickInfo[] = [];
   maxTargets = HEALING_RAIN_TARGETS;
   totalMaxTargets = 0;
-  unleashLifeRemaining = false;
-  lastUnleashLifeTimestamp: number = Number.MAX_SAFE_INTEGER;
   casts = 0;
-
-  unleashLifeSpells = {
-    [TALENTS.RIPTIDE_TALENT.id]: {},
-    [TALENTS.CHAIN_HEAL_TALENT.id]: {},
-    [SPELLS.HEALING_WAVE.id]: {},
-    [SPELLS.HEALING_SURGE.id]: {},
-    [TALENTS.HEALING_RAIN_TALENT.id]: {},
-    [TALENTS.DOWNPOUR_TALENT.id]: {},
-  };
 
   constructor(options: Options) {
     super(options);
@@ -55,7 +43,7 @@ class HealingRain extends Analyzer {
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.HEALING_RAIN_HEAL),
       this.onHealingRainHeal,
     );
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this._onCast);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.#onHealingRainCast);
   }
 
   get averageMaxTargets() {
@@ -101,37 +89,10 @@ class HealingRain extends Analyzer {
     }
   }
 
-  _onCast(event: CastEvent) {
-    const spellId = event.ability.guid;
-
-    if (spellId === TALENTS.HEALING_RAIN_TALENT.id) {
-      this.totalMaxTargets += HEALING_RAIN_TARGETS;
-      this.casts += 1;
-      this.maxTargets = HEALING_RAIN_TARGETS;
-      if (this.unleashLifeRemaining === true) {
-        this.maxTargets += 2;
-        this.totalMaxTargets += 2;
-      }
-    }
-
-    if (spellId === TALENTS.UNLEASH_LIFE_TALENT.id) {
-      this.unleashLifeRemaining = true;
-      this.lastUnleashLifeTimestamp = event.timestamp;
-    }
-
-    if (
-      this.unleashLifeRemaining &&
-      this.lastUnleashLifeTimestamp + UNLEASH_LIFE_DURATION <= event.timestamp
-    ) {
-      this.unleashLifeRemaining = false;
-      return;
-    }
-
-    if (this.unleashLifeRemaining) {
-      if (this.unleashLifeSpells[spellId]) {
-        this.unleashLifeRemaining = false;
-      }
-    }
+  #onHealingRainCast(event: CastEvent) {
+    this.totalMaxTargets += HEALING_RAIN_TARGETS;
+    this.casts += 1;
+    this.maxTargets = HEALING_RAIN_TARGETS;
   }
 
   /** Guide subsection describing the proper usage of Healing Rain */
@@ -142,11 +103,9 @@ class HealingRain extends Analyzer {
           <SpellLink spell={TALENTS_SHAMAN.HEALING_RAIN_TALENT} />
         </b>{' '}
         is one of your best sources of consistent throughput and can be augmented to do more healing
-        through <SpellLink spell={TALENTS.OVERFLOWING_SHORES_TALENT} />, more damage through{' '}
-        <SpellLink spell={TALENTS.ACID_RAIN_TALENT} />, and can hit additional targets through{' '}
-        <SpellLink spell={TALENTS.UNLEASH_LIFE_TALENT} />. Aside from being strong throughput, this{' '}
-        spell also buffs <SpellLink spell={SPELLS.HEALING_WAVE} />,{' '}
-        <SpellLink spell={SPELLS.HEALING_SURGE} /> and{' '}
+        through <SpellLink spell={TALENTS.OVERFLOWING_SHORES_TALENT} /> and more damage through{' '}
+        <SpellLink spell={TALENTS.ACID_RAIN_TALENT} />. Aside from being strong throughput, this{' '}
+        spell also buffs <SpellLink spell={SPELLS.HEALING_WAVE} /> and{' '}
         <SpellLink spell={TALENTS.CHAIN_HEAL_TALENT} /> through{' '}
         <SpellLink spell={TALENTS.DELUGE_TALENT} />
       </p>

--- a/src/analysis/retail/shaman/restoration/modules/talents/NaturesSwiftness.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/NaturesSwiftness.tsx
@@ -122,7 +122,6 @@ class NaturesSwiftness extends Analyzer {
       );
     }
 
-    console.log('nature', value, tooltip);
     this.castEntries.push({ value, tooltip });
   }
 

--- a/src/analysis/retail/shaman/restoration/modules/talents/NaturesSwiftness.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/NaturesSwiftness.tsx
@@ -3,7 +3,7 @@ import { TALENTS_SHAMAN } from 'common/TALENTS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Statistic from 'parser/ui/Statistic';
-import Events, { ApplyBuffEvent, CastEvent } from 'parser/core/Events';
+import Events, { CastEvent } from 'parser/core/Events';
 import SPELLS from 'common/SPELLS';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import TalentSpellText from 'parser/ui/TalentSpellText';
@@ -20,7 +20,6 @@ import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
 class NaturesSwiftness extends Analyzer {
   static AFFECTED_SPELLS = [
-    SPELLS.HEALING_SURGE,
     SPELLS.LIGHTNING_BOLT,
     TALENTS_SHAMAN.CHAIN_HEAL_TALENT,
     TALENTS_SHAMAN.HEALING_RAIN_TALENT,
@@ -31,7 +30,7 @@ class NaturesSwiftness extends Analyzer {
 
   static GOOD_SPELLS = [TALENTS_SHAMAN.CHAIN_HEAL_TALENT.id];
 
-  static OK_SPELLS = [SPELLS.HEALING_SURGE.id, TALENTS_SHAMAN.HEALING_RAIN_TALENT.id];
+  static OK_SPELLS = [SPELLS.HEALING_WAVE.id, TALENTS_SHAMAN.HEALING_RAIN_TALENT.id];
 
   manaSaved = 0;
   castCount = 0;
@@ -48,13 +47,20 @@ class NaturesSwiftness extends Analyzer {
       this.onRelevantCast,
     );
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.NATURES_SWIFTNESS_BUFF),
+      Events.applybuff
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.NATURES_SWIFTNESS_BUFF, SPELLS.ANCESTRAL_SWIFTNESS_CAST]),
       this.onApplyBuff,
     );
   }
 
   onRelevantCast(event: CastEvent) {
-    if (!this.selectedCombatant.hasBuff(SPELLS.NATURES_SWIFTNESS_BUFF.id)) {
+    if (
+      !(
+        this.selectedCombatant.hasBuff(SPELLS.NATURES_SWIFTNESS_BUFF.id) ||
+        this.selectedCombatant.hasBuff(SPELLS.ANCESTRAL_SWIFTNESS_CAST.id)
+      )
+    ) {
       return;
     }
 
@@ -63,14 +69,6 @@ class NaturesSwiftness extends Analyzer {
     }
 
     if (!event.resourceCost) {
-      return;
-    }
-
-    if (
-      this.selectedCombatant.hasBuff(SPELLS.SPIRITWALKERS_TIDAL_TOTEM_BUFF.id) &&
-      event.ability.guid === SPELLS.HEALING_SURGE.id
-    ) {
-      // if both SWTT and NS are present when a Healing Surge is cast, only SWTT is consumed base on my testing
       return;
     }
 
@@ -89,7 +87,7 @@ class NaturesSwiftness extends Analyzer {
     }
   }
 
-  onApplyBuff(event: ApplyBuffEvent) {
+  onApplyBuff() {
     this.castCount += 1;
   }
 
@@ -124,6 +122,7 @@ class NaturesSwiftness extends Analyzer {
       );
     }
 
+    console.log('nature', value, tooltip);
     this.castEntries.push({ value, tooltip });
   }
 
@@ -145,16 +144,13 @@ class NaturesSwiftness extends Analyzer {
   get guideSubsection(): JSX.Element {
     const explanation = (
       <p>
-        While{' '}
         <b>
           <SpellLink spell={TALENTS_SHAMAN.NATURES_SWIFTNESS_TALENT} />
         </b>{' '}
-        can be used to save someone's life with an instant{' '}
-        <SpellLink spell={SPELLS.HEALING_SURGE} />, it can also save you a substantial amount of
-        mana over the course of a fight. You should aim to use it on your most expensive spells,
-        like <SpellLink spell={TALENTS_SHAMAN.CHAIN_HEAL_TALENT} /> or sometimes{' '}
-        <SpellLink spell={SPELLS.HEALING_SURGE} />. Avoid using it with{' '}
-        <SpellLink spell={SPELLS.HEALING_WAVE} /> or DPS spells.
+        can save you a substantial amount of mana over the course of a fight. You should aim to use
+        it on your most expensive spells, like{' '}
+        <SpellLink spell={TALENTS_SHAMAN.CHAIN_HEAL_TALENT} />. Using it with{' '}
+        <SpellLink spell={SPELLS.HEALING_WAVE} /> could also save a life.
       </p>
     );
 
@@ -194,10 +190,9 @@ class NaturesSwiftness extends Analyzer {
         </b>{' '}
         is a crucial spell for Farseer Shamans. You should aim to cast this on cooldown to maximize
         your Ancestor uptime through{' '}
-        <SpellLink spell={TALENTS_SHAMAN.CALL_OF_THE_ANCESTORS_TALENT} /> . You should aim to use it
-        on your most expensive spells, like <SpellLink spell={TALENTS_SHAMAN.CHAIN_HEAL_TALENT} />{' '}
-        or sometimes <SpellLink spell={SPELLS.HEALING_SURGE} />. Avoid using it with{' '}
-        <SpellLink spell={SPELLS.HEALING_WAVE} /> or DPS spells.
+        <SpellLink spell={TALENTS_SHAMAN.CALL_OF_THE_ANCESTORS_TALENT} />. You should aim to use it
+        on your most expensive spells, like <SpellLink spell={TALENTS_SHAMAN.CHAIN_HEAL_TALENT} />.
+        Avoid using it with <SpellLink spell={SPELLS.HEALING_WAVE} /> or DPS spells.
       </p>
     );
 
@@ -211,6 +206,7 @@ class NaturesSwiftness extends Analyzer {
             <CastEfficiencyBar
               spell={SPELLS.ANCESTRAL_SWIFTNESS_CAST}
               useThresholds
+              minimizeIcons
               gapHighlightMode={GapHighlight.FullCooldown}
             />{' '}
             <br />

--- a/src/analysis/retail/shaman/restoration/modules/talents/UnleashLife.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/UnleashLife.tsx
@@ -20,23 +20,12 @@ import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
 
 import {
   CHAIN_HEAL_TARGETS,
-  DOWNPOUR_TARGETS,
-  HEALING_RAIN_TARGETS,
   RESTORATION_COLORS,
-  UNLEASH_LIFE_CHAIN_HEAL_INCREASE,
-  UNLEASH_LIFE_EXTRA_TARGETS,
   UNLEASH_LIFE_HEALING_INCREASE,
   UNLEASH_LIFE_REMOVE_MS,
 } from '../../constants';
 import CooldownThroughputTracker from '../features/CooldownThroughputTracker';
 import {
-  getHealingRainEvents,
-  getHealingRainHealEventsForTick,
-  getOverflowingShoresEvents,
-  getDownPourEvents,
-} from '../../normalizers/CastLinkNormalizer';
-import {
-  getCastEvent,
   getUnleashLifeHealingWaves,
   isBuffedByUnleashLife,
   wasUnleashLifeConsumed,
@@ -101,18 +90,6 @@ class UnleashLife extends Analyzer {
       amount: 0,
       casts: 0,
     },
-    [SPELLS.HEALING_SURGE.id]: {
-      amount: 0,
-      casts: 0,
-    },
-    [TALENTS.HEALING_RAIN_TALENT.id]: {
-      amount: 0,
-      casts: 0,
-    },
-    [SPELLS.DOWNPOUR_ABILITY.id]: {
-      amount: 0,
-      casts: 0,
-    },
   };
   //ul direct
   directHealing = 0;
@@ -123,21 +100,6 @@ class UnleashLife extends Analyzer {
   //chain heal
   chainHealHealing = 0;
   missedJumps = 0;
-
-  //healing rain
-  healingRainHealing = 0;
-  overflowingShoresActive: boolean;
-  overflowingShoresHealing = 0;
-  countedHealingRainEvents: Set<number> = new Set<number>();
-  extraTicks = 0;
-  missedTicks = 0;
-  extraOSTicks = 0;
-  missedOSTicks = 0;
-
-  //downpour
-  missedDownpourHits = 0;
-  extraDownpourHits = 0;
-  downpourActive: boolean;
 
   unleashLifeCount = 0;
   ulActive = false;
@@ -153,17 +115,7 @@ class UnleashLife extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.UNLEASH_LIFE_TALENT);
 
-    this.overflowingShoresActive = this.selectedCombatant.hasTalent(
-      TALENTS.OVERFLOWING_SHORES_TALENT,
-    );
-    this.downpourActive = this.selectedCombatant.hasTalent(TALENTS.DOWNPOUR_TALENT);
-    const spellFilter = [
-      TALENTS.CHAIN_HEAL_TALENT,
-      SPELLS.HEALING_WAVE,
-      SPELLS.HEALING_SURGE,
-      TALENTS.HEALING_RAIN_TALENT,
-      SPELLS.DOWNPOUR_ABILITY,
-    ];
+    const spellFilter = [TALENTS.CHAIN_HEAL_TALENT, SPELLS.HEALING_WAVE];
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(spellFilter), this._onCast);
     this.addEventListener(
       Events.heal.by(SELECTED_PLAYER).spell(TALENTS.UNLEASH_LIFE_TALENT),
@@ -182,8 +134,8 @@ class UnleashLife extends Analyzer {
       this._onRemoveUL,
     );
 
-    this.goodSpells.push(SPELLS.HEALING_WAVE.id);
-    this.okSpells.push(TALENTS.RIPTIDE_TALENT.id);
+    this.goodSpells.push(TALENTS.CHAIN_HEAL_TALENT.id);
+    this.okSpells.push(TALENTS.RIPTIDE_TALENT.id, SPELLS.HEALING_WAVE.id);
   }
   //necessary because riptide can be spellqued into the spell that actually consumed UL and event linking will match both
   _wasAlreadyConsumed(event: CastEvent | HealEvent) {
@@ -195,7 +147,7 @@ class UnleashLife extends Analyzer {
     return true;
   }
 
-  _onApplyUL(event: ApplyBuffEvent) {
+  _onApplyUL() {
     this.unleashLifeCount += 1;
     this.ulActive = true;
   }
@@ -222,18 +174,12 @@ class UnleashLife extends Analyzer {
         case SPELLS.HEALING_WAVE.id:
           this._onHealingWave(event);
           break;
-        case TALENTS.HEALING_RAIN_TALENT.id:
-          this._onHealingRain(event);
-          break;
         case TALENTS.CHAIN_HEAL_TALENT.id:
           this._onChainHeal(event);
           break;
-        case SPELLS.DOWNPOUR_ABILITY.id:
-          this._onDownpour(event);
-          break;
         default:
-          //riptide, healing surge, and wellspring are handled
-          //with their own event listeners
+          //riptide is handled
+          //with its own event listener
           return;
       }
     }
@@ -246,17 +192,6 @@ class UnleashLife extends Analyzer {
     }
     this.wastedBuffs += 1;
     this.tallyCastEntry(-1);
-  }
-
-  private _onHealingSurge(event: HealEvent) {
-    const castEvent = getCastEvent(event);
-    if (castEvent && isBuffedByUnleashLife(castEvent)) {
-      this.tallyCastEntry(event.ability.guid);
-      this.healingMap[event.ability.guid].amount += calculateEffectiveHealing(
-        event,
-        UNLEASH_LIFE_HEALING_INCREASE,
-      );
-    }
   }
 
   private _onRiptide(event: HealEvent) {
@@ -297,36 +232,6 @@ class UnleashLife extends Analyzer {
     }
   }
 
-  private _onHealingRain(event: CastEvent) {
-    //get all the healing rain events related to this cast
-    const healingRainEvents = getHealingRainEvents(event);
-    healingRainEvents.forEach((event) => {
-      //iterate through events grouped by tick to determine target hit count
-      if (!this.countedHealingRainEvents.has(event.timestamp)) {
-        this.countedHealingRainEvents.add(event.timestamp);
-        const tickEvents = getHealingRainHealEventsForTick(event);
-        const filteredTicks = tickEvents.splice(HEALING_RAIN_TARGETS);
-        if (filteredTicks.length < UNLEASH_LIFE_EXTRA_TARGETS) {
-          this.missedTicks += UNLEASH_LIFE_EXTRA_TARGETS - filteredTicks.length;
-        }
-        this.extraTicks += filteredTicks.length;
-        this.healingRainHealing += this._tallyHealing(filteredTicks);
-        this.healingMap[TALENTS.HEALING_RAIN_TALENT.id].amount += this._tallyHealing(filteredTicks);
-      }
-    });
-    //tally additional hits from overflowing shores if talented
-    if (this.overflowingShoresActive) {
-      const overflowingShoresEvents = getOverflowingShoresEvents(event);
-      const filteredhits = overflowingShoresEvents.splice(HEALING_RAIN_TARGETS);
-      if (filteredhits.length < UNLEASH_LIFE_EXTRA_TARGETS) {
-        this.missedOSTicks += UNLEASH_LIFE_EXTRA_TARGETS - filteredhits.length;
-      }
-      this.extraOSTicks += filteredhits.length;
-      this.overflowingShoresHealing += this._tallyHealing(filteredhits);
-      this.healingMap[TALENTS.HEALING_RAIN_TALENT.id].amount += this._tallyHealing(filteredhits);
-    }
-  }
-
   private _onHealingWave(event: CastEvent) {
     const spellId = event.ability.guid;
     const ulHealingWaves = getUnleashLifeHealingWaves(event);
@@ -353,20 +258,8 @@ class UnleashLife extends Analyzer {
       }
       this.healingMap[event.ability.guid].amount += this._tallyHealingIncrease(
         orderedChainHeal,
-        UNLEASH_LIFE_CHAIN_HEAL_INCREASE,
+        UNLEASH_LIFE_HEALING_INCREASE,
       );
-    }
-  }
-
-  private _onDownpour(event: CastEvent) {
-    const downpourEvents = getDownPourEvents(event);
-    if (downpourEvents.length > 0) {
-      const filteredhits = downpourEvents.splice(DOWNPOUR_TARGETS);
-      if (filteredhits.length < UNLEASH_LIFE_EXTRA_TARGETS) {
-        this.missedDownpourHits += UNLEASH_LIFE_EXTRA_TARGETS - filteredhits.length;
-      }
-      this.extraDownpourHits += filteredhits.length;
-      this.healingMap[SPELLS.DOWNPOUR_ABILITY.id].amount += this._tallyHealing(filteredhits);
     }
   }
 
@@ -477,29 +370,6 @@ class UnleashLife extends Analyzer {
         }),
       },
       {
-        color: RESTORATION_COLORS.DOWNPOUR,
-        label: <Trans id="shaman.restoration.spell.downpour">Downpour</Trans>,
-        spellId: TALENTS.DOWNPOUR_TALENT.id,
-        value: this.healingMap[SPELLS.DOWNPOUR_ABILITY.id].amount,
-        valueTooltip: this._tooltip({
-          spellId: SPELLS.DOWNPOUR_ABILITY.id,
-          amount: this.healingMap[SPELLS.DOWNPOUR_ABILITY.id].amount,
-          active: this.selectedCombatant.hasTalent(TALENTS.DOWNPOUR_TALENT),
-          extraHits: this.extraDownpourHits,
-        }),
-      },
-      {
-        color: RESTORATION_COLORS.HEALING_SURGE,
-        label: <Trans id="shaman.restoration.spell.healingSurge">Healing Surge</Trans>,
-        spellId: SPELLS.HEALING_SURGE.id,
-        value: this.healingMap[SPELLS.HEALING_SURGE.id].amount,
-        valueTooltip: this._tooltip({
-          spellId: SPELLS.HEALING_SURGE.id,
-          amount: this.healingMap[SPELLS.HEALING_SURGE.id].amount,
-          active: true,
-        }),
-      },
-      {
         color: RESTORATION_COLORS.HEALING_WAVE,
         label: <Trans id="shaman.restoration.spell.healingWave">Healing Wave</Trans>,
         spellId: SPELLS.HEALING_WAVE.id,
@@ -509,28 +379,6 @@ class UnleashLife extends Analyzer {
           amount: this.healingWaveHealing,
           active: true,
         }),
-      },
-      {
-        color: RESTORATION_COLORS.HEALING_RAIN,
-        label: <Trans id="shaman.restoration.spell.healing_rain">Healing Rain</Trans>,
-        spellId: TALENTS.HEALING_RAIN_TALENT.id,
-        value: this.healingMap[TALENTS.HEALING_RAIN_TALENT.id].amount,
-        valueTooltip: this._tooltip(
-          {
-            spellId: TALENTS.HEALING_RAIN_TALENT.id,
-            amount: this.healingRainHealing,
-            active: true,
-            extraHits: this.extraTicks,
-            missedHits: this.missedTicks,
-          },
-          {
-            spellId: TALENTS.OVERFLOWING_SHORES_TALENT.id,
-            amount: this.overflowingShoresHealing,
-            active: this.overflowingShoresActive,
-            extraHits: this.extraOSTicks,
-            missedHits: this.missedOSTicks,
-          },
-        ),
       },
       {
         color: RESTORATION_COLORS.RIPTIDE,


### PR DESCRIPTION
### Description
Updated main guide modules for 12.0.1. I didn't go into detail and just wanted to make sure the core analysis was okay.
#### Healing Rain
Removed mentions to Healing Surge and updated CD
#### Nature's/Ancestral Swiftness
Removed mentions to Healing Surge and updated performance requirements
#### Unleash life
Updated CD, performance requirements and relevant spells (now only affects Chain Heal, Healing Wave and Riptide)
#### Constants
Removed mentions of Healing Surge, Wellspring
Updated Healing Rain duration
Updated Riptide cooldown
#### Left to do
Earth shields buffs (base one and the additional with Elemental Orbit) are often not logged at all so the uptime bars show 0% most of the time.

### Testing

Totemic log: /report/D3BHGp2aMr6Kwxd8/23-Heroic+Lightblinded+Vanguard+-+Kill+(6:00)/8-Samtane/standard/overview
Farseer log: /report/D3BHGp2aMr6Kwxd8/23-Heroic+Lightblinded+Vanguard+-+Kill+(6:00)/19-Aman/standard/overview
