### PR TITLE
[Fury] Fix Sudden Death Procs Statistics

### DIFF
--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { Gambyt, Nevdok } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2026, 3, 26), 'Fix Statistics for Sudden Death Procs', Gambyt),
   change(date(2026, 3, 25), 'Update spellbook. Fix cooldown reset issues', Gambyt),
   change(date(2026, 3, 14), 'Midnight season 1 APL updates', Nevdok),
   change(date(2026, 1, 19), 'Midnight cleanup before prepatch', Nevdok),

--- a/src/analysis/retail/warrior/fury/modules/talents/SuddenDeath.tsx
+++ b/src/analysis/retail/warrior/fury/modules/talents/SuddenDeath.tsx
@@ -1,6 +1,6 @@
 import { formatPercentage, formatThousands } from 'common/format';
 import SPELLS from 'common/SPELLS';
-import talents from 'common/TALENTS/warrior';
+import TALENTS from 'common/TALENTS/warrior';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
@@ -36,8 +36,8 @@ class SuddenDeath extends Analyzer {
   constructor(options: Options) {
     super(options);
 
-    this.active = this.selectedCombatant.hasTalent(talents.SUDDEN_DEATH_TALENT);
-    this.executeThreshold = this.selectedCombatant.hasTalent(talents.MASSACRE_FURY_TALENT)
+    this.active = this.selectedCombatant.hasTalent(TALENTS.SUDDEN_DEATH_TALENT);
+    this.executeThreshold = this.selectedCombatant.hasTalent(TALENTS.MASSACRE_FURY_TALENT)
       ? 0.35
       : this.executeThreshold;
 
@@ -56,11 +56,11 @@ class SuddenDeath extends Analyzer {
       this.onExecuteDamage,
     );
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_DEATH_FURY_TALENT_BUFF),
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_DEATH_TALENT_BUFF),
       this.onSuddenDeathProc,
     );
     this.addEventListener(
-      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_DEATH_FURY_TALENT_BUFF),
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_DEATH_TALENT_BUFF),
       this.onSuddenDeathProc,
     );
   }
@@ -93,7 +93,7 @@ class SuddenDeath extends Analyzer {
   }
 
   onExecuteCast(event: CastEvent) {
-    if (this.selectedCombatant.hasBuff(SPELLS.SUDDEN_DEATH_FURY_TALENT_BUFF.id)) {
+    if (this.selectedCombatant.hasBuff(SPELLS.SUDDEN_DEATH_TALENT_BUFF.id)) {
       this.lastSuddenDeathExecuteCast = event.timestamp;
       this.suddenDeathProcsUsed += 1;
       this.lastSuddenDeathTargetID = event.targetID;
@@ -155,7 +155,7 @@ class SuddenDeath extends Analyzer {
           </>
         }
       >
-        <BoringSpellValueText spell={talents.SUDDEN_DEATH_TALENT}>
+        <BoringSpellValueText spell={TALENTS.SUDDEN_DEATH_TALENT}>
           <>
             {this.suddenDeathProcsUsed} / {this.suddenDeathProcs} procs used
           </>


### PR DESCRIPTION
### Description

Fixed sudden death procs statistic for fury warrior

### Testing

- Test report URL: `/report/FRWMPpYNCmn1qwGV/18-Heroic+Imperator+Averzian+-+Kill+(5:23)/3-Gambyt/standard/statistics`
- Screenshot(s):
Before:
<img width="373" height="235" alt="image" src="https://github.com/user-attachments/assets/2f59524a-9518-407b-85b4-15aa0a0cb96d" />
After:
<img width="346" height="217" alt="image" src="https://github.com/user-attachments/assets/dceebbe7-961a-4f5d-a608-374fb5dd7c3a" />

