### PR TITLE
[Survival] Takedown Analyser

### DIFF
--- a/src/analysis/retail/hunter/survival/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/survival/CHANGELOG.tsx
@@ -3,5 +3,6 @@ import { Kivlov,
  } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2026,3,25), 'Add Takedown, Raptor Swipe Analysers', Kivlov),
   change(date(2026, 3, 18), 'Update Survival for launch', Kivlov),
 ];

--- a/src/analysis/retail/hunter/survival/CONFIG.tsx
+++ b/src/analysis/retail/hunter/survival/CONFIG.tsx
@@ -9,8 +9,8 @@ const config: Config = {
   contributors: [Kivlov],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.0',
-  supportLevel: SupportLevel.Foundation,
+  patchCompatibility: '12.0.1',
+  supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/analysis/retail/hunter/survival/CombatLogParser.ts
+++ b/src/analysis/retail/hunter/survival/CombatLogParser.ts
@@ -37,6 +37,7 @@ import RaptorSwipeNormalizer from './normalizers/RaptorSwipeNormalizer';
 import RaptorSwipe from './modules/talents/RaptorSwipe';
 import TipOfTheSpear from './modules/talents/TipOfTheSpear';
 import AplCheck from './modules/apl/AplCheck';
+import Takedown from './modules/talents/Takedown/Takedown';
 import MoonlightChakram from '../shared/herotalents/MoonlightChakram';
 import MoonlightChakramNormalizer from '../shared/normalizers/MoonlightChakramNormalizer';
 import SentinelsMark from '../shared/herotalents/SentinelsMark';
@@ -84,6 +85,7 @@ class CombatLogParser extends CoreCombatLogParser {
     deathTracker: DeathTracker,
 
     //Spells
+    takedown: Takedown,
     bloodseeker: Bloodseeker,
     killCommand: KillCommand,
     raptorStrike: RaptorStrike,

--- a/src/analysis/retail/hunter/survival/modules/guide/sections/rotation/Cooldown.tsx
+++ b/src/analysis/retail/hunter/survival/modules/guide/sections/rotation/Cooldown.tsx
@@ -8,6 +8,7 @@ import CombatLogParser from 'analysis/retail/hunter/survival/CombatLogParser';
 import { SpellLink } from 'interface';
 import TALENTS from 'common/TALENTS/hunter';
 import SPELLS from 'common/SPELLS/hunter';
+import TakedownSection from '../../../talents/Takedown/TakedownSection';
 export default function CooldownSection({ modules, info }: GuideProps<typeof CombatLogParser>) {
   const castEfficiency = useAnalyzer(CastEfficiency);
   if (!info || !castEfficiency) {
@@ -45,6 +46,7 @@ export default function CooldownSection({ modules, info }: GuideProps<typeof Com
           gapHighlightMode={GapHighlight.FullCooldown}
         />
       )}
+      <TakedownSection />
     </Section>
   );
 }

--- a/src/analysis/retail/hunter/survival/modules/guide/sections/rotation/RotationSection.tsx
+++ b/src/analysis/retail/hunter/survival/modules/guide/sections/rotation/RotationSection.tsx
@@ -35,6 +35,7 @@ export default function RotationSection({
           segments show when the spell was cooling down. Red segments highlight times when you could
           have fit a whole extra use of the cooldown.
         </Trans>
+        {modules.raptorSwipe.guideSubsection}
         {modules.wildfireBomb.guideSubsection}
         {modules.boomstick.guideSubsection}
       </SubSection>

--- a/src/analysis/retail/hunter/survival/modules/talents/Takedown/Takedown.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/Takedown/Takedown.tsx
@@ -1,0 +1,311 @@
+import { PerformanceMark } from 'interface/guide';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELLS from 'common/SPELLS/hunter';
+import TALENTS from 'common/TALENTS/hunter';
+import Events, { CastEvent } from 'parser/core/Events';
+import { CooldownExpandableItem } from 'interface/guide/components/CooldownExpandable';
+import SpellLink from 'interface/SpellLink';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import { ReactNode } from 'react';
+import { TooltipElement } from 'interface/Tooltip';
+
+export const TAKEDOWN_WINDOW_MS = 8_000;
+export const WINDOW_EXTENSION_MS = 3_000;
+const BOOMSTICK_LOOKBACK_MS = 6_000;
+const MAX_TIP_STACKS = 3;
+
+export interface TakedownCast {
+  castEvent: CastEvent;
+  isFirstTakedown: boolean;
+  hasRaptorSwipeBuff: boolean;
+  tipStacks: number;
+  boomstickCooldownAtCast: number;
+  hasBoomstickBeforeCast: boolean;
+  wildfireBombCastInWindow: boolean;
+  wastedTipStacks: number;
+  castsInWindow: CastEvent[];
+  windowEnd: number;
+}
+
+export default class Takedown extends Analyzer.withDependencies({ spellUsable: SpellUsable }) {
+  readonly isPackLeader: boolean;
+  private readonly hasTwinFangs: boolean;
+  private readonly hasBoomstick: boolean;
+  private readonly kcStacksGenerated: number;
+
+  readonly takedownCasts: TakedownCast[] = [];
+
+  private lastBoomstickTimestamp = -Infinity;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.isPackLeader = !this.selectedCombatant.hasTalent(TALENTS.MOONLIGHT_CHAKRAM_TALENT);
+    this.hasTwinFangs = this.selectedCombatant.hasTalent(TALENTS.TWIN_FANGS_TALENT);
+    this.hasBoomstick = this.selectedCombatant.hasTalent(TALENTS.BOOMSTICK_TALENT);
+    this.kcStacksGenerated = this.selectedCombatant.hasTalent(TALENTS.PRIMAL_SURGE_TALENT) ? 2 : 1;
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS.TAKEDOWN_TALENT);
+
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onAnyCast);
+  }
+
+  private get currentWindow(): TakedownCast | undefined {
+    return this.takedownCasts.at(-1);
+  }
+
+  private onAnyCast(event: CastEvent) {
+    if (event.ability.guid === TALENTS.BOOMSTICK_TALENT.id) {
+      this.lastBoomstickTimestamp = event.timestamp;
+    }
+
+    if (event.ability.guid === SPELLS.TAKEDOWN_PLAYER.id) {
+      this.onTakedown(event);
+      return;
+    }
+
+    // Accumulate casts that fall inside the current window
+    const window = this.currentWindow;
+    if (window && event.timestamp <= window.windowEnd) {
+      window.castsInWindow.push(event);
+
+      if (event.ability.guid === TALENTS.WILDFIRE_BOMB_TALENT.id) {
+        window.wildfireBombCastInWindow = true;
+      }
+
+      // Kill Command while TotS would overflow the cap = wasted stacks
+      if (event.ability.guid === TALENTS.KILL_COMMAND_SURVIVAL_TALENT.id) {
+        const tipStacks = this.selectedCombatant.getBuffStacks(SPELLS.TIP_OF_THE_SPEAR_CAST.id);
+        const overflow = tipStacks + this.kcStacksGenerated - MAX_TIP_STACKS;
+        if (overflow > 0) {
+          window.wastedTipStacks += overflow;
+        }
+      }
+    }
+  }
+
+  private onTakedown(event: CastEvent) {
+    const isFirstTakedown = this.takedownCasts.length === 0;
+    const hasRaptorSwipeBuff =
+      this.selectedCombatant.hasBuff(SPELLS.RAPTOR_SWIPE_BUFF.id) ||
+      this.selectedCombatant.hasBuff(SPELLS.RAPTOR_SWIPE_BUFF_2.id);
+    const tipStacks = this.selectedCombatant.getBuffStacks(SPELLS.TIP_OF_THE_SPEAR_CAST.id);
+
+    const boomstickCooldownAtCast = this.hasBoomstick
+      ? this.deps.spellUsable.cooldownRemaining(TALENTS.BOOMSTICK_TALENT.id)
+      : 0;
+
+    const hasBoomstickBeforeCast =
+      this.hasBoomstick && event.timestamp - this.lastBoomstickTimestamp <= BOOMSTICK_LOOKBACK_MS;
+
+    const windowEnd = event.timestamp + TAKEDOWN_WINDOW_MS + WINDOW_EXTENSION_MS;
+
+    this.takedownCasts.push({
+      castEvent: event,
+      isFirstTakedown,
+      hasRaptorSwipeBuff,
+      tipStacks,
+      boomstickCooldownAtCast,
+      hasBoomstickBeforeCast,
+      wildfireBombCastInWindow: false,
+      wastedTipStacks: 0,
+      castsInWindow: [],
+      windowEnd,
+    });
+  }
+
+  checklist(cast: TakedownCast): {
+    checklist: CooldownExpandableItem[];
+    perf: QualitativePerformance;
+  } {
+    const items: CooldownExpandableItem[] = [];
+    let overallPerf = QualitativePerformance.Good;
+
+    const downgrade = (perf: QualitativePerformance) => {
+      if (perf < overallPerf) {
+        overallPerf = perf;
+      }
+    };
+
+    // 1. Raptor Swipe buffed before cast
+    const swipeBuffPerf = cast.hasRaptorSwipeBuff
+      ? QualitativePerformance.Good
+      : QualitativePerformance.Fail;
+    downgrade(swipeBuffPerf);
+    items.push({
+      label: (
+        <>
+          <SpellLink spell={SPELLS.RAPTOR_SWIPE_BUFF} />{' '}
+          <TooltipElement
+            content={
+              <>
+                <SpellLink spell={SPELLS.RAPTOR_SWIPE_BUFF} /> can be primed to maximise the number
+                of <SpellLink spell={TALENTS.STRIKE_AS_ONE_TALENT} /> procs from our Apex Talent
+                during <SpellLink spell={TALENTS.TAKEDOWN_TALENT} />.
+              </>
+            }
+          >
+            (?)
+          </TooltipElement>
+        </>
+      ),
+      result: <PerformanceMark perf={swipeBuffPerf} />,
+      details: !cast.hasRaptorSwipeBuff ? (
+        <TooltipElement content="not primed before cast">(?) </TooltipElement>
+      ) : null,
+    });
+
+    // 2. Tip of the Spear active at cast (only without Twin Fangs)
+    if (!this.hasTwinFangs) {
+      const tipPerf =
+        cast.tipStacks > 0 ? QualitativePerformance.Good : QualitativePerformance.Fail;
+      downgrade(tipPerf);
+      items.push({
+        label: (
+          <>
+            Takedown Tipped{' '}
+            <TooltipElement
+              content={
+                <>
+                  Without <SpellLink spell={TALENTS.TWIN_FANGS_TALENT} />, Takedown does not
+                  generate <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} /> stacks on its own.
+                  Cast Takedown with at least one stack active.
+                </>
+              }
+            >
+              (?)
+            </TooltipElement>
+          </>
+        ),
+        result: <PerformanceMark perf={tipPerf} />,
+        details: (
+          <TooltipElement
+            content={`${cast.tipStacks} stack${cast.tipStacks !== 1 ? 's' : ''} at cast`}
+          >
+            (?)
+          </TooltipElement>
+        ),
+      });
+    }
+
+    // 3. No Wildfire Bomb during the Takedown window (Pack Leader only)
+    if (this.isPackLeader) {
+      const wfbPerf = cast.wildfireBombCastInWindow
+        ? QualitativePerformance.Fail
+        : QualitativePerformance.Good;
+      downgrade(wfbPerf);
+      items.push({
+        label: (
+          <>
+            <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} />{' '}
+            <TooltipElement
+              content={
+                <>
+                  <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} /> to extend{' '}
+                  <SpellLink spell={SPELLS.WYVERNS_CRY} /> should be held until after{' '}
+                  <SpellLink spell={TALENTS.TAKEDOWN_TALENT} /> ends, or only used when out of focus
+                  and out of <SpellLink spell={TALENTS.KILL_COMMAND_SURVIVAL_TALENT} /> charges.
+                </>
+              }
+            >
+              (?)
+            </TooltipElement>
+          </>
+        ),
+        result: <PerformanceMark perf={wfbPerf} />,
+        details: cast.wildfireBombCastInWindow ? (
+          <TooltipElement content="cast during Takedown window">(?)</TooltipElement>
+        ) : null,
+      });
+    }
+
+    // 4. Wasted Tip of the Spear (KC cast while capped)
+    const tipWastePerf =
+      cast.wastedTipStacks === 0 ? QualitativePerformance.Good : QualitativePerformance.Fail;
+    downgrade(tipWastePerf);
+    items.push({
+      label: (
+        <>
+          <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} />{' '}
+          <TooltipElement
+            content={
+              <>
+                Spending <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} /> stacks always takes
+                priority over generating new ones. Never use{' '}
+                <SpellLink spell={TALENTS.KILL_COMMAND_SURVIVAL_TALENT} /> when already at 3 stacks
+                — spend on <SpellLink spell={SPELLS.RAPTOR_SWIPE_BUFF} /> first to avoid wasting the
+                generated stack.
+              </>
+            }
+          >
+            (?)
+          </TooltipElement>
+        </>
+      ),
+      result: <PerformanceMark perf={tipWastePerf} />,
+      details:
+        cast.wastedTipStacks > 0 ? (
+          <TooltipElement
+            content={`${cast.wastedTipStacks} stack${cast.wastedTipStacks !== 1 ? 's' : ''} wasted`}
+          >
+            (?)
+          </TooltipElement>
+        ) : null,
+    });
+
+    // 5. Boomstick before Takedown
+    //    First Takedown: always evaluated
+    //    Subsequent Takedowns: only evaluated if Boomstick was available at cast time;
+    //    It largely should not overlap other than on pull due to mismatched cd timess.
+    if (this.hasBoomstick && (cast.isFirstTakedown || cast.boomstickCooldownAtCast === 0)) {
+      let boomstickPerf: QualitativePerformance;
+      let details: ReactNode = null;
+
+      if (cast.hasBoomstickBeforeCast) {
+        boomstickPerf = QualitativePerformance.Good;
+      } else if (cast.isFirstTakedown && cast.boomstickCooldownAtCast > 0) {
+        // First Takedown only: still on CD from an earlier use is acceptable
+        boomstickPerf = QualitativePerformance.Good;
+        details = <TooltipElement content="on cooldown at cast time">(?) </TooltipElement>;
+      } else {
+        // Available but not cast immediately before Takedown
+        boomstickPerf = QualitativePerformance.Fail;
+        details = (
+          <TooltipElement content="was available but not cast before Takedown">(?) </TooltipElement>
+        );
+      }
+
+      downgrade(boomstickPerf);
+      items.push({
+        label: (
+          <>
+            <SpellLink spell={TALENTS.BOOMSTICK_TALENT} />{' '}
+            <TooltipElement
+              content={
+                <>
+                  <SpellLink spell={TALENTS.BOOMSTICK_TALENT} /> should be cast before{' '}
+                  <SpellLink spell={TALENTS.TAKEDOWN_TALENT} /> to build stacks of{' '}
+                  <SpellLink spell={SPELLS.MONGOOSE_FURY} />. If it becomes available during{' '}
+                  <SpellLink spell={TALENTS.TAKEDOWN_TALENT} /> it is fine to cast it then as Pack
+                  Leader, but when available beforehand it should always come first in Single
+                  Target.
+                </>
+              }
+            >
+              (?)
+            </TooltipElement>
+          </>
+        ),
+        result: <PerformanceMark perf={boomstickPerf} />,
+        details,
+      });
+    }
+
+    return { checklist: items, perf: overallPerf };
+  }
+}

--- a/src/analysis/retail/hunter/survival/modules/talents/Takedown/TakedownSection.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/Takedown/TakedownSection.tsx
@@ -1,0 +1,90 @@
+import { SubSection, useAnalyzer, useInfo } from 'interface/guide';
+import { JSX } from 'react';
+import Takedown from './Takedown';
+import SpellLink from 'interface/SpellLink';
+import TALENTS from 'common/TALENTS/hunter';
+import SPELLS from 'common/SPELLS/hunter';
+import { EventType } from 'parser/core/Events';
+import Explanation from 'interface/guide/components/Explanation';
+import CooldownGrid from 'interface/CooldownGrid/CooldownGrid';
+
+const TIMELINE_LOOKBACK_MS = 3_000;
+
+export default function TakedownSection(): JSX.Element | null {
+  const takedown = useAnalyzer(Takedown);
+  const info = useInfo();
+
+  if (!takedown || !info) {
+    return null;
+  }
+
+  if (!takedown.active) {
+    return null;
+  }
+
+  const isPackLeader = takedown.isPackLeader;
+  const hasTwinFangs = info.combatant.hasTalent(TALENTS.TWIN_FANGS_TALENT);
+  const hasBoomstick = info.combatant.hasTalent(TALENTS.BOOMSTICK_TALENT);
+
+  return (
+    <SubSection title={<SpellLink spell={TALENTS.TAKEDOWN_TALENT} />}>
+      <Explanation>
+        <p>
+          Always enter <SpellLink spell={TALENTS.TAKEDOWN_TALENT} /> with a{' '}
+          <SpellLink spell={SPELLS.RAPTOR_SWIPE_BUFF} /> buff active.
+          {isPackLeader && (
+            <>
+              {' '}
+              Never cast <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} /> during the window.
+            </>
+          )}
+        </p>
+        {hasBoomstick && (
+          <p>
+            When <SpellLink spell={TALENTS.BOOMSTICK_TALENT} /> is available, weave it directly
+            before Takedown: Prime Swipe if not active → Boomstick → Takedown.
+          </p>
+        )}
+        {hasTwinFangs ? (
+          <p>
+            With <SpellLink spell={TALENTS.TWIN_FANGS_TALENT} />, Takedown generates{' '}
+            <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} /> stacks on its own. Spend one stack
+            immediately to make room for the beast spawn: Swipe → Kill Command → Strike → Swipe →
+            Strike → Kill Command → Swipe.
+          </p>
+        ) : (
+          <p>
+            Without <SpellLink spell={TALENTS.TWIN_FANGS_TALENT} />, ensure{' '}
+            <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} /> is active when casting Takedown. If
+            you have 0-1 stack after casting Takedown, you can Kill Command immediately, otherwise
+            spend one stack on Raptor and then Kill Command to spawn the beast.
+          </p>
+        )}
+      </Explanation>
+      <CooldownGrid
+        label={<SpellLink spell={TALENTS.TAKEDOWN_TALENT} />}
+        timeline={{
+          cooldowns: [
+            TALENTS.KILL_COMMAND_SURVIVAL_TALENT,
+            TALENTS.WILDFIRE_BOMB_TALENT,
+            TALENTS.BOOMSTICK_TALENT,
+          ],
+        }}
+        table={{
+          type: EventType.Damage,
+        }}
+        items={takedown.takedownCasts.map((cast) => {
+          const { perf, checklist } = takedown.checklist(cast);
+          return {
+            perf,
+            checklistItems: checklist,
+            range: {
+              start: cast.castEvent.timestamp - TIMELINE_LOOKBACK_MS,
+              end: cast.windowEnd,
+            },
+          };
+        })}
+      />
+    </SubSection>
+  );
+}

--- a/src/analysis/retail/hunter/survival/modules/talents/WildfireShells.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/WildfireShells.tsx
@@ -59,12 +59,11 @@ class WildfireShells extends Analyzer.withDependencies({ spellUsable: SpellUsabl
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            Wildfire Shells reduced Wildfire Bomb's cooldown by{' '}
-            <strong>{(this.effectiveCDR / 1000).toFixed(1)}s</strong> total.
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-            <strong>{(this.wastedCDR / 1000).toFixed(1)}s</strong> was wasted (Wildfire Bomb not on
-            cooldown).
+            <p>Wildfire Shells reduced Wildfire Bomb's cooldown by </p>
+            <p>
+              <strong>{(this.wastedCDR / 1000).toFixed(1)}s</strong> was wasted (Wildfire Bomb not
+              on cooldown).
+            </p>
           </>
         }
       >

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -290,6 +290,11 @@ const spells = {
     name: 'Raptor Swipe',
     icon: 'inv12_apextalent_hunter_raptorswipe',
   },
+  RAPTOR_SWIPE_BUFF_2: {
+    id: 1275630,
+    name: 'Raptor Swipe',
+    icon: 'inv12_apextalent_hunter_raptorswipe',
+  },
   RAPTOR_SWIPE_AOTE: {
     id: 1262343,
     name: 'Raptor Swipe',


### PR DESCRIPTION
### Description

This includes the Raptor Swipe addition to the guide cause I forgot to include it on the previous but works out since changelog doesn't include it until now anyways.

Analysis based on Invoke Nizhao(sp?) from Brew. I opted to use a (?) in place of the text and have it apply a tooltip they can mouse over to get a longer explanation of what the error was, and then also for what the rule actually is.

I also discovered raptor swipe actually has two buffs, they do not alternate and they appear to be the same so I made it just check for either.

This also bumps Survival into full maintenance for 12.0.1

- Test report URL: `/report/Nvagzq7FH39ZyWBb/20-Heroic+Vorasius+-+Kill+(5:24)/349-Percival/standard` Pack Leader
-  `/report/T17dWkXFzQ2LjPcC/10/126` Sentinel
Since analysis for takedown differs slightly between them.
- Screenshot(s):
