### PR TITLE
[Holy Priest] Lightweaver module update

### DIFF
--- a/src/analysis/retail/priest/holy/CHANGELOG.tsx
+++ b/src/analysis/retail/priest/holy/CHANGELOG.tsx
@@ -5,6 +5,8 @@ import { Amiphite, Arlie, Hana, Litena, Liavre, squided, Topple, Trevor, Saeldur
 import { SpellLink } from 'interface';
 
 export default [
+  change(date(2026, 4, 1), <><SpellLink spell={TALENTS.LIGHTWEAVER_TALENT} /> update.</>, Amiphite),
+  change(date(2026, 4, 1), <><SpellLink spell={TALENTS.PRAYER_OF_HEALING_TALENT} /> guide section update and <SpellLink spell={TALENTS.SPIRITWELL_TALENT} /> support.</>, Amiphite),
   change(date(2026, 3, 26), <><SpellLink spell={TALENTS.PRAYER_OF_HEALING_TALENT} /> and <SpellLink spell={TALENTS.LIGHTWEAVER_TALENT} /> update.</>, Amiphite),
   change(date(2026, 3, 19), <>Partially updated for patch 12.0.1. Still need to implement modules and some talents.</>, Amiphite),
   change(date(2025, 6, 8), <>Add preparation section to overview.</>, Vetyst),

--- a/src/analysis/retail/priest/holy/modules/talents/BottomRow/Lightweaver.tsx
+++ b/src/analysis/retail/priest/holy/modules/talents/BottomRow/Lightweaver.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { HealEvent, CastEvent } from 'parser/core/Events';
+import Events, { CastEvent } from 'parser/core/Events';
 import SPELLS from 'common/SPELLS/';
 import TALENTS from 'common/TALENTS/priest';
 import Statistic from 'parser/ui/Statistic';
@@ -13,15 +13,10 @@ import { getHeal } from '../../../normalizers/CastLinkNormalizer';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../../Guide';
 import GradiatedPerformanceBar from 'interface/guide/components/GradiatedPerformanceBar';
-import { LW_CAST_TIME_DECREASE, LW_OVERHEAL_THRESHOLD } from '../../../constants';
+import { LW_CAST_TIME_DECREASE } from '../../../constants';
 import EOLAttrib from '../../core/EchoOfLightAttributor';
 import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
-
-/**
- * Lightweaver
- * Flash Heal reduces the cast time of your next Prayer of Healing within 20 sec by 30% and increases its healing done by 18%.
- * Can accumulate up to 4 charges.
- */
+import styles from '../../Styling.module.scss';
 
 class Lightweaver extends Analyzer {
   static dependencies = {
@@ -33,12 +28,11 @@ class Lightweaver extends Analyzer {
 
   totalFlashHealCasts = 0;
   wastedBuffFlashHealCasts = 0;
-  highOverhealFlashHealCasts = 0;
+  surgeOfLightFlashHealCasts = 0;
 
   trailHealing = 0;
   bindingHealing = 0;
-  prayerHealing = 0; // direct healing from the buffed Prayer of Healing
-
+  prayerHealing = 0;
   eolContrib = 0;
 
   get totalHealing() {
@@ -59,31 +53,29 @@ class Lightweaver extends Analyzer {
     );
   }
 
-  isHighOverheal(event: HealEvent) {
-    const rawHealing = (event.amount || 0) + (event.overheal || 0) + (event.absorbed || 0);
-    if (rawHealing === 0) {
-      return false;
-    }
-    return (event.overheal || 0) / rawHealing >= LW_OVERHEAL_THRESHOLD;
-  }
-
   onFlashHealCast(event: CastEvent) {
     const healEvent = getHeal(event);
-    if (healEvent) {
-      this.totalFlashHealCasts += 1;
-      if (this.selectedCombatant.getBuffStacks(SPELLS.LIGHTWEAVER_TALENT_BUFF.id) < 2) {
-        if (this.isHighOverheal(healEvent)) {
-          this.highOverhealFlashHealCasts += 1;
-        }
-      } else {
-        this.wastedBuffFlashHealCasts += 1;
-      }
+    if (!healEvent) {
+      return;
+    }
+
+    this.totalFlashHealCasts += 1;
+
+    const hasSurgeBuff = this.selectedCombatant.hasBuff(SPELLS.SURGE_OF_LIGHT_BUFF.id);
+    const lightweaverStacks = this.selectedCombatant.getBuffStacks(
+      SPELLS.LIGHTWEAVER_TALENT_BUFF.id,
+    );
+
+    if (hasSurgeBuff) {
+      this.surgeOfLightFlashHealCasts += 1;
+    } else if (lightweaverStacks >= 4) {
+      this.wastedBuffFlashHealCasts += 1;
     }
   }
 
   get goodFlashHeals() {
     return (
-      this.totalFlashHealCasts - this.wastedBuffFlashHealCasts - this.highOverhealFlashHealCasts
+      this.totalFlashHealCasts - this.wastedBuffFlashHealCasts - this.surgeOfLightFlashHealCasts
     );
   }
 
@@ -96,23 +88,24 @@ class Lightweaver extends Analyzer {
         <b>
           <SpellLink spell={TALENTS.LIGHTWEAVER_TALENT} />
         </b>{' '}
-        is a strong buff that you should be playing around to buff your{' '}
-        <SpellLink spell={TALENTS.PRAYER_OF_HEALING_TALENT} /> casts. Try not to overcap your{' '}
-        <SpellLink spell={TALENTS.LIGHTWEAVER_TALENT} /> stacks to avoid wasting mana.
+        increases healing of <SpellLink spell={TALENTS.PRAYER_OF_HEALING_TALENT} /> and reduces its
+        mana cost. Try to cast <SpellLink spell={TALENTS.PRAYER_OF_HEALING_TALENT} /> more often to
+        consume <SpellLink spell={TALENTS.LIGHTWEAVER_TALENT} /> stacks and save mana in situations
+        when at least three party members are injured.
       </p>
     );
 
     const goodFlashHeals = {
       count: this.goodFlashHeals,
-      label: 'Good Flash Heal Casts',
+      label: 'Good Flash Heal casts',
     };
 
-    const highOverhealFlashHeals = {
-      count: this.highOverhealFlashHealCasts,
-      label: 'High‑overheal Flash Heal Casts',
+    const surgeFlashHeals = {
+      count: this.surgeOfLightFlashHealCasts,
+      label: 'Surge of Light Flash Heal casts',
     };
 
-    const wastedBuffFlashHeals = {
+    const wastedFlashHeals = {
       count: this.wastedBuffFlashHealCasts,
       label: 'Flash Heal casts with four stacks of Lightweaver already',
     };
@@ -124,13 +117,15 @@ class Lightweaver extends Analyzer {
         </strong>
         <small>
           {' '}
-          – Green is a good cast. Yellow is a cast with very high overheal, and Red is a cast with
-          four stacks of <SpellLink spell={TALENTS.LIGHTWEAVER_TALENT} /> already active.
+          – <span className={styles.goodCast}>Green</span> is a good cast.{' '}
+          <span className={styles.okCast}>Yellow</span> is a cast with Surge of Light buff.{' '}
+          <span className={styles.badCast}>Red</span> is a cast with four stacks of{' '}
+          <SpellLink spell={TALENTS.LIGHTWEAVER_TALENT} /> already active.
         </small>
         <GradiatedPerformanceBar
           good={goodFlashHeals}
-          ok={highOverhealFlashHeals}
-          bad={wastedBuffFlashHeals}
+          ok={surgeFlashHeals}
+          bad={wastedFlashHeals}
         />
       </div>
     );

--- a/src/analysis/retail/priest/holy/modules/talents/BottomRow/Lightweaver.tsx
+++ b/src/analysis/retail/priest/holy/modules/talents/BottomRow/Lightweaver.tsx
@@ -5,7 +5,6 @@ import SPELLS from 'common/SPELLS/';
 import TALENTS from 'common/TALENTS/priest';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import { formatPercentage } from 'common/format';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import { SpellLink } from 'interface';
@@ -23,8 +22,6 @@ class Lightweaver extends Analyzer {
     eolAttrib: EOLAttrib,
   };
   protected eolAttrib!: EOLAttrib;
-
-  overhealingDoneFromTalent = 0;
 
   totalFlashHealCasts = 0;
   wastedBuffFlashHealCasts = 0;
@@ -134,22 +131,13 @@ class Lightweaver extends Analyzer {
   }
 
   statistic() {
-    const overhealingTooltipString = formatPercentage(
-      this.overhealingDoneFromTalent /
-        (this.prayerHealing +
-          this.trailHealing +
-          this.bindingHealing +
-          this.overhealingDoneFromTalent),
-    );
-
     return (
       <Statistic
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            <div>{`${overhealingTooltipString}% overhealing`}</div>
-            <div style={{ marginTop: '0.5rem', marginBottom: '0.5rem' }}>Breakdown:</div>
+            <div style={{ marginBottom: '0.5rem' }}>Breakdown:</div>
             <div>
               <SpellLink spell={TALENTS.LIGHTWEAVER_TALENT} />:{' '}
               <ItemPercentHealingDone amount={this.prayerHealing} />


### PR DESCRIPTION
### Summary:
This PR is a part of refactoring the `Lightweaver` analyzer. Outdated code related to high‑overheal tracking was removed and replaced with Surge of Light tracking; improve the guide visuals.

### Changes:
- Deleted `isHighOverheal()` method and the associated `LW_OVERHEAL_THRESHOLD` constant.
- Removed `overhealingDoneFromTalent` property and its usage in statistic tooltips.
- Replaced `highOverhealFlashHealCasts` with `surgeOfLightFlashHealCasts`