### PR TITLE
[Sub Rogue] - Shadow Blades module

### DIFF
--- a/src/analysis/retail/rogue/subtlety/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/subtlety/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import { Earosselot } from 'CONTRIBUTORS';
 import SHARED_CHANGELOG from 'analysis/retail/rogue/shared/CHANGELOG';
 
 export default [
+  change(date(2026, 3, 23), <>Fix Shadow Blades Module</>, Earosselot),
   change(date(2026, 3, 23), <>Adding Shadow Dance Module</>, Earosselot),
   change(date(2026, 3, 20), <>Enable Sublety for midnight</>, Earosselot),
   ...SHARED_CHANGELOG,

--- a/src/analysis/retail/rogue/subtlety/guide/CooldownGraphSubsection.tsx
+++ b/src/analysis/retail/rogue/subtlety/guide/CooldownGraphSubsection.tsx
@@ -42,7 +42,7 @@ const CooldownGraphSubsection = () => {
 
   return (
     <SubSection>
-      <>
+      <div>
         <strong>Cooldown Graph</strong> - This graph visualizes the usage of your cooldowns and
         highlights areas where optimizations can be made.
         <ul>
@@ -58,8 +58,7 @@ const CooldownGraphSubsection = () => {
         </ul>
         For Subtlety, <strong>Shadow Dance</strong> usage is crucial, as they define your burst
         windows.
-      </>
-      <p></p>
+      </div>
       {cooldowns.map((cooldownCheck) => (
         <CastEfficiencyBar
           key={cooldownCheck.spell.id}

--- a/src/analysis/retail/rogue/subtlety/guide/CooldownGraphSubsection.tsx
+++ b/src/analysis/retail/rogue/subtlety/guide/CooldownGraphSubsection.tsx
@@ -13,10 +13,8 @@ export interface Cooldown {
 }
 
 const cooldownsToCheck: Cooldown[] = [
-  { spell: SPELLS.SHADOW_DANCE },
-  // todo: fix secret technique CD graph
-  // { spell: SPELLS.SECRET_TECHNIQUE },
-  { spell: TALENTS.SHURIKEN_TORNADO_TALENT },
+  { spell: TALENTS.SHADOW_BLADES_TALENT },
+  { spell: SPELLS.SECRET_TECHNIQUE },
   { spell: SPELLS.VANISH },
 ];
 
@@ -44,7 +42,7 @@ const CooldownGraphSubsection = () => {
 
   return (
     <SubSection>
-      <p>
+      <>
         <strong>Cooldown Graph</strong> - This graph visualizes the usage of your cooldowns and
         highlights areas where optimizations can be made.
         <ul>
@@ -60,7 +58,8 @@ const CooldownGraphSubsection = () => {
         </ul>
         For Subtlety, <strong>Shadow Dance</strong> usage is crucial, as they define your burst
         windows.
-      </p>
+      </>
+      <p></p>
       {cooldowns.map((cooldownCheck) => (
         <CastEfficiencyBar
           key={cooldownCheck.spell.id}

--- a/src/analysis/retail/rogue/subtlety/guide/ShadowDanceGuide.tsx
+++ b/src/analysis/retail/rogue/subtlety/guide/ShadowDanceGuide.tsx
@@ -115,62 +115,57 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
     const deepeningShadows = <SpellLink spell={TALENTS.DEEPENING_SHADOWS_TALENT} />;
 
     const explanation = (
-      <>
+      <div>
         <p>
           {shadowDance} is our main short time cooldown. It interacts with several talents in our
           tree. During {shadowDance} we have increased damage and enhanced combo point and energy
           generation.
         </p>
-        <>
-          In order to maximize damage you want to:
-          <ul>
-            {this.isTrickster && <li>Enter with 6+ combo points.</li>}
-            {this.isDeathstalker && <li>Enter with low combo points.</li>}
-            <li>
-              Align this cooldown with {secretTechniques}, except in the second use during{' '}
-              {shadowBlades}.
-            </li>
-            <li>
-              Make sure you have enough energy to instantly throw your finisher, this is a common
-              mistake.
-            </li>
-            <li>Cast as many abilities as you can.</li>
-          </ul>
-        </>
-
-        <>
-          <h5>
-            <InformationIcon />
-            <i>Haste and GCDs notes</i>
-          </h5>
-          <p>
-            {shadowDance} duration increases with flat haste stat due to {deepeningShadows}. You
-            will want to fit the maximum amount of GCDs within your {shadowDance}.
-          </p>
-          <p>
-            i.e. if your {shadowDance} lasts 7.1s, you will want to squeeze 8 abilities within it.
-            Sometimes that .1s window is very tight.
-          </p>
-          <p>
-            If youre struggling to squeeze that last ability, you might want to increase your haste
-            a bit. Macros are of particular interest here. They will allow you to send {shadowDance}{' '}
-            and the first GCD at the exact same time.
-          </p>
-          <p>
-            Check
-            <a href="https://www.wowhead.com/guide/classes/rogue/subtlety/addons-macro-ui-imports#macros-macros-combining-abilities">
-              {' '}
-              wowhead{' '}
-            </a>
-            or
-            <a href="https://www.icy-veins.com/wow/subtlety-rogue-pve-dps-macros-addons">
-              {' '}
-              icy-veins{' '}
-            </a>
-            macros section for more information.
-          </p>
-        </>
-      </>
+        In order to maximize damage you want to:
+        <ul>
+          {this.isTrickster && <li>Enter with 6+ combo points.</li>}
+          {this.isDeathstalker && <li>Enter with low combo points.</li>}
+          <li>
+            Align this cooldown with {secretTechniques}, except in the second use during{' '}
+            {shadowBlades}.
+          </li>
+          <li>
+            Make sure you have enough energy to instantly throw your finisher, this is a common
+            mistake.
+          </li>
+          <li>Cast as many abilities as you can.</li>
+        </ul>
+        <h5>
+          <InformationIcon />
+          <i>Haste and GCDs notes</i>
+        </h5>
+        <p>
+          {shadowDance} duration increases with flat haste stat due to {deepeningShadows}. You will
+          want to fit the maximum amount of GCDs within your {shadowDance}.
+        </p>
+        <p>
+          i.e. if your {shadowDance} lasts 7.1s, you will want to squeeze 8 abilities within it.
+          Sometimes that .1s window is very tight.
+        </p>
+        <p>
+          If youre struggling to squeeze that last ability, you might want to increase your haste a
+          bit. Macros are of particular interest here. They will allow you to send {shadowDance} and
+          the first GCD at the exact same time.
+        </p>
+        <p>
+          Check
+          <a href="https://www.wowhead.com/guide/classes/rogue/subtlety/addons-macro-ui-imports#macros-macros-combining-abilities">
+            {' '}
+            wowhead{' '}
+          </a>
+          or
+          <a href="https://www.icy-veins.com/wow/subtlety-rogue-pve-dps-macros-addons">
+            {' '}
+            icy-veins{' '}
+          </a>
+          macros section for more information.
+        </p>
+      </div>
     );
 
     const totalDamageTooltip = <>Total Damage done through all {shadowDance} Uses.</>;

--- a/src/analysis/retail/rogue/subtlety/guide/ShadowDanceGuide.tsx
+++ b/src/analysis/retail/rogue/subtlety/guide/ShadowDanceGuide.tsx
@@ -121,7 +121,7 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
           tree. During {shadowDance} we have increased damage and enhanced combo point and energy
           generation.
         </p>
-        <p>
+        <>
           In order to maximize damage you want to:
           <ul>
             {this.isTrickster && <li>Enter with 6+ combo points.</li>}
@@ -136,9 +136,9 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
             </li>
             <li>Cast as many abilities as you can.</li>
           </ul>
-        </p>
+        </>
 
-        <p>
+        <>
           <h5>
             <InformationIcon />
             <i>Haste and GCDs notes</i>
@@ -169,7 +169,7 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
             </a>
             macros section for more information.
           </p>
-        </p>
+        </>
       </>
     );
 

--- a/src/analysis/retail/rogue/subtlety/modules/Abilities.ts
+++ b/src/analysis/retail/rogue/subtlety/modules/Abilities.ts
@@ -67,7 +67,7 @@ class Abilities extends CoreAbilities {
         category: SPELL_CATEGORY.COOLDOWNS,
         buffSpellId: SPELLS.SHADOW_DANCE_BUFF.id,
         charges: 1 + (combatant.hasTalent(TALENTS.DOUBLE_DANCE_TALENT) ? 1 : 0),
-        cooldown: 60,
+        cooldown: 20,
         gcd: null,
         castEfficiency: {
           suggestion: true,
@@ -125,8 +125,9 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: true,
-          recommendedEfficiency: 0.95,
-          extraSuggestion: 'Use Shadow Dance before it reaches maximum charges.',
+          recommendedEfficiency: 0.8,
+          extraSuggestion:
+            'Use Secret Technique whenever is available with Shadow Dance. Hold it for Shadow Blades.',
         },
       },
       {

--- a/src/analysis/retail/rogue/subtlety/modules/spells/ShadowBlades.tsx
+++ b/src/analysis/retail/rogue/subtlety/modules/spells/ShadowBlades.tsx
@@ -1,17 +1,24 @@
 import type { JSX } from 'react';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, {
+  CastEvent,
+  GetRelatedEvent,
+  GetRelatedEvents,
+  EventType,
+} from 'parser/core/Events';
 import SPELLS from 'common/SPELLS/rogue';
 import TALENTS from 'common/TALENTS/rogue';
 import { SpellLink } from 'interface';
 import { SpellUse, ChecklistUsageInfo } from 'parser/core/SpellUsage/core';
 import { createChecklistItem, createSpellUse } from 'parser/core/MajorCooldowns/MajorCooldown';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import { HideGoodCastsSpellUsageSubSection } from 'parser/core/SpellUsage/HideGoodCastsSpellUsageSubSection';
-import { logSpellUseEvent } from 'parser/core/SpellUsage/SpellUsageSubSection';
+import SpellUsageSubSection, {
+  logSpellUseEvent,
+} from 'parser/core/SpellUsage/SpellUsageSubSection';
 import CastPerformanceSummary from 'analysis/retail/demonhunter/shared/guide/CastPerformanceSummary';
 import ComboPointTracker from 'analysis/retail/rogue/shared/ComboPointTracker';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
+import { CustomType } from 'analysis/retail/rogue/subtlety/normalizers/CustomType';
 
 export default class ShadowBlades extends Analyzer {
   static dependencies = {
@@ -32,25 +39,34 @@ export default class ShadowBlades extends Analyzer {
   }
 
   get guideSubsection(): JSX.Element {
+    const shadowDance = <SpellLink spell={SPELLS.SHADOW_DANCE} />;
+    const secretTechniques = <SpellLink spell={SPELLS.SECRET_TECHNIQUE} />;
+    const shadowBlades = <SpellLink spell={TALENTS.SHADOW_BLADES_TALENT} />;
+
     const explanation = (
-      <p>
-        <strong>
-          <SpellLink spell={TALENTS.SHADOW_BLADES_TALENT} />
-        </strong>{' '}
-        is the most important Subtlety Rogue cooldowns. It should be used strategically with{' '}
-        <SpellLink spell={SPELLS.SECRET_TECHNIQUE} /> and <SpellLink spell={SPELLS.SHADOW_DANCE} />.
-      </p>
+      <>
+        <p>
+          <strong>{shadowBlades}</strong> is the most important Subtlety Rogue cooldown. It should
+          be used strategically with {secretTechniques} and {shadowDance}.
+        </p>
+        <p>
+          You should aim to fit 2 {shadowDance} casts during {shadowBlades} buff duration. For this
+          reason, the second {shadowDance} will be without {secretTechniques} available.
+        </p>
+      </>
     );
 
     const goodCasts = this.cooldownUses.filter(
-      (it) => it.performance === QualitativePerformance.Ok,
+      (it) =>
+        it.performance === QualitativePerformance.Ok ||
+        it.performance === QualitativePerformance.Perfect,
     ).length;
     const totalCasts = this.cooldownUses.length;
 
     return (
-      <HideGoodCastsSpellUsageSubSection
-        hideGoodCasts={false}
+      <SpellUsageSubSection
         explanation={explanation}
+        wideExplanation={true}
         uses={this.cooldownUses}
         castBreakdownSmallText={<> - Red indicates a wasted Shadow Blades.</>}
         onPerformanceBoxClick={logSpellUseEvent}
@@ -70,37 +86,114 @@ export default class ShadowBlades extends Analyzer {
       />
     );
   }
-  private onCast(event: CastEvent) {
-    const hasShadowDanceBuff = this.selectedCombatant.hasBuff(SPELLS.SHADOW_DANCE.id);
 
+  private onCast(event: CastEvent) {
+    const hasShadowDanceBuff = this.selectedCombatant.hasBuff(SPELLS.SHADOW_DANCE_BUFF.id);
+    const hasSecTecAvailable = this.spellUsable.isAvailable(SPELLS.SECRET_TECHNIQUE.id);
+    const hasShadowDanceAvailable = this.spellUsable.isAvailable(SPELLS.SHADOW_DANCE.id);
+
+    const shadowBladesRemove = GetRelatedEvent(event, EventType.RemoveBuff);
+    this.log('shadowBladesRemove', shadowBladesRemove);
+
+    const shadowDanceCasts = GetRelatedEvents(event, CustomType.SHADOW_DANCE_CASTS);
+    this.log('shadowDanceCasts', shadowDanceCasts);
+    const numberOfCasts = shadowDanceCasts.reduce((sum, cast) => sum + 1, 0);
+    // todo: check 2 SD usages within the Shadow Blades buff window.
     this.cooldownUses.push(
-      createSpellUse({ event }, [this.shadowDanceBuff(event, hasShadowDanceBuff)]),
+      createSpellUse({ event }, [
+        this.shadowDanceCheck(event, hasShadowDanceBuff, hasShadowDanceAvailable),
+        this.secTecCheck(event, hasSecTecAvailable),
+        this.shadowDanceCastsCheck(event, numberOfCasts),
+      ]),
     );
   }
 
-  private shadowDanceBuff(
+  private shadowDanceCastsCheck(
     event: CastEvent,
-    hasShadowDanceBuff: boolean,
+    shadowDanceCasts: number,
   ): ChecklistUsageInfo | undefined {
-    const performance = hasShadowDanceBuff
+    const performance =
+      shadowDanceCasts === 2 ? QualitativePerformance.Perfect : QualitativePerformance.Fail;
+
+    return createChecklistItem(
+      'shadow_dance_casts',
+      { event },
+      {
+        performance,
+        summary: <div>Shadow Dance Casts</div>,
+        details: (
+          <div>
+            {shadowDanceCasts === 2 ? (
+              <>
+                <SpellLink spell={SPELLS.SHADOW_DANCE} /> was used twice.
+              </>
+            ) : (
+              <>
+                <SpellLink spell={SPELLS.SHADOW_DANCE} /> was not used twice.
+              </>
+            )}
+          </div>
+        ),
+      },
+    );
+  }
+
+  private secTecCheck(
+    event: CastEvent,
+    hasSecTecAvailable: boolean,
+  ): ChecklistUsageInfo | undefined {
+    const performance = hasSecTecAvailable
       ? QualitativePerformance.Perfect
       : QualitativePerformance.Fail;
+
+    return createChecklistItem(
+      'sec_tec_alignment',
+      { event },
+      {
+        performance,
+        summary: <div>Secret Technique Alignment</div>,
+        details: (
+          <div>
+            {hasSecTecAvailable ? (
+              <>
+                <SpellLink spell={SPELLS.SECRET_TECHNIQUE} /> was available.
+              </>
+            ) : (
+              <>
+                <SpellLink spell={SPELLS.SECRET_TECHNIQUE} /> was not available.
+              </>
+            )}
+          </div>
+        ),
+      },
+    );
+  }
+
+  private shadowDanceCheck(
+    event: CastEvent,
+    hasShadowDanceBuff: boolean,
+    hasShadowDanceAvailable: boolean,
+  ): ChecklistUsageInfo | undefined {
+    const performance =
+      hasShadowDanceBuff || hasShadowDanceAvailable
+        ? QualitativePerformance.Perfect
+        : QualitativePerformance.Fail;
 
     return createChecklistItem(
       'shadow_dance_alignment',
       { event },
       {
         performance,
-        summary: <div>Shadow Dance Buff Alignment</div>,
+        summary: <div>Shadow Dance Alignment</div>,
         details: (
           <div>
-            {hasShadowDanceBuff ? (
+            {hasShadowDanceBuff || hasShadowDanceAvailable ? (
               <>
-                <SpellLink spell={SPELLS.SHADOW_DANCE} /> buff was present.
+                <SpellLink spell={SPELLS.SHADOW_DANCE} /> buff was present or available.
               </>
             ) : (
               <>
-                <SpellLink spell={SPELLS.SHADOW_DANCE} /> buff was not present.
+                <SpellLink spell={SPELLS.SHADOW_DANCE} /> buff was not present and not available.
               </>
             )}
           </div>

--- a/src/analysis/retail/rogue/subtlety/modules/spells/ShadowBlades.tsx
+++ b/src/analysis/retail/rogue/subtlety/modules/spells/ShadowBlades.tsx
@@ -1,11 +1,6 @@
 import type { JSX } from 'react';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, {
-  CastEvent,
-  GetRelatedEvent,
-  GetRelatedEvents,
-  EventType,
-} from 'parser/core/Events';
+import Events, { CastEvent, GetRelatedEvents } from 'parser/core/Events';
 import SPELLS from 'common/SPELLS/rogue';
 import TALENTS from 'common/TALENTS/rogue';
 import { SpellLink } from 'interface';
@@ -92,13 +87,8 @@ export default class ShadowBlades extends Analyzer {
     const hasSecTecAvailable = this.spellUsable.isAvailable(SPELLS.SECRET_TECHNIQUE.id);
     const hasShadowDanceAvailable = this.spellUsable.isAvailable(SPELLS.SHADOW_DANCE.id);
 
-    const shadowBladesRemove = GetRelatedEvent(event, EventType.RemoveBuff);
-    this.log('shadowBladesRemove', shadowBladesRemove);
-
     const shadowDanceCasts = GetRelatedEvents(event, CustomType.SHADOW_DANCE_CASTS);
-    this.log('shadowDanceCasts', shadowDanceCasts);
     const numberOfCasts = shadowDanceCasts.reduce((sum, cast) => sum + 1, 0);
-    // todo: check 2 SD usages within the Shadow Blades buff window.
     this.cooldownUses.push(
       createSpellUse({ event }, [
         this.shadowDanceCheck(event, hasShadowDanceBuff, hasShadowDanceAvailable),

--- a/src/analysis/retail/rogue/subtlety/normalizers/CustomType.ts
+++ b/src/analysis/retail/rogue/subtlety/normalizers/CustomType.ts
@@ -1,0 +1,3 @@
+export const CustomType = {
+  SHADOW_DANCE_CASTS: 'shadowDanceCasts',
+};

--- a/src/analysis/retail/rogue/subtlety/normalizers/SubletyNormalizers.ts
+++ b/src/analysis/retail/rogue/subtlety/normalizers/SubletyNormalizers.ts
@@ -57,12 +57,12 @@ const EVENT_LINKS = createEventLinks(
     spell: TALENTS.SHADOW_BLADES_TALENT.id,
     parentType: EventType.Cast,
     links: [
-      link(EventType.RemoveBuff, { forwardBuffer: 18000, maxLinks: 1, anyTarget: true }),
+      link(EventType.RemoveBuff, { forwardBuffer: 21000, maxLinks: 1, anyTarget: true }),
       {
         relation: CustomType.SHADOW_DANCE_CASTS,
         type: EventType.Cast,
         id: SPELLS.SHADOW_DANCE.id,
-        forwardBuffer: 17000,
+        forwardBuffer: 21000,
         condition: (linkingEvent, referencedEvent) => {
           const debuffEnd = GetRelatedEvent(linkingEvent, EventType.RemoveBuff);
           return debuffEnd ? referencedEvent.timestamp < debuffEnd.timestamp : false;

--- a/src/analysis/retail/rogue/subtlety/normalizers/SubletyNormalizers.ts
+++ b/src/analysis/retail/rogue/subtlety/normalizers/SubletyNormalizers.ts
@@ -3,53 +3,74 @@ import { Options } from 'parser/core/Module';
 import { EventType, GetRelatedEvent } from 'parser/core/Events';
 import EventLinkNormalizer from 'parser/core/EventLinkNormalizer';
 import SPELLS from 'common/SPELLS/rogue';
+import TALENTS from 'common/TALENTS/rogue';
+import { CustomType } from './CustomType';
 
-const EVENT_LINKS = createEventLinks({
-  spell: SPELLS.SHADOW_DANCE_BUFF.id,
-  parentType: EventType.ApplyBuff,
-  links: [
-    link(EventType.RemoveBuff, { forwardBuffer: 15000, maxLinks: 1, anyTarget: true }),
-    {
-      relation: EventType.Damage,
-      type: EventType.Damage,
-      id: [
-        // Builders
-        SPELLS.SHADOWSTRIKE.id,
-        SPELLS.SHURIKEN_STORM.id,
-        // Big Finishers
-        SPELLS.SECRET_TECHNIQUE.id,
-        SPELLS.SECRET_TECHNIQUE_DAMAGE.id,
-        SPELLS.COUP_DE_GRACE_DAMAGE.id,
-        // Black Powder
-        SPELLS.BLACK_POWDER.id,
-        SPELLS.BLACK_POWDER_SHADOW.id,
-        SPELLS.BLACK_POWDER_ANCIENT_ARTS_DAMAGE.id,
-        // Eviscerate
-        SPELLS.EVISCERATE.id,
-        SPELLS.EVISCERATE_SHADOWED_FINISHERS_DAMAGE.id,
-        SPELLS.EVISCERATE_ANCIENT_ARTS_DAMAGE.id,
-        SPELLS.EVISCERATE_COUP_DE_GRACE_DAMAGE.id,
-        SPELLS.EVISCERATE_COUP_DE_GRACE_2_DAMAGE.id,
-        SPELLS.EVISCERATE_COUP_DE_GRACE_3_DAMAGE.id,
-        SPELLS.EVISCERATE_COUP_DE_GRACE_4_DAMAGE.id,
-        SPELLS.EVISCERATE_COUP_DE_GRACE_5_DAMAGE.id,
-        SPELLS.EVISCERATE_COUP_DE_GRACE_6_DAMAGE.id,
-        1, // Melee damage
-        // Pasives
-        SPELLS.LASHE_MACABRE_DAMAGE.id,
-        SPELLS.SHADOW_BLADES_DAMAGE.id,
-        SPELLS.UNSEEN_BLADE_DAMAGE.id,
-        SPELLS.NIMBLE_FURY_DAMAGE.id,
-      ],
-      anyTarget: true,
-      forwardBuffer: 15000,
-      condition: (linkingEvent, referencedEvent) => {
-        const debuffEnd = GetRelatedEvent(linkingEvent, EventType.RemoveBuff);
-        return debuffEnd ? referencedEvent.timestamp < debuffEnd.timestamp : false;
+const EVENT_LINKS = createEventLinks(
+  {
+    spell: SPELLS.SHADOW_DANCE_BUFF.id,
+    parentType: EventType.ApplyBuff,
+    links: [
+      link(EventType.RemoveBuff, { forwardBuffer: 15000, maxLinks: 1, anyTarget: true }),
+      {
+        relation: EventType.Damage,
+        type: EventType.Damage,
+        id: [
+          // Builders
+          SPELLS.SHADOWSTRIKE.id,
+          SPELLS.SHURIKEN_STORM.id,
+          // Big Finishers
+          SPELLS.SECRET_TECHNIQUE.id,
+          SPELLS.SECRET_TECHNIQUE_DAMAGE.id,
+          SPELLS.COUP_DE_GRACE_DAMAGE.id,
+          // Black Powder
+          SPELLS.BLACK_POWDER.id,
+          SPELLS.BLACK_POWDER_SHADOW.id,
+          SPELLS.BLACK_POWDER_ANCIENT_ARTS_DAMAGE.id,
+          // Eviscerate
+          SPELLS.EVISCERATE.id,
+          SPELLS.EVISCERATE_SHADOWED_FINISHERS_DAMAGE.id,
+          SPELLS.EVISCERATE_ANCIENT_ARTS_DAMAGE.id,
+          SPELLS.EVISCERATE_COUP_DE_GRACE_DAMAGE.id,
+          SPELLS.EVISCERATE_COUP_DE_GRACE_2_DAMAGE.id,
+          SPELLS.EVISCERATE_COUP_DE_GRACE_3_DAMAGE.id,
+          SPELLS.EVISCERATE_COUP_DE_GRACE_4_DAMAGE.id,
+          SPELLS.EVISCERATE_COUP_DE_GRACE_5_DAMAGE.id,
+          SPELLS.EVISCERATE_COUP_DE_GRACE_6_DAMAGE.id,
+          1, // Melee damage
+          // Pasives
+          SPELLS.LASHE_MACABRE_DAMAGE.id,
+          SPELLS.SHADOW_BLADES_DAMAGE.id,
+          SPELLS.UNSEEN_BLADE_DAMAGE.id,
+          SPELLS.NIMBLE_FURY_DAMAGE.id,
+        ],
+        anyTarget: true,
+        forwardBuffer: 15000,
+        condition: (linkingEvent, referencedEvent) => {
+          const debuffEnd = GetRelatedEvent(linkingEvent, EventType.RemoveBuff);
+          return debuffEnd ? referencedEvent.timestamp < debuffEnd.timestamp : false;
+        },
       },
-    },
-  ],
-});
+    ],
+  },
+  {
+    spell: TALENTS.SHADOW_BLADES_TALENT.id,
+    parentType: EventType.Cast,
+    links: [
+      link(EventType.RemoveBuff, { forwardBuffer: 18000, maxLinks: 1, anyTarget: true }),
+      {
+        relation: CustomType.SHADOW_DANCE_CASTS,
+        type: EventType.Cast,
+        id: SPELLS.SHADOW_DANCE.id,
+        forwardBuffer: 17000,
+        condition: (linkingEvent, referencedEvent) => {
+          const debuffEnd = GetRelatedEvent(linkingEvent, EventType.RemoveBuff);
+          return debuffEnd ? referencedEvent.timestamp < debuffEnd.timestamp : false;
+        },
+      },
+    ],
+  },
+);
 
 /**
  * Links the damage events for spells to their cast event. This allows for more

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,7 +62,6 @@
     "src/analysis/retail/paladin/holy/CONFIG.tsx",
     "src/analysis/retail/rogue/assassination/CONFIG.tsx",
     "src/analysis/retail/rogue/outlaw/CONFIG.tsx",
-    "src/analysis/retail/warrior/protection/CONFIG.tsx",
-    "./src/analysis/retail/rogue/subtlety/normalizers/CustomType.ts"
+    "src/analysis/retail/warrior/protection/CONFIG.tsx"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,6 +62,7 @@
     "src/analysis/retail/paladin/holy/CONFIG.tsx",
     "src/analysis/retail/rogue/assassination/CONFIG.tsx",
     "src/analysis/retail/rogue/outlaw/CONFIG.tsx",
-    "src/analysis/retail/warrior/protection/CONFIG.tsx"
+    "src/analysis/retail/warrior/protection/CONFIG.tsx",
+    "./src/analysis/retail/rogue/subtlety/normalizers/CustomType.ts"
   ]
 }


### PR DESCRIPTION
### Description

- Updated shadow blades module to be consistent with current correct usage.
- Fixed some HTML error from previous PR.
- Removed shuriken tornado from cooldowns subsection, it's passive now.
- Removed Shadow Dance from Cooldown subsection. I think it was missleading, even 100 parses got 24% usage. Now we shouldn't sent it on CD, but wait for SecTec to be ready.

### Testing

- Test report URL: `/report/1r3DVHjWXG4L8vqw/18-Heroic+Fallen-King+Salhadaar+-+Kill+(4:35)/12-Rektoone/standard`
- Screenshot(s):
<img width="1283" height="703" alt="image" src="https://github.com/user-attachments/assets/dc36dabb-ecc2-4527-940a-d61eacae3a50" />