### PR TITLE
[Fire Mage] Fix Hot Streak and Heating Up

### DIFF
--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,8 @@ import { Sharrq } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2026, 3, 20), <>Fixed an issue that prevented <SpellLink spell={TALENTS.FLAMESTRIKE_2_FIRE_TALENT} /> from being detected as a <SpellLink spell={SPELLS.HOT_STREAK} /> spender if the player chose the talent to cast <SpellLink spell={TALENTS.FLAMESTRIKE_2_FIRE_TALENT} /> at your target instead of your cursor.</>, Sharrq),
+  change(date(2026, 3, 20), <>Fixed an issue that caused some <SpellLink spell={SPELLS.FIRE_BLAST.id} /> casts to not detect that <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> was active.</>, Sharrq),
   change(date(2026, 3, 6), <>Removed Searing Touch and Feel the Burn modules.</>, Sharrq),
   change(date(2026, 3, 6), <>Updated the Fire and Shared Mage Spellbook with the latest cooldown reductions, haste buffs, and cooldowns.</>, Sharrq),
   change(date(2026, 3, 6), <>Added support for <SpellLink spell={TALENTS.FIRED_UP_1_FIRE_TALENT} />.</>, Sharrq),

--- a/src/analysis/retail/mage/fire/core/HeatingUp.tsx
+++ b/src/analysis/retail/mage/fire/core/HeatingUp.tsx
@@ -74,6 +74,7 @@ export default class HeatingUp extends Analyzer {
     } else if (this.hasFirestarter && targetHealth && targetHealth > 0.9) {
       buff.push(TALENTS.FIRESTARTER_TALENT);
     } else if (
+      this.selectedCombatant.hasBuff(TALENTS.COMBUSTION_TALENT.id) ||
       this.selectedCombatant.hasBuff(
         TALENTS.COMBUSTION_TALENT.id,
         event.timestamp - COMBUSTION_END_BUFFER,

--- a/src/analysis/retail/mage/fire/core/HotStreak.tsx
+++ b/src/analysis/retail/mage/fire/core/HotStreak.tsx
@@ -21,6 +21,12 @@ import {
 } from 'parser/ui/QualitativePerformance';
 import { encodeTargetString } from 'parser/shared/modules/Enemies';
 
+const HOT_STREAK_SPENDERS = [
+  TALENTS.PYROBLAST_TALENT.id,
+  TALENTS.FLAMESTRIKE_1_FIRE_TALENT.id,
+  TALENTS.FLAMESTRIKE_2_FIRE_TALENT.id,
+];
+
 export default class HotStreak extends Analyzer {
   hasFirestarter: boolean = this.selectedCombatant.hasTalent(TALENTS.FIRESTARTER_TALENT);
   hasScorch: boolean = this.selectedCombatant.hasTalent(TALENTS.SCORCH_TALENT);
@@ -67,6 +73,7 @@ export default class HotStreak extends Analyzer {
     ) {
       buff.push(TALENTS.FIRESTARTER_TALENT);
     } else if (
+      this.selectedCombatant.hasBuff(TALENTS.COMBUSTION_TALENT.id) ||
       this.selectedCombatant.hasBuff(
         TALENTS.COMBUSTION_TALENT.id,
         event.timestamp - COMBUSTION_END_BUFFER,

--- a/src/analysis/retail/mage/fire/guide/HotStreak.tsx
+++ b/src/analysis/retail/mage/fire/guide/HotStreak.tsx
@@ -58,7 +58,9 @@ class HotStreakGuide extends Analyzer {
       (hs) => hs.spender?.ability.guid === TALENTS.PYROBLAST_TALENT.id,
     ).length;
     const flamestrikeCount = this.hotStreak.hotStreaks.filter(
-      (hs) => hs.spender?.ability.guid === SPELLS.FLAMESTRIKE.id,
+      (hs) =>
+        hs.spender?.ability.guid === TALENTS.FLAMESTRIKE_1_FIRE_TALENT.id ||
+        hs.spender?.ability.guid === TALENTS.FLAMESTRIKE_2_FIRE_TALENT.id,
     ).length;
 
     return [

--- a/src/analysis/retail/mage/fire/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/fire/normalizers/CastLinkNormalizer.ts
@@ -86,7 +86,15 @@ const EVENT_LINKS = createEventLinks(
     ],
   },
   {
-    spell: SPELLS.FLAMESTRIKE.id,
+    spell: TALENTS.FLAMESTRIKE_1_FIRE_TALENT.id,
+    parentType: EventType.Cast,
+    links: [
+      link(EventType.BeginCast, { backwardBuffer: 2000, maxLinks: 1, anyTarget: true }),
+      link(EventType.Damage, { forwardBuffer: 1000, anyTarget: true }),
+    ],
+  },
+  {
+    spell: TALENTS.FLAMESTRIKE_2_FIRE_TALENT.id,
     parentType: EventType.Cast,
     links: [
       link(EventType.BeginCast, { backwardBuffer: 2000, maxLinks: 1, anyTarget: true }),
@@ -112,7 +120,8 @@ const EVENT_LINKS = createEventLinks(
           SPELLS.FIREBALL.id,
           TALENTS.PYROBLAST_TALENT.id,
           SPELLS.SCORCH.id,
-          SPELLS.FLAMESTRIKE.id,
+          TALENTS.FLAMESTRIKE_1_FIRE_TALENT.id,
+          TALENTS.FLAMESTRIKE_2_FIRE_TALENT.id,
           TALENTS.FROSTFIRE_BOLT_TALENT.id,
         ],
         type: EventType.Cast,
@@ -124,7 +133,11 @@ const EVENT_LINKS = createEventLinks(
         },
       }),
       link(EventType.Cast, {
-        id: [TALENTS.PYROBLAST_TALENT.id, SPELLS.FLAMESTRIKE.id],
+        id: [
+          TALENTS.PYROBLAST_TALENT.id,
+          TALENTS.FLAMESTRIKE_1_FIRE_TALENT.id,
+          TALENTS.FLAMESTRIKE_2_FIRE_TALENT.id,
+        ],
         forwardBuffer: 20000,
         backwardBuffer: 2500,
         anyTarget: true,
@@ -144,6 +157,7 @@ const EVENT_LINKS = createEventLinks(
             referencedEvent as CastEvent,
             EventType.Damage,
           )[0];
+          if (!damage || !buffApply || !buffRemove) return false;
           return damage.timestamp >= buffApply.timestamp && damage.timestamp < buffRemove.timestamp;
         },
       }),
@@ -164,7 +178,11 @@ const EVENT_LINKS = createEventLinks(
     parentType: EventType.RemoveBuff,
     links: [
       link(CustomType.CONSUME, {
-        id: [TALENTS.PYROBLAST_TALENT.id, SPELLS.FLAMESTRIKE.id],
+        id: [
+          TALENTS.PYROBLAST_TALENT.id,
+          TALENTS.FLAMESTRIKE_1_FIRE_TALENT.id,
+          TALENTS.FLAMESTRIKE_2_FIRE_TALENT.id,
+        ],
         type: EventType.Cast,
         maxLinks: 1,
         anyTarget: true,


### PR DESCRIPTION
- Fixed an issue where Fire Blasts cast at the beginning of Combustion were not counted as having a crit buff active
- Fixed an issue where Hot Streaks spent on Flamestrike were not being detected if the player was talented into the version of Flamestrike that casts at the target instead of the cursor
- Fixed a crash in the way Hot Streak spenders are linked to Combustion casts

Before
<img width="1230" height="1014" alt="image" src="https://github.com/user-attachments/assets/414295c7-906e-43ac-8423-0ae1fd1082a3" />

After
<img width="1230" height="1014" alt="image" src="https://github.com/user-attachments/assets/12182baf-9f0b-4ecb-b406-e7f817f0112c" />
