### PR TITLE
Add Ancestral Call (Mag'har Orc) racial support

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -27,12 +27,14 @@ import {
   Rex,
   squided,
   Gambyt,
+  MarchingCube,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 3, 24), "Add Ancestral Call (Mag'har Orc) racial support", MarchingCube),
   change(date(2026, 3, 23), "Update close kill times to match new WCL API", Putro),
   change(date(2026, 3, 20), 'Update FoodChecker for Midnight', Gambyt),
   change(date(2026, 3, 18), 'Fixed bug with HoT Extension tracking.', squided),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2828,3 +2828,8 @@ export const defgfed: Contributor = {
   github: 'defgfed',
   discord: 'defgfed',
 };
+
+export const MarchingCube: Contributor = {
+  nickname: 'MarchingCube',
+  github: 'MarchingCube',
+};

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -52,6 +52,7 @@ import Pets from '../shared/modules/Pets';
 import ArcaneTorrent from '../shared/modules/racials/bloodelf/ArcaneTorrent';
 import GiftOfTheNaaru from '../shared/modules/racials/draenei/GiftOfTheNaaru';
 import Stoneform from '../shared/modules/racials/dwarf/Stoneform';
+import AncestralCall from '../shared/modules/racials/magharorc/AncestralCall';
 import BloodFury from '../shared/modules/racials/orc/BloodFury';
 import Berserking from '../shared/modules/racials/troll/Berserking';
 import SpellHistory from '../shared/modules/SpellHistory';
@@ -200,6 +201,7 @@ class CombatLogParser {
     stoneform: Stoneform,
     berserking: Berserking,
     bloodFury: BloodFury,
+    ancestralCall: AncestralCall,
     otherRacials: OtherRacials,
 
     // Items:

--- a/src/parser/shared/modules/racials/magharorc/AncestralCall.ts
+++ b/src/parser/shared/modules/racials/magharorc/AncestralCall.ts
@@ -1,0 +1,45 @@
+import SPELLS from 'common/SPELLS';
+import RACES from 'game/RACES';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Abilities from 'parser/core/modules/Abilities';
+import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+
+class AncestralCall extends Analyzer {
+  static dependencies = {
+    abilities: Abilities,
+  };
+
+  castEfficiency = 0.8;
+  extraSuggestion = null;
+
+  constructor(
+    options: Options & {
+      castEfficiency?: number;
+      abilities: Abilities;
+    },
+  ) {
+    super(options);
+    this.active = this.selectedCombatant.race === RACES.MagharOrc;
+    if (!this.active) {
+      return;
+    }
+
+    this.castEfficiency =
+      options.castEfficiency === undefined ? this.castEfficiency : options.castEfficiency;
+
+    options.abilities.add({
+      spell: SPELLS.ANCESTRAL_CALL.id,
+      category: SPELL_CATEGORY.COOLDOWNS,
+      cooldown: 120,
+      gcd: null,
+      timelineSortIndex: 35,
+      castEfficiency: {
+        suggestion: this.castEfficiency !== null,
+        recommendedEfficiency: this.castEfficiency,
+        extraSuggestion: this.extraSuggestion,
+      },
+    });
+  }
+}
+
+export default AncestralCall;


### PR DESCRIPTION
### Description
When checking my own horrible log I've noticed that Mag'har orc racial is not detected correctly. Implemented something similar to regular Orc setup and it seems to work now.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: /report/GAzkTHPbF2KQnpZm/33-Heroic+Chimaerus,+the+Undreamt+God+-+Kill+(9:33)/228-Scharfer
- Screenshot(s):
<img width="772" height="1072" alt="image" src="https://github.com/user-attachments/assets/da4f2c5d-ad6d-4f63-af57-0409f5c8decb" />

and after
<img width="1530" height="901" alt="image" src="https://github.com/user-attachments/assets/63634f16-7011-4d4b-9fb6-410784829e95" />