### PR TITLE
[Survival] - Bomb and Sentinel Mark

### DIFF
--- a/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
@@ -38,6 +38,7 @@ export default class MoonlightChakram extends Analyzer {
   private useEntries: BoxRowEntry[] = [];
   private isSurvival = false;
   private hasStalkAndStrike = false;
+  private lastTriggerTarget = 'unknown';
 
   constructor(options: Options) {
     super(options);
@@ -55,15 +56,18 @@ export default class MoonlightChakram extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell([TALENTS.TRUESHOT_TALENT, SPELLS.TAKEDOWN_PLAYER]),
       this.onTriggerCast,
     );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.MOONLIGHT_CHAKRAM_CAST),
+      this.onChakramCast,
+    );
   }
 
+  /** Handles missed Chakram windows — when Trueshot/Takedown fires but no Chakram follows */
   private onTriggerCast(event: CastEvent) {
-    // Chakram is a 15s duration availability after using cooldown.
+    this.lastTriggerTarget = this.owner.getTargetName(event) || 'unknown';
     const chakramCast = GetRelatedEvents(event, TRIGGER_TO_CHAKRAM_CAST)[0] as
       | CastEvent
       | undefined;
-    const chakramTarget = this.owner.getTargetName(event) || 'unknown';
-
     if (!chakramCast) {
       this.missedCasts += 1;
       this.useEntries.push({
@@ -73,22 +77,24 @@ export default class MoonlightChakram extends Analyzer {
             <h5 style={{ color: BadColor }}>
               FAIL: No <SpellLink spell={SPELLS.MOONLIGHT_CHAKRAM_CAST} /> cast
             </h5>
-            Target: <strong>{chakramTarget}</strong>
+            Target: <strong>{this.lastTriggerTarget}</strong>
             {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
             <br />@ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
           </>
         ),
       });
-      return;
     }
+  }
 
+  /** Handles Chakram casts — SpellUsable state is accurate here for CDR checks */
+  private onChakramCast(event: CastEvent) {
     this.chakramCasts += 1;
-    const targetName = this.owner.getTargetName(chakramCast) || chakramTarget;
+
+    const targetName = this.owner.getTargetName(event) || this.lastTriggerTarget;
 
     //Currently hits 16 times, but will only hit for 7 at level 90 with the extra hero talents
     // So analysis is a little weird. The important bit is did they even cast the ability or did they forget
-    const damageEvents =
-      (GetRelatedEvents(chakramCast, CHAKRAM_CAST_TO_DAMAGE) as DamageEvent[]) || [];
+    const damageEvents = (GetRelatedEvents(event, CHAKRAM_CAST_TO_DAMAGE) as DamageEvent[]) || [];
     const damage = damageEvents.reduce((sum, dmg) => sum + dmg.amount + (dmg.absorbed || 0), 0);
     const hits = damageEvents.length;
 
@@ -106,10 +112,8 @@ export default class MoonlightChakram extends Analyzer {
 
     if (this.hasStalkAndStrike) {
       if (this.isSurvival) {
-        const cdRemaining = this.spellUsable.cooldownRemaining(
-          TALENTS.WILDFIRE_BOMB_TALENT.id,
-          chakramCast.timestamp,
-        );
+        // event.timestamp is the Chakram cast time — SpellUsable state is correct here
+        const cdRemaining = this.spellUsable.cooldownRemaining(TALENTS.WILDFIRE_BOMB_TALENT.id);
         if (cdRemaining <= STALK_AND_STRIKE_CDR) {
           wastedCDR = STALK_AND_STRIKE_CDR - cdRemaining;
           if (wastedCDR > STALK_AND_STRIKE_WASTE_THRESHOLD) {
@@ -121,7 +125,7 @@ export default class MoonlightChakram extends Analyzer {
       } else {
         wastedLockAndLoad = this.selectedCombatant.hasBuff(
           SPELLS.LOCK_AND_LOAD_BUFF.id,
-          chakramCast.timestamp,
+          event.timestamp,
         );
         if (wastedLockAndLoad) {
           performance = QualitativePerformance.Fail;

--- a/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
@@ -38,6 +38,7 @@ export default class MoonlightChakram extends Analyzer {
   private useEntries: BoxRowEntry[] = [];
   private isSurvival = false;
   private hasStalkAndStrike = false;
+  private lastTriggerTarget = 'unknown';
 
   constructor(options: Options) {
     super(options);
@@ -55,15 +56,18 @@ export default class MoonlightChakram extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell([SPELLS.TRUESHOT, SPELLS.TAKEDOWN_PLAYER]),
       this.onTriggerCast,
     );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.MOONLIGHT_CHAKRAM_CAST),
+      this.onChakramCast,
+    );
   }
 
+  /** Handles missed Chakram windows — when Trueshot/Takedown fires but no Chakram follows */
   private onTriggerCast(event: CastEvent) {
-    // Chakram is a 15s duration availability after using cooldown.
+    this.lastTriggerTarget = this.owner.getTargetName(event) || 'unknown';
     const chakramCast = GetRelatedEvents(event, TRIGGER_TO_CHAKRAM_CAST)[0] as
       | CastEvent
       | undefined;
-    const chakramTarget = this.owner.getTargetName(event) || 'unknown';
-
     if (!chakramCast) {
       this.missedCasts += 1;
       this.useEntries.push({
@@ -73,21 +77,23 @@ export default class MoonlightChakram extends Analyzer {
             <h5 style={{ color: BadColor }}>
               FAIL: No <SpellLink spell={SPELLS.MOONLIGHT_CHAKRAM_CAST} /> cast
             </h5>
-            Target: <strong>{chakramTarget}</strong>
+            Target: <strong>{this.lastTriggerTarget}</strong>
             <br />@ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
           </>
         ),
       });
-      return;
     }
+  }
 
+  /** Handles Chakram casts — SpellUsable state is accurate here for CDR checks */
+  private onChakramCast(event: CastEvent) {
     this.chakramCasts += 1;
-    const targetName = this.owner.getTargetName(chakramCast) || chakramTarget;
+
+    const targetName = this.owner.getTargetName(event) || this.lastTriggerTarget;
 
     //Currently hits 16 times, but will only hit for 7 at level 90 with the extra hero talents
     // So analysis is a little weird. The important bit is did they even cast the ability or did they forget
-    const damageEvents =
-      (GetRelatedEvents(chakramCast, CHAKRAM_CAST_TO_DAMAGE) as DamageEvent[]) || [];
+    const damageEvents = (GetRelatedEvents(event, CHAKRAM_CAST_TO_DAMAGE) as DamageEvent[]) || [];
     const damage = damageEvents.reduce((sum, dmg) => sum + dmg.amount + (dmg.absorbed || 0), 0);
     const hits = damageEvents.length;
 
@@ -105,10 +111,8 @@ export default class MoonlightChakram extends Analyzer {
 
     if (this.hasStalkAndStrike) {
       if (this.isSurvival) {
-        const cdRemaining = this.spellUsable.cooldownRemaining(
-          TALENTS.WILDFIRE_BOMB_TALENT.id,
-          chakramCast.timestamp,
-        );
+        // event.timestamp is the Chakram cast time — SpellUsable state is correct here
+        const cdRemaining = this.spellUsable.cooldownRemaining(TALENTS.WILDFIRE_BOMB_TALENT.id);
         if (cdRemaining <= STALK_AND_STRIKE_CDR) {
           wastedCDR = STALK_AND_STRIKE_CDR - cdRemaining;
           if (wastedCDR > STALK_AND_STRIKE_WASTE_THRESHOLD) {
@@ -120,7 +124,7 @@ export default class MoonlightChakram extends Analyzer {
       } else {
         wastedLockAndLoad = this.selectedCombatant.hasBuff(
           SPELLS.LOCK_AND_LOAD_BUFF.id,
-          chakramCast.timestamp,
+          event.timestamp,
         );
         if (wastedLockAndLoad) {
           performance = QualitativePerformance.Fail;

--- a/src/analysis/retail/hunter/shared/normalizers/SentinelsMarkNormalizer.ts
+++ b/src/analysis/retail/hunter/shared/normalizers/SentinelsMarkNormalizer.ts
@@ -16,8 +16,8 @@ const links: EventLink[] = [
     referencedEventId: [SPELLS.WILDFIRE_BOMB_IMPACT.id, TALENTS.AIMED_SHOT_TALENT.id],
     anyTarget: false,
     anySource: false,
-    forwardBufferMs: 50,
-    backwardBufferMs: 50,
+    forwardBufferMs: 100,
+    backwardBufferMs: 100,
     maximumLinks: 1,
   },
   {

--- a/src/analysis/retail/hunter/survival/modules/talents/WildfireBomb.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/WildfireBomb.tsx
@@ -89,12 +89,19 @@ class WildfireBomb extends Analyzer.withDependencies({
       this.sentinelProcs += 1;
     }
 
-    // Classify performance: Perfect if tipped + sentinel proc, Good if just tipped, Fail if not tipped
+    // Classify performance: pre-pull (first bomb within 5s of fight start) is always Good;
+    // This lets us deal with throwing a bomb late due to an early pull or other shenanigans on pull.
+    const isPrePull =
+      this.casts === 1 && !wasTipped && event.timestamp - this.owner.fight.start_time <= 5_000;
     let value: QualitativePerformance;
     let header: string;
     let color: string;
 
-    if (wasTipped && hadSentinelProc) {
+    if (isPrePull) {
+      value = QualitativePerformance.Good;
+      header = 'Good: pre-pull cast.';
+      color = GoodColor;
+    } else if (wasTipped && hadSentinelProc) {
       value = QualitativePerformance.Perfect;
       header = "Perfect: tipped and proc'd Sentinel's Mark.";
       color = PerfectColor;


### PR DESCRIPTION
### Description
No Changelog changes as this is part of 2-3 PRs and the last PR will have the changelog.


Had a weird merge conflict which is why the prepull allowance showed up twice.. Unsure how to resolve that better.

Wildfire bomb change - Survival throws bomb pre-pull with no tip. Occasionally someone pulls early and we pretty much never throw more than one bomb untipped on opener so allowing up to 5s for shenanigans to mark the bomb as a good cast.

Sentinel Mark was occasionally being removed without linking correctly to the event that removed it on 50ms so extending to 100ms for better capture.


- Test report URL: `/report/87hcKmZjqHDgWrXa/15-Heroic+Vorasius+-+Kill+(5:52)/17-Juzomido/standard`
