### PR TITLE
[BrM] APL / Rotation updates

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from './spell-list_Monk_Brewmaster.retail';
 
 // prettier-ignore
 export default [
+  change(date(2026, 3, 24), <>Add cast breakdowns and <SpellLink spell={SPELLS.BLACKOUT_COMBO_TALENT} /> breakdown to Rotation section.</>, emallson),
   change(date(2026, 3, 24), <>Allow using <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> before combo <SpellLink spell={SPELLS.TIGER_PALM} /> in the APL in some cases.</>, emallson),
   change(date(2026, 3, 24), <>Move <SpellLink spell={SPELLS.CHI_BURST_TALENT} /> out of the main APL and into the cooldown list to improve APL behavior.</>, emallson),
   change(date(2026, 3, 16), <>Add several missing sources of <SpellLink spell={SPELLS.KEG_SMASH_TALENT} /> and Brew CDR / resets.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -5,6 +5,8 @@ import SPELLS from './spell-list_Monk_Brewmaster.retail';
 
 // prettier-ignore
 export default [
+  change(date(2026, 3, 24), <>Allow using <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> before combo <SpellLink spell={SPELLS.TIGER_PALM} /> in the APL in some cases.</>, emallson),
+  change(date(2026, 3, 24), <>Move <SpellLink spell={SPELLS.CHI_BURST_TALENT} /> out of the main APL and into the cooldown list to improve APL behavior.</>, emallson),
   change(date(2026, 3, 16), <>Add several missing sources of <SpellLink spell={SPELLS.KEG_SMASH_TALENT} /> and Brew CDR / resets.</>, emallson),
   change(date(2026, 3, 16), <>Add rotation support for Midnight S1</>, emallson),
   change(date(2026, 2, 22), <>Add new <SpellLink spell={SPELLS.STAGGER_TALENT} /> implementation and section</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/Guide.module.scss
+++ b/src/analysis/retail/monk/brewmaster/Guide.module.scss
@@ -1,0 +1,22 @@
+.castEfficiencyColumn {
+  width: 100%;
+  & > * {
+    width: 100%;
+  }
+}
+
+.rotationTipBoxRow {
+  display: grid;
+  gap: 1rem;
+
+  @media (min-width: 1100px) {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.rotationTipBox {
+  & header {
+    padding-bottom: 1rem;
+    font-weight: bold;
+  }
+}

--- a/src/analysis/retail/monk/brewmaster/Guide.tsx
+++ b/src/analysis/retail/monk/brewmaster/Guide.tsx
@@ -40,12 +40,13 @@ export default function Guide({ info }: GuideProps<typeof CombatLogParser>) {
         <SubSection title="Rotation">
           <AplChoiceDescription />
         </SubSection>
-        <SubSection title="Major Cooldowns">
+        <SubSection title="Cooldowns">
           <Explanation>
             <p>
-              Major cooldowns like <SpellLink spell={spells.INVOKE_NIUZAO_THE_BLACK_OX_TALENT} />{' '}
-              are a major contributor to your overall damage. As a tank, they are also key to
-              establishing threat on pull and when new enemies spawn or are pulled.
+              Cooldowns like <SpellLink spell={spells.INVOKE_NIUZAO_THE_BLACK_OX_TALENT} /> and{' '}
+              <SpellLink spell={talents.EXPLODING_KEG_TALENT} /> are a major contributor to your
+              overall damage. As a tank, they are also key to establishing threat on pull and when
+              new enemies spawn or are pulled.
             </p>
             <p>
               It is generally correct to hold your cooldowns by a small amount in order to line up
@@ -67,6 +68,13 @@ export default function Guide({ info }: GuideProps<typeof CombatLogParser>) {
           {info.combatant.hasTalent(talents.EXPLODING_KEG_TALENT) && (
             <CastEfficiencyBar
               spell={talents.EXPLODING_KEG_TALENT}
+              gapHighlightMode={GapHighlight.FullCooldown}
+              useThresholds
+            />
+          )}
+          {info.combatant.hasTalent(talents.CHI_BURST_TALENT) && (
+            <CastEfficiencyBar
+              spell={talents.CHI_BURST_TALENT}
               gapHighlightMode={GapHighlight.FullCooldown}
               useThresholds
             />

--- a/src/analysis/retail/monk/brewmaster/Guide.tsx
+++ b/src/analysis/retail/monk/brewmaster/Guide.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import { useMemo, type JSX } from 'react';
 import SPELLS from 'common/SPELLS';
 import { SpellLink, TooltipElement } from 'interface';
 import CombatLogParser from './CombatLogParser';
@@ -18,6 +18,20 @@ import PreparationSection from 'interface/guide/components/Preparation/Preparati
 import InvokeNiuzaoSection from './modules/talents/InvokeNiuzao/InvokeNiuzaoSection';
 import StaggerPoolSection from './modules/core/StaggerPool/StaggerPoolSection';
 import AplChoiceDescription from './modules/core/AplCheck/AplChoiceDescription';
+import { TipBox } from 'interface/guide/components';
+import {
+  amountBar,
+  literalNumberColumn,
+  OTHER_SPECIAL_ID,
+  spellName,
+} from 'interface/Table/ThroughputTable';
+import Table, { Column } from 'interface/Table/Table';
+import BlackoutCombo from './modules/spells/BlackoutCombo';
+import DamageTracker from 'parser/shared/modules/AbilityTracker';
+import PassFailBar from 'interface/guide/components/PassFailBar';
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import Spell from 'common/SPELLS/Spell';
+import styles from './Guide.module.scss';
 
 export default function Guide({ info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -39,6 +53,11 @@ export default function Guide({ info }: GuideProps<typeof CombatLogParser>) {
       <Section title="Rotation & Cooldowns">
         <SubSection title="Rotation">
           <AplChoiceDescription />
+          <RotationTipBoxRow>
+            <CastEfficiencyTipBox title={'Rotational Abilities'} spells={ROTATIONAL_SPELLS} />
+            <CastEfficiencyTipBox title={'Short-Cooldown Brews'} spells={ROTATIONAL_BREWS} />
+            <BlackoutComboTipBox />
+          </RotationTipBoxRow>
         </SubSection>
         <SubSection title="Cooldowns">
           <Explanation>
@@ -132,4 +151,160 @@ function MasterOfHarmonySection(): JSX.Element | null {
       />
     </Section>
   );
+}
+
+function BlackoutComboTipBox() {
+  const blackoutCombo = useAnalyzer(BlackoutCombo);
+  const abilityTracker = useAnalyzer(DamageTracker);
+  const data = useMemo(() => {
+    if (!blackoutCombo || !abilityTracker) {
+      return [];
+    }
+
+    const data = Object.entries(blackoutCombo.spellsBOCWasUsedOn).map(([spellId, count]) => ({
+      spell: Number(spellId),
+      amount: count,
+      casts: abilityTracker.getAbility(Number(spellId)).casts as number | null,
+      type: '',
+    }));
+
+    data.push({
+      spell: OTHER_SPECIAL_ID,
+      type: 'Other',
+      amount: blackoutCombo.blackoutComboBuffs - blackoutCombo.blackoutComboConsumed,
+      casts: null,
+    });
+
+    return data;
+  }, [blackoutCombo, abilityTracker]);
+
+  if (!blackoutCombo || !abilityTracker || !blackoutCombo.active) {
+    return null;
+  }
+
+  return (
+    <div className={styles.rotationTipBox}>
+      <header>
+        <SpellLink spell={talents.BLACKOUT_COMBO_TALENT} />
+      </header>
+      <p>
+        <SpellLink spell={talents.BLACKOUT_COMBO_TALENT}>BoC</SpellLink> should be spent on{' '}
+        <SpellLink spell={SPELLS.TIGER_PALM} /> in virtually all situations. The main exception is
+        during <SpellLink spell={talents.INVOKE_NIUZAO_THE_BLACK_OX_TALENT}>Niuzao</SpellLink> as{' '}
+        <SpellLink spell={talents.FLURRY_STRIKES_TALENT}>Shado-Pan</SpellLink>, where you may ignore{' '}
+        <SpellLink spell={talents.BLACKOUT_COMBO_TALENT}>BoC</SpellLink> entirely.
+      </p>
+      <div>
+        <Table
+          ctx={{
+            total: blackoutCombo.blackoutComboBuffs,
+            max: Math.max.apply(null, Object.values(blackoutCombo.spellsBOCWasUsedOn)),
+          }}
+          columns={{
+            spellName: spellName.withLabels({
+              [OTHER_SPECIAL_ID]: (
+                <TooltipElement
+                  content={
+                    'Combo buffs that were either overwritten or expired without being consumed.'
+                  }
+                >
+                  Wasted
+                </TooltipElement>
+              ),
+            }),
+            amountBar: amountBar('Combos'),
+            casts: literalNumberColumn('Casts', 'casts'),
+          }}
+          data={data}
+        />
+      </div>
+    </div>
+  );
+}
+
+const ROTATIONAL_SPELLS = [
+  SPELLS.BLACKOUT_KICK_BRM,
+  talents.KEG_SMASH_TALENT,
+  talents.BREATH_OF_FIRE_TALENT,
+];
+
+const ROTATIONAL_BREWS = [
+  talents.PURIFYING_BREW_TALENT,
+  talents.CELESTIAL_BREW_TALENT,
+  talents.CELESTIAL_INFUSION_TALENT,
+  talents.BLACK_OX_BREW_TALENT,
+];
+
+const castEfficiencyColumn: Column<{ casts: number; maxCasts: number }> = {
+  label: 'Cast Efficiency',
+  expand: true,
+  render({ casts, maxCasts }) {
+    return (
+      <div className={styles.castEfficiencyColumn}>
+        <PassFailBar pass={casts} total={maxCasts} />
+      </div>
+    );
+  },
+};
+
+function CastEfficiencyTipBox({
+  spells,
+  title,
+  children: description,
+}: {
+  spells: Spell[];
+  title: React.ReactNode;
+  children?: React.ReactNode;
+}) {
+  const castEfficiency = useAnalyzer(CastEfficiency);
+  const data = useMemo(() => {
+    if (!castEfficiency) {
+      return [];
+    }
+
+    return spells
+      .filter((spell) => castEfficiency.getCastEfficiencyForSpell(spell))
+      .map((spell) => {
+        const eff = castEfficiency.getCastEfficiencyForSpell(spell)!;
+
+        return {
+          casts: eff.casts,
+          maxCasts: eff.maxCasts,
+          cpm: eff.cpm.toFixed(1),
+          spell: spell.id,
+        };
+      });
+  }, [spells, castEfficiency]);
+
+  if (!castEfficiency) {
+    return null;
+  }
+
+  return (
+    <div className={styles.rotationTipBox}>
+      <header>{title}</header>
+      {description && <p>{description}</p>}
+      <div>
+        <Table
+          ctx={{}}
+          columns={{
+            spellName,
+            castEfficiencyColumn,
+            casts: literalNumberColumn('Casts', 'casts'),
+            maxCasts: literalNumberColumn('Max Casts', 'maxCasts'),
+            cpm: literalNumberColumn(
+              <TooltipElement content={'Casts per Minute'}>CPM</TooltipElement>,
+              'cpm',
+              false,
+            ),
+          }}
+          data={data}
+        />
+      </div>
+    </div>
+  );
+}
+
+function RotationTipBoxRow({ children }: { children: React.ReactNode }) {
+  return <div className={styles.rotationTipBoxRow}>{children}</div>;
 }

--- a/src/analysis/retail/monk/brewmaster/constants.tsx
+++ b/src/analysis/retail/monk/brewmaster/constants.tsx
@@ -17,9 +17,6 @@ export const GIFT_OF_THE_OX_SPELLS = [
 export const GIFT_OF_THE_OX_SPELL_IDS = GIFT_OF_THE_OX_SPELLS.map(({ id }) => id);
 
 export const SPELLS_WHICH_REMOVE_BOC = [SPELLS.TIGER_PALM, talents.KEG_SMASH_TALENT];
-
-export const WALK_WITH_THE_OX_DAMAGE_INCREASE = [0, 0.1, 0.2];
-
 // Legendaries
 export const STORMSTOUTS_LK_MODIFIER = 0.2;
 

--- a/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/AplCheck.tsx
@@ -85,13 +85,24 @@ const standardApl = build([
   CHP_SETUP,
   SPELLS.BLACKOUT_KICK,
   {
-    spell: SPELLS.CHI_BURST_TALENT,
-    condition: cnd.hasTalent(talents.MANIFESTATION_TALENT),
-    description: (
-      <>
-        Cast <SpellLink spell={SPELLS.CHI_BURST_TALENT} /> (as{' '}
-        <SpellLink spell={SPELLS.ASPECT_OF_HARMONY_TALENT}>MoH</SpellLink>)
-      </>
+    // special-case allowing BoF before Combo TP if doing so would
+    // not violate a later rule (manually listed: currently just Empty Barrel check)
+    // and would not delay your next BoK
+    spell: SPELLS.BREATH_OF_FIRE_TALENT,
+    condition: cnd.optionalRule(
+      cnd.describe(
+        cnd.and(
+          withCombo,
+          cnd.not(cnd.buffPresent(SPELLS_COMMON.EMPTY_BARREL_BUFF)),
+          cnd.spellCooldownRemaining(SPELLS.BLACKOUT_KICK, { atLeast: 2000 }),
+        ),
+        (tense) => (
+          <>
+            it {tenseAlt(tense, 'is', 'was')} a correct{' '}
+            <SpellLink spell={SPELLS.BLACKOUT_COMBO_TALENT}>Combo</SpellLink> filler
+          </>
+        ),
+      ),
     ),
   },
   {
@@ -116,7 +127,6 @@ const standardApl = build([
     ),
   },
   SPELLS.BREATH_OF_FIRE_TALENT,
-  SPELLS.CHI_BURST_TALENT,
   SPELLS.KEG_SMASH_TALENT,
 ]);
 

--- a/src/analysis/retail/monk/brewmaster/modules/core/StaggerPool/StaggerPoolSection.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/StaggerPool/StaggerPoolSection.tsx
@@ -140,26 +140,11 @@ export default function StaggerPoolSection(): JSX.Element | null {
   );
 }
 
-const staggerSpellName: typeof spellName = {
-  ...spellName,
-  render({ spell, school, isPet }, ctx) {
-    const spellId = typeof spell === 'object' ? spell.id : spell;
-    if (spellId === SPELLS.STAGGER_TALENT.id) {
-      return (
-        <>
-          <SpellLink spell={spell} />
-          &nbsp;(DoT)
-        </>
-      );
-    }
-
-    return spellName.render({ spell, school, isPet }, ctx);
-  },
-};
-
 const commonTableColumns = {
-  staggerSpellName,
-  amountBar: amountBar(EventType.Damage),
+  staggerSpellName: spellName.withLabels({
+    [SPELLS.STAGGER_TALENT.id]: <>Stagger (DoT)</>,
+  }),
+  amountBar: amountBar('Damage'),
 };
 
 const damageTakenColumns = {
@@ -188,7 +173,7 @@ function StaggerTakenTable(): JSX.Element | null {
     }
 
     const total = rows.reduce((total, row) => row.amount + total, 0);
-    const max = rows.reduce((max, row) => Math.max(row.amount, max), 0);
+    let max = rows.reduce((max, row) => Math.max(row.amount, max), 0);
 
     rows.sort((a, b) => b.amount - a.amount);
 
@@ -202,6 +187,7 @@ function StaggerTakenTable(): JSX.Element | null {
           hits: rows.slice(MAX_DATA_ROWS).reduce((total, row) => (row.hits ?? 0) + total, 0),
         },
       ];
+      max = Math.max(max, rows[rows.length - 1].amount);
     }
 
     return { rows, ctx: { total, max } };

--- a/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.module.scss
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.module.scss
@@ -1,0 +1,10 @@
+.bofResetList {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  column-gap: 1rem;
+  margin-bottom: 0; // overrides base style
+
+  dt {
+    font-weight: normal;
+  }
+}

--- a/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/InvokeNiuzao/InvokeNiuzao.tsx
@@ -18,6 +18,9 @@ import {
 import { TooltipElement } from 'interface/Tooltip';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import { formatDurationMillisMinSec } from 'common/format';
+import Spell from 'common/SPELLS/Spell';
+import styles from './InvokeNiuzao.module.scss';
+import Abilities from 'parser/core/modules/Abilities';
 
 /**
  * @internal
@@ -30,11 +33,15 @@ export interface NiuzaoCast {
   cooldowns: Map<number, number>;
 }
 
+const NIUZAO_DURATION = 25000;
 const EXPECTED_STOMP_COUNT = Math.floor(25 / 4);
 const EXPECTED_STOMP_COUNT_FOM = Math.floor(25 / 3);
 const EXPECTED_BOF_COUNT = 8; // made up in pre-patch. TODO this probably changes with apex talent resets
 
-export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsable: SpellUsable }) {
+export default class InvokeNiuzao extends Analyzer.withDependencies({
+  spellUsable: SpellUsable,
+  abilities: Abilities,
+}) {
   private hasWotW = this.selectedCombatant.hasTalent(SPELLS.WISDOM_OF_THE_WALL_TALENT);
 
   readonly niuzaoCasts: NiuzaoCast[] = [];
@@ -47,6 +54,10 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
 
     return undefined;
   }
+
+  private cbSpell = this.selectedCombatant.hasTalent(SPELLS.CELESTIAL_INFUSION_TALENT)
+    ? SPELLS.CELESTIAL_INFUSION_TALENT
+    : SPELLS.CELESTIAL_BREW_TALENT;
 
   constructor(options: Options) {
     super(options);
@@ -84,6 +95,7 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
   }
 
   private onSummon(event: SummonEvent) {
+    // record cooldown state. for shp specifically cooldown alignment is important to force resets
     const cooldowns = new Map();
 
     cooldowns.set(
@@ -92,12 +104,21 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
     );
     cooldowns.set(
       SPELLS.BREATH_OF_FIRE_TALENT.id,
-      this.deps.spellUsable.fractionalChargesAvailable(SPELLS.BREATH_OF_FIRE_TALENT.id),
+      this.deps.spellUsable.cooldownRemaining(SPELLS.BREATH_OF_FIRE_TALENT.id),
     );
     cooldowns.set(
       SPELLS.KEG_SMASH_TALENT.id,
       this.deps.spellUsable.fractionalChargesAvailable(SPELLS.KEG_SMASH_TALENT.id),
     );
+    cooldowns.set(
+      SPELLS.EXPLODING_KEG_TALENT.id,
+      this.deps.spellUsable.cooldownRemaining(SPELLS.EXPLODING_KEG_TALENT.id),
+    );
+    cooldowns.set(
+      SPELLS.BLACK_OX_BREW_TALENT.id,
+      this.deps.spellUsable.cooldownRemaining(SPELLS.BLACK_OX_BREW_TALENT.id),
+    );
+    cooldowns.set(this.cbSpell.id, this.deps.spellUsable.cooldownRemaining(this.cbSpell.id));
 
     this.niuzaoCasts.push({
       summonEvent: event,
@@ -131,64 +152,34 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
   } {
     const items: CooldownExpandableItem[] = [];
 
-    const expectedStomps = this.selectedCombatant.hasTalent(SPELLS.FLUIDITY_OF_MOTION_TALENT)
-      ? EXPECTED_STOMP_COUNT_FOM
-      : EXPECTED_STOMP_COUNT;
-
     let overallPerf = QualitativePerformance.Fail;
-    const initialBoKCooldown = cast.cooldowns.get(SPELLS.BLACKOUT_KICK.id) ?? 0;
-    items.push({
-      label: (
-        <>
-          <SpellLink spell={SPELLS.BLACKOUT_KICK} /> available immediately
-        </>
-      ),
-      result: (
-        <PerformanceMark
-          perf={
-            initialBoKCooldown < 1000 ? QualitativePerformance.Good : QualitativePerformance.Fail
-          }
-        />
-      ),
-      details:
-        initialBoKCooldown > 1000 ? (
-          <>{formatDurationMillisMinSec(initialBoKCooldown, 1)} remaining on cooldown</>
-        ) : null,
-    });
-
-    const stompPerf = evaluateQualitativePerformanceByThreshold({
-      isGreaterThanOrEqual: {
-        perfect: expectedStomps + 1,
-        good: expectedStomps,
-        ok: expectedStomps - 2,
-        fail: expectedStomps - 3,
-      },
-      actual: cast.stompCount,
-    });
-    overallPerf = stompPerf;
-    items.push({
-      label: (
-        <>
-          <SpellLink spell={SPELLS_COMMON.NIUZAO_STOMP_DAMAGE} /> triggers{' '}
-        </>
-      ),
-      details: (
-        <>
-          {cast.stompCount} / {expectedStomps}
-        </>
-      ),
-      result: <PerformanceMark perf={overallPerf} />,
-    });
-
     if (this.selectedCombatant.hasTalent(SPELLS.WISDOM_OF_THE_WALL_TALENT)) {
       const wotwPerf = evaluateQualitativePerformanceByThreshold({
         actual: cast.wotwTriggers.length,
         isGreaterThanOrEqual: {
-          perfect: EXPECTED_BOF_COUNT + 1,
+          perfect: EXPECTED_BOF_COUNT + 2,
           good: EXPECTED_BOF_COUNT,
           ok: EXPECTED_BOF_COUNT - 2,
         },
       });
+
+      const initialBoFCooldown = cast.cooldowns.get(SPELLS.BREATH_OF_FIRE_TALENT.id) ?? 0;
+      const initialKSCharges = cast.cooldowns.get(SPELLS.KEG_SMASH_TALENT.id) ?? 0;
+
+      const resetCount = (spell: Spell) =>
+        (cast.cooldowns.get(spell.id) ?? 0) > NIUZAO_DURATION - 1000 ? 0 : 1;
+
+      const estimatedKSChargeCDs = Math.floor(
+        NIUZAO_DURATION /
+          1000 /
+          this.deps.abilities.getAbility(SPELLS.KEG_SMASH_TALENT.id)!.cooldown,
+      );
+
+      const availableResets =
+        resetCount(SPELLS.EXPLODING_KEG_TALENT) +
+        resetCount(SPELLS.BLACK_OX_BREW_TALENT) +
+        resetCount(this.cbSpell) +
+        Math.floor(initialKSCharges + estimatedKSChargeCDs);
 
       overallPerf = wotwPerf; // WotW is more important than Stomp, overwrite the overall value.
       items.push({
@@ -197,8 +188,132 @@ export default class InvokeNiuzao extends Analyzer.withDependencies({ spellUsabl
             <SpellLink spell={SPELLS.WISDOM_OF_THE_WALL_TALENT}>WotW</SpellLink> triggers
           </>
         ),
-        details: <>{cast.wotwTriggers.length}</>,
+        details: (
+          <>
+            {cast.wotwTriggers.length} / {EXPECTED_BOF_COUNT}
+          </>
+        ),
         result: <PerformanceMark perf={wotwPerf} />,
+      });
+      items.push({
+        label: (
+          <>
+            <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> available immediately
+          </>
+        ),
+        result:
+          initialBoFCooldown > 1000 ? (
+            <TooltipElement
+              content={
+                <>
+                  On CD (<SpellLink spell={SPELLS.KEG_SMASH_TALENT}>KS</SpellLink>{' '}
+                  {initialKSCharges >= 1 ? 'available' : 'unavailable'})
+                </>
+              }
+            >
+              <PerformanceMark
+                perf={
+                  initialKSCharges >= 1 ? QualitativePerformance.Ok : QualitativePerformance.Fail
+                }
+              />
+            </TooltipElement>
+          ) : (
+            <PerformanceMark perf={QualitativePerformance.Good} />
+          ),
+      });
+      items.push({
+        label: (
+          <>
+            Deterministic <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT}>BoF</SpellLink> resets
+            available
+          </>
+        ),
+        result: (
+          <PerformanceMark
+            perf={evaluateQualitativePerformanceByThreshold({
+              isGreaterThanOrEqual: {
+                perfect: 8,
+                good: 6.5,
+                ok: 5,
+              },
+              actual: availableResets,
+            })}
+          />
+        ),
+        details: (
+          <TooltipElement
+            content={
+              <dl className={styles.bofResetList}>
+                <dt>
+                  <SpellLink spell={SPELLS.KEG_SMASH_TALENT} />
+                </dt>
+                <dd>{Math.floor(initialKSCharges + estimatedKSChargeCDs)}</dd>
+                <dt>
+                  <SpellLink spell={this.cbSpell} />
+                </dt>
+                <dd>{resetCount(this.cbSpell)}</dd>
+                <dt>
+                  <SpellLink spell={SPELLS.EXPLODING_KEG_TALENT} />
+                </dt>
+                <dd>{resetCount(SPELLS.EXPLODING_KEG_TALENT)}</dd>
+                <dt>
+                  <SpellLink spell={SPELLS.BLACK_OX_BREW_TALENT} />
+                </dt>
+                <dd>{resetCount(SPELLS.BLACK_OX_BREW_TALENT)}</dd>
+              </dl>
+            }
+          >
+            {availableResets}
+          </TooltipElement>
+        ),
+      });
+    } else {
+      const expectedStomps = this.selectedCombatant.hasTalent(SPELLS.FLUIDITY_OF_MOTION_TALENT)
+        ? EXPECTED_STOMP_COUNT_FOM
+        : EXPECTED_STOMP_COUNT;
+
+      const initialBoKCooldown = cast.cooldowns.get(SPELLS.BLACKOUT_KICK.id) ?? 0;
+      items.push({
+        label: (
+          <>
+            <SpellLink spell={SPELLS.BLACKOUT_KICK} /> available immediately
+          </>
+        ),
+        result: (
+          <PerformanceMark
+            perf={
+              initialBoKCooldown < 1000 ? QualitativePerformance.Good : QualitativePerformance.Fail
+            }
+          />
+        ),
+        details:
+          initialBoKCooldown > 1000 ? (
+            <>{formatDurationMillisMinSec(initialBoKCooldown, 1)} remaining on cooldown</>
+          ) : null,
+      });
+
+      const stompPerf = evaluateQualitativePerformanceByThreshold({
+        isGreaterThanOrEqual: {
+          perfect: expectedStomps + 1,
+          good: expectedStomps,
+          ok: expectedStomps - 2,
+          fail: expectedStomps - 3,
+        },
+        actual: cast.stompCount,
+      });
+      overallPerf = stompPerf;
+      items.push({
+        label: (
+          <>
+            <SpellLink spell={SPELLS_COMMON.NIUZAO_STOMP_DAMAGE} /> triggers{' '}
+          </>
+        ),
+        details: (
+          <>
+            {cast.stompCount} / {expectedStomps}
+          </>
+        ),
+        result: <PerformanceMark perf={overallPerf} />,
       });
     }
 

--- a/src/interface/Table/Table.tsx
+++ b/src/interface/Table/Table.tsx
@@ -50,6 +50,10 @@ const TableCell = styled.div<TableCellProps>`
   @container (width < 500px) {
     ${(props) => (props.optional ? 'display: none;' : '')}
   }
+
+  &:last-of-type {
+    border-right: unset;
+  }
 `;
 
 const TableHeader = styled.div`
@@ -64,8 +68,8 @@ const TableHeader = styled.div`
   & ${TableCell} {
     border-color: ${design.level2.border};
 
-    &:first-of-type {
-      border-left: unset;
+    &:last-of-type {
+      border-right: unset;
     }
   }
 

--- a/src/interface/Table/Table.tsx
+++ b/src/interface/Table/Table.tsx
@@ -64,8 +64,8 @@ const TableHeader = styled.div`
   & ${TableCell} {
     border-color: ${design.level2.border};
 
-    &:last-of-type {
-      border-right: unset;
+    &:first-of-type {
+      border-left: unset;
     }
   }
 

--- a/src/interface/Table/ThroughputTable.tsx
+++ b/src/interface/Table/ThroughputTable.tsx
@@ -29,7 +29,9 @@ const actorName: Column<{ actorId: number }> = {
   },
 };
 
-export const spellName: Column<{ spell: number | Spell; school?: number; isPet?: boolean }> = {
+export const spellName: Column<{ spell: number | Spell; school?: number; isPet?: boolean }> & {
+  withLabels(labels: Record<number, React.ReactNode>): typeof spellName;
+} = {
   label: 'Ability',
   render({ spell, school, isPet }) {
     if (spell === OTHER_SPECIAL_ID) {
@@ -42,15 +44,40 @@ export const spellName: Column<{ spell: number | Spell; school?: number; isPet?:
       </>
     );
   },
+  withLabels(labels: Record<number, React.ReactNode>): typeof spellName {
+    const parentRender = this.render.bind(this);
+    return {
+      ...this,
+      render({ spell, school, isPet }, ctx) {
+        const id = typeof spell === 'number' ? spell : spell.id;
+        if (id in labels) {
+          if (id === OTHER_SPECIAL_ID) {
+            return labels[id];
+          } else {
+            return (
+              <>
+                <SpellLink className={school ? `spell-school-${school}` : ''} spell={spell}>
+                  {labels[id]}
+                </SpellLink>
+                {isPet ? <>&nbsp;(Pet)</> : null}
+              </>
+            );
+          }
+        }
+
+        return parentRender({ spell, school, isPet }, ctx);
+      },
+    };
+  },
 };
 
 export const amountBar = (
-  type: EventType.Damage | EventType.Heal,
+  label: string,
 ): Column<
   { amount: number; school?: number; type?: string; isAbsorb?: boolean },
   { max: number; total: number }
 > => ({
-  label: type === EventType.Damage ? 'Damage' : 'Healing',
+  label,
   render({ amount, school, type, isAbsorb }, { max, total }) {
     return (
       <div
@@ -85,13 +112,14 @@ export const amountBar = (
 export const literalNumberColumn = <K extends string>(
   label: React.ReactNode,
   key: K,
-): Column<Record<K, number>> => ({
+  optional = true,
+): Column<Record<K, number | null>> => ({
   label,
   render(row) {
     return row[key];
   },
   align: 'right',
-  optional: true,
+  optional,
 });
 
 const critPct: Column<{ hits: number; crits: number }> = {
@@ -447,7 +475,7 @@ function ThroughputTableRaw({
     <Table
       columns={{
         nameColumn,
-        amountBar: amountBar(type),
+        amountBar: amountBar(type === EventType.Damage ? 'Damage' : 'Healing'),
         hits: literalNumberColumn('Hits', 'hits'),
         avgHit,
         critPct,

--- a/src/interface/guide/components/TipBox.tsx
+++ b/src/interface/guide/components/TipBox.tsx
@@ -5,14 +5,16 @@ interface TipBoxProps {
   children: ReactNode;
   icon?: ReactNode;
   title?: string;
+  style?: React.CSSProperties;
+  className?: string;
 }
 
 /**
  * A reusable box for displaying tips, warnings, or informational messages in guides.``
  */
-export function TipBox({ children, icon, title }: TipBoxProps) {
+export function TipBox({ children, icon, title, style, className }: TipBoxProps) {
   return (
-    <Container>
+    <Container style={style} className={className}>
       <ContentWrapper>
         {icon && <IconWrapper>{icon}</IconWrapper>}
         <Content>


### PR DESCRIPTION
### Description

- APL updates (move Chi Burst to cooldowns, allow BoF before combo TP)
- add cpm breakdown tables and BoC breakdown table
- update Niuzao checklist for ShP


### Testing

`/report/WnhG8H6mqjCKF43L/26-Heroic+Fallen-King+Salhadaar+-+Kill+(6:12)/7-Eisenpelz/standard`

<img width="1255" height="612" alt="image" src="https://github.com/user-attachments/assets/95020c62-4408-4df2-ac59-41c5ff13f336" />

`/report/grTZpkhQHnV29Bxy/45-Heroic+Vorasius+-+Kill+(5:46)/289-Bearcuddler/standard`

<img width="1252" height="678" alt="image" src="https://github.com/user-attachments/assets/e4e0282c-0199-41d8-a4f3-082339a61dbc" />

`/report/K3rZRBMazbvmQw7c/5-Heroic+Vorasius+-+Kill+(6:14)/40-Nytharion/standard

<img width="1212" height="264" alt="image" src="https://github.com/user-attachments/assets/72bd5b08-2a0f-48e3-9186-305393efd772" />
