### PR TITLE
Add `WeightedPerformance` as alternative to `QualitativePerformance` + Elemental Shaman implementation

### DIFF
--- a/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/elemental/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [  
+  change(date(2026, 3, 26), <>Fixed <SpellLink spell={TALENTS_SHAMAN.MASTER_OF_THE_ELEMENTS_TALENT} /> buff ordering, updated performance calculations for <ResourceLink id={RESOURCE_TYPES.MAELSTROM.id} /> spender guide.</>, Seriousnes),
   change(date(2026, 3, 21), <>Updated <SpellLink spell={TALENTS_SHAMAN.ASCENDANCE_ELEMENTAL_TALENT} /> & <ResourceLink id={RESOURCE_TYPES.MAELSTROM.id} /> Spender guides.</>, Seriousnes),
   change(date(2026, 2, 3), <>Updating <SpellLink spell={TALENTS_SHAMAN.STORMKEEPER_TALENT} /> sources of CDR</>, Seriousnes),
   change(date(2025, 12, 17), <>Updated for Midnight</>, Seriousnes)

--- a/src/analysis/retail/shaman/elemental/constants.tsx
+++ b/src/analysis/retail/shaman/elemental/constants.tsx
@@ -24,6 +24,8 @@ export enum NORMALIZER_ORDER {
 export enum EVENT_LINKS {
   Stormkeeper = 'stormkeeper',
   CallOfTheAncestors = 'call-of-the-ancestor',
+  MasterOfTheElementsBuff = 'master-of-the-elements-buff',
+  MasterOfTheElementsConsume = 'master-of-the-elements-consume',
 }
 
 type OverloadSpell = {
@@ -64,4 +66,17 @@ export const OVERLOAD_SPELLS: OverloadSpell[] = [
     spell: TALENTS.TEMPEST_TALENT,
     overloadSpell: SPELLS.TEMPEST_OVERLOAD,
   },
+];
+
+export const MASTER_OF_THE_ELEMENTS_SPELL_WHITELIST = [
+  TALENTS.FROST_SHOCK_TALENT,
+  SPELLS.LIGHTNING_BOLT,
+  TALENTS.CHAIN_LIGHTNING_TALENT,
+  SPELLS.TEMPEST_CAST,
+  TALENTS.ELEMENTAL_BLAST_TALENT,
+  TALENTS.EARTH_SHOCK_TALENT,
+  TALENTS.EARTHQUAKE_1_ELEMENTAL_TALENT,
+  TALENTS.EARTHQUAKE_2_ELEMENTAL_TALENT,
+  TALENTS.VOLTAIC_BLAZE_TALENT,
+  SPELLS.FLAME_SHOCK,
 ];

--- a/src/analysis/retail/shaman/elemental/modules/Buffs.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/Buffs.tsx
@@ -62,6 +62,11 @@ class Buffs extends CoreAuras {
         enabled: combatant.has2PieceByTier(TIERS.MID1),
         triggeredBySpellId: SPELLS.STORMKEEPER_BUFF_AND_CAST.id,
       },
+      {
+        spellId: TALENTS.SPIRITWALKERS_GRACE_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.SPIRITWALKERS_GRACE_TALENT),
+        triggeredBySpellId: TALENTS.SPIRITWALKERS_GRACE_TALENT.id,
+      },
     ];
   }
 }

--- a/src/analysis/retail/shaman/elemental/modules/features/MaelstromSpenders.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/features/MaelstromSpenders.tsx
@@ -1,6 +1,5 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { formatNumber, formatSeconds } from 'common/format';
-import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/shaman';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { SpellLink } from 'interface';
@@ -13,6 +12,7 @@ import GuideSection from 'interface/guide/components/GuideSection';
 import ResourceLink from 'interface/ResourceLink';
 import Events, {
   CastEvent,
+  GetRelatedEvent,
   UpdateSpellUsableEvent,
   UpdateSpellUsableType,
 } from 'parser/core/Events';
@@ -27,6 +27,7 @@ import {
 } from 'parser/ui/WeightedPerformance';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import { type JSX, type ReactNode } from 'react';
+import { EVENT_LINKS } from '../../constants';
 
 interface SpenderCast {
   event: CastEvent;
@@ -107,7 +108,7 @@ class MaelstromSpenders extends Analyzer.withDependencies({
       event: event,
       hasMoTE:
         this.enabledTalents.masterOfTheElements &&
-        this.selectedCombatant.hasBuff(SPELLS.MASTER_OF_THE_ELEMENTS_BUFF.id, event.timestamp, 5),
+        GetRelatedEvent(event, EVENT_LINKS.MasterOfTheElementsConsume) !== undefined,
       currentMaelstrom:
         this.deps.maelstromTracker.current +
         (this.deps.maelstromTracker.lastSpenderInfo?.amount ?? 0),
@@ -286,7 +287,7 @@ class MaelstromSpenders extends Analyzer.withDependencies({
     );
   }
 
-  private getCastStats(cast: SpenderCast): PerCastStat[] {
+  private getCastStats(cast: SpenderCast, overallScore: number): PerCastStat[] {
     const stats: PerCastStat[] = [this.getMaelstromStat(cast), this.getLavaBurstStat(cast)];
 
     if (this.getWasteSinceLastSpender(cast) > 0) {
@@ -297,7 +298,6 @@ class MaelstromSpenders extends Analyzer.withDependencies({
       stats.push(this.getMoteStat(cast));
     }
 
-    const overallScore = this.getOverallScore(cast);
     stats.push({
       value: `${Math.round(overallScore * 100)}%`,
       label: 'Score',
@@ -312,7 +312,7 @@ class MaelstromSpenders extends Analyzer.withDependencies({
    * The two LvB checks measure increasingly severe misses of the same optimization window.
    */
   private static readonly SCORING = {
-    wasteWeight: 2,
+    wasteWeight: 3,
     lavaBurstWeight: 1,
     lavaBurstExtremeWeight: 1,
     /** LvB available beyond this threshold (ms) incurs additional exponential penalty. */
@@ -352,8 +352,8 @@ class MaelstromSpenders extends Analyzer.withDependencies({
 
   private buildPerCastData(): PerCastData[] {
     return this.spenderCasts.map((cast) => {
-      const stats = this.getCastStats(cast);
       const overallScore = this.getOverallScore(cast);
+      const stats = this.getCastStats(cast, overallScore);
 
       return {
         performance: scoreToQualitativePerformance(overallScore),

--- a/src/analysis/retail/shaman/elemental/modules/features/MaelstromSpenders.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/features/MaelstromSpenders.tsx
@@ -18,11 +18,13 @@ import Events, {
 } from 'parser/core/Events';
 import MaelstromTracker from '../resources/MaelstromTracker';
 import MaelstromSpenderInfo from '../core/MaelstromSpenderInfo';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import {
-  evaluateQualitativePerformanceByThreshold,
-  getLowestPerf,
-  QualitativePerformance,
-} from 'parser/ui/QualitativePerformance';
+  computeScore,
+  getAggregatedScore,
+  scoreFromBreakpoints,
+  scoreToQualitativePerformance,
+} from 'parser/ui/WeightedPerformance';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import { type JSX, type ReactNode } from 'react';
 
@@ -105,7 +107,7 @@ class MaelstromSpenders extends Analyzer.withDependencies({
       event: event,
       hasMoTE:
         this.enabledTalents.masterOfTheElements &&
-        this.selectedCombatant.hasBuff(SPELLS.MASTER_OF_THE_ELEMENTS_BUFF.id, event.timestamp),
+        this.selectedCombatant.hasBuff(SPELLS.MASTER_OF_THE_ELEMENTS_BUFF.id, event.timestamp, 5),
       currentMaelstrom:
         this.deps.maelstromTracker.current +
         (this.deps.maelstromTracker.lastSpenderInfo?.amount ?? 0),
@@ -117,19 +119,19 @@ class MaelstromSpenders extends Analyzer.withDependencies({
     this.spenderCasts.push(cast);
   }
 
-  private getLavaBurstOpportunityPerformance(cast: SpenderCast): QualitativePerformance {
+  private getLavaBurstScore(cast: SpenderCast): number {
     if (!this.enabledTalents.masterOfTheElements || cast.hasMoTE) {
-      return QualitativePerformance.Perfect;
+      return 1.0;
     }
+    return scoreFromBreakpoints(cast.lavaBurstAvailableDuration / 1000, [
+      { value: 0, score: 1.0 },
+      { value: 5, score: 0.75 },
+      { value: 10, score: 0.0 },
+    ]);
+  }
 
-    return evaluateQualitativePerformanceByThreshold({
-      actual: cast.lavaBurstAvailableDuration,
-      isLessThan: {
-        perfect: LAVA_BURST_PERFECT_MS,
-        good: LAVA_BURST_GOOD_MS,
-        ok: LAVA_BURST_OK_MS,
-      },
-    });
+  private getLavaBurstOpportunityPerformance(cast: SpenderCast): QualitativePerformance {
+    return scoreToQualitativePerformance(this.getLavaBurstScore(cast));
   }
 
   private isMoteRelevant(cast: SpenderCast): boolean {
@@ -147,16 +149,17 @@ class MaelstromSpenders extends Analyzer.withDependencies({
     return this.getWasteSinceLastSpender(cast) > SIGNIFICANT_OVERCAP_WASTE;
   }
 
+  private getWasteScore(cast: SpenderCast): number {
+    return scoreFromBreakpoints(this.getWasteSinceLastSpender(cast), [
+      { value: 0, score: 1.0 },
+      { value: 5, score: 0.75 },
+      { value: 15, score: 0.5 },
+      { value: SIGNIFICANT_OVERCAP_WASTE, score: 0.0 },
+    ]);
+  }
+
   private getWastePerformance(cast: SpenderCast): QualitativePerformance {
-    if (this.getWasteSinceLastSpender(cast) <= 0) {
-      return QualitativePerformance.Perfect;
-    }
-
-    if (this.isSignificantOvercap(cast)) {
-      return QualitativePerformance.Fail;
-    }
-
-    return QualitativePerformance.Ok;
+    return scoreToQualitativePerformance(this.getWasteScore(cast));
   }
 
   private getMaelstromStat(cast: SpenderCast): PerCastStat {
@@ -294,20 +297,66 @@ class MaelstromSpenders extends Analyzer.withDependencies({
       stats.push(this.getMoteStat(cast));
     }
 
+    const overallScore = this.getOverallScore(cast);
+    stats.push({
+      value: `${Math.round(overallScore * 100)}%`,
+      label: 'Score',
+      performance: scoreToQualitativePerformance(overallScore),
+    });
+
     return stats;
+  }
+
+  /**
+   * Waste is weighted more heavily because overcapping a more serious misplay.
+   * The two LvB checks measure increasingly severe misses of the same optimization window.
+   */
+  private static readonly SCORING = {
+    wasteWeight: 2,
+    lavaBurstWeight: 1,
+    lavaBurstExtremeWeight: 1,
+    /** LvB available beyond this threshold (ms) incurs additional exponential penalty. */
+    lavaBurstExtremeThresholdMs: 10_000,
+    /** Decay rate for the exponential penalty; higher values produce a steeper falloff. */
+    lavaBurstExtremeDecayRate: 0.05,
+  } as const;
+
+  /** Exponential decay penalty for extreme LvB delays (>10s). */
+  private getExtremeLavaBurstScore(cast: SpenderCast): number {
+    if (!this.enabledTalents.masterOfTheElements || cast.hasMoTE) {
+      return 1.0;
+    }
+    return computeScore(cast.lavaBurstAvailableDuration, (ms) =>
+      ms <= MaelstromSpenders.SCORING.lavaBurstExtremeThresholdMs
+        ? 1.0
+        : Math.exp(
+            -MaelstromSpenders.SCORING.lavaBurstExtremeDecayRate *
+              (ms / 1000 - MaelstromSpenders.SCORING.lavaBurstExtremeThresholdMs / 1000),
+          ),
+    );
+  }
+
+  private getOverallScore(cast: SpenderCast): number {
+    return getAggregatedScore([
+      { score: this.getWasteScore(cast), weight: MaelstromSpenders.SCORING.wasteWeight },
+      {
+        score: this.getLavaBurstScore(cast),
+        weight: MaelstromSpenders.SCORING.lavaBurstWeight,
+      },
+      {
+        score: this.getExtremeLavaBurstScore(cast),
+        weight: MaelstromSpenders.SCORING.lavaBurstExtremeWeight,
+      },
+    ]);
   }
 
   private buildPerCastData(): PerCastData[] {
     return this.spenderCasts.map((cast) => {
       const stats = this.getCastStats(cast);
-      const statPerformances = stats.flatMap((stat) =>
-        stat.performance === undefined || stat.label === 'Maelstrom' ? [] : [stat.performance],
-      );
+      const overallScore = this.getOverallScore(cast);
 
       return {
-        performance: this.isSignificantOvercap(cast)
-          ? QualitativePerformance.Fail
-          : getLowestPerf(statPerformances),
+        performance: scoreToQualitativePerformance(overallScore),
         timestamp: this.owner.formatTimestamp(cast.event.timestamp),
         additionalContent: {
           title: 'Cast Details',
@@ -353,7 +402,7 @@ class MaelstromSpenders extends Analyzer.withDependencies({
             },
             {
               value: `${lavaBurstReadyMisses}`,
-              label: 'LvB-Ready Spends',
+              label: 'Missed MOTE Opportunities',
               tooltip: (
                 <>
                   Spenders cast without <SpellLink spell={TALENTS.MASTER_OF_THE_ELEMENTS_TALENT} />{' '}

--- a/src/analysis/retail/shaman/elemental/modules/normalizers/EventLinkNormalizer.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/normalizers/EventLinkNormalizer.tsx
@@ -1,42 +1,84 @@
 import SPELLS from 'common/SPELLS/shaman';
 import TALENTS from 'common/TALENTS/shaman';
 import { Options } from 'parser/core/Analyzer';
-import BaseEventLinkNormalizer from 'parser/core/EventLinkNormalizer';
+import BaseEventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
 import { AnyEvent, EventType, GetRelatedEvents } from 'parser/core/Events';
-import { EVENT_LINKS, NORMALIZER_ORDER } from '../../constants';
+import {
+  EVENT_LINKS,
+  MASTER_OF_THE_ELEMENTS_SPELL_WHITELIST,
+  NORMALIZER_ORDER,
+} from '../../constants';
+
+// stormkeeper applybuff -> stormkeeper begincast
+const stormkeeperEventLink: EventLink = {
+  linkRelation: EVENT_LINKS.Stormkeeper,
+  linkingEventId: SPELLS.STORMKEEPER_BUFF_AND_CAST.id,
+  linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
+  referencedEventId: SPELLS.STORMKEEPER_BUFF_AND_CAST.id,
+  referencedEventType: EventType.BeginCast,
+  forwardBufferMs: -1,
+  backwardBufferMs: 2000,
+  anySource: true,
+  anyTarget: true,
+  maximumLinks: 1,
+  isActive: (c) => c.hasTalent(TALENTS.STORMKEEPER_TALENT),
+};
+
+// call of the ancestors summon -> ancestral swiftness cast
+const callOfTheAncestorsEventLink: EventLink = {
+  linkRelation: EVENT_LINKS.CallOfTheAncestors,
+  linkingEventId: SPELLS.CALL_OF_THE_ANCESTORS_SUMMON.id,
+  linkingEventType: EventType.Summon,
+  referencedEventId: SPELLS.ANCESTRAL_SWIFTNESS_CAST.id,
+  referencedEventType: EventType.Cast,
+  forwardBufferMs: -1, // only look backwards
+  backwardBufferMs: 5,
+  anySource: true,
+  anyTarget: true,
+  maximumLinks: 1,
+  isActive: (c) => c.hasTalent(TALENTS.CALL_OF_THE_ANCESTORS_TALENT),
+  additionalCondition: (le: AnyEvent, re: AnyEvent) =>
+    GetRelatedEvents(re, EVENT_LINKS.CallOfTheAncestors).length === 0,
+};
+
+// lava burst cast -> master of the elements applybuff/refreshbuff
+const masterOfTheElementsBuffEventLink: EventLink = {
+  linkRelation: EVENT_LINKS.MasterOfTheElementsBuff,
+  linkingEventId: TALENTS.LAVA_BURST_TALENT.id,
+  linkingEventType: EventType.Cast,
+  referencedEventId: SPELLS.MASTER_OF_THE_ELEMENTS_BUFF.id,
+  referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+  forwardBufferMs: 30,
+  backwardBufferMs: 10,
+  anyTarget: true,
+  maximumLinks: 1,
+  isActive: (c) => c.hasTalent(TALENTS.MASTER_OF_THE_ELEMENTS_TALENT),
+};
+
+// master of the elements applybuff/refreshbuff -> first whitelist spell cast
+const masterOfTheElementsConsumeEventLink: EventLink = {
+  linkRelation: EVENT_LINKS.MasterOfTheElementsConsume,
+  linkingEventId: SPELLS.MASTER_OF_THE_ELEMENTS_BUFF.id,
+  linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+  referencedEventId: MASTER_OF_THE_ELEMENTS_SPELL_WHITELIST.map((spell) => spell.id),
+  referencedEventType: EventType.Cast,
+  forwardBufferMs: 15_100, // slightly longer than 15s buff duration
+  backwardBufferMs: -1, // only look forward
+  anyTarget: true,
+  maximumLinks: 1,
+  reverseLinkRelation: EVENT_LINKS.MasterOfTheElementsConsume,
+  isActive: (c) => c.hasTalent(TALENTS.MASTER_OF_THE_ELEMENTS_TALENT),
+  additionalCondition: (le: AnyEvent, re: AnyEvent) =>
+    GetRelatedEvents(re, EVENT_LINKS.MasterOfTheElementsConsume).length === 0,
+};
 
 class EventLinkNormalizer extends BaseEventLinkNormalizer {
   constructor(options: Options) {
     super(options, [
-      // stormkeeper applybuff -> stormkeeper begincast
-      {
-        linkRelation: EVENT_LINKS.Stormkeeper,
-        linkingEventId: SPELLS.STORMKEEPER_BUFF_AND_CAST.id,
-        linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
-        referencedEventId: SPELLS.STORMKEEPER_BUFF_AND_CAST.id,
-        referencedEventType: EventType.BeginCast,
-        forwardBufferMs: -1,
-        backwardBufferMs: 2000,
-        anySource: true,
-        anyTarget: true,
-        maximumLinks: 1,
-        isActive: (c) => c.hasTalent(TALENTS.STORMKEEPER_TALENT),
-      },
-      {
-        linkRelation: EVENT_LINKS.CallOfTheAncestors,
-        linkingEventId: SPELLS.CALL_OF_THE_ANCESTORS_SUMMON.id,
-        linkingEventType: EventType.Summon,
-        referencedEventId: SPELLS.ANCESTRAL_SWIFTNESS_CAST.id,
-        referencedEventType: EventType.Cast,
-        forwardBufferMs: -1, // only look backwards
-        backwardBufferMs: 5,
-        anySource: true,
-        anyTarget: true,
-        maximumLinks: 1,
-        isActive: (c) => c.hasTalent(TALENTS.CALL_OF_THE_ANCESTORS_TALENT),
-        additionalCondition: (le: AnyEvent, re: AnyEvent) =>
-          GetRelatedEvents(re, EVENT_LINKS.CallOfTheAncestors).length === 0,
-      },
+      stormkeeperEventLink,
+      callOfTheAncestorsEventLink,
+      masterOfTheElementsBuffEventLink,
+      masterOfTheElementsConsumeEventLink,
     ]);
     this.priority = NORMALIZER_ORDER.EventLink;
   }

--- a/src/analysis/retail/shaman/elemental/modules/talents/Ascendance.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/talents/Ascendance.tsx
@@ -13,6 +13,7 @@ import Events, {
   EventType,
   FightEndEvent,
   GlobalCooldownEvent,
+  ResourceChangeEvent,
   RefreshBuffEvent,
   SpendResourceEvent,
 } from 'parser/core/Events';
@@ -34,7 +35,7 @@ import MaelstromTracker from '../resources/MaelstromTracker';
 import ResourceLink from 'interface/ResourceLink';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { getGlobalCooldown } from 'analysis/retail/shaman/shared/shared';
-import { ON_CAST_BUFF_REMOVAL_GRACE_MS, OVERLOAD_SPELLS } from '../../constants';
+import { OVERLOAD_SPELLS } from '../../constants';
 
 interface AscendanceTimeline {
   start: number;
@@ -54,9 +55,11 @@ type AscendanceTimelineEvent =
 interface AscendanceCooldownCast {
   event: CastEvent | ApplyBuffEvent | RefreshBuffEvent;
   timeline: AscendanceTimeline;
+  startingMaelstrom: number;
   endingMaelstrom: number;
   spendersCast: number;
   maelstromSpent: number;
+  resourceChanges: ResourceChangeEvent[];
 }
 
 interface CastWindowInterval {
@@ -88,6 +91,7 @@ class Ascendance extends Analyzer.withDependencies({
     }
 
     this.addEventListener(Events.GlobalCooldown, this.onGlobalCooldown);
+    this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.onResourceChange);
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS.ASCENDANCE_ELEMENTAL_TALENT),
       this.onApplyAscendance,
@@ -131,9 +135,11 @@ class Ascendance extends Analyzer.withDependencies({
           start: Math.max(event.timestamp, this.globalCooldownEnds),
           events: [],
         },
+        startingMaelstrom: this.deps.maelstromTracker.current,
         endingMaelstrom: this.deps.maelstromTracker.current,
         spendersCast: 0,
         maelstromSpent: 0,
+        resourceChanges: [],
       };
     }
   }
@@ -180,6 +186,18 @@ class Ascendance extends Analyzer.withDependencies({
       this.currentCooldown.spendersCast += 1;
       this.currentCooldown.maelstromSpent += event.resourceChange;
     }
+  }
+
+  onResourceChange(event: ResourceChangeEvent) {
+    if (
+      !this.currentCooldown ||
+      event.resourceChangeType !== RESOURCE_TYPES.MAELSTROM.id ||
+      event.targetID !== this.selectedCombatant.id
+    ) {
+      return;
+    }
+
+    this.currentCooldown.resourceChanges.push(event);
   }
 
   private getGlobalCooldownEnd(event: CastEvent | BeginCastEvent | BeginChannelEvent) {
@@ -359,7 +377,7 @@ class Ascendance extends Analyzer.withDependencies({
   }
 
   private getAverageGlobalCooldown(cast: AscendanceCooldownCast) {
-    const gcdDurations = this.buildCastIntervals(cast)
+    const gcdDurations = this.getActionableCastIntervals(cast)
       .map((interval) => getGlobalCooldown(interval.triggerEvent))
       .filter((event): event is GlobalCooldownEvent => event !== undefined)
       .map((event) => event.duration);
@@ -371,15 +389,66 @@ class Ascendance extends Analyzer.withDependencies({
     return gcdDurations.reduce((total, duration) => total + duration, 0) / gcdDurations.length;
   }
 
+  private isAscendanceActivationEvent(event: CastEvent | BeginCastEvent | BeginChannelEvent) {
+    return event.ability.guid === TALENTS.ASCENDANCE_ELEMENTAL_TALENT.id;
+  }
+
+  private getActionableCastIntervals(cast: AscendanceCooldownCast) {
+    return this.buildCastIntervals(cast).filter(
+      (interval) =>
+        interval.triggerEvent.sourceID === this.selectedCombatant.id &&
+        !this.isAscendanceActivationEvent(interval.triggerEvent),
+    );
+  }
+
+  private getNetMaelstromGenerated(events: ResourceChangeEvent[]) {
+    return events.reduce(
+      (total, event) => total + Math.max(event.resourceChange - event.waste, 0),
+      0,
+    );
+  }
+
+  private getMaxSpenders(cast: AscendanceCooldownCast) {
+    const actionableIntervals = this.getActionableCastIntervals(cast);
+    const lastInterval = actionableIntervals.at(-1);
+    const averageGlobalCooldown = this.getAverageGlobalCooldown(cast);
+    const trailingAvailableTime = this.getTrailingAvailableTime(cast);
+
+    let spendableGeneration = this.getNetMaelstromGenerated(cast.resourceChanges);
+
+    if (lastInterval && trailingAvailableTime < averageGlobalCooldown) {
+      spendableGeneration -= this.getNetMaelstromGenerated(
+        cast.resourceChanges.filter((event) => event.timestamp >= lastInterval.start),
+      );
+    }
+
+    const totalSpendableMaelstrom = cast.startingMaelstrom + Math.max(spendableGeneration, 0);
+
+    return Math.max(Math.floor(totalSpendableMaelstrom / this.spenderCost), cast.spendersCast);
+  }
+
   private getSpenderPerformance(cast: AscendanceCooldownCast): PerCastStat {
+    const maxSpenders = this.getMaxSpenders(cast);
+    const missedSpenders = Math.max(maxSpenders - cast.spendersCast, 0);
+
     return {
-      value: `${cast.spendersCast}`,
+      value: `${cast.spendersCast}/${maxSpenders}`,
       label: 'Spenders',
+      tooltip: (
+        <>
+          You cast <strong>{cast.spendersCast}</strong> out of a maximum of{' '}
+          <strong>{maxSpenders}</strong> <SpellLink spell={this.spender.spell} /> casts this window,
+          based on starting <ResourceLink id={RESOURCE_TYPES.MAELSTROM.id} />, net{' '}
+          <ResourceLink id={RESOURCE_TYPES.MAELSTROM.id} /> gained during Ascendance, and any gain
+          that happened too late to convert into another spender.
+        </>
+      ),
       performance: evaluateQualitativePerformanceByThreshold({
-        actual: cast.spendersCast,
-        isGreaterThanOrEqual: {
-          perfect: 2,
-          ok: 1,
+        actual: missedSpenders,
+        isLessThanOrEqual: {
+          perfect: 0,
+          good: 1,
+          ok: 2,
         },
       }),
     };
@@ -403,16 +472,12 @@ class Ascendance extends Analyzer.withDependencies({
   }
 
   private getNonOverloadCapableSpellCount(cast: AscendanceCooldownCast) {
-    return this.buildCastIntervals(cast).filter((interval) => {
+    return this.getActionableCastIntervals(cast).filter((interval) => {
       const event = interval.triggerEvent;
 
       return (
         event.sourceID === this.selectedCombatant.id &&
         getGlobalCooldown(event) !== undefined &&
-        !(
-          event.ability.guid === TALENTS.ASCENDANCE_ELEMENTAL_TALENT.id &&
-          event.timestamp === cast.timeline.start
-        ) &&
         !overloadCapableSpellIds.has(event.ability.guid)
       );
     }).length;
@@ -421,13 +486,11 @@ class Ascendance extends Analyzer.withDependencies({
   private getNonOverloadCapableSpellBreakdown(cast: AscendanceCooldownCast) {
     const spellCounts = new Map<number, { name: string; count: number }>();
 
-    this.buildCastIntervals(cast).forEach((interval) => {
+    this.getActionableCastIntervals(cast).forEach((interval) => {
       const event = interval.triggerEvent;
       if (
         event.sourceID !== this.selectedCombatant.id ||
         getGlobalCooldown(event) === undefined ||
-        (event.ability.guid === TALENTS.ASCENDANCE_ELEMENTAL_TALENT.id &&
-          event.timestamp === cast.timeline.start) ||
         overloadCapableSpellIds.has(event.ability.guid)
       ) {
         return;
@@ -483,35 +546,33 @@ class Ascendance extends Analyzer.withDependencies({
   }
 
   private buildSpellSequence(cast: AscendanceCooldownCast): CastInSequence[] {
-    return this.buildCastIntervals(cast)
-      .filter((interval) => interval.triggerEvent.sourceID === this.selectedCombatant.id)
-      .map((interval) => {
-        const event = interval.triggerEvent;
-        const ability = event.ability;
-        const isCancelled =
-          (event.type === EventType.BeginChannel || event.type === EventType.BeginCast) &&
-          (interval.cancelled || event.isCancelled);
+    return this.getActionableCastIntervals(cast).map((interval) => {
+      const event = interval.triggerEvent;
+      const ability = event.ability;
+      const isCancelled =
+        (event.type === EventType.BeginChannel || event.type === EventType.BeginCast) &&
+        (interval.cancelled || event.isCancelled);
 
-        return {
-          timestamp: event.timestamp,
-          spellId: ability.guid,
-          spellName: ability.name,
-          icon: ability.abilityIcon.replace('.jpg', ''),
-          performance: isCancelled ? QualitativePerformance.Fail : undefined,
-          tooltip: (
-            <>
-              <strong>
-                {event.type === EventType.BeginChannel || event.type === EventType.BeginCast
-                  ? 'Started'
-                  : 'Cast'}
-              </strong>{' '}
-              <SpellLink spell={ability.guid} />
-              <div>@ {this.owner.formatTimestamp(event.timestamp)}</div>
-              {isCancelled ? <div>Cast never finished.</div> : null}
-            </>
-          ),
-        };
-      });
+      return {
+        timestamp: event.timestamp,
+        spellId: ability.guid,
+        spellName: ability.name,
+        icon: ability.abilityIcon.replace('.jpg', ''),
+        performance: isCancelled ? QualitativePerformance.Fail : undefined,
+        tooltip: (
+          <>
+            <strong>
+              {event.type === EventType.BeginChannel || event.type === EventType.BeginCast
+                ? 'Started'
+                : 'Cast'}
+            </strong>{' '}
+            <SpellLink spell={ability.guid} />
+            <div>@ {this.owner.formatTimestamp(event.timestamp)}</div>
+            {isCancelled ? <div>Cast never finished.</div> : null}
+          </>
+        ),
+      };
+    });
   }
 
   get spenderCost() {
@@ -522,58 +583,13 @@ class Ascendance extends Analyzer.withDependencies({
     return this.deps.spenderInfo.spender;
   }
 
-  private isValidSpenderReplacement(event: CastEvent | BeginCastEvent | BeginChannelEvent) {
-    return (
-      event.ability.guid === SPELLS.TEMPEST_CAST.id ||
-      (event.ability.guid === SPELLS.LIGHTNING_BOLT.id &&
-        this.selectedCombatant.hasBuff(
-          SPELLS.STORMKEEPER_BUFF_AND_CAST.id,
-          event.timestamp,
-          ON_CAST_BUFF_REMOVAL_GRACE_MS,
-        ))
-    );
-  }
-
-  private getMissedSpendersPerformance(cast: AscendanceCooldownCast): PerCastStat {
-    const possibleAdditionalSpenders = Math.min(
-      Math.floor(cast.endingMaelstrom / this.spenderCost),
-      Math.floor(this.getTrailingAvailableTime(cast) / this.getAverageGlobalCooldown(cast)),
-    );
-    const validReplacementCasts = this.buildCastIntervals(cast).filter(
-      (interval) =>
-        interval.triggerEvent.sourceID === this.selectedCombatant.id &&
-        !interval.cancelled &&
-        this.isValidSpenderReplacement(interval.triggerEvent),
-    ).length;
-    const missedSpenders = Math.max(possibleAdditionalSpenders - validReplacementCasts, 0);
-
-    return {
-      value: `${missedSpenders}`,
-      label: 'Missed Spenders',
-      tooltip: (
-        <>
-          Additional <SpellLink spell={this.spender.spell} /> casts that could have fit into the
-          window.
-        </>
-      ),
-      performance: evaluateQualitativePerformanceByThreshold({
-        actual: missedSpenders,
-        isLessThanOrEqual: {
-          perfect: 1,
-          ok: 2,
-        },
-      }),
-    };
-  }
-
   private buildPerCastData(): PerCastData[] {
     return this.cooldownWindows.map((cast) => {
       const sequence = this.buildSpellSequence(cast);
       const spendersStat = this.getSpenderPerformance(cast);
       const downtimeStat = this.getDowntimePerformance(cast);
       const nonOverloadStat = this.getNonOverloadPerformance(cast);
-      const extraSpendersStat = this.getMissedSpendersPerformance(cast);
-      const scoredStats = [spendersStat, downtimeStat, nonOverloadStat, extraSpendersStat];
+      const scoredStats = [spendersStat, downtimeStat, nonOverloadStat];
 
       return {
         performance: getAveragePerf(
@@ -585,7 +601,7 @@ class Ascendance extends Analyzer.withDependencies({
           {
             value: `${cast.endingMaelstrom}`,
             label: 'Ending Maelstrom',
-            performance: extraSpendersStat.performance,
+            performance: spendersStat.performance,
           },
         ],
         details: null,

--- a/src/analysis/retail/shaman/elemental/modules/talents/MasterOfTheElements.tsx
+++ b/src/analysis/retail/shaman/elemental/modules/talents/MasterOfTheElements.tsx
@@ -1,22 +1,15 @@
-import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/shaman';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, { CastEvent, GetRelatedEvent } from 'parser/core/Events';
 import Statistic from 'parser/ui/Statistic';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import Combatant from 'parser/core/Combatant';
-import Spell from 'common/SPELLS/Spell';
 import { addAdditionalCastInformation } from 'parser/core/EventMetaLib';
 import styled from '@emotion/styled';
 import { isMythicPlus } from 'common/isMythicPlus';
-
-interface MasterOfTheElementsSpellConfig {
-  castSpell: Spell | Spell[];
-  condition?: ((c: Combatant) => boolean) | boolean | undefined;
-}
+import { EVENT_LINKS, MASTER_OF_THE_ELEMENTS_SPELL_WHITELIST } from '../../constants';
 
 const MasterOfTheElementsTable = styled.table`
   font-size: 16px;
@@ -25,36 +18,6 @@ const MasterOfTheElementsTable = styled.table`
   }
   width: 100%;
 `;
-
-const MASTER_OF_THE_ELEMENTS_CONFIG: Record<string, MasterOfTheElementsSpellConfig> = {
-  FROST_SHOCK: {
-    castSpell: TALENTS.FROST_SHOCK_TALENT,
-    condition: (c) => c.hasTalent(TALENTS.FROST_SHOCK_TALENT),
-  },
-  LIGHTNING_BOLT: {
-    castSpell: SPELLS.LIGHTNING_BOLT,
-  },
-  CHAIN_LIGHTNING: {
-    castSpell: TALENTS.CHAIN_LIGHTNING_TALENT,
-  },
-  TEMPEST: {
-    castSpell: SPELLS.TEMPEST_CAST,
-  },
-  ELEMENTAL_BLAST: {
-    castSpell: TALENTS.ELEMENTAL_BLAST_TALENT,
-    condition: (c) => c.hasTalent(TALENTS.ELEMENTAL_BLAST_TALENT),
-  },
-  EARTH_SHOCK: {
-    castSpell: TALENTS.EARTH_SHOCK_TALENT,
-    condition: (c) => c.hasTalent(TALENTS.EARTH_SHOCK_TALENT),
-  },
-  EARTHQUAKE: {
-    castSpell: [TALENTS.EARTHQUAKE_1_ELEMENTAL_TALENT, TALENTS.EARTHQUAKE_2_ELEMENTAL_TALENT],
-    condition: (c) =>
-      c.hasTalent(TALENTS.EARTHQUAKE_1_ELEMENTAL_TALENT) ||
-      c.hasTalent(TALENTS.EARTHQUAKE_2_ELEMENTAL_TALENT),
-  },
-};
 
 class MasterOfTheElements extends Analyzer {
   moteBuffedAbilities = new Map<number, number>();
@@ -69,28 +32,17 @@ class MasterOfTheElements extends Analyzer {
       return;
     }
 
-    const castSpellFilter: Spell[] = [];
-
-    Object.keys(MASTER_OF_THE_ELEMENTS_CONFIG).forEach((spell) => {
-      const config = MASTER_OF_THE_ELEMENTS_CONFIG[spell];
-      if (
-        !config.condition ||
-        (typeof config.condition === 'boolean' && config.condition) ||
-        config.condition(this.selectedCombatant)
-      ) {
-        const castSpells = Array.isArray(config.castSpell) ? config.castSpell : [config.castSpell];
-        castSpellFilter.push(...castSpells);
-        this.moteSpellIds.push(...castSpells.map((s) => s.id));
-      }
-    });
-
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(castSpellFilter), this.onCast);
+    this.moteSpellIds = MASTER_OF_THE_ELEMENTS_SPELL_WHITELIST.map((s) => s.id);
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(MASTER_OF_THE_ELEMENTS_SPELL_WHITELIST),
+      this.onCast,
+    );
   }
 
   onCast(event: CastEvent) {
     if (
       this.moteSpellIds.includes(event.ability.guid) &&
-      this.selectedCombatant.hasBuff(SPELLS.MASTER_OF_THE_ELEMENTS_BUFF, event.timestamp)
+      GetRelatedEvent(event, EVENT_LINKS.MasterOfTheElementsConsume) !== undefined
     ) {
       this.moteBuffedAbilities.set(
         event.ability.guid,
@@ -113,28 +65,26 @@ class MasterOfTheElements extends Analyzer {
         size="flexible"
       >
         <TalentSpellText talent={TALENTS.MASTER_OF_THE_ELEMENTS_TALENT}>
-          <MasterOfTheElementsTable>
-            <table className="table table-condensed">
-              <thead>
-                <tr>
-                  <th>Ability</th>
-                  <th>Number of Buffed Casts</th>
-                </tr>
-              </thead>
-              <tbody>
-                {[...this.moteBuffedAbilities.entries()]
-                  .sort((a, b) => b[1] - a[1])
-                  .filter(([_, casts]) => casts > 0)
-                  .map(([spellId, casts]) => (
-                    <tr key={spellId}>
-                      <td>
-                        <SpellLink spell={spellId} />
-                      </td>
-                      <td>{casts}</td>
-                    </tr>
-                  ))}
-              </tbody>
-            </table>
+          <MasterOfTheElementsTable className="table table-condensed">
+            <thead>
+              <tr>
+                <th>Ability</th>
+                <th>Number of Buffed Casts</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[...this.moteBuffedAbilities.entries()]
+                .sort((a, b) => b[1] - a[1])
+                .filter(([_, casts]) => casts > 0)
+                .map(([spellId, casts]) => (
+                  <tr key={spellId}>
+                    <td>
+                      <SpellLink spell={spellId} />
+                    </td>
+                    <td>{casts}</td>
+                  </tr>
+                ))}
+            </tbody>
           </MasterOfTheElementsTable>
         </TalentSpellText>
       </Statistic>

--- a/src/analysis/retail/shaman/shared/Abilities.tsx
+++ b/src/analysis/retail/shaman/shared/Abilities.tsx
@@ -177,9 +177,7 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS.SPIRITWALKERS_GRACE_TALENT),
         category: SPELL_CATEGORY.UTILITY,
         cooldown: combatant.hasTalent(TALENTS.GRACEFUL_SPIRIT_TALENT) ? 90 : 120,
-        gcd: {
-          static: 0,
-        },
+        gcd: null,
       },
       {
         spell: TALENTS.PURGE_TALENT.id,

--- a/src/analysis/retail/shaman/shared/Abilities.tsx
+++ b/src/analysis/retail/shaman/shared/Abilities.tsx
@@ -177,7 +177,9 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS.SPIRITWALKERS_GRACE_TALENT),
         category: SPELL_CATEGORY.UTILITY,
         cooldown: combatant.hasTalent(TALENTS.GRACEFUL_SPIRIT_TALENT) ? 90 : 120,
-        gcd: null,
+        gcd: {
+          static: 0,
+        },
       },
       {
         spell: TALENTS.PURGE_TALENT.id,

--- a/src/parser/ui/WeightedPerformance.ts
+++ b/src/parser/ui/WeightedPerformance.ts
@@ -19,19 +19,19 @@ export interface ScoreBreakpoint {
 }
 
 /**
- * A single scored check with a relative importance weighting and optional penalty cap.
+ * A single scored check with a relative importance weighting and optional score floor.
  *
  * `score` should be in [0.0, 1.0].
  * `weight` is a relative importance factor — only the ratio between weights matters.
- * `maxPenalty` (optional, 0.0–1.0) caps how much penalty this check can contribute.
- *   Without it, a score of 0.0 contributes a full penalty of 1.0.
- *   With maxPenalty=0.3, even a score of 0.0 contributes at most 0.3 penalty.
+ * `minScore` (optional, 0.0–1.0) floors the effective score this check contributes.
+ *   Without it, a score of 0.0 contributes 0.0 to the weighted average.
+ *   With minScore=0.7, even a score of 0.0 contributes at least 0.7.
  *   This allows secondary checks to influence the result without dominating it.
  */
 export interface ScoredCheck {
   score: number;
   weight: number;
-  maxPenalty?: number;
+  minScore?: number;
 }
 
 /**
@@ -92,21 +92,23 @@ export function computeScore(actual: number, strategy: ScoringStrategy): number 
  */
 export function scoreFromBreakpoints(actual: number, breakpoints: ScoreBreakpoint[]): number {
   if (breakpoints.length === 0) {
-    return 0;
+    throw new Error('scoreFromBreakpoints: breakpoints array must not be empty');
   }
   if (breakpoints.length === 1) {
-    return Math.max(0, Math.min(1, breakpoints[0].score));
+    throw new Error(
+      'scoreFromBreakpoints: at least two breakpoints are required for interpolation',
+    );
   }
 
   // Clamp below first breakpoint
   if (actual <= breakpoints[0].value) {
-    return breakpoints[0].score;
+    return Math.max(0, Math.min(1, breakpoints[0].score));
   }
 
   // Clamp above last breakpoint
   const last = breakpoints[breakpoints.length - 1];
   if (actual >= last.value) {
-    return last.score;
+    return Math.max(0, Math.min(1, last.score));
   }
 
   // Linear interpolation between the two surrounding breakpoints
@@ -114,25 +116,30 @@ export function scoreFromBreakpoints(actual: number, breakpoints: ScoreBreakpoin
     const lower = breakpoints[i];
     const upper = breakpoints[i + 1];
     if (actual >= lower.value && actual <= upper.value) {
-      const t = (actual - lower.value) / (upper.value - lower.value);
+      const range = upper.value - lower.value;
+      if (range === 0) {
+        throw new Error(
+          `scoreFromBreakpoints: adjacent breakpoints at index ${i} and ${i + 1} have the same value (${lower.value})`,
+        );
+      }
+      const t = (actual - lower.value) / range;
       const interpolated = lower.score + t * (upper.score - lower.score);
       return Math.max(0, Math.min(1, interpolated));
     }
   }
 
-  return last.score;
+  return Math.max(0, Math.min(1, last.score));
 }
 
 /**
  * Computes a weighted average score from an array of checks, with optional per-check
- * penalty capping via `maxPenalty`.
+ * score floor via `minScore`.
  *
- * Each check's penalty is `1 - score`. If `maxPenalty` is set, the penalty is capped
- * at that value before entering the weighted average. The final score is:
+ * Each check's effective score is `max(score, minScore ?? 0)`. The final score is:
  *
- *   `1 - Σ(effectivePenalty × weight) / Σ(weight)`
+ *   `Σ(effectiveScore × weight) / Σ(weight)`
  *
- * When no check has `maxPenalty`, this is equivalent to a standard weighted average.
+ * When no check has `minScore`, this is a standard weighted average of the scores.
  *
  * Returns a value in [0.0, 1.0]. Returns 0 if the array is empty or total weight is zero.
  */
@@ -145,18 +152,17 @@ export function getAggregatedScore(checks: ScoredCheck[]): number {
     return 0;
   }
 
-  let weightedPenaltySum = 0;
+  let weightedScoreSum = 0;
   for (const check of checks) {
     const score = Math.max(0, Math.min(1, check.score));
-    const penalty = 1 - score;
-    const effectivePenalty =
-      check.maxPenalty !== undefined
-        ? Math.min(penalty, Math.max(0, Math.min(1, check.maxPenalty)))
-        : penalty;
-    weightedPenaltySum += effectivePenalty * check.weight;
+    const effectiveScore =
+      check.minScore !== undefined
+        ? Math.max(score, Math.max(0, Math.min(1, check.minScore)))
+        : score;
+    weightedScoreSum += effectiveScore * check.weight;
   }
 
-  return Math.max(0, Math.min(1, 1 - weightedPenaltySum / totalWeight));
+  return Math.max(0, Math.min(1, weightedScoreSum / totalWeight));
 }
 
 /**

--- a/src/parser/ui/WeightedPerformance.ts
+++ b/src/parser/ui/WeightedPerformance.ts
@@ -1,0 +1,181 @@
+import { QualitativePerformance } from './QualitativePerformance';
+
+/**
+ * A single breakpoint defining what score a raw value maps to.
+ * Breakpoints must be provided sorted ascending by `value`.
+ *
+ * Supports both "lower is better" and "higher is better" by varying the
+ * direction of `score` values across breakpoints.
+ *
+ * Example — "lower is better" (e.g. resource waste):
+ *   [{ value: 0, score: 1.0 }, { value: 5, score: 0.75 }, { value: 25, score: 0.0 }]
+ *
+ * Example — "higher is better" (e.g. uptime):
+ *   [{ value: 0.0, score: 0.0 }, { value: 0.75, score: 0.75 }, { value: 1.0, score: 1.0 }]
+ */
+export interface ScoreBreakpoint {
+  value: number;
+  score: number;
+}
+
+/**
+ * A single scored check with a relative importance weighting and optional penalty cap.
+ *
+ * `score` should be in [0.0, 1.0].
+ * `weight` is a relative importance factor — only the ratio between weights matters.
+ * `maxPenalty` (optional, 0.0–1.0) caps how much penalty this check can contribute.
+ *   Without it, a score of 0.0 contributes a full penalty of 1.0.
+ *   With maxPenalty=0.3, even a score of 0.0 contributes at most 0.3 penalty.
+ *   This allows secondary checks to influence the result without dominating it.
+ */
+export interface ScoredCheck {
+  score: number;
+  weight: number;
+  maxPenalty?: number;
+}
+
+/**
+ * Configurable thresholds for mapping a continuous score to a QualitativePerformance rating.
+ * Each threshold is the minimum score required for that rating.
+ * Defaults: perfect ≥ 0.95, good ≥ 0.75, ok ≥ 0.5, fail < 0.5.
+ */
+export interface PerformanceScoreThresholds {
+  perfect?: number;
+  good?: number;
+  ok?: number;
+}
+
+const DEFAULT_THRESHOLDS: Required<PerformanceScoreThresholds> = {
+  perfect: 0.95,
+  good: 0.75,
+  ok: 0.5,
+};
+
+/**
+ * A function that maps a raw value to a score in [0.0, 1.0].
+ * The function is responsible for its own clamping — the output will be
+ * clamped to [0, 1] by `computeScore`.
+ *
+ * Example — exponential decay for resource waste:
+ *   `(waste) => Math.exp(-waste / 10)`
+ *
+ * Example — logarithmic scaling for uptime percentage:
+ *   `(uptime) => Math.min(1, Math.log(1 + uptime * 9) / Math.log(10))`
+ */
+export type ScoreFunction = (actual: number) => number;
+
+/**
+ * A scoring strategy: either an array of breakpoints for linear interpolation,
+ * or a custom function for arbitrary mappings (exponential, logarithmic, etc.).
+ */
+export type ScoringStrategy = ScoreBreakpoint[] | ScoreFunction;
+
+/**
+ * Maps a raw value to a continuous score in [0.0, 1.0] using the provided strategy.
+ *
+ * - If `strategy` is a `ScoreBreakpoint[]`, uses linear interpolation (via `scoreFromBreakpoints`).
+ * - If `strategy` is a function, calls it directly and clamps the result to [0, 1].
+ */
+export function computeScore(actual: number, strategy: ScoringStrategy): number {
+  if (typeof strategy === 'function') {
+    return Math.max(0, Math.min(1, strategy(actual)));
+  }
+  return scoreFromBreakpoints(actual, strategy);
+}
+
+/**
+ * Maps a raw value to a continuous score in [0.0, 1.0] using linear interpolation
+ * between the provided breakpoints.
+ *
+ * Breakpoints must be sorted ascending by `value`. Values outside the breakpoint
+ * range are clamped to the nearest boundary's score.
+ */
+export function scoreFromBreakpoints(actual: number, breakpoints: ScoreBreakpoint[]): number {
+  if (breakpoints.length === 0) {
+    return 0;
+  }
+  if (breakpoints.length === 1) {
+    return Math.max(0, Math.min(1, breakpoints[0].score));
+  }
+
+  // Clamp below first breakpoint
+  if (actual <= breakpoints[0].value) {
+    return breakpoints[0].score;
+  }
+
+  // Clamp above last breakpoint
+  const last = breakpoints[breakpoints.length - 1];
+  if (actual >= last.value) {
+    return last.score;
+  }
+
+  // Linear interpolation between the two surrounding breakpoints
+  for (let i = 0; i < breakpoints.length - 1; i++) {
+    const lower = breakpoints[i];
+    const upper = breakpoints[i + 1];
+    if (actual >= lower.value && actual <= upper.value) {
+      const t = (actual - lower.value) / (upper.value - lower.value);
+      const interpolated = lower.score + t * (upper.score - lower.score);
+      return Math.max(0, Math.min(1, interpolated));
+    }
+  }
+
+  return last.score;
+}
+
+/**
+ * Computes a weighted average score from an array of checks, with optional per-check
+ * penalty capping via `maxPenalty`.
+ *
+ * Each check's penalty is `1 - score`. If `maxPenalty` is set, the penalty is capped
+ * at that value before entering the weighted average. The final score is:
+ *
+ *   `1 - Σ(effectivePenalty × weight) / Σ(weight)`
+ *
+ * When no check has `maxPenalty`, this is equivalent to a standard weighted average.
+ *
+ * Returns a value in [0.0, 1.0]. Returns 0 if the array is empty or total weight is zero.
+ */
+export function getAggregatedScore(checks: ScoredCheck[]): number {
+  if (checks.length === 0) {
+    return 0;
+  }
+  const totalWeight = checks.reduce((sum, c) => sum + c.weight, 0);
+  if (totalWeight === 0) {
+    return 0;
+  }
+
+  let weightedPenaltySum = 0;
+  for (const check of checks) {
+    const score = Math.max(0, Math.min(1, check.score));
+    const penalty = 1 - score;
+    const effectivePenalty =
+      check.maxPenalty !== undefined
+        ? Math.min(penalty, Math.max(0, Math.min(1, check.maxPenalty)))
+        : penalty;
+    weightedPenaltySum += effectivePenalty * check.weight;
+  }
+
+  return Math.max(0, Math.min(1, 1 - weightedPenaltySum / totalWeight));
+}
+
+/**
+ * Maps a 0.0–1.0 score to a QualitativePerformance rating using configurable thresholds.
+ * Falls back to per-field defaults if not specified:
+ */
+export function scoreToQualitativePerformance(
+  score: number,
+  thresholds?: PerformanceScoreThresholds,
+): QualitativePerformance {
+  const t = { ...DEFAULT_THRESHOLDS, ...thresholds };
+  if (score >= t.perfect) {
+    return QualitativePerformance.Perfect;
+  }
+  if (score >= t.good) {
+    return QualitativePerformance.Good;
+  }
+  if (score >= t.ok) {
+    return QualitativePerformance.Ok;
+  }
+  return QualitativePerformance.Fail;
+}


### PR DESCRIPTION
### Description

#### Elemental Shaman
Implements the below `WeightedPerformance` for `MaelstromSpenders` analysis.

---

#### Summary

Introduces `WeightedPerformance.ts` as an opt-in alternative to the existing
`getLowestPerf` / `getAveragePerf` helpers. Instead of collapsing multiple
checks into a single qualitative bucket, each check produces a continuous
**0.0–1.0 score** that is combined via a weighted average before being mapped
back to the existing `Perfect / Good / Ok / Fail` enum for display.

#### Motivation
The current helpers have two opposing failure modes:

- `getLowestPerf` - a minor mistake in a low-priority check drags the entire
  cast rating down to Fail, even if the important checks were fine.
- `getAveragePerf` - a critical mistake can be "averaged away" by several
  perfect checks, understating the severity.

Neither approach allows a module author to express that "wasting 30 Maelstrom
is 3× more important than missing a MoTE buff".

#### Design

**API** - `src/parser/ui/WeightedPerformance.ts`

**`scoreFromBreakpoints(actual, breakpoints)`**
Maps a raw value to a score using **linear interpolation** between breakpoints.
Clamps to the nearest boundary outside the defined range.
Breakpoints must be sorted ascending by `value`; direction (lower-is-better vs
higher-is-better) is encoded through the `score` direction.

```ts
// "lower is better" - resource waste
scoreFromBreakpoints(2, [
  { value: 0,  score: 1.0 },   // 0 waste  → perfect
  { value: 5,  score: 0.75 },  // 5 waste  → good edge
  { value: 25, score: 0.0 },   // 25 waste → fail
])
// actual=2 → interpolated: 1.0 + (2/5) * (0.75-1.0) = 0.90
```

```ts
// "higher is better" - uptime
scoreFromBreakpoints(0.82, [
  { value: 0.0,  score: 0.0 },
  { value: 0.75, score: 0.75 },
  { value: 1.0,  score: 1.0 },
])
// actual=0.82 → interpolated: 0.84
```

**`computeScore(actual, strategy)`**
Top-level dispatcher: accepts either a `ScoreBreakpoint[]` (delegates to
`scoreFromBreakpoints`) or a `ScoreFunction` — a plain
`(actual: number) => number` for custom mappings (exponential decay,
logarithmic scaling, etc.). Output is always clamped to [0, 1].

```ts
// Custom ScoreFunction — exponential decay for resource waste
computeScore(5, (waste) => Math.exp(-waste / 10))
// → ~0.607
```

**`getAggregatedScore(checks: ScoredCheck[])`**
Penalty-based weighted average: `1 - Σ(effectivePenalty × weight) / Σ(weight)`
where `effectivePenalty = 1 - score`. Without `maxPenalty` this is equivalent
to a standard weighted average of the scores. Only the ratio between weights
matters, not the absolute values.

`ScoredCheck.maxPenalty` (optional, 0.0–1.0) caps how much a single failing
check can drag the overall rating down — useful for secondary checks that
should influence but not dominate the result.

```ts
getAggregatedScore([
  { score: 0.90, weight: 3 },  // waste  (high importance)
  { score: 0.40, weight: 1 },  // MoTE   (lower importance)
])
// → 1 - ((0.10×3 + 0.60×1) / 4) = 0.775  →  Good

// With maxPenalty — cap a secondary check's influence
getAggregatedScore([
  { score: 0.90, weight: 3 },
  { score: 0.00, weight: 1, maxPenalty: 0.3 },  // even total failure = 0.3 penalty max
])
// → 1 - ((0.10×3 + 0.30×1) / 4) = 0.850  →  Good
```

**`scoreToQualitativePerformance(score, thresholds?)`**
Maps a 0–1 score to `QualitativePerformance`.
Default thresholds (overridable per call):

```
≥ 0.95  →  Perfect
≥ 0.75  →  Good
≥ 0.50  →  Ok
 < 0.50  →  Fail
```


### Testing


- Test report URL: `/report/...`
- Screenshot(s):
