### PR TITLE
Create analyzer to add CDR to Dark Harvest

### DIFF
--- a/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 
 export default [
+  change(date(2026, 3, 22), <>Created an analyzer for the cooldown reduction on <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> based on <SpellLink spell={TALENTS.CULL_THE_WEAK_TALENT} />.</>, Katorri),
   change(date(2026, 3, 20), "Add Demonic Healthstone Tracker.", Katorri),
   change(date(2026, 3, 9), <>Created new analyzers for <SpellLink spell={SPELLS.CORRUPTION_DEBUFF} /> / <SpellLink spell={TALENTS.WITHER_TALENT} />, <SpellLink spell={SPELLS.AGONY} />, and <SpellLink spell={TALENTS.HAUNT_TALENT} />. </>, Katorri),
   change(date(2026, 2, 21), "Initial Midnight update to activate Affliction", Katorri),

--- a/src/analysis/retail/warlock/affliction/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/affliction/CombatLogParser.ts
@@ -25,6 +25,7 @@ import Haunt from './modules/analyzers/Haunt';
 import Nightfall from './modules/analyzers/Nightfall';
 import { UnendingResolve, DarkPact, DemonicCircle, DemonicHealthstone } from '../shared';
 import Guide from './Guide';
+import CullTheWeak from './modules/analyzers/CulltheWeak';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -60,6 +61,7 @@ class CombatLogParser extends CoreCombatLogParser {
     grimoireOfSacrifice: GrimoireOfSacrifice,
     haunt: Haunt,
     nightfall: Nightfall,
+    cullTheWeak: CullTheWeak,
 
     // Shared Spells
     unendingResolve: UnendingResolve,

--- a/src/analysis/retail/warlock/affliction/modules/analyzers/CulltheWeak.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/analyzers/CulltheWeak.tsx
@@ -30,7 +30,7 @@ class CullTheWeak extends Analyzer.withDependencies({
     );
   }
 
-  onCast(event: CastEvent) {
+  onCast(_event: CastEvent) {
     const targetSpellId = TALENTS.DARK_HARVEST_TALENT.id;
 
     const actualReduction = this.deps.spellUsable.reduceCooldown(targetSpellId, CDR_MS);

--- a/src/analysis/retail/warlock/affliction/modules/analyzers/CulltheWeak.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/analyzers/CulltheWeak.tsx
@@ -1,0 +1,43 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent } from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
+
+const CDR_MS = 1500;
+
+class CullTheWeak extends Analyzer.withDependencies({
+  spellUsable: SpellUsable,
+}) {
+  protected spellUsable!: SpellUsable;
+
+  effectiveCdrMs = 0;
+  wastedCdrMs = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS.CULL_THE_WEAK_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.cast
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.UNSTABLE_AFFLICTION, SPELLS.SEED_OF_CORRUPTION_DEBUFF]),
+      this.onCast,
+    );
+  }
+
+  onCast(event: CastEvent) {
+    const targetSpellId = TALENTS.DARK_HARVEST_TALENT.id;
+
+    const actualReduction = this.deps.spellUsable.reduceCooldown(targetSpellId, CDR_MS);
+
+    this.effectiveCdrMs += actualReduction;
+    this.wastedCdrMs += CDR_MS - actualReduction;
+  }
+}
+
+export default CullTheWeak;


### PR DESCRIPTION
### Description

Creates an analyzer to add the Cooldown Reduction to Dark Harvest via the talent Cull The Weak

### Testing


- Test report URL: `/report/gQbcDRCvm2dxfKBh/12-Mythic+Commander+Kroluk+-+Kill+(2:14)/3-Katorrí/standard/`
- Screenshot(s):
**Before**
<img width="1380" height="236" alt="image" src="https://github.com/user-attachments/assets/061a84e9-9759-4881-b119-6138e73688ac" />


**After**
<img width="1354" height="259" alt="image" src="https://github.com/user-attachments/assets/6a21f7df-3862-4ba5-97d0-2b853e954239" />
