### PR TITLE
[Core] Add Darkmoon Sigil: Hunt embellishment support

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -34,6 +34,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 3, 24), <>Add <SpellLink spell={ITEMS.DARKMOON_SIGIL_HUNT} /> embellishment analyzer with stat buff tracking.</>, MarchingCube),
   change(date(2026, 3, 24), "Add Ancestral Call (Mag'har Orc) racial support", MarchingCube),
   change(date(2026, 3, 23), "Update close kill times to match new WCL API", Putro),
   change(date(2026, 3, 20), 'Update FoodChecker for Midnight', Gambyt),

--- a/src/common/ITEMS/midnight/embellishments.ts
+++ b/src/common/ITEMS/midnight/embellishments.ts
@@ -1,5 +1,12 @@
 import { Enchant } from '../Item';
 
-const embellishments = {} satisfies Record<string, Enchant>;
+const embellishments = {
+  DARKMOON_SIGIL_HUNT: {
+    id: 1230076,
+    name: 'Darkmoon Sigil: Hunt',
+    icon: 'inv_12_profession_inscriptions_darkmoonsigil_bloom',
+    effectId: 12693,
+  },
+} satisfies Record<string, Enchant>;
 
 export default embellishments;

--- a/src/common/SPELLS/midnight/embellishments.ts
+++ b/src/common/SPELLS/midnight/embellishments.ts
@@ -2,22 +2,22 @@ import Spell from '../Spell';
 
 const embellishments = {
   /** Darkmoon Sigil: Hunt — grants 56 secondary stats for 15s based on target creature type */
-  HASTY_HUNT: {
+  DARKMOON_SIGIL_HUNT_HASTE: {
     id: 1252486,
     name: 'Hasty Hunt',
     icon: 'inv_eyeofnzothpet',
   },
-  FOCUSED_HUNT: {
+  DARKMOON_SIGIL_HUNT_CRIT: {
     id: 1252487,
     name: 'Focused Hunt',
     icon: 'inv_eyeofnzothpet',
   },
-  MASTERFUL_HUNT: {
+  DARKMOON_SIGIL_HUNT_MASTERY: {
     id: 1252488,
     name: 'Masterful Hunt',
     icon: 'inv_eyeofnzothpet',
   },
-  VERSATILE_HUNT: {
+  DARKMOON_SIGIL_HUNT_VERSATILITY: {
     id: 1252489,
     name: 'Versatile Hunt',
     icon: 'inv_eyeofnzothpet',

--- a/src/common/SPELLS/midnight/embellishments.ts
+++ b/src/common/SPELLS/midnight/embellishments.ts
@@ -1,5 +1,27 @@
 import Spell from '../Spell';
 
-const embellishments = {} satisfies Record<string, Spell>;
+const embellishments = {
+  /** Darkmoon Sigil: Hunt — grants 56 secondary stats for 15s based on target creature type */
+  HASTY_HUNT: {
+    id: 1252486,
+    name: 'Hasty Hunt',
+    icon: 'inv_eyeofnzothpet',
+  },
+  FOCUSED_HUNT: {
+    id: 1252487,
+    name: 'Focused Hunt',
+    icon: 'inv_eyeofnzothpet',
+  },
+  MASTERFUL_HUNT: {
+    id: 1252488,
+    name: 'Masterful Hunt',
+    icon: 'inv_eyeofnzothpet',
+  },
+  VERSATILE_HUNT: {
+    id: 1252489,
+    name: 'Versatile Hunt',
+    icon: 'inv_eyeofnzothpet',
+  },
+} satisfies Record<string, Spell>;
 
 export default embellishments;

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -98,6 +98,7 @@ import {
   DarkmoonSigilAscension,
   StormridersFury,
 } from 'parser/retail/modules/items/thewarwithin';
+import { DarkmoonSigilHunt } from 'parser/retail/modules/items/midnight';
 import CritRacial from 'parser/shared/modules/racials/CritRacial';
 import TreacherousTransmitter from 'parser/retail/modules/items/thewarwithin/trinkets/TreacherousTransmitter';
 import MadQueensMandate from 'parser/retail/modules/items/thewarwithin/trinkets/MadQueensMandate';
@@ -220,6 +221,7 @@ class CombatLogParser {
 
     // Embellishments
     darkmoonSigilAscension: DarkmoonSigilAscension,
+    darkmoonSigilHunt: DarkmoonSigilHunt,
 
     // Enchants
 

--- a/src/parser/retail/modules/items/midnight/embellishments/DarkmoonSigilHunt.tsx
+++ b/src/parser/retail/modules/items/midnight/embellishments/DarkmoonSigilHunt.tsx
@@ -1,0 +1,125 @@
+import EmbellishmentAnalyzer from '../../EmbellishmentAnalyzer';
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import ITEMS from 'common/ITEMS';
+import SPELLS from 'common/SPELLS';
+import Spell from 'common/SPELLS/Spell';
+import Events from 'parser/core/Events';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import STAT, { getIcon, getName } from 'parser/shared/modules/features/STAT';
+import UptimeBar from 'parser/ui/UptimeBar';
+import SpellLink from 'interface/SpellLink';
+import { formatDuration, formatPercentage } from 'common/format';
+
+const STAT_RATING = 56;
+
+const BUFFS = {
+  [SPELLS.HASTY_HUNT.id]: {
+    spell: SPELLS.HASTY_HUNT,
+    stat: STAT.HASTE,
+  },
+  [SPELLS.FOCUSED_HUNT.id]: {
+    spell: SPELLS.FOCUSED_HUNT,
+    stat: STAT.CRITICAL_STRIKE,
+  },
+  [SPELLS.MASTERFUL_HUNT.id]: {
+    spell: SPELLS.MASTERFUL_HUNT,
+    stat: STAT.MASTERY,
+  },
+  [SPELLS.VERSATILE_HUNT.id]: {
+    spell: SPELLS.VERSATILE_HUNT,
+    stat: STAT.VERSATILITY,
+  },
+} satisfies Record<number, { spell: Spell; stat: STAT }>;
+
+class DarkmoonSigilHunt extends EmbellishmentAnalyzer.withDependencies({
+  ...EmbellishmentAnalyzer.dependencies,
+  statTracker: StatTracker,
+}) {
+  procs = 0;
+  private statRating = STAT_RATING;
+
+  constructor(options: Options) {
+    super(ITEMS.DARKMOON_SIGIL_HUNT, 'any-slot', options);
+    if (!this.active) {
+      return;
+    }
+
+    // Using two Darkmoon Sigil: Hunt embellishments doubles the stat gain
+    if (this.getItemSlots(ITEMS.DARKMOON_SIGIL_HUNT.effectId, 'any-slot').length >= 2) {
+      this.statRating *= 2;
+    }
+
+    const rating = this.statRating;
+
+    this.deps.statTracker.add(SPELLS.HASTY_HUNT.id, { haste: rating });
+    this.deps.statTracker.add(SPELLS.FOCUSED_HUNT.id, { crit: rating });
+    this.deps.statTracker.add(SPELLS.MASTERFUL_HUNT.id, { mastery: rating });
+    this.deps.statTracker.add(SPELLS.VERSATILE_HUNT.id, { versatility: rating });
+
+    this.addEventListener(
+      Events.applybuff.to(SELECTED_PLAYER).spell(Object.values(BUFFS).map((b) => b.spell)),
+      () => (this.procs += 1),
+    );
+  }
+
+  statisticParts() {
+    const entries = Object.values(BUFFS)
+      .map((buff) => {
+        const uptime = this.selectedCombatant.getBuffUptime(buff.spell.id);
+        return { ...buff, uptime };
+      })
+      .filter((e) => e.uptime > 0);
+
+    const totalUptime = entries.reduce((sum, e) => sum + e.uptime, 0);
+    const totalUptimePercent = totalUptime / this.owner.fightDuration;
+
+    return {
+      tooltip: (
+        <>
+          {this.procCount(this.procs)} with {formatPercentage(totalUptimePercent, 1)}% total uptime.
+          {entries.map((entry) => {
+            const StatIcon = getIcon(entry.stat);
+            const statName = getName(entry.stat)!.toLowerCase();
+            const uptimePercent = entry.uptime / this.owner.fightDuration;
+            return (
+              <p key={entry.spell.id}>
+                <SpellLink spell={entry.spell} /> gave <StatIcon /> <b>{this.statRating}</b>{' '}
+                {statName} for <b>{formatDuration(entry.uptime)}</b> (
+                {formatPercentage(uptimePercent, 1)}%)
+              </p>
+            );
+          })}
+        </>
+      ),
+      content: (
+        <>
+          {entries.map((entry) => {
+            const StatIcon = getIcon(entry.stat);
+            const statName = getName(entry.stat);
+            const uptimePercent = entry.uptime / this.owner.fightDuration;
+            return (
+              <p key={entry.spell.id}>
+                <StatIcon /> {Math.round(this.statRating * uptimePercent)}{' '}
+                <small>{statName} over time</small>
+              </p>
+            );
+          })}
+          <UptimeBar
+            uptimeHistory={entries
+              .flatMap((entry) =>
+                this.selectedCombatant.getBuffHistory(entry.spell.id).map((b) => ({
+                  start: b.start,
+                  end: b.end ?? this.owner.fight.end_time,
+                })),
+              )
+              .sort((a, b) => a.start - b.start)}
+            start={this.owner.fight.start_time}
+            end={this.owner.fight.end_time}
+          />
+        </>
+      ),
+    };
+  }
+}
+
+export default DarkmoonSigilHunt;

--- a/src/parser/retail/modules/items/midnight/embellishments/DarkmoonSigilHunt.tsx
+++ b/src/parser/retail/modules/items/midnight/embellishments/DarkmoonSigilHunt.tsx
@@ -13,20 +13,20 @@ import { formatDuration, formatPercentage } from 'common/format';
 const STAT_RATING = 56;
 
 const BUFFS = {
-  [SPELLS.HASTY_HUNT.id]: {
-    spell: SPELLS.HASTY_HUNT,
+  [SPELLS.DARKMOON_SIGIL_HUNT_HASTE.id]: {
+    spell: SPELLS.DARKMOON_SIGIL_HUNT_HASTE,
     stat: STAT.HASTE,
   },
-  [SPELLS.FOCUSED_HUNT.id]: {
-    spell: SPELLS.FOCUSED_HUNT,
+  [SPELLS.DARKMOON_SIGIL_HUNT_CRIT.id]: {
+    spell: SPELLS.DARKMOON_SIGIL_HUNT_CRIT,
     stat: STAT.CRITICAL_STRIKE,
   },
-  [SPELLS.MASTERFUL_HUNT.id]: {
-    spell: SPELLS.MASTERFUL_HUNT,
+  [SPELLS.DARKMOON_SIGIL_HUNT_MASTERY.id]: {
+    spell: SPELLS.DARKMOON_SIGIL_HUNT_MASTERY,
     stat: STAT.MASTERY,
   },
-  [SPELLS.VERSATILE_HUNT.id]: {
-    spell: SPELLS.VERSATILE_HUNT,
+  [SPELLS.DARKMOON_SIGIL_HUNT_VERSATILITY.id]: {
+    spell: SPELLS.DARKMOON_SIGIL_HUNT_VERSATILITY,
     stat: STAT.VERSATILITY,
   },
 } satisfies Record<number, { spell: Spell; stat: STAT }>;
@@ -51,10 +51,10 @@ class DarkmoonSigilHunt extends EmbellishmentAnalyzer.withDependencies({
 
     const rating = this.statRating;
 
-    this.deps.statTracker.add(SPELLS.HASTY_HUNT.id, { haste: rating });
-    this.deps.statTracker.add(SPELLS.FOCUSED_HUNT.id, { crit: rating });
-    this.deps.statTracker.add(SPELLS.MASTERFUL_HUNT.id, { mastery: rating });
-    this.deps.statTracker.add(SPELLS.VERSATILE_HUNT.id, { versatility: rating });
+    this.deps.statTracker.add(SPELLS.DARKMOON_SIGIL_HUNT_HASTE.id, { haste: rating });
+    this.deps.statTracker.add(SPELLS.DARKMOON_SIGIL_HUNT_CRIT.id, { crit: rating });
+    this.deps.statTracker.add(SPELLS.DARKMOON_SIGIL_HUNT_MASTERY.id, { mastery: rating });
+    this.deps.statTracker.add(SPELLS.DARKMOON_SIGIL_HUNT_VERSATILITY.id, { versatility: rating });
 
     this.addEventListener(
       Events.applybuff.to(SELECTED_PLAYER).spell(Object.values(BUFFS).map((b) => b.spell)),

--- a/src/parser/retail/modules/items/midnight/index.tsx
+++ b/src/parser/retail/modules/items/midnight/index.tsx
@@ -1,0 +1,1 @@
+export { default as DarkmoonSigilHunt } from './embellishments/DarkmoonSigilHunt';


### PR DESCRIPTION
### Description
Tracks https://www.wowhead.com/item=245876/darkmoon-sigil-hunt in a similar way as  TWW ascension. Embellishment can proc several stat buffs based on creature type.

I've added stat tracking since it seems this embellishment was one source of wrong rune regen tracking for unholy DK (which I am trying to fix a bit).

In general I've tried to mostly copy TWW setup so if anything should be done differently now - let me know.
I'm linking to the craft spell because there is no single spell that maps cleanly here like in ascension case.

### Testing
- Test report URL: /report/GAzkTHPbF2KQnpZm/33-Heroic+Chimaerus,+the+Undreamt+God+-+Kill+(9:33)/228-Scharfer/standard/statistics
- Screenshot(s):
<img width="887" height="580" alt="image" src="https://github.com/user-attachments/assets/56844b4a-a920-4108-8166-14a3656e7d94" />
<img width="803" height="183" alt="image" src="https://github.com/user-attachments/assets/6befa47d-5f13-43da-b56a-d4c85df63a4a" />
