### PR TITLE
RDruid bugfixes

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2026, 3, 20), <>Bug fixes for wild growth CDR statistics, lifebloom uptime in guide, and Soul of the Forest Consumes. Improved Power of the Archdruid tracking.</>, squided),
   change(date(2026, 3, 18), <>Improve Verdancy talent statistic. Fix bug in Everbloom tracking and Control of the Dream CDR calculation.</>, squided),
   change(date(2026, 3, 16), <>Added full support for both hero talents. Guide is now complete for Midnight season 1 raid launch.</>, squided),
   change(date(2026, 2, 26), <>Activating Resto Druid analyzer for Midnight! Full support is not yet implemented, but partial support is there.</>, squided),

--- a/src/analysis/retail/druid/restoration/modules/core/hottracking/HotAttributor.ts
+++ b/src/analysis/retail/druid/restoration/modules/core/hottracking/HotAttributor.ts
@@ -24,6 +24,13 @@ const BUFFER_MS = 150;
 
 const DEBUG = false;
 
+/** Tracks one PotA proc (one SotF consumption) and how many extras landed */
+export interface PotaProc {
+  timestamp: number;
+  extrasCount: number;
+  fromHardcast: boolean;
+}
+
 /**
  * Many Resto HoTs can be applied from multiple different sources including talents and hardcasts.
  * In order to attribute where a HoT came from we have to keep all the
@@ -65,6 +72,11 @@ class HotAttributor extends Analyzer {
   powerOfTheArchdruidRegrowthAttrib = HotTracker.getNewAttribution('PowerOfTheArchdruid-Regrowth');
   rampantGrowthAttrib = HotTracker.getNewAttribution('RampantGrowth');
   // Convoke handled separately in Resto Convoke module
+
+  /** Per-proc tracking of how many PotA extras landed (for use by PowerOfTheArchdruid) */
+  potaProcs: PotaProc[] = [];
+  /** Tracks the current PotA proc being filled with extras */
+  private currentPotaProc: PotaProc | undefined;
 
   constructor(options: Options) {
     super(options);
@@ -123,6 +135,40 @@ class HotAttributor extends Analyzer {
       Events.heal.by(SELECTED_PLAYER).spell(SPELLS.REGROWTH),
       this.onHealRegrowth,
     );
+    this.addEventListener(Events.fightend, this.onFightEnd);
+
+    if (this.hasPowerOfTheArchdruid) {
+      this.addEventListener(
+        Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.POWER_OF_THE_ARCHDRUID),
+        this.onPotaBuff,
+      );
+      this.addEventListener(
+        Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.POWER_OF_THE_ARCHDRUID),
+        this.onPotaBuff,
+      );
+    }
+  }
+
+  onPotaBuff(event: ApplyBuffEvent | RefreshBuffEvent) {
+    if (event.prepull) {
+      return;
+    }
+    // Finalize previous proc if any
+    if (this.currentPotaProc) {
+      this.potaProcs.push(this.currentPotaProc);
+    }
+    this.currentPotaProc = {
+      timestamp: event.timestamp,
+      extrasCount: 0,
+      fromHardcast: !isConvoking(this.selectedCombatant),
+    };
+  }
+
+  /** Called when a PotA extra is attributed — increments the current proc's extras count */
+  private trackPotaExtra() {
+    if (this.currentPotaProc) {
+      this.currentPotaProc.extrasCount += 1;
+    }
   }
 
   onApplyRejuv(event: ApplyBuffEvent | RefreshBuffEvent) {
@@ -141,6 +187,7 @@ class HotAttributor extends Analyzer {
       ) {
         this.hotTracker.addAttributionFromApply(this.powerOfTheArchdruidRejuvAttrib, event);
         this._logAttrib(event, this.powerOfTheArchdruidRejuvAttrib);
+        this.trackPotaExtra();
       }
       this.lastConvokeRejuvOrRegrowthBuffTimestamp = event.timestamp;
       // convoke module adds the attribution for Convoke
@@ -148,6 +195,7 @@ class HotAttributor extends Analyzer {
     } else if (possiblePota) {
       this.hotTracker.addAttributionFromApply(this.powerOfTheArchdruidRejuvAttrib, event);
       this._logAttrib(event, this.powerOfTheArchdruidRejuvAttrib);
+      this.trackPotaExtra();
     } else {
       this._logAttrib(event, undefined);
     }
@@ -183,6 +231,7 @@ class HotAttributor extends Analyzer {
       ) {
         this.hotTracker.addAttributionFromApply(this.powerOfTheArchdruidRegrowthAttrib, event);
         this._logAttrib(event, this.powerOfTheArchdruidRegrowthAttrib);
+        this.trackPotaExtra();
       }
       if (!possibleRg) {
         this.lastConvokeRejuvOrRegrowthBuffTimestamp = event.timestamp;
@@ -195,6 +244,7 @@ class HotAttributor extends Analyzer {
     } else if (possiblePota) {
       this.hotTracker.addAttributionFromApply(this.powerOfTheArchdruidRegrowthAttrib, event);
       this._logAttrib(event, this.powerOfTheArchdruidRegrowthAttrib);
+      this.trackPotaExtra();
     } else {
       this._logAttrib(event, undefined);
     }
@@ -296,6 +346,14 @@ class HotAttributor extends Analyzer {
             ' to ' +
             (typeof attrib === 'object' ? attrib.name : attrib),
         );
+    }
+  }
+
+  /** Finalize any in-progress PotA proc at fight end */
+  onFightEnd() {
+    if (this.currentPotaProc) {
+      this.potaProcs.push(this.currentPotaProc);
+      this.currentPotaProc = undefined;
     }
   }
 }

--- a/src/analysis/retail/druid/restoration/modules/spells/KeeperOfTheGrove/EarlySpring.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/KeeperOfTheGrove/EarlySpring.tsx
@@ -62,8 +62,9 @@ export default class EarlySpring extends Analyzer {
     if (data.previousCastTimestamp !== null) {
       const fullCooldownWithTalent = this.spellUsable.fullCooldownDuration(spellId);
       const fullCooldownWithoutTalent = fullCooldownWithTalent + CDR_PER_CAST_MS;
+      const castDurationMs = event.channel?.duration ?? 0;
       const castWithoutEarlySpringTimestamp =
-        data.previousCastTimestamp + fullCooldownWithoutTalent;
+        data.previousCastTimestamp + fullCooldownWithoutTalent + castDurationMs;
 
       const effectiveCdr = Math.max(
         0,

--- a/src/analysis/retail/druid/restoration/modules/spells/Lifebloom.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Lifebloom.tsx
@@ -37,6 +37,7 @@ class Lifebloom extends Analyzer {
   private hasVerdancy = false;
   private showCastPanel = false;
   private hasActiveLifebloom = false;
+  private activeLifebloomTarget: number | undefined = undefined;
   private possibleVerdancyBlooms = 0;
   private actualVerdancyBlooms = 0;
   private currentLifebloomStacks = 0;
@@ -80,6 +81,7 @@ class Lifebloom extends Analyzer {
   onApplyLifebloom(event: ApplyBuffEvent) {
     this.recordCast(event, this.currentLifebloomStacks);
     this.currentLifebloomStacks = 1;
+    this.activeLifebloomTarget = event.targetID;
 
     if (this.hasActiveLifebloom) {
       return;
@@ -94,7 +96,14 @@ class Lifebloom extends Analyzer {
       return;
     }
 
+    // Ignore Remove for a target that is no longer the active Lifebloom target
+    // (happens during target swaps when the new Apply arrives before the old Remove)
+    if (event.targetID !== this.activeLifebloomTarget) {
+      return;
+    }
+
     this.hasActiveLifebloom = false;
+    this.activeLifebloomTarget = undefined;
     this.currentLifebloomStacks = 0;
     if (this.lifebloomUptimes.length > 0) {
       this.lifebloomUptimes[this.lifebloomUptimes.length - 1].end = event.timestamp;

--- a/src/analysis/retail/druid/restoration/modules/spells/PowerOfTheArchdruid.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/PowerOfTheArchdruid.tsx
@@ -1,7 +1,7 @@
 import { formatNth, formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, CastEvent, RefreshBuffEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, RefreshBuffEvent } from 'parser/core/Events';
 import { binomialCDF } from 'parser/shared/modules/helpers/Probability';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
@@ -9,11 +9,16 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
-import HotAttributor from 'analysis/retail/druid/restoration/modules/core/hottracking/HotAttributor';
+import HotAttributor, {
+  PotaProc,
+} from 'analysis/retail/druid/restoration/modules/core/hottracking/HotAttributor';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import { SpellLink } from 'interface';
 
 const PROC_PROB = 0.6;
+const EXPECTED_EXTRAS = 2;
+/** Buffer for matching PotA proc timestamps to SotF consumption timestamps */
+const BUFFER_MS = 150;
 
 /**
  * **Power of the Archdruid**
@@ -29,26 +34,38 @@ class PowerOfTheArchdruid extends Analyzer {
 
   hotAttributor!: HotAttributor;
 
-  procs = 0;
-
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.POWER_OF_THE_ARCHDRUID_TALENT);
-
-    this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.POWER_OF_THE_ARCHDRUID),
-      this.onApply,
-    );
-    this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.POWER_OF_THE_ARCHDRUID),
-      this.onApply,
-    );
   }
 
-  onApply(event: ApplyBuffEvent | RefreshBuffEvent) {
-    if (!event.prepull) {
-      this.procs += 1;
-    }
+  /** Per-proc tracking data from HotAttributor */
+  get potaProcs(): PotaProc[] {
+    return this.hotAttributor.potaProcs;
+  }
+
+  get procs(): number {
+    return this.potaProcs.length;
+  }
+
+  /** Number of hardcast SotF consumptions where PotA generated fewer than 2 extras */
+  get incompleteHardcastProcs(): number {
+    return this.potaProcs.filter((p) => p.fromHardcast && p.extrasCount < EXPECTED_EXTRAS).length;
+  }
+
+  /** Total number of hardcast PotA procs */
+  get totalHardcastProcs(): number {
+    return this.potaProcs.filter((p) => p.fromHardcast).length;
+  }
+
+  /** Check if a given timestamp corresponds to an incomplete hardcast PotA proc */
+  isIncompleteHardcastProcAt(timestamp: number): boolean {
+    return this.potaProcs.some(
+      (p) =>
+        p.fromHardcast &&
+        p.extrasCount < EXPECTED_EXTRAS &&
+        Math.abs(p.timestamp - timestamp) <= BUFFER_MS,
+    );
   }
 
   get rejuvsCreated() {
@@ -93,7 +110,14 @@ class PowerOfTheArchdruid extends Analyzer {
                 <strong>{this.owner.formatItemHealingDone(this.regrowthProcHealing)}</strong>
               </li>
             </ul>
-            <br />
+            {this.incompleteHardcastProcs > 0 && (
+              <>
+                <strong>{this.incompleteHardcastProcs}</strong> of{' '}
+                <strong>{this.totalHardcastProcs}</strong> procs created fewer than 2 extra HoTs —
+                make sure allies are within 20 yards of the target. (This does not include any procs
+                consumed during Convoke)
+              </>
+            )}
           </>
         }
       >

--- a/src/analysis/retail/druid/restoration/modules/spells/SoulOfTheForest.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/SoulOfTheForest.tsx
@@ -197,16 +197,18 @@ class SoulOfTheForest extends Analyzer {
       this.lastBuffFromHardcast = false;
     } else {
       const buffed = getSotfBuffs(event);
+      const consumedByHardcastOrConvoke =
+        buffed.length > 0 && (isFromHardcast(buffed[0]) || isFromConvoke(buffed[0]));
+      if (!consumedByHardcastOrConvoke && !this.lastBuffFromHardcast) {
+        // SotF procced and consumed entirely within Convoke - don't count it
+        return;
+      }
+
       if (buffed.length === 0) {
         useText = 'Expired';
         value = QualitativePerformance.Fail;
         this.wastedBuffs += 1;
       } else {
-        if (!isFromHardcast(buffed[0]) && !isFromConvoke(buffed[0]) && !this.lastBuffFromHardcast) {
-          // SM during Convoke also consumed during Convoke - don't count it
-          return;
-        }
-
         // even if generated during Convoke, we count it if consumed by hardcast
         const firstGuid = buffed[0].ability.guid;
         const hasPota = this.selectedCombatant.hasTalent(

--- a/src/analysis/retail/druid/restoration/modules/spells/SoulOfTheForest.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/SoulOfTheForest.tsx
@@ -34,6 +34,7 @@ import { explanationAndDataSubsection } from 'interface/guide/components/Explana
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
 import { isConvoking } from 'analysis/retail/druid/shared/spells/ConvokeSpirits';
 import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
+import PowerOfTheArchdruid from 'analysis/retail/druid/restoration/modules/spells/PowerOfTheArchdruid';
 
 const SOTF_SPELLS = [SPELLS.REJUVENATION, SPELLS.REJUVENATION_GERMINATION, SPELLS.REGROWTH];
 
@@ -51,9 +52,11 @@ const debug = false;
 class SoulOfTheForest extends Analyzer {
   static dependencies = {
     hotTracker: HotTrackerRestoDruid,
+    powerOfTheArchdruid: PowerOfTheArchdruid,
   };
 
   hotTracker!: HotTrackerRestoDruid;
+  powerOfTheArchdruid!: PowerOfTheArchdruid;
 
   sotfRejuvInfo = {
     boost: REJUVENATION_HEALING_INCREASE,
@@ -206,15 +209,42 @@ class SoulOfTheForest extends Analyzer {
 
         // even if generated during Convoke, we count it if consumed by hardcast
         const firstGuid = buffed[0].ability.guid;
+        const hasPota = this.selectedCombatant.hasTalent(
+          TALENTS_DRUID.POWER_OF_THE_ARCHDRUID_TALENT,
+        );
+        const incompletePota =
+          hasPota &&
+          isFromHardcast(buffed[0]) &&
+          this.powerOfTheArchdruid.isIncompleteHardcastProcAt(event.timestamp);
         if (
           firstGuid === SPELLS.REJUVENATION.id ||
           firstGuid === SPELLS.REJUVENATION_GERMINATION.id
         ) {
-          useText = <SpellLink spell={SPELLS.REJUVENATION} />;
-          value = QualitativePerformance.Good;
+          if (incompletePota) {
+            useText = (
+              <>
+                <SpellLink spell={SPELLS.REJUVENATION} /> - fewer than 2{' '}
+                <SpellLink spell={TALENTS_DRUID.POWER_OF_THE_ARCHDRUID_TALENT} /> extra HoTs
+              </>
+            );
+            value = QualitativePerformance.Fail;
+          } else {
+            useText = <SpellLink spell={SPELLS.REJUVENATION} />;
+            value = QualitativePerformance.Good;
+          }
         } else if (firstGuid === SPELLS.REGROWTH.id) {
-          useText = <SpellLink spell={SPELLS.REGROWTH} />;
-          value = QualitativePerformance.Good;
+          if (incompletePota) {
+            useText = (
+              <>
+                <SpellLink spell={SPELLS.REGROWTH} /> - fewer than 2{' '}
+                <SpellLink spell={TALENTS_DRUID.POWER_OF_THE_ARCHDRUID_TALENT} /> extra HoTs
+              </>
+            );
+            value = QualitativePerformance.Fail;
+          } else {
+            useText = <SpellLink spell={SPELLS.REGROWTH} />;
+            value = QualitativePerformance.Good;
+          }
         } else {
           console.warn('SoTF: SOTF reported as consumed by unexpected spell ID: ' + firstGuid);
         }
@@ -268,6 +298,8 @@ class SoulOfTheForest extends Analyzer {
 
   /** Guide subsection describing the proper usage of Soul of the Forest */
   get guideSubsection(): JSX.Element {
+    const hasPota = this.selectedCombatant.hasTalent(TALENTS_DRUID.POWER_OF_THE_ARCHDRUID_TALENT);
+
     const explanation = (
       <p>
         <strong>
@@ -281,6 +313,13 @@ class SoulOfTheForest extends Analyzer {
             before casting Convoke. Never let a proc expire.
           </>
         )}
+        {hasPota && (
+          <>
+            {' '}
+            With <SpellLink spell={TALENTS_DRUID.POWER_OF_THE_ARCHDRUID_TALENT} />, make sure your
+            target is within 20 yards of at least 2 other allies when consuming a proc.
+          </>
+        )}
       </p>
     );
 
@@ -291,7 +330,16 @@ class SoulOfTheForest extends Analyzer {
           castEntries={this.useEntries}
           usesInsteadOfCasts
           goodExtraExplanation={<>used on Rejuvenation or Regrowth</>}
-          badExtraExplanation={<>proc expired or was overwritten</>}
+          badExtraExplanation={
+            hasPota ? (
+              <>
+                proc expired, was overwritten, or created less than 2 extra HoTs from Power of the
+                Archdruid
+              </>
+            ) : (
+              <>proc expired or was overwritten</>
+            )
+          }
         />
       </div>
     );

--- a/src/analysis/retail/druid/restoration/modules/tier/S1TierSet.tsx
+++ b/src/analysis/retail/druid/restoration/modules/tier/S1TierSet.tsx
@@ -58,7 +58,9 @@ class S1TierSet extends Analyzer {
 
     if (this.previousWildGrowthCastTimestamp !== null) {
       const fullCooldownMs = this.spellUsable.fullCooldownDuration(SPELLS.WILD_GROWTH.id) || 10000;
-      const castWithoutTierTimestamp = this.previousWildGrowthCastTimestamp + fullCooldownMs;
+      const castDurationMs = event.channel?.duration ?? 0;
+      const castWithoutTierTimestamp =
+        this.previousWildGrowthCastTimestamp + fullCooldownMs + castDurationMs;
 
       const effectiveCdr = Math.max(
         0,

--- a/src/analysis/retail/druid/restoration/normalizers/SoulOfTheForestLinkNormalizer.ts
+++ b/src/analysis/retail/druid/restoration/normalizers/SoulOfTheForestLinkNormalizer.ts
@@ -17,7 +17,7 @@ import { isFromConvoke, isFromHardcast } from './CastLinkNormalizer';
 const BUFFED_BY_SOTF = 'BuffedBySotf';
 const SOTF_BUFFS_HEAL = 'BuffsHeal';
 
-const SOTF_BUFFER_MS = 50;
+const SOTF_BUFFER_MS = 150;
 
 /** Additional condition for rejuv requires the SotF to be buffing nothing else */
 const REJUV_CONDITION = (linkingEvent: AnyEvent, referencedEvent: AnyEvent) =>


### PR DESCRIPTION
### Description

Fixing a few bugs found in the resto druid modules.

Fixed Lifebloom uptime tracking, Wild Growth cooldown reduction calculations, and Soul of the Forest (SotF) / Power of the Archdruid (PotA) consume logic (including handling SotF consumption during Convoke and detecting missed PotA consumes)

### Testing

- Test report URL: https://www.warcraftlogs.com/reports/x9dhm8MQaDfwJvcn?fight=8&type=summary&source=17&view=events
- Screenshot(s):
<img width="771" height="178" alt="image" src="https://github.com/user-attachments/assets/b6c49276-d8e3-44db-a6e8-481554f6651f" />

<img width="746" height="124" alt="image" src="https://github.com/user-attachments/assets/be860abc-2643-4340-be45-70a3ed609584" />

<img width="330" height="250" alt="image" src="https://github.com/user-attachments/assets/80a07cad-6db9-467e-8150-4ab748c17dd3" />


