### PR TITLE
windwalker: update out of date talents and abilities

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -6,6 +6,18 @@ import SpellLink from 'interface/SpellLink';
 
 export default [
   change(
+    date(2026, 3, 29),
+    <>
+      Updated Windwalker statistics for current talents and cooldowns: fixed{' '}
+      <SpellLink spell={SPELLS.FISTS_OF_FURY_CAST} /> tick handling for{' '}
+      <SpellLink spell={TALENTS.CRASHING_FISTS_TALENT} />, added{' '}
+      <SpellLink spell={TALENTS.GLORY_OF_THE_DAWN_TALENT} /> tracking, updated{' '}
+      <SpellLink spell={TALENTS.XUENS_BATTLEGEAR_TALENT} /> cooldown reduction handling, and
+      cleaned obsolete statistics and cooldown entries.
+    </>,
+    Durpn,
+  ),
+  change(
     date(2026, 3, 21),
     <>
       Reworked <SpellLink spell={SPELLS.COMBO_BREAKER_BUFF} />,{' '}

--- a/src/analysis/retail/monk/windwalker/CONFIG.tsx
+++ b/src/analysis/retail/monk/windwalker/CONFIG.tsx
@@ -11,7 +11,7 @@ const config: Config = {
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '12.0.0',
-  supportLevel: SupportLevel.MaintainedPartial,
+  supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/analysis/retail/monk/windwalker/CombatLogParser.ts
+++ b/src/analysis/retail/monk/windwalker/CombatLogParser.ts
@@ -1,4 +1,4 @@
-import { JadefireStomp, MysticTouch, TouchOfDeath } from 'analysis/retail/monk/shared';
+import { MysticTouch, TouchOfDeath } from 'analysis/retail/monk/shared';
 import CoreCombatLogParser from 'parser/core/CombatLogParser';
 
 // Features
@@ -7,7 +7,6 @@ import Buffs from './modules/Buffs';
 // import WeaponsOfOrderWindwalker from './modules/covenants/WeaponsOfOrder';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
-import MoTCGraph from './modules/features/MoTCGraph';
 import JadeIgnition from './modules/talents/JadeIgnition';
 import XuensBattlegear from './modules/talents/XuensBattlegear';
 // Resources
@@ -31,6 +30,7 @@ import ChiBurst from './modules/spells/ChiBurst';
 import RisingSunKick from './modules/spells/RisingSunKick';
 import StrikeoftheWindlord from './modules/spells/StrikeoftheWindlord';
 import DanceOfChiJi from './modules/talents/DanceOfChiJi';
+import GloryOfTheDawn from './modules/talents/GloryOfTheDawn';
 import HitCombo from './modules/talents/HitCombo';
 import HitComboGraph from './modules/talents/HitComboGraph';
 import HitComboTracker from './modules/talents/HitComboTracker';
@@ -74,8 +74,6 @@ class CombatLogParser extends CoreCombatLogParser {
     abilities: Abilities,
     buffs: Buffs,
     cooldownThroughputTracker: CooldownThroughputTracker,
-    moTCGraph: MoTCGraph,
-
     // Resources
     chiTracker: ChiTracker,
     chiDetails: ChiDetails,
@@ -84,6 +82,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Talents:
     danceOfChiJi: DanceOfChiJi,
+    gloryOfTheDawn: GloryOfTheDawn,
     hitCombo: HitCombo,
     strikeoftheWindlord: StrikeoftheWindlord,
     chiBurst: ChiBurst,
@@ -104,7 +103,6 @@ class CombatLogParser extends CoreCombatLogParser {
     touchOfDeath: TouchOfDeath,
     comboStrikes: ComboStrikes,
     blackoutKick: BlackoutKick,
-    jadefireStomp: JadefireStomp,
     risingSunKick: RisingSunKick,
     invokeXuen: InvokeXuen,
     slicingWinds: SlicingWinds,

--- a/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
@@ -71,6 +71,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           static: 500,
         },
+        enabled: !combatant.hasTalent(TALENTS_MONK.COMBAT_WISDOM_TALENT),
         castEfficiency: {
           suggestion: true,
         },
@@ -93,15 +94,6 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS_MONK.CHI_BURST_TALENT),
         castEfficiency: {
           suggestion: true,
-        },
-      },
-      {
-        spell: TALENTS_MONK.JADEFIRE_STOMP_TALENT.id,
-        category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 30,
-        enabled: combatant.hasTalent(TALENTS_MONK.JADEFIRE_STOMP_TALENT),
-        gcd: {
-          base: 1000,
         },
       },
       {
@@ -132,17 +124,6 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.STORM_EARTH_AND_FIRE_CAST.id,
-        category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 90,
-        gcd: null,
-        charges: 2,
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.95,
-        },
-      },
-      {
         spell: TALENTS_MONK.ZENITH_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: 90,
@@ -162,6 +143,9 @@ class Abilities extends CoreAbilities {
           base: 1000,
           minimum: 750,
         },
+        enabled:
+          combatant.hasTalent(TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT) &&
+          combatant.hasTalent(TALENTS_MONK.CELESTIAL_CONDUIT_WINDWALKER_TALENT),
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.95,
@@ -305,11 +289,6 @@ class Abilities extends CoreAbilities {
           base: 1000,
           minimum: 750,
         },
-      },
-      {
-        spell: SPELLS.STORM_EARTH_AND_FIRE_FIXATE.id,
-        category: SPELL_CATEGORY.UTILITY,
-        gcd: null,
       },
       // Defensives
       {

--- a/src/analysis/retail/monk/windwalker/modules/features/CooldownThroughputTracker.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/features/CooldownThroughputTracker.tsx
@@ -15,6 +15,10 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
       spell: TALENTS_MONK.INVOKE_XUEN_THE_WHITE_TIGER_TALENT.id,
       summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
     },
+    {
+      spell: TALENTS_MONK.ZENITH_TALENT.id,
+      summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
+    },
   ];
 }
 

--- a/src/analysis/retail/monk/windwalker/modules/spells/BlackoutKick.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/BlackoutKick.tsx
@@ -63,7 +63,10 @@ class BlackoutKick extends Analyzer {
     if (this.selectedCombatant.hasTalent(TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT)) {
       this.IMPORTANT_SPELLS.push(TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT.id);
     }
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.BLACKOUT_KICK), this.onCast);
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell([SPELLS.BLACKOUT_KICK, SPELLS.BLACKOUT_KICK_TOTM]),
+      this.onCast,
+    );
   }
 
   applyCdr(spellId: number): [number, number] {
@@ -78,6 +81,7 @@ class BlackoutKick extends Analyzer {
         BLACKOUT_KICK_COOLDOWN_REDUCTION_MS,
       );
       effective += reductionMs;
+      wasted += cdr - reductionMs;
     }
     return [effective, wasted];
   }

--- a/src/analysis/retail/monk/windwalker/modules/spells/FistsofFury.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/FistsofFury.tsx
@@ -27,6 +27,9 @@ import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 // next-tick hits will repeat previously hit targets. Keep a modest idle buffer for new targets and
 // use repeated targets to detect the next real tick without collapsing high-haste channels.
 const FISTS_OF_FURY_SAME_TICK_BUFFER_MS = 200;
+const BASE_FISTS_OF_FURY_TICKS = 5;
+const CRASHING_FISTS_FISTS_OF_FURY_TICKS = 6;
+const MAX_FISTS_OF_FURY_TICKS = 6;
 
 class FistsofFury extends Analyzer {
   static dependencies = {
@@ -64,7 +67,9 @@ class FistsofFury extends Analyzer {
   }
 
   get expectedTicks() {
-    return this.selectedCombatant.hasTalent(TALENTS_MONK.CRASHING_FISTS_TALENT) ? 6 : 5;
+    return this.selectedCombatant.getTalentRank(TALENTS_MONK.CRASHING_FISTS_TALENT) > 0
+      ? CRASHING_FISTS_FISTS_OF_FURY_TICKS
+      : BASE_FISTS_OF_FURY_TICKS;
   }
 
   isNewFistsTick(event: DamageEvent) {
@@ -77,8 +82,7 @@ class FistsofFury extends Analyzer {
 
   onFistsDamage(event: DamageEvent) {
     if (this.isNewFistsTick(event)) {
-      this.currentChannelTicks += 1;
-      this.fistsTicks += 1;
+      this.currentChannelTicks = Math.min(this.currentChannelTicks + 1, MAX_FISTS_OF_FURY_TICKS);
       this.currentTickTargets.clear();
     }
 
@@ -91,12 +95,9 @@ class FistsofFury extends Analyzer {
       return;
     }
 
-    if (this.currentChannelTicks > this.expectedTicks) {
-      console.log('error, detected too many ticks of fof');
-      return;
-    }
-
-    this.ticksHit[this.currentChannelTicks - 1] += 1;
+    const finalizedTicks = Math.min(this.currentChannelTicks, this.expectedTicks);
+    this.fistsTicks += finalizedTicks;
+    this.ticksHit[finalizedTicks - 1] += 1;
   }
 
   onChannelEnd(event: EndChannelEvent) {
@@ -124,12 +125,13 @@ class FistsofFury extends Analyzer {
   }
 
   get suggestionThresholds() {
+    const expectedTicks = this.expectedTicks;
     return {
       actual: this.averageTicks,
       isLessThan: {
-        minor: 5,
-        average: 4.75,
-        major: 4.5,
+        minor: expectedTicks,
+        average: expectedTicks - 0.25,
+        major: expectedTicks - 0.5,
       },
       style: ThresholdStyle.DECIMAL,
     };
@@ -170,13 +172,9 @@ class FistsofFury extends Analyzer {
         <b>
           <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} />
         </b>{' '}
-        is one of your primary dps skills, and should be channeled to completion.
-        <br />
-        <br />
-        When <SpellLink spell={TALENTS_MONK.XUENS_BATTLEGEAR_TALENT} /> is talented, it gives the
-        buff <SpellLink spell={SPELLS.PRESSURE_POINT_BUFF} />, increasing the critical strike chance
-        of all <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT} />
-        's over the next 5 seconds by 40%.
+        is one of your primary dps skills, and should be channeled to completion. It ticks{' '}
+        {BASE_FISTS_OF_FURY_TICKS} times by default, or {CRASHING_FISTS_FISTS_OF_FURY_TICKS} times
+        with <SpellLink spell={TALENTS_MONK.CRASHING_FISTS_TALENT} />.
       </p>
     );
 

--- a/src/analysis/retail/monk/windwalker/modules/spells/RisingSunKick.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/RisingSunKick.tsx
@@ -22,9 +22,7 @@ class RisingSunKick extends Analyzer {
           <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT} />
         </b>{' '}
         is one of your primary dps skills and should be used immediately in most cases, as dictated
-        by the APL. When <SpellLink spell={TALENTS_MONK.XUENS_BATTLEGEAR_TALENT} /> is talented,{' '}
-        <SpellLink spell={TALENTS_MONK.RISING_SUN_KICK_TALENT} /> reduces the cooldown of{' '}
-        <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} /> by 4 seconds.
+        by the APL.
       </p>
     );
 

--- a/src/analysis/retail/monk/windwalker/modules/spells/SpinningCraneKick.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/SpinningCraneKick.tsx
@@ -148,50 +148,7 @@ class SpinningCraneKick extends Analyzer {
   }
 
   statistic() {
-    // Spinning Crane Kick is usually not used outside aoe, so we're avoiding rendering it when it's not used
-    if (this.casts > 0) {
-      return (
-        <Statistic
-          position={STATISTIC_ORDER.CORE(7)}
-          size="flexible"
-          tooltip={<>Total damage increase: {formatNumber(this.totalDamage)}</>}
-          dropdown={
-            <>
-              <table className="table table-condensed">
-                <thead>
-                  <tr>
-                    <th>Stacks</th>
-                    <th>Casts</th>
-                    <th>Casts (%)</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {Object.values(this.stackHistory).map((e, i) => (
-                    <tr key={i}>
-                      <th>{i}</th>
-                      <td>{formatNumber(e)}</td>
-                      <td>{formatPercentage(e / this.casts)}%</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </>
-          }
-        >
-          <BoringSpellValueText spell={SPELLS.MARK_OF_THE_CRANE}>
-            <img src="/img/sword.png" alt="Damage" className="icon" /> {formatNumber(this.dps)} DPS{' '}
-            <small>
-              {formatPercentage(this.owner.getPercentageOfTotalDamageDone(this.totalDamage))} % of
-              total
-            </small>
-            <br />
-            {this.averageStacks.toFixed(2)} <small>Average stacks per cast</small>
-            <br />
-            {this.averageEnemiesHit.toFixed(2)} <small>Average enemies hit per cast</small>
-          </BoringSpellValueText>
-        </Statistic>
-      );
-    }
+    return null;
   }
 }
 

--- a/src/analysis/retail/monk/windwalker/modules/talents/GloryOfTheDawn.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/GloryOfTheDawn.tsx
@@ -1,0 +1,60 @@
+import { formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import { TALENTS_MONK } from 'common/TALENTS';
+import HIT_TYPES from 'game/HIT_TYPES';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
+
+class GloryOfTheDawn extends Analyzer {
+  totalHits = 0;
+  critHits = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.GLORY_OF_THE_DAWN_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.GLORY_OF_THE_DAWN_DAMAGE),
+      this.onDamage,
+    );
+  }
+
+  onDamage(event: DamageEvent) {
+    this.totalHits += 1;
+
+    const isCrit = event.hitType === HIT_TYPES.CRIT || event.hitType === HIT_TYPES.BLOCKED_CRIT;
+    if (isCrit) {
+      this.critHits += 1;
+    }
+  }
+
+  get critRate() {
+    return this.totalHits > 0 ? this.critHits / this.totalHits : 0;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(1)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <BoringSpellValueText spell={TALENTS_MONK.GLORY_OF_THE_DAWN_TALENT}>
+          {formatPercentage(this.critRate, 0)}% <small>Crit rate</small>
+          <br />
+          {this.critHits} / {this.totalHits} <small>Crits / Hits</small>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default GloryOfTheDawn;

--- a/src/analysis/retail/monk/windwalker/modules/talents/XuensBattlegear.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/XuensBattlegear.tsx
@@ -4,7 +4,6 @@ import { SpellIcon } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { DamageEvent } from 'parser/core/Events';
 import { ThresholdStyle } from 'parser/core/ParseResults';
-import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import SpellUsable from 'analysis/retail/monk/windwalker/modules/core/SpellUsable';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -13,19 +12,20 @@ import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import { TALENTS_MONK } from 'common/TALENTS';
 
 const FISTS_OF_FURY_COOLDOWN_REDUCTION_MS = 4000;
+const XUENS_BATTLEGEAR_TRIGGER_SPELLS = [
+  SPELLS.RISING_SUN_KICK_DAMAGE,
+  SPELLS.GLORY_OF_THE_DAWN_DAMAGE,
+];
 
 class XuensBattlegear extends Analyzer {
   static dependencies = {
     spellUsable: SpellUsable,
-    abilityTracker: AbilityTracker,
   };
 
   protected spellUsable!: SpellUsable;
-  protected abilityTracker!: AbilityTracker;
 
   effectiveFistsOfFuryReductionMs = 0;
   wastedFistsOfFuryReductionMs = 0;
-  buffedHits = 0;
 
   constructor(options: Options) {
     super(options);
@@ -35,15 +35,12 @@ class XuensBattlegear extends Analyzer {
       return;
     }
     this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RISING_SUN_KICK_DAMAGE),
-      this.onRisingSunKickHit,
+      Events.damage.by(SELECTED_PLAYER).spell(XUENS_BATTLEGEAR_TRIGGER_SPELLS),
+      this.onTriggerDamage,
     );
   }
 
-  onRisingSunKickHit(event: DamageEvent) {
-    if (this.selectedCombatant.hasBuff(SPELLS.PRESSURE_POINT_BUFF.id)) {
-      this.buffedHits += 1;
-    }
+  onTriggerDamage(event: DamageEvent) {
     const isCrit = event.hitType === HIT_TYPES.CRIT || event.hitType === HIT_TYPES.BLOCKED_CRIT;
     if (!isCrit) {
       return;
@@ -62,10 +59,6 @@ class XuensBattlegear extends Analyzer {
 
   get wastedReductionPerMinute() {
     return (this.wastedFistsOfFuryReductionMs / this.owner.fightDuration) * 60;
-  }
-
-  get totalHits() {
-    return this.abilityTracker.getAbility(SPELLS.RISING_SUN_KICK_DAMAGE.id).damageHits;
   }
 
   get suggestionThresholds() {
@@ -98,15 +91,6 @@ class XuensBattlegear extends Analyzer {
             />{' '}
             {(this.effectiveFistsOfFuryReductionMs / 1000).toFixed(1)}{' '}
             <small>Seconds reduced</small>
-            <br />
-            <SpellIcon
-              spell={TALENTS_MONK.RISING_SUN_KICK_TALENT}
-              style={{
-                height: '1.3em',
-                marginTop: '-1.em',
-              }}
-            />{' '}
-            {this.buffedHits} / {this.totalHits} <small>Buffed / Total hits</small>
           </span>
         </BoringSpellValueText>
       </Statistic>

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -921,6 +921,11 @@ const spells = {
     name: 'Rising Sun Kick',
     icon: 'ability_monk_risingsunkick',
   },
+  GLORY_OF_THE_DAWN_DAMAGE: {
+    id: 392959,
+    name: 'Glory of the Dawn',
+    icon: 'ability_monk_mightyoxkick',
+  },
   RUSHING_WIND_KICK_BUFF: {
     id: 1250554,
     name: 'Rushing Wind Kick',


### PR DESCRIPTION
### Description

Remove out of date abilities, and generally clean up analysis on the statistics page. This includes removing long removed abilities such as MoTC and SEF.

### Testing

- Test report URL: `/report/Rn3yYDzhtfgxkWNr/21-Normal+Vorasius+-+Kill+(4:39)/73-Nightszen/standard/statistics`
- Screenshot(s):

<img width="1164" height="944" alt="image" src="https://github.com/user-attachments/assets/b932a66b-7124-4668-adb6-d4b594d600d9" />
<img width="317" height="332" alt="image" src="https://github.com/user-attachments/assets/1ba0662a-2d16-4dea-9a3c-b9da7a6bcd7b" />

<img width="986" height="997" alt="image" src="https://github.com/user-attachments/assets/79e29199-c0ae-4cf2-84f1-f28c70c1aace" />