### PR TITLE
simplify usage of generated overrides. fix chi burst pre-pull for brew

### DIFF
--- a/src/analysis/classic/monk/windwalker/gen.ts
+++ b/src/analysis/classic/monk/windwalker/gen.ts
@@ -26,10 +26,6 @@ export const Abilities = genAbilities({
   omit: [spells.JAB],
   overrides: {
     [spells.FISTS_OF_FURY.id]: (combatant, generated) => {
-      if (!generated) {
-        throw new Error(); // type checker can't tell that we're guaranteed to have this spell in the list
-      }
-
       const hofTierSetCount = combatant.tierPieces.filter((item) =>
         MSV_HOF_TOES_TIER_ITEM_IDS.includes(item.id),
       ).length;

--- a/src/analysis/classic/warlock/demonology/gen.ts
+++ b/src/analysis/classic/warlock/demonology/gen.ts
@@ -20,11 +20,6 @@ export const Abilities = genAbilities({
   ],
   overrides: {
     [spells.DARK_SOUL_KNOWLEDGE.id]: (combatant, generated) => {
-      if (!generated) {
-        throw new Error(
-          "type checker can't tell that we're guaranteed to have this spell in the list",
-        );
-      }
       const archimondes = combatant.hasClassicTalent(spells.ARCHIMONDES_DARKNESS_TALENT);
       if (archimondes) {
         return {
@@ -34,11 +29,6 @@ export const Abilities = genAbilities({
       } else return generated;
     },
     [spells.IMP_SWARM.id]: (combatant, generated) => {
-      if (!generated) {
-        throw new Error(
-          "type checker can't tell that we're guaranteed to have this spell in the list",
-        );
-      }
       const impswarm = combatant.hasGlyph(spells.GLYPH_OF_IMP_SWARM.glyphId);
       if (impswarm) {
         return {

--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from './spell-list_Monk_Brewmaster.retail';
 
 // prettier-ignore
 export default [
+  change(date(2026, 3, 29), <>Fix handling of pre-pull <SpellLink spell={SPELLS.CHI_BURST_TALENT} /> casts.</>, emallson),
   change(date(2026, 3, 24), <>Add cast breakdowns and <SpellLink spell={SPELLS.BLACKOUT_COMBO_TALENT} /> breakdown to Rotation section.</>, emallson),
   change(date(2026, 3, 24), <>Allow using <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> before combo <SpellLink spell={SPELLS.TIGER_PALM} /> in the APL in some cases.</>, emallson),
   change(date(2026, 3, 24), <>Move <SpellLink spell={SPELLS.CHI_BURST_TALENT} /> out of the main APL and into the cooldown list to improve APL behavior.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/gen.ts
+++ b/src/analysis/retail/monk/brewmaster/gen.ts
@@ -1,5 +1,6 @@
 import genAbilities from 'parser/core/modules/genAbilities';
 import spells from './spell-list_Monk_Brewmaster.retail';
+import SPELLS_COMMON from 'common/SPELLS';
 
 export const Abilities = genAbilities({
   allSpells: spells,
@@ -12,4 +13,10 @@ export const Abilities = genAbilities({
   cooldowns: [spells.INVOKE_NIUZAO_THE_BLACK_OX_TALENT, spells.EXPLODING_KEG_TALENT],
   defensives: [spells.FORTIFYING_BREW],
   omit: [spells.BREATH_OF_FIRE_TALENT],
+  overrides: {
+    [spells.CHI_BURST_TALENT.id]: (_combatant, generated) => ({
+      ...generated,
+      damageSpellIds: [SPELLS_COMMON.CHI_BURST_TALENT_DAMAGE.id],
+    }),
+  },
 });

--- a/src/parser/core/modules/genAbilities.ts
+++ b/src/parser/core/modules/genAbilities.ts
@@ -17,9 +17,12 @@ export interface GenAbilityConfig {
   rotational: GenSpell[];
   cooldowns: GenSpell[];
   defensives: GenSpell[];
+  /**
+   * Overrides for generated spells. These handlers are only called if a spell has a definition in the generated spell list.
+   */
   overrides?: Record<
     number,
-    (combatant: Combatant, generated?: SpellbookAbility) => SpellbookAbility
+    (combatant: Combatant, generated: SpellbookAbility) => SpellbookAbility
   >;
   /**
    * Spells to be omitted from abilities. Typically, these are added externally (such as by ExecuteHelper).
@@ -78,13 +81,19 @@ export default function genAbilities(config: GenAbilityConfig): typeof Abilities
       return [
         ...spells.filter((spell) => !config.overrides?.[spell.spell as number]),
         ...others.filter((spell) => !config.overrides?.[spell.spell as number]),
-        ...Object.entries(config.overrides ?? {}).map(([key, fn]) =>
-          fn(
-            this.selectedCombatant,
-            spells.find((spell) => spell.spell === Number(key)) ??
-              others.find((spell) => spell.spell === Number(key)),
-          ),
-        ),
+        ...Object.keys(config.overrides ?? {})
+          .filter((spellId) => allSpells[Number(spellId)] !== undefined)
+          .map(
+            (spellId) =>
+              spells.concat(others).find((spell) => spell.spell === Number(spellId)) ??
+              spellbookDefinition(
+                this.selectedCombatant,
+                allSpells[Number(spellId)],
+                SPELL_CATEGORY.OTHERS,
+                allSpells,
+              ),
+          )
+          .map((spell) => config.overrides![spell.spell as number](this.selectedCombatant, spell)),
       ];
     }
   };


### PR DESCRIPTION
### Description

generated spell overrides have an annoying bit of ceremony where the `generated` spell may not be defined. this changes the API so that if the spell exists in the generated list, the override is always called with a non-undefined object. (but: if the spell is not in the generated list, it is never called)