### PR TITLE
[Survival] Raptor Swipe Analyzer

### DIFF
--- a/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
@@ -38,6 +38,7 @@ export default class MoonlightChakram extends Analyzer {
   private useEntries: BoxRowEntry[] = [];
   private isSurvival = false;
   private hasStalkAndStrike = false;
+  private lastTriggerTarget = 'unknown';
 
   constructor(options: Options) {
     super(options);
@@ -55,15 +56,18 @@ export default class MoonlightChakram extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell([TALENTS.TRUESHOT_TALENT, SPELLS.TAKEDOWN_PLAYER]),
       this.onTriggerCast,
     );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.MOONLIGHT_CHAKRAM_CAST),
+      this.onChakramCast,
+    );
   }
 
+  /** Handles missed Chakram windows — when Trueshot/Takedown fires but no Chakram follows */
   private onTriggerCast(event: CastEvent) {
-    // Chakram is a 15s duration availability after using cooldown.
+    this.lastTriggerTarget = this.owner.getTargetName(event) || 'unknown';
     const chakramCast = GetRelatedEvents(event, TRIGGER_TO_CHAKRAM_CAST)[0] as
       | CastEvent
       | undefined;
-    const chakramTarget = this.owner.getTargetName(event) || 'unknown';
-
     if (!chakramCast) {
       this.missedCasts += 1;
       this.useEntries.push({
@@ -73,22 +77,24 @@ export default class MoonlightChakram extends Analyzer {
             <h5 style={{ color: BadColor }}>
               FAIL: No <SpellLink spell={SPELLS.MOONLIGHT_CHAKRAM_CAST} /> cast
             </h5>
-            Target: <strong>{chakramTarget}</strong>
+            Target: <strong>{this.lastTriggerTarget}</strong>
             {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
             <br />@ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
           </>
         ),
       });
-      return;
     }
+  }
 
+  /** Handles Chakram casts — SpellUsable state is accurate here for CDR checks */
+  private onChakramCast(event: CastEvent) {
     this.chakramCasts += 1;
-    const targetName = this.owner.getTargetName(chakramCast) || chakramTarget;
+
+    const targetName = this.owner.getTargetName(event) || this.lastTriggerTarget;
 
     //Currently hits 16 times, but will only hit for 7 at level 90 with the extra hero talents
     // So analysis is a little weird. The important bit is did they even cast the ability or did they forget
-    const damageEvents =
-      (GetRelatedEvents(chakramCast, CHAKRAM_CAST_TO_DAMAGE) as DamageEvent[]) || [];
+    const damageEvents = (GetRelatedEvents(event, CHAKRAM_CAST_TO_DAMAGE) as DamageEvent[]) || [];
     const damage = damageEvents.reduce((sum, dmg) => sum + dmg.amount + (dmg.absorbed || 0), 0);
     const hits = damageEvents.length;
 
@@ -106,10 +112,8 @@ export default class MoonlightChakram extends Analyzer {
 
     if (this.hasStalkAndStrike) {
       if (this.isSurvival) {
-        const cdRemaining = this.spellUsable.cooldownRemaining(
-          TALENTS.WILDFIRE_BOMB_TALENT.id,
-          chakramCast.timestamp,
-        );
+        // event.timestamp is the Chakram cast time — SpellUsable state is correct here
+        const cdRemaining = this.spellUsable.cooldownRemaining(TALENTS.WILDFIRE_BOMB_TALENT.id);
         if (cdRemaining <= STALK_AND_STRIKE_CDR) {
           wastedCDR = STALK_AND_STRIKE_CDR - cdRemaining;
           if (wastedCDR > STALK_AND_STRIKE_WASTE_THRESHOLD) {
@@ -121,7 +125,7 @@ export default class MoonlightChakram extends Analyzer {
       } else {
         wastedLockAndLoad = this.selectedCombatant.hasBuff(
           SPELLS.LOCK_AND_LOAD_BUFF.id,
-          chakramCast.timestamp,
+          event.timestamp,
         );
         if (wastedLockAndLoad) {
           performance = QualitativePerformance.Fail;

--- a/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
+++ b/src/analysis/retail/hunter/shared/herotalents/MoonlightChakram.tsx
@@ -38,6 +38,7 @@ export default class MoonlightChakram extends Analyzer {
   private useEntries: BoxRowEntry[] = [];
   private isSurvival = false;
   private hasStalkAndStrike = false;
+  private lastTriggerTarget = 'unknown';
 
   constructor(options: Options) {
     super(options);
@@ -55,15 +56,18 @@ export default class MoonlightChakram extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell([SPELLS.TRUESHOT, SPELLS.TAKEDOWN_PLAYER]),
       this.onTriggerCast,
     );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.MOONLIGHT_CHAKRAM_CAST),
+      this.onChakramCast,
+    );
   }
 
+  /** Handles missed Chakram windows — when Trueshot/Takedown fires but no Chakram follows */
   private onTriggerCast(event: CastEvent) {
-    // Chakram is a 15s duration availability after using cooldown.
+    this.lastTriggerTarget = this.owner.getTargetName(event) || 'unknown';
     const chakramCast = GetRelatedEvents(event, TRIGGER_TO_CHAKRAM_CAST)[0] as
       | CastEvent
       | undefined;
-    const chakramTarget = this.owner.getTargetName(event) || 'unknown';
-
     if (!chakramCast) {
       this.missedCasts += 1;
       this.useEntries.push({
@@ -73,21 +77,23 @@ export default class MoonlightChakram extends Analyzer {
             <h5 style={{ color: BadColor }}>
               FAIL: No <SpellLink spell={SPELLS.MOONLIGHT_CHAKRAM_CAST} /> cast
             </h5>
-            Target: <strong>{chakramTarget}</strong>
+            Target: <strong>{this.lastTriggerTarget}</strong>
             <br />@ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
           </>
         ),
       });
-      return;
     }
+  }
 
+  /** Handles Chakram casts — SpellUsable state is accurate here for CDR checks */
+  private onChakramCast(event: CastEvent) {
     this.chakramCasts += 1;
-    const targetName = this.owner.getTargetName(chakramCast) || chakramTarget;
+
+    const targetName = this.owner.getTargetName(event) || this.lastTriggerTarget;
 
     //Currently hits 16 times, but will only hit for 7 at level 90 with the extra hero talents
     // So analysis is a little weird. The important bit is did they even cast the ability or did they forget
-    const damageEvents =
-      (GetRelatedEvents(chakramCast, CHAKRAM_CAST_TO_DAMAGE) as DamageEvent[]) || [];
+    const damageEvents = (GetRelatedEvents(event, CHAKRAM_CAST_TO_DAMAGE) as DamageEvent[]) || [];
     const damage = damageEvents.reduce((sum, dmg) => sum + dmg.amount + (dmg.absorbed || 0), 0);
     const hits = damageEvents.length;
 
@@ -105,10 +111,8 @@ export default class MoonlightChakram extends Analyzer {
 
     if (this.hasStalkAndStrike) {
       if (this.isSurvival) {
-        const cdRemaining = this.spellUsable.cooldownRemaining(
-          TALENTS.WILDFIRE_BOMB_TALENT.id,
-          chakramCast.timestamp,
-        );
+        // event.timestamp is the Chakram cast time — SpellUsable state is correct here
+        const cdRemaining = this.spellUsable.cooldownRemaining(TALENTS.WILDFIRE_BOMB_TALENT.id);
         if (cdRemaining <= STALK_AND_STRIKE_CDR) {
           wastedCDR = STALK_AND_STRIKE_CDR - cdRemaining;
           if (wastedCDR > STALK_AND_STRIKE_WASTE_THRESHOLD) {
@@ -120,7 +124,7 @@ export default class MoonlightChakram extends Analyzer {
       } else {
         wastedLockAndLoad = this.selectedCombatant.hasBuff(
           SPELLS.LOCK_AND_LOAD_BUFF.id,
-          chakramCast.timestamp,
+          event.timestamp,
         );
         if (wastedLockAndLoad) {
           performance = QualitativePerformance.Fail;

--- a/src/analysis/retail/hunter/shared/normalizers/SentinelsMarkNormalizer.ts
+++ b/src/analysis/retail/hunter/shared/normalizers/SentinelsMarkNormalizer.ts
@@ -16,8 +16,8 @@ const links: EventLink[] = [
     referencedEventId: [SPELLS.WILDFIRE_BOMB_IMPACT.id, TALENTS.AIMED_SHOT_TALENT.id],
     anyTarget: false,
     anySource: false,
-    forwardBufferMs: 50,
-    backwardBufferMs: 50,
+    forwardBufferMs: 100,
+    backwardBufferMs: 100,
     maximumLinks: 1,
   },
   {

--- a/src/analysis/retail/hunter/survival/CombatLogParser.ts
+++ b/src/analysis/retail/hunter/survival/CombatLogParser.ts
@@ -33,13 +33,15 @@ import BoomstickNormalizer from './normalizers/BoomstickNormalizer';
 import WildfireShells from './modules/talents/WildfireShells';
 import LethalCalibration from './modules/talents/LethalCalibration';
 import WildfireBombNormalizer from './normalizers/WildfireBombNormalizer';
+import RaptorSwipeNormalizer from './normalizers/RaptorSwipeNormalizer';
+import RaptorSwipe from './modules/talents/RaptorSwipe';
 import TipOfTheSpear from './modules/talents/TipOfTheSpear';
 import AplCheck from './modules/apl/AplCheck';
 import MoonlightChakram from '../shared/herotalents/MoonlightChakram';
 import MoonlightChakramNormalizer from '../shared/normalizers/MoonlightChakramNormalizer';
 import SentinelsMark from '../shared/herotalents/SentinelsMark';
 import SentinelsMarkNormalizer from '../shared/normalizers/SentinelsMarkNormalizer';
-import EventLinkNormalizer from '../shared/normalizers/HunterEventLinkNormalizers'; // This has a pack leader normalizer in it useful to Survival so not deleting yet.
+import EventLinkNormalizer from '../shared/normalizers/HunterEventLinkNormalizers';
 import StampedeAnalyzer from '../shared/herotalents/Stampede';
 import HowlBoar from '../shared/herotalents/HowlBoar';
 class CombatLogParser extends CoreCombatLogParser {
@@ -73,6 +75,7 @@ class CombatLogParser extends CoreCombatLogParser {
     tipOfTheSpearNormalizer: TipOfTheSpearNormalizer,
     boomstickNormalizer: BoomstickNormalizer,
     wildfireBombNormalizer: WildfireBombNormalizer,
+    raptorSwipeNormalizer: RaptorSwipeNormalizer,
     moonlightChakramNormalizer: MoonlightChakramNormalizer,
     sentinelsMarkNormalizer: SentinelsMarkNormalizer,
     EventLinkNormalizers: EventLinkNormalizer,
@@ -84,6 +87,7 @@ class CombatLogParser extends CoreCombatLogParser {
     bloodseeker: Bloodseeker,
     killCommand: KillCommand,
     raptorStrike: RaptorStrike,
+    raptorSwipe: RaptorSwipe,
     wildfireBomb: WildfireBomb,
     boomstick: Boomstick,
     tipOfTheSpear: TipOfTheSpear,

--- a/src/analysis/retail/hunter/survival/modules/talents/RaptorSwipe.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/RaptorSwipe.tsx
@@ -1,0 +1,162 @@
+import { formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/hunter';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent, DamageEvent, GetRelatedEvents } from 'parser/core/Events';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
+import { BadColor, GoodColor } from 'interface/guide';
+import {
+  RAPTOR_SWIPE_CAST_IMPACT,
+  RAPTOR_SWIPE_STRIKE_AS_ONE,
+} from '../../normalizers/RaptorSwipeNormalizer';
+
+/**
+ * Raptor Swipe - A cone slash dealing physical damage to all nearby enemies.
+ * Should always be cast with Tip of the Spear active to proc Strike as One.
+ */
+
+class RaptorSwipe extends Analyzer {
+  private useEntries: BoxRowEntry[] = [];
+  private casts = 0;
+  private tippedCasts = 0;
+  private missedCasts = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS.RAPTOR_SWIPE_1_SURVIVAL_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.RAPTOR_SWIPE_DAMAGE),
+      this.onCast,
+    );
+  }
+
+  private onCast = (event: CastEvent) => {
+    this.casts += 1;
+
+    const damageEvents = GetRelatedEvents<DamageEvent>(event, RAPTOR_SWIPE_CAST_IMPACT);
+    const strikeAsOneEvents = GetRelatedEvents<DamageEvent>(event, RAPTOR_SWIPE_STRIKE_AS_ONE);
+    const strikeAsOneDamage = strikeAsOneEvents.reduce(
+      (sum, dmg) => sum + dmg.amount + (dmg.absorbed ?? 0),
+      0,
+    );
+    const hitSomething = damageEvents.length > 0;
+    const wasTipped = this.selectedCombatant.hasBuff(
+      SPELLS.TIP_OF_THE_SPEAR_CAST.id,
+      event.timestamp,
+    );
+
+    if (wasTipped) {
+      this.tippedCasts += 1;
+    }
+    if (!hitSomething) {
+      this.missedCasts += 1;
+    }
+
+    let value: QualitativePerformance;
+    let header: string;
+    let color: string;
+
+    if (!hitSomething) {
+      value = QualitativePerformance.Fail;
+      header = 'Bad cast: missed all targets.';
+      color = BadColor;
+    } else if (wasTipped) {
+      value = QualitativePerformance.Good;
+      header = 'Good cast: tipped.';
+      color = GoodColor;
+    } else {
+      value = QualitativePerformance.Fail;
+      header = 'Bad cast: no tip.';
+      color = BadColor;
+    }
+
+    const targetsHit = damageEvents.length;
+    const swipeDamage = damageEvents.reduce(
+      (sum, dmg) => sum + dmg.amount + (dmg.absorbed ?? 0),
+      0,
+    );
+    const tooltip = (
+      <div>
+        <h5 style={{ color }}>{header}</h5>
+        <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
+        <div>
+          <SpellLink spell={SPELLS.RAPTOR_SWIPE_DAMAGE} />: <strong>{targetsHit}</strong> targets
+          hit <small>({formatNumber(swipeDamage)} damage)</small>
+        </div>
+        {strikeAsOneDamage > 0 && (
+          <div>
+            <SpellLink spell={SPELLS.STRIKE_AS_ONE} />: <strong>{strikeAsOneEvents.length}</strong>{' '}
+            targets hit <small>({formatNumber(strikeAsOneDamage)} damage)</small>
+          </div>
+        )}
+      </div>
+    );
+
+    this.useEntries.push({ value, tooltip });
+  };
+
+  get guideSubsection() {
+    const explanation = (
+      <p>
+        <strong>
+          <SpellLink spell={TALENTS.RAPTOR_SWIPE_1_SURVIVAL_TALENT} />
+        </strong>{' '}
+        should always be cast with <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} />.
+      </p>
+    );
+
+    const data = (
+      <CastSummaryAndBreakdown
+        spell={TALENTS.RAPTOR_SWIPE_1_SURVIVAL_TALENT}
+        castEntries={this.useEntries}
+        badExtraExplanation={<>without Tip of the Spear</>}
+        usesInsteadOfCasts
+      />
+    );
+
+    return explanationAndDataSubsection(explanation, data);
+  }
+
+  statistic() {
+    const tippedPercentage = this.casts > 0 ? (this.tippedCasts / this.casts) * 100 : 0;
+
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(1)}
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+      >
+        <BoringSpellValueText spell={TALENTS.RAPTOR_SWIPE_1_SURVIVAL_TALENT}>
+          <>
+            {this.casts} <small>casts</small>
+            <p>
+              {this.tippedCasts} <small>tipped casts ({tippedPercentage.toFixed(1)}%)</small>
+            </p>
+            {this.missedCasts > 0 && (
+              <>
+                <p>
+                  {this.missedCasts} <small>missed (hit no targets)</small>
+                </p>
+              </>
+            )}
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default RaptorSwipe;

--- a/src/analysis/retail/hunter/survival/modules/talents/WildfireBomb.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/WildfireBomb.tsx
@@ -89,12 +89,19 @@ class WildfireBomb extends Analyzer.withDependencies({
       this.sentinelProcs += 1;
     }
 
-    // Classify performance: Perfect if tipped + sentinel proc, Good if just tipped, Fail if not tipped
+    // Classify performance: pre-pull (first bomb within 5s of fight start) is always Good;
+    // This lets us deal with throwing a bomb late due to an early pull or other shenanigans on pull.
+    const isPrePull =
+      this.casts === 1 && !wasTipped && event.timestamp - this.owner.fight.start_time <= 5_000;
     let value: QualitativePerformance;
     let header: string;
     let color: string;
 
-    if (wasTipped && hadSentinelProc) {
+    if (isPrePull) {
+      value = QualitativePerformance.Good;
+      header = 'Good: pre-pull cast.';
+      color = GoodColor;
+    } else if (wasTipped && hadSentinelProc) {
       value = QualitativePerformance.Perfect;
       header = "Perfect: tipped and proc'd Sentinel's Mark.";
       color = PerfectColor;

--- a/src/analysis/retail/hunter/survival/normalizers/RaptorSwipeNormalizer.ts
+++ b/src/analysis/retail/hunter/survival/normalizers/RaptorSwipeNormalizer.ts
@@ -1,0 +1,39 @@
+import SPELLS from 'common/SPELLS/hunter';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { EventType } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+
+export const RAPTOR_SWIPE_CAST_IMPACT = 'raptor-swipe-cast-impact';
+export const RAPTOR_SWIPE_STRIKE_AS_ONE = 'raptor-swipe-strike-as-one';
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: RAPTOR_SWIPE_CAST_IMPACT,
+    reverseLinkRelation: RAPTOR_SWIPE_CAST_IMPACT,
+    linkingEventId: SPELLS.RAPTOR_SWIPE_DAMAGE.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.RAPTOR_SWIPE_DAMAGE.id,
+    referencedEventType: EventType.Damage,
+    forwardBufferMs: 100,
+    anyTarget: true,
+  },
+  {
+    linkRelation: RAPTOR_SWIPE_STRIKE_AS_ONE,
+    reverseLinkRelation: RAPTOR_SWIPE_STRIKE_AS_ONE,
+    linkingEventId: SPELLS.RAPTOR_SWIPE_DAMAGE.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.STRIKE_AS_ONE.id,
+    referencedEventType: EventType.Damage,
+    forwardBufferMs: 300,
+    anyTarget: true,
+    anySource: true,
+  },
+];
+
+class RaptorSwipeNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export default RaptorSwipeNormalizer;

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -295,6 +295,11 @@ const spells = {
     name: 'Raptor Swipe',
     icon: 'inv12_apextalent_hunter_raptorswipe',
   },
+  STRIKE_AS_ONE: {
+    id: 1251779,
+    name: 'Strike as One',
+    icon: 'inv_coordinatedassault',
+  },
   TAKEDOWN_PET_DAMAGE: {
     id: 1253862,
     name: 'Takedown',


### PR DESCRIPTION
### Description

Adding Analyser for Raptor Swipe Apex. It is a massive misplay to fail to tip swipe as it both hits hard & when tipped causes a 300% strike as one hit so making a cast summary that makes it obvious if it wasn't tipped.

Still no changelog as I have a PR for Takedown (where I'll add the changelog) and then an AplCheck.tsx PR that will come on it's own after that.

- Test report URL: `/report/y6mgBPCHWG72bAx4/10-Heroic+Fallen-King+Salhadaar+-+Kill+(5:49)/203-Percival/standard`

