### PR TITLE
Devastation update Guide section for midnight

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -34,7 +34,6 @@
     "src/analysis/retail/druid/restoration/**",
     "src/analysis/retail/druid/shared/**",
     "src/analysis/retail/evoker/augmentation/**",
-    "src/analysis/retail/evoker/devastation/**",
     "src/analysis/retail/evoker/preservation/**",
     "src/analysis/retail/evoker/shared/**",
     "src/analysis/retail/hunter/beastmastery/**",

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import ItemSetLink from 'interface/ItemSetLink';
 import { EVOKER_MID1_ID } from 'common/ITEMS';
 
 export default [
+  change(date(2026, 3, 23), "Update guide section for midnight and introduce new No Wasted Buffs section.", Vollmer),
   change(date(2026, 3, 17), <>Add statistics for <SpellLink spell={TALENTS.RISING_FURY_3_DEVASTATION_TALENT}/> and <ItemSetLink id={EVOKER_MID1_ID}>MID Season 1 Tier Set</ItemSetLink>.</>, Vollmer),
   change(date(2026, 2, 7), <>Add statistics for <SpellLink spell={TALENTS.CONCENTRATED_POWER_TALENT} />.</>, Vollmer),
   change(date(2026, 2, 1), <>Improve statistics for <SpellLink spell={TALENTS.IRIDESCENCE_TALENT} />.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
@@ -440,16 +440,6 @@ class Disintegrate extends Analyzer {
             ' tick(s) with: ' +
             this.disintegrateClipSpell.ability.name,
         });
-      } else {
-        this.problemPoints.push({
-          timestamp: event.timestamp,
-          count: this.currentRemainingTicks,
-          tooltip:
-            'Bad Clip, you clipped: ' +
-            this.currentRemainingTicks +
-            ' tick(s) with: ' +
-            this.disintegrateClipSpell.ability.name,
-        });
       }
     } // We clipped outside of Dragonrage, bad
     // In TWW S1 this is now optimal, will prolly become un-optimal again

--- a/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
@@ -526,33 +526,34 @@ class Disintegrate extends Analyzer {
     return (
       <SubSection title="Disintegrate">
         <div>
-          Use the graph below to deep dive into your <SpellLink spell={DISINTEGRATE} /> casts.
-          <ul>
-            <li>
-              Casts are highlighted in <span style={{ color: '#2ecc71' }}>green</span>
-            </li>
-            {this.massDisintegrateCasts.length > 0 && (
-              <>
-                <li>
-                  Mass Disintegrate Casts are highlighted in{' '}
-                  <span style={{ color: '#aa774f' }}>brown</span>
-                </li>
-              </>
-            )}
-            <li>
-              Chained casts are highlighted in <span style={{ color: 'orange' }}>orange</span>
-            </li>
-            <li>
-              Clipped casts are highlighted in <span style={{ color: '#9b59b6' }}>purple</span>
-            </li>
-            <li>
-              Problem points are highlighted in <span style={{ color: 'red' }}>red</span>
-            </li>
-            <li>
-              <SpellLink spell={DRAGONRAGE_TALENT} /> is shown as a filled in background.
-            </li>
-          </ul>
-          <br />
+          <p>
+            Use the graph below to deep dive into your <SpellLink spell={DISINTEGRATE} /> casts.
+            <ul>
+              <li>
+                Casts are highlighted in <span style={{ color: '#2ecc71' }}>green</span>
+              </li>
+              {this.massDisintegrateCasts.length > 0 && (
+                <>
+                  <li>
+                    Mass Disintegrate Casts are highlighted in{' '}
+                    <span style={{ color: '#aa774f' }}>brown</span>
+                  </li>
+                </>
+              )}
+              <li>
+                Chained casts are highlighted in <span style={{ color: 'orange' }}>orange</span>
+              </li>
+              <li>
+                Clipped casts are highlighted in <span style={{ color: '#9b59b6' }}>purple</span>
+              </li>
+              <li>
+                Problem points are highlighted in <span style={{ color: 'red' }}>red</span>
+              </li>
+              <li>
+                <SpellLink spell={DRAGONRAGE_TALENT} /> is shown as a filled in background.
+              </li>
+            </ul>
+          </p>
           <b>
             <InformationIcon /> Mouseover each point on the graph for more detailed explanations.
           </b>

--- a/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
@@ -100,6 +100,18 @@ class Disintegrate extends Analyzer {
     TALENTS.AZURE_SWEEP_TALENT,
   ];
 
+  goodClipSpellIds = [
+    SPELLS.FIRE_BREATH,
+    SPELLS.FIRE_BREATH_FONT,
+    SPELLS.ETERNITY_SURGE,
+    SPELLS.ETERNITY_SURGE_FONT,
+    SPELLS.DEEP_BREATH,
+    SPELLS.DEEP_BREATH_SCALECOMMANDER,
+  ].map((spell) => spell.id);
+
+  maxAllowedClippedTicks = 1;
+  maxAllowedEarlyChainedTicks = 0;
+
   graphData: GraphData[] = [];
 
   disintegrateTicksCounter: SpellTracker[] = [];
@@ -311,9 +323,15 @@ class Disintegrate extends Analyzer {
         count: this.currentRemainingTicks,
         tooltip: 'Bad Chain, you chained before the 3rd tick.',
       });
-    } // Clipped ticks outside of DR, bad - for TWW S1 this is optimal
-    // In TWW S1 this is now optimal, will prolly become un-optimal again
-    /* else if (!this.inDragonRageWindow && this.currentRemainingTicks > 1) {
+    } else if (this.currentRemainingTicks > this.maxAllowedEarlyChainedTicks + 1) {
+      this.problemPoints.push({
+        timestamp: event.timestamp,
+        count: this.currentRemainingTicks,
+        tooltip: 'Bad Chain, you clipped: ' + (this.currentRemainingTicks - 1) + ' tick(s)',
+      });
+    }
+    // Clipped ticks outside of DR, bad
+    else if (!this.inDragonRageWindow && this.currentRemainingTicks > 1) {
       this.problemPoints.push({
         timestamp: event.timestamp,
         count: this.currentRemainingTicks,
@@ -322,17 +340,21 @@ class Disintegrate extends Analyzer {
           (this.currentRemainingTicks - 1) +
           ' tick(s) outside of Dragonrage',
       });
-    }  */
-    else {
+    } else {
       if (this.isCurrentCastMassDisintegrate) {
-        this.massDisintegrateCasts.push({
-          timestamp: event.timestamp,
-          count: this.currentRemainingTicks,
-          tooltip:
-            this.currentRemainingTicks >= 2
-              ? 'Good Chain, you clipped: ' + this.currentRemainingTicks + ` tick(s)`
-              : 'Good Chain',
-        });
+        if (this.currentRemainingTicks >= 2) {
+          this.problemPoints.push({
+            timestamp: event.timestamp,
+            count: this.currentRemainingTicks,
+            tooltip: 'Bad Chain, you clipped: ' + (this.currentRemainingTicks - 1) + ' tick(s)',
+          });
+        } else {
+          this.massDisintegrateCasts.push({
+            timestamp: event.timestamp,
+            count: this.currentRemainingTicks,
+            tooltip: 'Good Chain',
+          });
+        }
       } else {
         this.disintegrateChainCasts.push({
           timestamp: event.timestamp,
@@ -392,12 +414,32 @@ class Disintegrate extends Analyzer {
             this.disintegrateClipSpell.ability.name +
             ' before the 3rd tick.',
         });
-      } else {
+      } else if (this.currentRemainingTicks > this.maxAllowedClippedTicks) {
+        this.problemPoints.push({
+          timestamp: event.timestamp,
+          count: this.currentRemainingTicks,
+          tooltip:
+            'Bad Clip, you clipped: ' +
+            this.currentRemainingTicks +
+            ' tick(s) with: ' +
+            this.disintegrateClipSpell.ability.name,
+        });
+      } else if (this.goodClipSpellIds.includes(this.disintegrateClipSpell.ability.guid)) {
         this.disintegrateClips.push({
           timestamp: event.timestamp,
           count: this.currentRemainingTicks,
           tooltip:
             'Good clip, you clipped: ' +
+            this.currentRemainingTicks +
+            ' tick(s) with: ' +
+            this.disintegrateClipSpell.ability.name,
+        });
+      } else {
+        this.problemPoints.push({
+          timestamp: event.timestamp,
+          count: this.currentRemainingTicks,
+          tooltip:
+            'Bad Clip, you clipped: ' +
             this.currentRemainingTicks +
             ' tick(s) with: ' +
             this.disintegrateClipSpell.ability.name,

--- a/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/abilities/Disintegrate.tsx
@@ -81,9 +81,10 @@ class Disintegrate extends Analyzer {
 
   isCurrentCastMassDisintegrate = false;
 
-  /** Spells that you can/should clip with
+  /** Spells that you *can* clip with
    * Any other spell used to clip Disintegrate
    * is counted as a cancelled cast
+   * Fill with most spells so it's easy to se what was used to clip with on the graph
    */
   trackedSpells = [
     SPELLS.LIVING_FLAME_CAST,
@@ -97,9 +98,14 @@ class Disintegrate extends Analyzer {
     TALENTS.DRAGONRAGE_TALENT,
     SPELLS.DEEP_BREATH,
     SPELLS.DEEP_BREATH_SCALECOMMANDER,
-    TALENTS.AZURE_SWEEP_TALENT,
+    SPELLS.AZURE_SWEEP,
+    TALENTS.OBSIDIAN_SCALES_TALENT,
+    TALENTS.ZEPHYR_TALENT,
+    SPELLS.HOVER,
+    TALENTS.RESCUE_TALENT,
   ];
 
+  /** Spells that you should clip with */
   goodClipSpellIds = [
     SPELLS.FIRE_BREATH,
     SPELLS.FIRE_BREATH_FONT,

--- a/src/analysis/retail/evoker/devastation/modules/guide/CoreSection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/CoreSection.tsx
@@ -60,7 +60,8 @@ export function CoreSection({ modules, events, info }: GuideProps<typeof CombatL
               for achieving good DPS as a caster.
             </b>
           </em>
-          <br />
+        </p>
+        <p>
           There should be no delay at all between your spell casts, it's better to start casting the
           wrong spell than to think for a few seconds and then cast the right spell. You should be
           able to handle a fight's mechanics with the minimum possible interruption to your casting.

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -248,8 +248,8 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
           }
           data={
             <PassFail
-              value={modules.massDisintegrate.castCount}
-              total={modules.massDisintegrate.buffCount}
+              value={modules.massDisintegrate.consumedBuffs}
+              total={modules.massDisintegrate.totalBuffs}
               passed={modules.massDisintegrate.wastedBuffs === 0}
             />
           }
@@ -273,12 +273,9 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
           }
           data={
             <PassFail
-              value={modules.imminentDestruction.buffStacksConsumed}
-              total={modules.imminentDestruction.totalBuffStacks}
-              passed={
-                modules.imminentDestruction.buffStacksConsumed ===
-                modules.imminentDestruction.totalBuffStacks
-              }
+              value={modules.imminentDestruction.consumedBuffs}
+              total={modules.imminentDestruction.totalBuffs}
+              passed={modules.imminentDestruction.wastedBuffs === 0}
             />
           }
         />
@@ -300,9 +297,9 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
           }
           data={
             <PassFail
-              value={modules.strafingRun.buffsConsumed}
-              total={modules.strafingRun.buffsWasted + modules.strafingRun.buffsConsumed}
-              passed={modules.strafingRun.buffsWasted === 0}
+              value={modules.strafingRun.consumedBuffs}
+              total={modules.strafingRun.totalBuffs}
+              passed={modules.strafingRun.wastedBuffs === 0}
             />
           }
         />

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -1,5 +1,5 @@
 import { GuideProps, PassFailCheckmark, Section, SubSection } from 'interface/guide';
-import { SpellLink } from 'interface';
+import { ResourceLink, SpellLink } from 'interface';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 import CombatLogParser from '../../CombatLogParser';
 import SPELLS from 'common/SPELLS';
@@ -7,6 +7,8 @@ import SPELLS from 'common/SPELLS';
 import PassFailBar from 'interface/guide/components/PassFailBar';
 import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
 import { TIERS } from 'game/TIERS';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { IMMINENT_DESTRUCTION_INITIAL_STACKS_DEVA } from 'analysis/retail/evoker/shared';
 
 const EXPLANATION_PERCENTAGE = 70;
 function PassFail({
@@ -36,6 +38,7 @@ export function DamageEfficiency(props: GuideProps<typeof CombatLogParser>) {
     <Section title="Damage Efficiency">
       <DisintegrateSubsection {...props} />
       <NoWastedProcsSubsection {...props} />
+      <NoWastedBuffsSubsection {...props} />
     </Section>
   );
 }
@@ -190,6 +193,53 @@ function NoWastedProcsSubsection({ modules, info }: GuideProps<typeof CombatLogP
               passed={
                 modules.burnout.consumedProcs ===
                 Math.max(modules.burnout.procs, modules.burnout.consumedProcs)
+              }
+            />
+          }
+        />
+      )}
+    </SubSection>
+  );
+}
+
+function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogParser>) {
+  const hasImminentDestruction = info.combatant.hasTalent(
+    TALENTS_EVOKER.IMMINENT_DESTRUCTION_DEVASTATION_TALENT,
+  );
+
+  if (!hasImminentDestruction) {
+    return null;
+  }
+
+  return (
+    <SubSection title="No Wasted Buffs">
+      {hasImminentDestruction && (
+        <ExplanationAndDataSubSection
+          explanationPercent={EXPLANATION_PERCENTAGE}
+          explanation={
+            <p>
+              <strong>
+                <SpellLink spell={TALENTS_EVOKER.IMMINENT_DESTRUCTION_DEVASTATION_TALENT} />
+              </strong>{' '}
+              reduces the <ResourceLink id={RESOURCE_TYPES.ESSENCE.id} /> cost of your next{' '}
+              <strong>{IMMINENT_DESTRUCTION_INITIAL_STACKS_DEVA}</strong>{' '}
+              <SpellLink spell={SPELLS.DISINTEGRATE} /> and <SpellLink spell={SPELLS.PYRE} />. None
+              should go to waste.
+            </p>
+          }
+          data={
+            <PassFail
+              value={modules.imminentDestruction.buffStacksConsumed}
+              total={Math.max(
+                modules.imminentDestruction.totalBuffStacks,
+                modules.imminentDestruction.buffStacksConsumed,
+              )}
+              passed={
+                modules.imminentDestruction.buffStacksConsumed ===
+                Math.max(
+                  modules.imminentDestruction.totalBuffStacks,
+                  modules.imminentDestruction.buffStacksConsumed,
+                )
               }
             />
           }

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -100,7 +100,7 @@ function DisintegrateSubsection({ modules, info }: GuideProps<typeof CombatLogPa
         explanation={
           <div>
             <p>
-              <SpellLink spell={SPELLS.DISINTEGRATE} /> efficiency during
+              <SpellLink spell={SPELLS.DISINTEGRATE} /> efficiency during{' '}
               <SpellLink spell={TALENTS_EVOKER.DRAGONRAGE_TALENT} />
             </p>
             <p>

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -78,7 +78,7 @@ function DisintegrateSubsection({ modules, info }: GuideProps<typeof CombatLogPa
       <p>
         See the{' '}
         <a href="https://www.wowhead.com/guide/classes/evoker/devastation/rotation-cooldowns-pve-dps#advanced-disintegrate-chaining-and-clipping">
-          Chaining Chaining and Clipping
+          Disintegrate Chaining and Clipping
         </a>{' '}
         section on wowhead for a more in-depth explanation.
       </p>

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -256,16 +256,10 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
           data={
             <PassFail
               value={modules.imminentDestruction.buffStacksConsumed}
-              total={Math.max(
-                modules.imminentDestruction.totalBuffStacks,
-                modules.imminentDestruction.buffStacksConsumed,
-              )}
+              total={modules.imminentDestruction.totalBuffStacks}
               passed={
                 modules.imminentDestruction.buffStacksConsumed ===
-                Math.max(
-                  modules.imminentDestruction.totalBuffStacks,
-                  modules.imminentDestruction.buffStacksConsumed,
-                )
+                modules.imminentDestruction.totalBuffStacks
               }
             />
           }
@@ -280,17 +274,15 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
                 <SpellLink spell={TALENTS_EVOKER.STRAFING_RUN_TALENT} />
               </strong>{' '}
               allows <SpellLink spell={SPELLS.DEEP_BREATH} /> to be cast again within{' '}
-              {formatDurationMillisMinSec(STRAFING_RUN_DURATION, 0)} of being used.
+              {formatDurationMillisMinSec(STRAFING_RUN_DURATION, 0)} of being used. None should go
+              to waste.
             </p>
           }
           data={
             <PassFail
               value={modules.strafingRun.buffsConsumed}
-              total={Math.max(modules.strafingRun.buffsWasted, modules.strafingRun.buffsConsumed)}
-              passed={
-                modules.strafingRun.buffsConsumed ===
-                Math.max(modules.strafingRun.buffsWasted, modules.strafingRun.buffsConsumed)
-              }
+              total={modules.strafingRun.buffsWasted + modules.strafingRun.buffsConsumed}
+              passed={modules.strafingRun.buffsWasted === 0}
             />
           }
         />

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -193,8 +193,10 @@ function NoWastedProcsSubsection({ modules, info }: GuideProps<typeof CombatLogP
               <SpellLink spell={TALENTS_EVOKER.BURNOUT_TALENT} /> procs allow you to cast{' '}
               <SpellLink spell={SPELLS.LIVING_FLAME_CAST} /> instantly.
               <div>
-                Ideally none should go to waste, but some may drop during an intense{' '}
-                <SpellLink spell={TALENTS_EVOKER.DRAGONRAGE_TALENT} /> window.
+                <strong>
+                  Ideally none should go to waste, but some may drop during an intense{' '}
+                  <SpellLink spell={TALENTS_EVOKER.DRAGONRAGE_TALENT} /> window.
+                </strong>
               </div>
             </p>
           }
@@ -220,10 +222,13 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
   );
   const hasStrafingRun = info.combatant.hasTalent(TALENTS_EVOKER.STRAFING_RUN_TALENT);
   const hasMassDisintegrate = info.combatant.hasTalent(TALENTS_EVOKER.MASS_DISINTEGRATE_TALENT);
+  const hasAzureSweep = info.combatant.hasTalent(TALENTS_EVOKER.AZURE_SWEEP_TALENT);
 
-  if (!hasImminentDestruction && !hasStrafingRun && !hasMassDisintegrate) {
+  if (!hasImminentDestruction && !hasStrafingRun && !hasMassDisintegrate && !hasAzureSweep) {
     return null;
   }
+
+  console.log(modules.azureSweep.buffRatio);
 
   return (
     <SubSection title="No Wasted Buffs">
@@ -307,6 +312,33 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
               value={modules.strafingRun.consumedBuffs}
               total={modules.strafingRun.totalBuffs}
               passed={modules.strafingRun.wastedBuffs === 0}
+            />
+          }
+        />
+      )}
+      {hasAzureSweep && (
+        <ExplanationAndDataSubSection
+          explanationPercent={EXPLANATION_PERCENTAGE}
+          explanation={
+            <p>
+              <strong>
+                <SpellLink spell={TALENTS_EVOKER.AZURE_SWEEP_TALENT} />
+              </strong>{' '}
+              is an upgraded version of <SpellLink spell={SPELLS.AZURE_STRIKE} /> that is gained
+              after casting <SpellLink spell={SPELLS.ETERNITY_SURGE} />.
+              <div>
+                <strong>
+                  Ideally none should go to waste, but some may be wasted due to having to cast
+                  higher priority spells.
+                </strong>
+              </div>
+            </p>
+          }
+          data={
+            <PassFail
+              value={modules.azureSweep.consumedBuffs}
+              total={modules.azureSweep.totalBuffs}
+              passed={modules.azureSweep.buffRatio > 0.9}
             />
           }
         />

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -9,6 +9,8 @@ import { ExplanationAndDataSubSection } from 'interface/guide/components/Explana
 import { TIERS } from 'game/TIERS';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { IMMINENT_DESTRUCTION_INITIAL_STACKS_DEVA } from 'analysis/retail/evoker/shared';
+import { STRAFING_RUN_DURATION } from 'analysis/retail/evoker/devastation/constants';
+import { formatDurationMillisMinSec } from 'common/format';
 
 const EXPLANATION_PERCENTAGE = 70;
 function PassFail({
@@ -206,8 +208,9 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
   const hasImminentDestruction = info.combatant.hasTalent(
     TALENTS_EVOKER.IMMINENT_DESTRUCTION_DEVASTATION_TALENT,
   );
+  const hasStrafingRun = info.combatant.hasTalent(TALENTS_EVOKER.STRAFING_RUN_TALENT);
 
-  if (!hasImminentDestruction) {
+  if (!hasImminentDestruction && !hasStrafingRun) {
     return null;
   }
 
@@ -240,6 +243,30 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
                   modules.imminentDestruction.totalBuffStacks,
                   modules.imminentDestruction.buffStacksConsumed,
                 )
+              }
+            />
+          }
+        />
+      )}
+      {hasStrafingRun && (
+        <ExplanationAndDataSubSection
+          explanationPercent={EXPLANATION_PERCENTAGE}
+          explanation={
+            <p>
+              <strong>
+                <SpellLink spell={TALENTS_EVOKER.STRAFING_RUN_TALENT} />
+              </strong>{' '}
+              allows <SpellLink spell={SPELLS.DEEP_BREATH} /> to be cast again within{' '}
+              {formatDurationMillisMinSec(STRAFING_RUN_DURATION, 0)} of being used.
+            </p>
+          }
+          data={
+            <PassFail
+              value={modules.strafingRun.buffsConsumed}
+              total={Math.max(modules.strafingRun.buffsWasted, modules.strafingRun.buffsConsumed)}
+              passed={
+                modules.strafingRun.buffsConsumed ===
+                Math.max(modules.strafingRun.buffsWasted, modules.strafingRun.buffsConsumed)
               }
             />
           }

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -6,6 +6,7 @@ import SPELLS from 'common/SPELLS';
 
 import PassFailBar from 'interface/guide/components/PassFailBar';
 import { ExplanationAndDataSubSection } from 'interface/guide/components/ExplanationRow';
+import { TIERS } from 'game/TIERS';
 
 const EXPLANATION_PERCENTAGE = 70;
 function PassFail({
@@ -45,6 +46,8 @@ function DisintegrateSubsection({ modules, info }: GuideProps<typeof CombatLogPa
     return null;
   }
 
+  const isEarlyChainingOptimal = false;
+
   return (
     <SubSection title="Clipping/Chaining Disintegrate">
       <p>
@@ -55,18 +58,21 @@ function DisintegrateSubsection({ modules, info }: GuideProps<typeof CombatLogPa
         losing a tick. This is essentially just the same Pandemic effect that DoTs have since{' '}
         <SpellLink spell={SPELLS.DISINTEGRATE} /> functions as a DoT.
       </p>
+      {isEarlyChainingOptimal && (
+        <p>
+          Inside of <SpellLink spell={TALENTS_EVOKER.DRAGONRAGE_TALENT} /> you should be clipping{' '}
+          <SpellLink spell={SPELLS.DISINTEGRATE} /> after the third tick with more important spells
+          such <SpellLink spell={SPELLS.FIRE_BREATH} />, <SpellLink spell={SPELLS.ETERNITY_SURGE} />
+          , <SpellLink spell={SPELLS.SHATTERING_STAR} /> or{' '}
+          <SpellLink spell={SPELLS.BURNOUT_BUFF} />. As well as early chaining your{' '}
+          <SpellLink spell={SPELLS.DISINTEGRATE} /> after the third tick to maximize resources
+          generation and expenditure.
+        </p>
+      )}
       <p>
-        Inside of <SpellLink spell={TALENTS_EVOKER.DRAGONRAGE_TALENT} /> you should be clipping{' '}
-        <SpellLink spell={SPELLS.DISINTEGRATE} /> after the third tick with more important spells
-        such <SpellLink spell={SPELLS.FIRE_BREATH} />, <SpellLink spell={SPELLS.ETERNITY_SURGE} />,{' '}
-        <SpellLink spell={SPELLS.SHATTERING_STAR} /> or <SpellLink spell={SPELLS.BURNOUT_BUFF} />.
-        As well as early chaining your <SpellLink spell={SPELLS.DISINTEGRATE} /> after the third
-        tick to maximize resources generation and expenditure.
-      </p>
-      <p>
-        See{' '}
-        <a href="https://www.wowhead.com/guide/classes/evoker/devastation/rotation-cooldowns-pve-dps#chaining-disintegrate">
-          Chaining Disintegrate casts
+        See the{' '}
+        <a href="https://www.wowhead.com/guide/classes/evoker/devastation/rotation-cooldowns-pve-dps#advanced-disintegrate-chaining-and-clipping">
+          Chaining Chaining and Clipping
         </a>{' '}
         section on wowhead for a more in-depth explanation.
       </p>
@@ -89,7 +95,6 @@ function DisintegrateSubsection({ modules, info }: GuideProps<typeof CombatLogPa
           />
         }
       />
-
       <ExplanationAndDataSubSection
         explanationPercent={EXPLANATION_PERCENTAGE}
         explanation={
@@ -99,8 +104,8 @@ function DisintegrateSubsection({ modules, info }: GuideProps<typeof CombatLogPa
               <SpellLink spell={TALENTS_EVOKER.DRAGONRAGE_TALENT} />
             </p>
             <p>
-              Aim to drop 70%-90% of ticks (i.e. clip) so you can consume resources faster, as well
-              as getting off more casts of important spells.
+              It can sometimes be beneficial to clip <SpellLink spell={SPELLS.DISINTEGRATE} /> early
+              in order to to cast more important spells.
             </p>
           </div>
         }
@@ -108,8 +113,8 @@ function DisintegrateSubsection({ modules, info }: GuideProps<typeof CombatLogPa
           <PassFail
             value={tickData.dragonRageTicks}
             total={tickData.totalPossibleDragonRageTicks}
-            customTotal={tickData.totalPossibleDragonRageTicks * 0.75}
-            passed={tickData.dragonRageTickRatio < 0.9 && tickData.dragonRageTickRatio > 0.7}
+            /*customTotal={tickData.totalPossibleDragonRageTicks * 0.75}*/
+            passed={tickData.dragonRageTickRatio > 0.9}
           />
         }
       />
@@ -142,6 +147,8 @@ function DisintegrateSubsection({ modules, info }: GuideProps<typeof CombatLogPa
 }
 
 function NoWastedProcsSubsection({ modules, info }: GuideProps<typeof CombatLogParser>) {
+  const hasMID1TierSet = info.combatant.has2PieceByTier(TIERS.MID1);
+
   return (
     <SubSection title="No Wasted Procs">
       <ExplanationAndDataSubSection
@@ -165,27 +172,29 @@ function NoWastedProcsSubsection({ modules, info }: GuideProps<typeof CombatLogP
           />
         }
       />
-      <ExplanationAndDataSubSection
-        explanationPercent={EXPLANATION_PERCENTAGE}
-        explanation={
-          <p>
-            <SpellLink spell={TALENTS_EVOKER.BURNOUT_TALENT} /> procs allow you to cast{' '}
-            <SpellLink spell={SPELLS.LIVING_FLAME_CAST} /> instantly. Ideally none should go to
-            waste, but some may drop during an intense{' '}
-            <SpellLink spell={TALENTS_EVOKER.DRAGONRAGE_TALENT} /> window.
-          </p>
-        }
-        data={
-          <PassFail
-            value={modules.burnout.consumedProcs}
-            total={Math.max(modules.burnout.procs, modules.burnout.consumedProcs)}
-            passed={
-              modules.burnout.consumedProcs ===
-              Math.max(modules.burnout.procs, modules.burnout.consumedProcs)
-            }
-          />
-        }
-      />
+      {!hasMID1TierSet && (
+        <ExplanationAndDataSubSection
+          explanationPercent={EXPLANATION_PERCENTAGE}
+          explanation={
+            <p>
+              <SpellLink spell={TALENTS_EVOKER.BURNOUT_TALENT} /> procs allow you to cast{' '}
+              <SpellLink spell={SPELLS.LIVING_FLAME_CAST} /> instantly. Ideally none should go to
+              waste, but some may drop during an intense{' '}
+              <SpellLink spell={TALENTS_EVOKER.DRAGONRAGE_TALENT} /> window.
+            </p>
+          }
+          data={
+            <PassFail
+              value={modules.burnout.consumedProcs}
+              total={Math.max(modules.burnout.procs, modules.burnout.consumedProcs)}
+              passed={
+                modules.burnout.consumedProcs ===
+                Math.max(modules.burnout.procs, modules.burnout.consumedProcs)
+              }
+            />
+          }
+        />
+      )}
     </SubSection>
   );
 }

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -209,13 +209,36 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
     TALENTS_EVOKER.IMMINENT_DESTRUCTION_DEVASTATION_TALENT,
   );
   const hasStrafingRun = info.combatant.hasTalent(TALENTS_EVOKER.STRAFING_RUN_TALENT);
+  const hasMassDisintegrate = info.combatant.hasTalent(TALENTS_EVOKER.MASS_DISINTEGRATE_TALENT);
 
-  if (!hasImminentDestruction && !hasStrafingRun) {
+  if (!hasImminentDestruction && !hasStrafingRun && !hasMassDisintegrate) {
     return null;
   }
 
   return (
     <SubSection title="No Wasted Buffs">
+      {hasMassDisintegrate && (
+        <ExplanationAndDataSubSection
+          explanationPercent={EXPLANATION_PERCENTAGE}
+          explanation={
+            <p>
+              <strong>
+                <SpellLink spell={SPELLS.MASS_DISINTEGRATE_BUFF} />
+              </strong>{' '}
+              is a powerful buff that increases the damage of{' '}
+              <SpellLink spell={SPELLS.DISINTEGRATE} /> and allows it to strike multiple targets.
+              None should go to waste.
+            </p>
+          }
+          data={
+            <PassFail
+              value={modules.massDisintegrate.castCount}
+              total={modules.massDisintegrate.buffCount}
+              passed={modules.massDisintegrate.wastedBuffs === 0}
+            />
+          }
+        />
+      )}
       {hasImminentDestruction && (
         <ExplanationAndDataSubSection
           explanationPercent={EXPLANATION_PERCENTAGE}

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -11,6 +11,7 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { IMMINENT_DESTRUCTION_INITIAL_STACKS_DEVA } from 'analysis/retail/evoker/shared';
 import { STRAFING_RUN_DURATION } from 'analysis/retail/evoker/devastation/constants';
 import { formatDurationMillisMinSec } from 'common/format';
+import { InformationIcon } from 'interface/icons';
 
 const EXPLANATION_PERCENTAGE = 70;
 function PassFail({
@@ -156,6 +157,10 @@ function NoWastedProcsSubsection({ modules, info }: GuideProps<typeof CombatLogP
 
   return (
     <SubSection title="No Wasted Procs">
+      <p>
+        <InformationIcon /> Note that procs that weren't used by the time the fight ended are
+        counted as wasted.
+      </p>
       <ExplanationAndDataSubSection
         explanationPercent={EXPLANATION_PERCENTAGE}
         explanation={
@@ -163,7 +168,10 @@ function NoWastedProcsSubsection({ modules, info }: GuideProps<typeof CombatLogP
             <SpellLink spell={SPELLS.ESSENCE_BURST_BUFF} /> procs are essential because they help
             you cast your primary damaging spells,
             <SpellLink spell={SPELLS.DISINTEGRATE} /> and{' '}
-            <SpellLink spell={TALENTS_EVOKER.PYRE_TALENT} />, for free. None should go to waste.
+            <SpellLink spell={TALENTS_EVOKER.PYRE_TALENT} />, for free.
+            <div>
+              <strong>None should go to waste.</strong>
+            </div>
           </p>
         }
         data={
@@ -183,9 +191,11 @@ function NoWastedProcsSubsection({ modules, info }: GuideProps<typeof CombatLogP
           explanation={
             <p>
               <SpellLink spell={TALENTS_EVOKER.BURNOUT_TALENT} /> procs allow you to cast{' '}
-              <SpellLink spell={SPELLS.LIVING_FLAME_CAST} /> instantly. Ideally none should go to
-              waste, but some may drop during an intense{' '}
-              <SpellLink spell={TALENTS_EVOKER.DRAGONRAGE_TALENT} /> window.
+              <SpellLink spell={SPELLS.LIVING_FLAME_CAST} /> instantly.
+              <div>
+                Ideally none should go to waste, but some may drop during an intense{' '}
+                <SpellLink spell={TALENTS_EVOKER.DRAGONRAGE_TALENT} /> window.
+              </div>
             </p>
           }
           data={
@@ -217,6 +227,10 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
 
   return (
     <SubSection title="No Wasted Buffs">
+      <p>
+        <InformationIcon /> Note that buffs that weren't used by the time the fight ended are
+        counted as wasted.
+      </p>
       {hasMassDisintegrate && (
         <ExplanationAndDataSubSection
           explanationPercent={EXPLANATION_PERCENTAGE}
@@ -225,9 +239,11 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
               <strong>
                 <SpellLink spell={SPELLS.MASS_DISINTEGRATE_BUFF} />
               </strong>{' '}
-              is a powerful buff that increases the damage of{' '}
+              is a powerful buff gained by casting Empowers which increases the damage of{' '}
               <SpellLink spell={SPELLS.DISINTEGRATE} /> and allows it to strike multiple targets.
-              None should go to waste.
+              <div>
+                <strong>None should go to waste.</strong>
+              </div>
             </p>
           }
           data={
@@ -249,8 +265,10 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
               </strong>{' '}
               reduces the <ResourceLink id={RESOURCE_TYPES.ESSENCE.id} /> cost of your next{' '}
               <strong>{IMMINENT_DESTRUCTION_INITIAL_STACKS_DEVA}</strong>{' '}
-              <SpellLink spell={SPELLS.DISINTEGRATE} /> and <SpellLink spell={SPELLS.PYRE} />. None
-              should go to waste.
+              <SpellLink spell={SPELLS.DISINTEGRATE} /> and <SpellLink spell={SPELLS.PYRE} />.
+              <div>
+                <strong>None should go to waste.</strong>
+              </div>
             </p>
           }
           data={
@@ -274,8 +292,10 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
                 <SpellLink spell={TALENTS_EVOKER.STRAFING_RUN_TALENT} />
               </strong>{' '}
               allows <SpellLink spell={SPELLS.DEEP_BREATH} /> to be cast again within{' '}
-              {formatDurationMillisMinSec(STRAFING_RUN_DURATION, 0)} of being used. None should go
-              to waste.
+              {formatDurationMillisMinSec(STRAFING_RUN_DURATION, 0)} of being used.
+              <div>
+                <strong>None should go to waste.</strong>
+              </div>
             </p>
           }
           data={

--- a/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DamageEfficiencySection.tsx
@@ -290,6 +290,13 @@ function NoWastedBuffsSubsection({ modules, info }: GuideProps<typeof CombatLogP
               </strong>{' '}
               allows <SpellLink spell={SPELLS.DEEP_BREATH} /> to be cast again within{' '}
               {formatDurationMillisMinSec(STRAFING_RUN_DURATION, 0)} of being used.
+              {hasMassDisintegrate && (
+                <div>
+                  When playing as Scalecommander, you should wait with re-casting{' '}
+                  <SpellLink spell={SPELLS.DEEP_BREATH} /> until{' '}
+                  <SpellLink spell={TALENTS_EVOKER.MELT_ARMOR_TALENT} /> runs out.
+                </div>
+              )}
               <div>
                 <strong>None should go to waste.</strong>
               </div>

--- a/src/analysis/retail/evoker/devastation/modules/guide/DragonRageSection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DragonRageSection.tsx
@@ -1,13 +1,19 @@
 import { SpellLink } from 'interface';
 import { TALENTS_EVOKER } from 'common/TALENTS';
-import SPELLS from 'common/SPELLS';
+import SPELLS from 'common/SPELLS/evoker';
 import { GuideProps, Section } from 'interface/guide';
 import CombatLogParser from '../../CombatLogParser';
 
 import { DragonRageWindowSection } from './DragonRageWindows';
+import { TIERS } from 'game/TIERS';
+import { EVOKER_MID1_ID } from 'common/ITEMS';
+import ItemSetLink from 'interface/ItemSetLink';
 
 export function DragonRageSection({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   const rageWindows = Object.values(modules.dragonRage.rageWindowCounters);
+
+  const hasIridescence = info.combatant.hasTalent(TALENTS_EVOKER.IRIDESCENCE_TALENT);
+  const hasMID1TierSet = info.combatant.has2PieceByTier(TIERS.MID1);
 
   return (
     <Section title="Dragonrage">
@@ -18,7 +24,7 @@ export function DragonRageSection({ modules, events, info }: GuideProps<typeof C
         <SpellLink spell={TALENTS_EVOKER.TYRANNY_TALENT} /> and guaranteed{' '}
         <SpellLink spell={SPELLS.ESSENCE_BURST_DEV_BUFF} /> procs, we need to utilize the talent{' '}
         <SpellLink spell={TALENTS_EVOKER.ANIMOSITY_TALENT} /> to extend the buff duration as long as
-        possible. We do this by getting in 2 rounds of{' '}
+        possible. We do this by getting in <strong>at least</strong> 2 rounds of{' '}
         <SpellLink spell={TALENTS_EVOKER.ETERNITY_SURGE_TALENT} /> and{' '}
         <SpellLink spell={SPELLS.FIRE_BREATH} /> by making the most of the talents:{' '}
         <SpellLink spell={TALENTS_EVOKER.CAUSALITY_TALENT} /> and{' '}
@@ -28,10 +34,30 @@ export function DragonRageSection({ modules, events, info }: GuideProps<typeof C
         To generate <SpellLink spell={SPELLS.ESSENCE_BURST_DEV_BUFF} /> procs inside of{' '}
         <SpellLink spell={TALENTS_EVOKER.DRAGONRAGE_TALENT} /> you should be casting{' '}
         <SpellLink spell={SPELLS.LIVING_FLAME_CAST} /> with{' '}
-        <SpellLink spell={SPELLS.BURNOUT_BUFF} /> or <SpellLink spell={SPELLS.IRIDESCENCE_RED} /> or{' '}
-        <SpellLink spell={SPELLS.IRIDESCENCE_BLUE} /> is active. Use{' '}
+        <SpellLink spell={SPELLS.BURNOUT_BUFF} /> or{' '}
+        <SpellLink spell={SPELLS.LEAPING_FLAMES_BUFF} /> active. Use{' '}
         <SpellLink spell={SPELLS.AZURE_STRIKE} /> as a fallback filler.
       </p>
+      {hasMID1TierSet && (
+        <p>
+          When playing with the{' '}
+          <strong>
+            <ItemSetLink id={EVOKER_MID1_ID}>MID Season 1 Tier Set</ItemSetLink>
+          </strong>{' '}
+          <SpellLink spell={SPELLS.AZURE_SWEEP} /> should be prioritized over{' '}
+          <SpellLink spell={SPELLS.LIVING_FLAME_CAST} />.
+        </p>
+      )}
+      {hasIridescence && (
+        <p>
+          When playing with{' '}
+          <strong>
+            <SpellLink spell={TALENTS_EVOKER.IRIDESCENCE_TALENT} />
+          </strong>{' '}
+          you should avoid using <SpellLink spell={SPELLS.AZURE_STRIKE} /> with{' '}
+          <SpellLink spell={SPELLS.IRIDESCENCE_BLUE} /> active.
+        </p>
+      )}
 
       <DragonRageWindowSection rageWindows={rageWindows} events={events} info={info} />
     </Section>

--- a/src/analysis/retail/evoker/devastation/modules/guide/PerformancePercentage.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/PerformancePercentage.tsx
@@ -26,14 +26,18 @@ const PerformancePercentage = ({
       performance={performance}
       tooltip={
         <>
-          <PerformanceMark perf={QualitativePerformance.Perfect} /> Perfect usage {perfectSign}{' '}
-          {formatPercentage(perfectPercentage, 0)}%
-          <br />
-          <PerformanceMark perf={QualitativePerformance.Good} /> Good usage &lt;={' '}
-          {formatPercentage(goodPercentage, 0)}%
-          <br />
-          <PerformanceMark perf={QualitativePerformance.Ok} /> OK usage &lt;={' '}
-          {formatPercentage(okPercentage, 0)}%
+          <div>
+            <PerformanceMark perf={QualitativePerformance.Perfect} /> Perfect usage {perfectSign}{' '}
+            {formatPercentage(perfectPercentage, 0)}%
+          </div>
+          <div>
+            <PerformanceMark perf={QualitativePerformance.Good} /> Good usage &lt;={' '}
+            {formatPercentage(goodPercentage, 0)}%
+          </div>
+          <div>
+            <PerformanceMark perf={QualitativePerformance.Ok} /> OK usage &lt;={' '}
+            {formatPercentage(okPercentage, 0)}%
+          </div>
         </>
       }
     >

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/StrafingRun.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/StrafingRun.ts
@@ -1,13 +1,22 @@
 import TALENTS from 'common/TALENTS/evoker';
+import SPELLS from 'common/SPELLS/evoker';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import { Options } from 'parser/core/Module';
-import { CastEvent, EventType, GetRelatedEvent, HasRelatedEvent } from 'parser/core/Events';
+import {
+  CastEvent,
+  EventType,
+  GetRelatedEvent,
+  HasRelatedEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
 import { STRAFING_RUN_DURATION } from '../../constants';
 import { DEEP_BREATH_SPELL_IDS } from 'analysis/retail/evoker/shared';
 
 const STRAFING_RUN_PRIMARY = 'StrafingPrimary';
 const STRAFING_RUN_SECONDARY = 'StrafingSecondary';
 const STRAFING_RUN_BUFFER_MS = STRAFING_RUN_DURATION * 1.1;
+
+const STRAFING_RUN_BUFF_CONSUME = 'StrafingRunBuffConsume';
 
 const EVENT_LINKS: EventLink[] = [
   {
@@ -24,6 +33,18 @@ const EVENT_LINKS: EventLink[] = [
       !HasRelatedEvent(linkingEvent, STRAFING_RUN_PRIMARY) &&
       !HasRelatedEvent(referencedEvent, STRAFING_RUN_SECONDARY),
   },
+  {
+    linkRelation: STRAFING_RUN_BUFF_CONSUME,
+    reverseLinkRelation: STRAFING_RUN_BUFF_CONSUME,
+    linkingEventId: SPELLS.STRAFING_RUN_BUFF.id,
+    linkingEventType: EventType.RemoveBuff,
+    referencedEventId: DEEP_BREATH_SPELL_IDS,
+    referencedEventType: EventType.Cast,
+    forwardBufferMs: 100,
+    backwardBufferMs: 100,
+    anyTarget: true,
+    maximumLinks: 1,
+  },
 ];
 
 export default class StrafingRunNormalizer extends EventLinkNormalizer {
@@ -39,4 +60,8 @@ export function getSecondaryDeepBreathEvent(event: CastEvent): CastEvent | undef
 
 export function getPrimaryDeepBreathEvent(event: CastEvent): CastEvent | undefined {
   return GetRelatedEvent<CastEvent>(event, STRAFING_RUN_PRIMARY);
+}
+
+export function isFromStrafingRunConsume(event: CastEvent | RemoveBuffEvent) {
+  return HasRelatedEvent(event, STRAFING_RUN_BUFF_CONSUME);
 }

--- a/src/analysis/retail/evoker/devastation/modules/talents/AzureSweep.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/talents/AzureSweep.tsx
@@ -89,6 +89,27 @@ class AzureSweep extends Analyzer {
     this.currentStacks = event.stack;
   }
 
+  get consumedBuffs() {
+    return this.buffsUsed;
+  }
+
+  get wastedBuffs() {
+    return this.buffsWasted + this.buffsOvercapped;
+  }
+
+  get totalBuffs() {
+    return this.wastedBuffs + this.consumedBuffs;
+  }
+
+  get buffRatio() {
+    const wastedBuffs = this.wastedBuffs;
+    if (wastedBuffs === 0) {
+      return 1;
+    }
+
+    return 1 - wastedBuffs / this.totalBuffs;
+  }
+
   statistic() {
     const items = [
       {

--- a/src/analysis/retail/evoker/devastation/modules/talents/StrafingRun.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/talents/StrafingRun.tsx
@@ -61,6 +61,18 @@ class StrafingRun extends Analyzer {
     }
   }
 
+  get consumedBuffs() {
+    return this.buffsConsumed;
+  }
+
+  get wastedBuffs() {
+    return this.buffsWasted;
+  }
+
+  get totalBuffs() {
+    return this.consumedBuffs + this.wastedBuffs;
+  }
+
   statistic() {
     return (
       <Statistic

--- a/src/analysis/retail/evoker/devastation/modules/talents/StrafingRun.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/talents/StrafingRun.tsx
@@ -1,6 +1,7 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import TALENTS from 'common/TALENTS/evoker';
-import Events, { CastEvent } from 'parser/core/Events';
+import SPELLS from 'common/SPELLS/evoker';
+import Events, { CastEvent, RemoveBuffEvent } from 'parser/core/Events';
 import { DEEP_BREATH_SPELLS } from 'analysis/retail/evoker/shared';
 import { getDamageEventsFromCast } from '../normalizers/CastLinkNormalizer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
@@ -11,18 +12,25 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import { formatNumber } from 'common/format';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import SpellLink from 'interface/SpellLink';
-import { getPrimaryDeepBreathEvent } from '../normalizers/StrafingRun';
+import { getPrimaryDeepBreathEvent, isFromStrafingRunConsume } from '../normalizers/StrafingRun';
 
 /** Deep Breath deals 20% increased damage and can be cast again within 18 sec of being used. */
 class StrafingRun extends Analyzer {
   damageFromAmp = 0;
   damageFromExtraCasts = 0;
 
+  buffsWasted = 0;
+  buffsConsumed = 0;
+
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.STRAFING_RUN_TALENT);
 
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(DEEP_BREATH_SPELLS), this.onCast);
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.STRAFING_RUN_BUFF),
+      this.onRemoveBuff,
+    );
   }
 
   private onCast(event: CastEvent) {
@@ -43,6 +51,14 @@ class StrafingRun extends Analyzer {
       (acc, e) => acc + e.amount + (e.absorbed || 0),
       0,
     );
+  }
+
+  private onRemoveBuff(event: RemoveBuffEvent) {
+    if (isFromStrafingRunConsume(event)) {
+      this.buffsConsumed += 1;
+    } else {
+      this.buffsWasted += 1;
+    }
   }
 
   statistic() {

--- a/src/analysis/retail/evoker/devastation/modules/talents/Volatility.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/talents/Volatility.tsx
@@ -115,10 +115,7 @@ class Volatility extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            <li>
-              Procs: {Math.floor(this.volatilityProcs)}
-              <br />
-            </li>
+            <li>Procs: {Math.floor(this.volatilityProcs)}</li>
             <li>
               Expected procs: {Math.floor(this.volatilityProcAttempts * this.volatilityProcChance)}
             </li>

--- a/src/analysis/retail/evoker/shared/modules/talents/ImminentDestruction.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/ImminentDestruction.tsx
@@ -50,6 +50,8 @@ class ImminentDestruction extends Analyzer {
 
   currentBuffStacks = 0;
   wastedBuffStacks = 0;
+  totalBuffStacks = 0;
+  buffStacksConsumed = 0;
 
   constructor(options: Options) {
     super(options);
@@ -76,9 +78,11 @@ class ImminentDestruction extends Analyzer {
 
   private onApplyBuff(_event: ApplyBuffEvent) {
     this.currentBuffStacks = this.initialBuffStacks;
+    this.totalBuffStacks += this.currentBuffStacks;
   }
 
   private onApplyBuffStack(event: ApplyBuffStackEvent) {
+    this.totalBuffStacks += event.stack - this.currentBuffStacks;
     this.currentBuffStacks = event.stack;
   }
 
@@ -108,6 +112,7 @@ class ImminentDestruction extends Analyzer {
       return false;
     }
 
+    this.buffStacksConsumed += 1;
     this.totalEssenceReduction += IMMINENT_DESTRUCTION_ESSENCE_REDUCTION;
 
     return true;

--- a/src/analysis/retail/evoker/shared/modules/talents/ImminentDestruction.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/ImminentDestruction.tsx
@@ -118,6 +118,18 @@ class ImminentDestruction extends Analyzer {
     return true;
   }
 
+  get consumedBuffs() {
+    return this.buffStacksConsumed;
+  }
+
+  get wastedBuffs() {
+    return this.totalBuffs - this.consumedBuffs;
+  }
+
+  get totalBuffs() {
+    return this.totalBuffStacks;
+  }
+
   statistic() {
     const hasWastedBuffStacks = this.wastedBuffStacks > 0;
 

--- a/src/analysis/retail/evoker/shared/modules/talents/hero/scalecommander/MassDisintegrate.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/hero/scalecommander/MassDisintegrate.tsx
@@ -243,8 +243,16 @@ class MassDisintegrate extends Analyzer {
     return this.targetCount / this.castCount;
   }
 
+  get consumedBuffs() {
+    return this.castCount;
+  }
+
   get wastedBuffs() {
     return this.buffCount - this.castCount;
+  }
+
+  get totalBuffs() {
+    return this.buffCount;
   }
 
   statistic() {

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -799,6 +799,11 @@ const spells = {
     name: 'Risen Fury',
     icon: 'ability_evoker_oppressingroar2',
   },
+  STRAFING_RUN_BUFF: {
+    id: 1266165,
+    name: 'Strafing Run',
+    icon: 'ability_evoker_blackattunementalt',
+  },
   // endregion
 } satisfies Record<string, Spell>;
 


### PR DESCRIPTION
### Description

Updates the Guide section for Midnight. Also went through and removed the remaining illegal `<br>` tags.

Added in a new "No Wasted Buffs" section since it was requested.

### Testing

- Test report URL: `/report/F4Anm6gvhfpGzkHL/2-Normal+Chimaerus,+the+Undreamt+God+-+Kill+(4:37)/26-Xephyris/standard`
- Screenshot(s):
<img width="2560" height="6198" alt="image" src="https://github.com/user-attachments/assets/e06a0587-6b8b-461c-a595-0ae6bb3dd4eb" />

<img width="1307" height="435" alt="image" src="https://github.com/user-attachments/assets/508d50df-7704-4557-96b5-a2a305dce1de" />
<img width="1307" height="482" alt="image" src="https://github.com/user-attachments/assets/d5b97db6-3a6e-4e47-ad2c-d78844510f8d" />

