### PR TITLE
Updates to various cooldown reductions for aimed shot

### DIFF
--- a/src/analysis/retail/hunter/marksmanship/CombatLogParser.ts
+++ b/src/analysis/retail/hunter/marksmanship/CombatLogParser.ts
@@ -28,18 +28,19 @@ import SurgingShots from './modules/talents/SurgingShots';
 import Focus from './modules/resources/Focus';
 import MarksmanshipFocusUsage from './modules/resources/MarksmanshipFocusUsage';
 import AimedShot from './modules/talents/AimedShot';
-import PreciseShots from './modules/spells/PreciseShots';
-import RapidFire from './modules/spells/RapidFire';
+import PreciseShots from './modules/talents/PreciseShots';
+import RapidFire from './modules/talents/RapidFire';
 import SteadyShot from './modules/spells/SteadyShot';
-import Trueshot from './modules/spells/Trueshot';
+import Trueshot from './modules/talents/Trueshot';
 import CallingTheShots from './modules/talents/CallingTheShots';
-
+import TargetAcquisition from './modules/talents/TargetAcquisition';
 import LockAndLoad from './modules/talents/LockAndLoad';
 import MasterMarksman from '../shared/talents/MasterMarksman';
 import Volley from './modules/talents/Volley';
 import FocusedAim from './modules/talents/FocusedAim';
 import AimedShotPrepullNormalizer from './normalizers/AimedShotPrepullNormalizer';
 import Deathblow from '../shared/talents/Deathblow';
+import SentinelsMark from '../shared/herotalents/SentinelsMark';
 import FoundationGuide from 'interface/guide/foundation/FoundationGuide';
 import OvinaxMercurialEgg from 'parser/retail/modules/items/thewarwithin/trinkets/OvinaxMercurialEgg';
 import MadQueensMandate from 'parser/retail/modules/items/thewarwithin/trinkets/MadQueensMandate';
@@ -92,6 +93,7 @@ class CombatLogParser extends CoreCombatLogParser {
     callingTheShots: CallingTheShots,
     deathblow: Deathblow,
     surgingShots: SurgingShots,
+    targetAcquisition: TargetAcquisition,
 
     //Shared Talents
     rejuvenatingWind: RejuvenatingWind,
@@ -101,6 +103,7 @@ class CombatLogParser extends CoreCombatLogParser {
     bornToBeWild: BornToBeWild,
     masterMarksman: MasterMarksman,
     blackArrow: BlackArrow,
+    sentinelsMark: SentinelsMark,
 
     // items
     ovinaxMercurialEgg: OvinaxMercurialEgg,

--- a/src/analysis/retail/hunter/marksmanship/constants.ts
+++ b/src/analysis/retail/hunter/marksmanship/constants.ts
@@ -41,7 +41,7 @@ export const LONE_WOLF_AFFECTED_SPELLS = [
 ];
 /** Precise Shots */
 //Changes from 11.05 has made it so this is definitely 1 proc
-export const PRECISE_SHOTS_ASSUMED_PROCS = 1;
+export const PRECISE_SHOTS_ASSUMED_PROCS = 2;
 //Precise Shots increase damage of Arcane or Multi-Shot by 100%
 export const PRECISE_SHOTS_MODIFIER = 1;
 //Because the spells have traveltime we need to take it into account

--- a/src/analysis/retail/hunter/marksmanship/constants.ts
+++ b/src/analysis/retail/hunter/marksmanship/constants.ts
@@ -40,8 +40,10 @@ export const LONE_WOLF_AFFECTED_SPELLS = [
   SPELLS.KILL_SHOT_MM_BM,
 ];
 /** Precise Shots */
-//Changes from 11.05 has made it so this is definitely 1 proc
-export const PRECISE_SHOTS_ASSUMED_PROCS = 2;
+//Precise Shots procs with Windrunner talents
+export const WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS = 2;
+//Precise Shots procs without Windrunner talents
+export const PRECISE_SHOTS_ASSUMED_PROCS = 1;
 //Precise Shots increase damage of Arcane or Multi-Shot by 100%
 export const PRECISE_SHOTS_MODIFIER = 1;
 //Because the spells have traveltime we need to take it into account

--- a/src/analysis/retail/hunter/marksmanship/modules/Abilities.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/Abilities.tsx
@@ -84,7 +84,7 @@ class Abilities extends CoreAbilities {
       },
       {
         spell: SPELLS.MOONLIGHT_CHAKRAM_CAST.id,
-        category: SPELL_CATEGORY.COOLDOWNS,
+        category: SPELL_CATEGORY.ROTATIONAL,
         gcd: {
           base: 1500,
         },

--- a/src/analysis/retail/hunter/marksmanship/modules/core/SpellUsable.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/core/SpellUsable.tsx
@@ -1,5 +1,6 @@
 import TALENTS from 'common/TALENTS/hunter';
-import { CastEvent, DamageEvent } from 'parser/core/Events';
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
 
 class SpellUsable extends CoreSpellUsable {
@@ -7,22 +8,33 @@ class SpellUsable extends CoreSpellUsable {
     ...CoreSpellUsable.dependencies,
   };
 
-  lastPotentialTriggerForRapidFireReset: CastEvent | null = null;
+  lastPotentialTriggerForRapidFireReset: CastEvent | DamageEvent | null = null;
   rapidFireResets = 0;
+
+  constructor(options: Options) {
+    super(options);
+    if (this.selectedCombatant.hasTalent(TALENTS.SURGING_SHOTS_TALENT)) {
+      this.addEventListener(
+        Events.cast.by(SELECTED_PLAYER).spell(TALENTS.AIMED_SHOT_TALENT),
+        this.onAimedShotCast,
+      );
+      this.addEventListener(
+        Events.damage.by(SELECTED_PLAYER).spell(TALENTS.AIMED_SHOT_TALENT),
+        this.onAimedShotDamage,
+      );
+    }
+  }
+
+  onAimedShotCast(event: CastEvent) {
+    this.lastPotentialTriggerForRapidFireReset = event;
+  }
+
+  onAimedShotDamage(event: DamageEvent) {
+    this.lastPotentialTriggerForRapidFireReset = event;
+  }
 
   onCast(event: CastEvent) {
     const spellId = event.ability.guid;
-    if (this.selectedCombatant.hasTalent(TALENTS.SURGING_SHOTS_TALENT)) {
-      if (spellId === TALENTS.AIMED_SHOT_TALENT.id) {
-        this.lastPotentialTriggerForRapidFireReset = event;
-      } else if (spellId === TALENTS.RAPID_FIRE_TALENT.id) {
-        this.lastPotentialTriggerForRapidFireReset = null;
-      }
-    }
-    super.onCast(event);
-  }
-
-  beginCooldown(triggerEvent: CastEvent | DamageEvent, spellId: number) {
     if (
       spellId === TALENTS.RAPID_FIRE_TALENT.id &&
       this.selectedCombatant.hasTalent(TALENTS.SURGING_SHOTS_TALENT)
@@ -35,8 +47,13 @@ class SpellUsable extends CoreSpellUsable {
             ? this.lastPotentialTriggerForRapidFireReset.timestamp
             : undefined,
         );
+        this.lastPotentialTriggerForRapidFireReset = null;
       }
     }
+    super.onCast(event);
+  }
+
+  beginCooldown(triggerEvent: CastEvent | DamageEvent, spellId: number) {
     super.beginCooldown(triggerEvent, spellId);
   }
 }

--- a/src/analysis/retail/hunter/marksmanship/modules/spells/SteadyShot.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/spells/SteadyShot.tsx
@@ -1,13 +1,24 @@
 import SPELLS from 'common/SPELLS';
+import TALENTS_HUNTER from 'common/TALENTS/hunter';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ResourceChangeEvent } from 'parser/core/Events';
+import Events, { CastEvent, ResourceChangeEvent } from 'parser/core/Events';
+import Abilities from 'parser/core/modules/Abilities';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
 class SteadyShot extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+    abilities: Abilities,
+  };
+
   effectiveFocusGain = 0;
   focusWasted = 0;
+
+  protected spellUsable!: SpellUsable;
+  protected abilities!: Abilities;
 
   constructor(options: Options) {
     super(options);
@@ -15,6 +26,13 @@ class SteadyShot extends Analyzer {
       Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.STEADY_SHOT_FOCUS),
       this.onEnergize,
     );
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.STEADY_SHOT), this.onCast);
+  }
+
+  onCast(event: CastEvent) {
+    if (this.spellUsable.isOnCooldown(TALENTS_HUNTER.AIMED_SHOT_TALENT.id)) {
+      this.spellUsable.reduceCooldown(TALENTS_HUNTER.AIMED_SHOT_TALENT.id, 2000, event.timestamp);
+    }
   }
 
   onEnergize(event: ResourceChangeEvent) {

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/AimedShot.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/AimedShot.tsx
@@ -14,6 +14,12 @@ import Abilities from 'parser/core/modules/Abilities';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
+/**
+ * A powerful aimed shot that deals [(248.4% of Attack power) * ((max(0, min(Level - 10, 10)) * 8 + 130) / 210)] Physical damage.
+ *
+ * Example log with timeline warnings:
+ * https://www.warcraftlogs.com/reports/9Ljy6fh1TtCDHXVB#fight=2&type=damage-done&source=25&ability=-19434
+ */
 const debug = false;
 
 class AimedShot extends Analyzer {
@@ -66,6 +72,10 @@ class AimedShot extends Analyzer {
     if (this.lastReductionTimestamp === 0 || event.timestamp <= this.lastReductionTimestamp) {
       return;
     }
+    /**
+     * modRate is what the value is called in-game that defines how fast a cooldown recharges, so reusing that terminology here
+     * Dead Eye and Trueshot scale multiplicatively off each other, which can lead to extremely fast cooldown reduction that this should properly handle.
+     */
     let modRate = 1;
     if (this.selectedCombatant.hasBuff(TALENTS_HUNTER.TRUESHOT_TALENT.id)) {
       modRate /= 1 + TRUESHOT_AIMED_SHOT_RECHARGE_INCREASE;

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/AimedShot.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/AimedShot.tsx
@@ -14,12 +14,6 @@ import Abilities from 'parser/core/modules/Abilities';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import { addInefficientCastReason } from 'parser/core/EventMetaLib';
 
-/**
- * A powerful aimed shot that deals [(248.4% of Attack power) * ((max(0, min(Level - 10, 10)) * 8 + 130) / 210)] Physical damage.
- *
- * Example log with timeline warnings:
- * https://www.warcraftlogs.com/reports/9Ljy6fh1TtCDHXVB#fight=2&type=damage-done&source=25&ability=-19434
- */
 const debug = false;
 
 class AimedShot extends Analyzer {
@@ -62,11 +56,6 @@ class AimedShot extends Analyzer {
     );
   }
 
-  //Steady Shot reduces the cooldown of Aimed Shot by 2 seconds
-  onSteadyShot(event: CastEvent) {
-    this.spellUsable.reduceCooldown(TALENTS_HUNTER.AIMED_SHOT_TALENT.id, 2000);
-  }
-
   onEvent(event: AnyEvent) {
     if (!this.selectedCombatant.hasBuff(TALENTS_HUNTER.TRUESHOT_TALENT.id)) {
       return;
@@ -77,10 +66,6 @@ class AimedShot extends Analyzer {
     if (this.lastReductionTimestamp === 0 || event.timestamp <= this.lastReductionTimestamp) {
       return;
     }
-    /**
-     * modRate is what the value is called in-game that defines how fast a cooldown recharges, so reusing that terminology here
-     * Dead Eye and Trueshot scale multiplicatively off each other, which can lead to extremely fast cooldown reduction that this should properly handle.
-     */
     let modRate = 1;
     if (this.selectedCombatant.hasBuff(TALENTS_HUNTER.TRUESHOT_TALENT.id)) {
       modRate /= 1 + TRUESHOT_AIMED_SHOT_RECHARGE_INCREASE;

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/FocusedAim.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/FocusedAim.tsx
@@ -1,16 +1,14 @@
 import SpellUsable from 'parser/shared/modules/SpellUsable';
-import Events from 'parser/core/Events';
-import Abilities from 'parser/core/modules/Abilities';
+import Events, { RemoveBuffEvent, RemoveBuffStackEvent } from 'parser/core/Events';
 import { TALENTS_HUNTER } from 'common/TALENTS';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 
-const REDUCTION_MS = 750;
+const REDUCTION_MS = 2000;
 
 class FocusedAim extends Analyzer {
   static dependencies = {
     spellUsable: SpellUsable,
-    abilities: Abilities,
   };
 
   protected spellUsable!: SpellUsable;
@@ -22,12 +20,19 @@ class FocusedAim extends Analyzer {
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.PRECISE_SHOTS_BUFF),
       this.onPSRemoved,
     );
+    this.addEventListener(
+      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.PRECISE_SHOTS_BUFF),
+      this.onPSRemoved,
+    );
   }
 
-  private onPSRemoved() {
-    this.spellUsable.reduceCooldown(TALENTS_HUNTER.AIMED_SHOT_TALENT.id, REDUCTION_MS);
-    if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.WINDRUNNER_QUIVER_TALENT)) {
-      this.spellUsable.reduceCooldown(TALENTS_HUNTER.AIMED_SHOT_TALENT.id, REDUCTION_MS * 2);
+  private onPSRemoved(event: RemoveBuffEvent | RemoveBuffStackEvent) {
+    if (this.spellUsable.isOnCooldown(TALENTS_HUNTER.AIMED_SHOT_TALENT.id)) {
+      this.spellUsable.reduceCooldown(
+        TALENTS_HUNTER.AIMED_SHOT_TALENT.id,
+        REDUCTION_MS,
+        event.timestamp,
+      );
     }
   }
 }

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/PreciseShots.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/PreciseShots.tsx
@@ -47,14 +47,6 @@ class PreciseShots extends Analyzer {
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.PRECISE_SHOTS_BUFF),
       this.onPreciseShotsRemoval,
     );
-    /*this.addEventListener(
-      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.PRECISE_SHOTS_BUFF),
-      this.onPreciseShotsStackRemoval,
-    );
-    this.addEventListener(
-      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.PRECISE_SHOTS_BUFF),
-      this.onPreciseShotsStackApplication,
-    );*/
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell([SPELLS.ARCANE_SHOT, SPELLS.MULTISHOT_MM]),
       this.onPreciseCast,
@@ -90,17 +82,6 @@ class PreciseShots extends Analyzer {
     this.buffsSpent += 2;
     this.buffsActive = 0;
   }
-
-  /*onPreciseShotsStackRemoval() {
-    this.buffsSpent += 1;
-    this.buffsActive -= 1;
-  }*/
-
-  /*onPreciseShotsStackApplication() {
-    this.minOverwrittenProcs += 1;
-    this.maxOverwrittenProcs += 2;
-    this.buffsActive = PRECISE_SHOTS_ASSUMED_PROCS;
-  }*/
 
   onPreciseCast(event: CastEvent) {
     if (!this.selectedCombatant.hasBuff(SPELLS.PRECISE_SHOTS_BUFF.id)) {

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/PreciseShots.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/PreciseShots.tsx
@@ -47,14 +47,14 @@ class PreciseShots extends Analyzer {
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.PRECISE_SHOTS_BUFF),
       this.onPreciseShotsRemoval,
     );
-    this.addEventListener(
+    /*this.addEventListener(
       Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.PRECISE_SHOTS_BUFF),
       this.onPreciseShotsStackRemoval,
     );
     this.addEventListener(
       Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.PRECISE_SHOTS_BUFF),
       this.onPreciseShotsStackApplication,
-    );
+    );*/
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell([SPELLS.ARCANE_SHOT, SPELLS.MULTISHOT_MM]),
       this.onPreciseCast,
@@ -87,20 +87,20 @@ class PreciseShots extends Analyzer {
   }
 
   onPreciseShotsRemoval() {
-    this.buffsSpent += 1;
+    this.buffsSpent += 2;
     this.buffsActive = 0;
   }
 
-  onPreciseShotsStackRemoval() {
+  /*onPreciseShotsStackRemoval() {
     this.buffsSpent += 1;
     this.buffsActive -= 1;
-  }
+  }*/
 
-  onPreciseShotsStackApplication() {
+  /*onPreciseShotsStackApplication() {
     this.minOverwrittenProcs += 1;
     this.maxOverwrittenProcs += 2;
     this.buffsActive = PRECISE_SHOTS_ASSUMED_PROCS;
-  }
+  }*/
 
   onPreciseCast(event: CastEvent) {
     if (!this.selectedCombatant.hasBuff(SPELLS.PRECISE_SHOTS_BUFF.id)) {

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/PreciseShots.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/PreciseShots.tsx
@@ -1,5 +1,6 @@
 import {
   ARCANE_SHOT_MAX_TRAVEL_TIME,
+  WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS,
   PRECISE_SHOTS_ASSUMED_PROCS,
   PRECISE_SHOTS_MODIFIER,
 } from 'analysis/retail/hunter/marksmanship/constants';
@@ -75,12 +76,21 @@ class PreciseShots extends Analyzer {
   }
 
   onPreciseShotsApplication() {
-    this.buffsActive = PRECISE_SHOTS_ASSUMED_PROCS;
+    if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.WINDRUNNER_QUIVER_TALENT)) {
+      this.buffsActive = WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS;
+    } else {
+      this.buffsActive = PRECISE_SHOTS_ASSUMED_PROCS;
+    }
   }
 
   onPreciseShotsRemoval() {
-    this.buffsSpent += 2;
-    this.buffsActive = 0;
+    if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.WINDRUNNER_QUIVER_TALENT)) {
+      this.buffsSpent += 2;
+      this.buffsActive = 0;
+    } else {
+      this.buffsSpent += 1;
+      this.buffsActive = 0;
+    }
   }
 
   onPreciseCast(event: CastEvent) {

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/RapidFire.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/RapidFire.tsx
@@ -111,6 +111,9 @@ class RapidFire extends Analyzer {
     if (this.lastReductionTimestamp === 0 || event.timestamp <= this.lastReductionTimestamp) {
       return;
     }
+    /**
+     * modRate is what the value is called in-game that defines how fast a cooldown recharges, so reusing that terminology here
+     */
     let modRate = 1;
     if (this.selectedCombatant.hasBuff(TALENTS.TRUESHOT_TALENT.id)) {
       modRate /= 1 + TRUESHOT_RAPID_FIRE_RECHARGE_INCREASE;

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/RapidFire.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/RapidFire.tsx
@@ -1,8 +1,4 @@
-import {
-  RAPID_FIRE_FOCUS_PER_TICK,
-  TRUESHOT_RAPID_FIRE_RECHARGE_INCREASE,
-} from 'analysis/retail/hunter/marksmanship/constants';
-import { MS_BUFFER_100 } from 'analysis/retail/hunter/shared/constants';
+import { TRUESHOT_RAPID_FIRE_RECHARGE_INCREASE } from 'analysis/retail/hunter/marksmanship/constants';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/hunter';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
@@ -13,6 +9,7 @@ import Events, {
   EventType,
   RefreshBuffEvent,
   RemoveBuffEvent,
+  CastEvent,
 } from 'parser/core/Events';
 import Abilities from 'parser/core/modules/Abilities';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
@@ -20,9 +17,19 @@ import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 
+const BASE_TICKS = 7;
+const QUICK_DRAW_TICKS = 10;
+const DOUBLE_TAP_TICKS = 13;
+const QUICK_DRAW_DOUBLE_TAP_TICKS = 18;
+const TAKE_AIM_CDR_MS = 500;
+
 /**
- * Shoot a stream of 7 shots at your target over 2 sec, dealing a total of 242% attack power Physical damage.
+ * Shoot a stream of shots at your target over 2 sec, dealing Physical damage.
  * Each shot generates 1 focus.
+ * - Base: 7 shots
+ * - Quick Draw: 10 shots
+ * - Double Tap: 13 shots
+ * - Quick Draw + Double Tap: 18 shots
  *
  * Example log:
  *
@@ -39,12 +46,8 @@ class RapidFire extends Analyzer {
   casts = 0;
   effectiveCDRFromTrueshot = 0;
   wastedCDRFromTrueshot = 0;
-  currentFocusTicks = 0;
   effectiveFocusGain = 0;
   focusWasted = 0;
-  additionalFocusFromTrueshot = 0;
-  possibleAdditionalFocusFromTrueshot = 0;
-  lastFocusTickTimestamp = 0;
 
   protected spellUsable!: SpellUsable;
   protected abilities!: Abilities;
@@ -73,6 +76,29 @@ class RapidFire extends Analyzer {
       Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.RAPID_FIRE_FOCUS),
       this.onEnergize,
     );
+
+    if (this.selectedCombatant.hasTalent(TALENTS.TAKE_AIM_1_MARKSMANSHIP_TALENT)) {
+      this.addEventListener(
+        Events.resourcechange.by(SELECTED_PLAYER).spell(SPELLS.RAPID_FIRE_FOCUS),
+        this.onTakeAimTick,
+      );
+    }
+  }
+
+  getExpectedTicks(): number {
+    const hasQuickDraw = this.selectedCombatant.hasTalent(TALENTS.QUICK_DRAW_TALENT);
+    const hasDoubleTap = this.selectedCombatant.hasBuff(SPELLS.DOUBLE_TAP_BUFF.id);
+
+    if (hasQuickDraw && hasDoubleTap) {
+      return QUICK_DRAW_DOUBLE_TAP_TICKS;
+    }
+    if (hasQuickDraw) {
+      return QUICK_DRAW_TICKS;
+    }
+    if (hasDoubleTap) {
+      return DOUBLE_TAP_TICKS;
+    }
+    return BASE_TICKS;
   }
 
   onEvent(event: AnyEvent) {
@@ -85,9 +111,6 @@ class RapidFire extends Analyzer {
     if (this.lastReductionTimestamp === 0 || event.timestamp <= this.lastReductionTimestamp) {
       return;
     }
-    /**
-     * modRate is what the value is called in-game that defines how fast a cooldown recharges, so reusing that terminology here
-     */
     let modRate = 1;
     if (this.selectedCombatant.hasBuff(TALENTS.TRUESHOT_TALENT.id)) {
       modRate /= 1 + TRUESHOT_RAPID_FIRE_RECHARGE_INCREASE;
@@ -123,22 +146,23 @@ class RapidFire extends Analyzer {
     this.lastReductionTimestamp = event.timestamp;
   }
 
-  onCast() {
+  onCast(event: CastEvent) {
     this.casts += 1;
-    this.currentFocusTicks = 0;
+    debug && console.log('Rapid Fire cast — expected ticks:', this.getExpectedTicks());
   }
 
   onEnergize(event: ResourceChangeEvent) {
     this.effectiveFocusGain += event.resourceChange - event.waste;
     this.focusWasted += event.waste;
-    const hasTrueshot = this.selectedCombatant.hasBuff(TALENTS.TRUESHOT_TALENT.id);
+  }
 
-    /** If Trueshot is active Rapid Fire has a 50% chance to fire an additional energize event
-     *  However because focus can't be fractional and WoW rounds down on halves, we simply attribute 1 focus gain per additional energize tick over the baseline amount
-     */
-    if (hasTrueshot && this.lastFocusTickTimestamp + MS_BUFFER_100 / 2 > event.timestamp) {
-      this.additionalFocusFromTrueshot += event.resourceChange - event.waste;
-      this.possibleAdditionalFocusFromTrueshot += RAPID_FIRE_FOCUS_PER_TICK;
+  private onTakeAimTick(event: ResourceChangeEvent) {
+    if (this.spellUsable.isOnCooldown(TALENTS.AIMED_SHOT_TALENT.id)) {
+      this.spellUsable.reduceCooldown(
+        TALENTS.AIMED_SHOT_TALENT.id,
+        TAKE_AIM_CDR_MS,
+        event.timestamp,
+      );
     }
   }
 

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/TargetAcquisition.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/TargetAcquisition.tsx
@@ -1,0 +1,45 @@
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import Events from 'parser/core/Events';
+import Abilities from 'parser/core/modules/Abilities';
+import { TALENTS_HUNTER } from 'common/TALENTS';
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+
+const REDUCTION_MS = 1000;
+const AVIAN_SPEC_COOLDOWN_MS = 1500;
+
+class TargetAcquisition extends Analyzer {
+  static dependencies = {
+    spellUsable: SpellUsable,
+    abilities: Abilities,
+  };
+
+  protected spellUsable!: SpellUsable;
+  private lastAvianProcTimestamp = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_HUNTER.TARGET_ACQUISITION_TALENT);
+
+    if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.AVIAN_SPECIALIZATION_TALENT)) {
+      const markSpell = this.selectedCombatant.hasTalent(TALENTS_HUNTER.SENTINEL_TALENT)
+        ? SPELLS.SENTINELS_MARK_DEBUFF
+        : SPELLS.SPOTTERS_MARK_DEBUFF;
+
+      this.addEventListener(
+        Events.removedebuff.by(SELECTED_PLAYER).spell(markSpell),
+        this.onMarkRemoved,
+      );
+    }
+  }
+
+  private onMarkRemoved(event: { timestamp: number }) {
+    if (event.timestamp - this.lastAvianProcTimestamp < AVIAN_SPEC_COOLDOWN_MS) {
+      return;
+    }
+    this.lastAvianProcTimestamp = event.timestamp;
+    this.spellUsable.reduceCooldown(TALENTS_HUNTER.AIMED_SHOT_TALENT.id, REDUCTION_MS);
+  }
+}
+
+export default TargetAcquisition;

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/Trueshot.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/Trueshot.tsx
@@ -1,4 +1,4 @@
-import RapidFire from 'analysis/retail/hunter/marksmanship/modules/spells/RapidFire';
+import RapidFire from 'analysis/retail/hunter/marksmanship/modules/talents/RapidFire';
 import SteadyShot from 'analysis/retail/hunter/marksmanship/modules/spells/SteadyShot';
 import { TALENTS_HUNTER } from 'common/TALENTS';
 import { SpellIcon } from 'interface';

--- a/src/analysis/retail/hunter/shared/herotalents/SentinelsMark.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/SentinelsMark.tsx
@@ -316,6 +316,7 @@ export default class SentinelsMark extends Analyzer.withDependencies({
   }
 
   private onMarkApply(event: ApplyDebuffEvent) {
+    // Handle edge case: new apply on target that already has a tracked mark (previous expired quietly)
     if (this.activeMarks.has(event.targetID)) {
       this.finalizeMarkAsExpired(event.targetID, event.timestamp);
     }

--- a/src/analysis/retail/hunter/shared/herotalents/SentinelsMark.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/SentinelsMark.tsx
@@ -316,12 +316,21 @@ export default class SentinelsMark extends Analyzer.withDependencies({
   }
 
   private onMarkApply(event: ApplyDebuffEvent) {
-    // Handle edge case: new apply on target that already has a tracked mark (previous expired quietly)
     if (this.activeMarks.has(event.targetID)) {
       this.finalizeMarkAsExpired(event.targetID, event.timestamp);
     }
 
     this.totalApplies += 1;
+
+    if (!this.isSurvival && this.hasMoonsBlessing) {
+      if (this.deps.spellUsable.isOnCooldown(TALENTS.AIMED_SHOT_TALENT.id)) {
+        this.deps.spellUsable.reduceCooldown(
+          TALENTS.AIMED_SHOT_TALENT.id,
+          AIMED_SHOT_CDR,
+          event.timestamp,
+        );
+      }
+    }
 
     this.activeMarks.set(event.targetID, {
       applyTimestamp: event.timestamp,
@@ -333,6 +342,16 @@ export default class SentinelsMark extends Analyzer.withDependencies({
   }
 
   private onMarkRefresh(event: RefreshDebuffEvent) {
+    if (!this.isSurvival && this.hasMoonsBlessing) {
+      if (this.deps.spellUsable.isOnCooldown(TALENTS.AIMED_SHOT_TALENT.id)) {
+        this.deps.spellUsable.reduceCooldown(
+          TALENTS.AIMED_SHOT_TALENT.id,
+          AIMED_SHOT_CDR,
+          event.timestamp,
+        );
+      }
+    }
+
     this.totalRefreshes += 1;
     // Mark the existing mark as a fail and remove it from tracking.
     const previousMark = this.activeMarks.get(event.targetID);

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -176,7 +176,7 @@ const spells = {
     name: 'Rapid Fire',
     icon: 'ability_hunter_efficiency',
   },
-  SPOTTERS_MARK_BUFF: {
+  SPOTTERS_MARK_DEBUFF: {
     id: 466872,
     name: "Spotter's Mark",
     icon: 'inv_111_hunter_ability_eaglemark',


### PR DESCRIPTION
Fixed the various cooldown reduction effects for Aimed Shot.

- Steady shot CDR moved from AimedShot to SteadyShot
- FocusedAim updated for midnight
- Added TargetAcquisition to handle CDR from that talent
- Updated Sentinels Mark to handle CDR from Moon's Blessing (only for MM, haven't really looked into SV)
- Updated RapidFire to handle CDR from Take Aim rank 1

Updated PreciseShots to handle stacks/procs based on whether or not you have Windrunners Quiver talent

Surging shots logic was already being handled in the hunter SpellUsable file, so I fixed the logic and kept it in that file. Pretty new to this sort of thing so I don't know if there is a reason why this should be in SpellUsable, or if I could move it to the SurgingShots file.