### PR TITLE
Replaced Outdated Browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
           <small>Loading...</small>
           <p>
             If the app won't load your browser might not be compatible. Get a compatible browser at
-            <a href="https://outdatedbrowser.com/">outdatedbrowser.com</a>.<br />
+            <a href="https://browser-update.org/update-browser.html">browser-update.org</a>.<br />
             Let us know on <a href="https://wowanalyzer.com/discord">Discord</a> if the problem
             persist.
           </p>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,12 @@
           <small>Loading...</small>
           <p>
             If the app won't load your browser might not be compatible. Get a compatible browser at
-            <a href="https://browser-update.org/update-browser.html">browser-update.org</a>.<br />
+            <a
+              href="https://browser-update.org/update-browser.html"
+              target="_blank"
+              rel="noopener noreferrer"
+              >browser-update.org</a
+            >.<br />
             Let us know on <a href="https://wowanalyzer.com/discord">Discord</a> if the problem
             persist.
           </p>

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -34,6 +34,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 2), <>Link out-dated browsers to a functional website alternative</>, Vetyst),
   change(date(2026, 3, 24), <>Add <SpellLink spell={ITEMS.DARKMOON_SIGIL_HUNT} /> embellishment analyzer with stat buff tracking.</>, MarchingCube),
   change(date(2026, 3, 24), "Add Ancestral Call (Mag'har Orc) racial support", MarchingCube),
   change(date(2026, 3, 23), "Update close kill times to match new WCL API", Putro),

--- a/src/interface/layouts/AppLayout.tsx
+++ b/src/interface/layouts/AppLayout.tsx
@@ -53,6 +53,8 @@ export function AppLayout() {
               className="btn btn-primary"
               href="https://browser-update.org/update-browser.html"
               style={{ textTransform: 'none' }}
+              target="_blank"
+              rel="noopener noreferrer"
             >
               Update your Browser
             </a>

--- a/src/interface/layouts/AppLayout.tsx
+++ b/src/interface/layouts/AppLayout.tsx
@@ -51,10 +51,10 @@ export function AppLayout() {
             {/* Lower case the button so it doesn't seem to aggressive */}
             <a
               className="btn btn-primary"
-              href="https://outdatedbrowser.com/"
+              href="https://browser-update.org/update-browser.html"
               style={{ textTransform: 'none' }}
             >
-              Download a proper browser
+              Update your Browser
             </a>
           </FullscreenError>
         )}


### PR DESCRIPTION
### Description

Noticed the link to outdatedbrowser.com has become quite shady redirecting to a different domain. Found an alternative that gives the visitors suggestions to install a new browser/update the current one.

Old site:
<img width="1914" height="985" alt="image" src="https://github.com/user-attachments/assets/cdc5aca0-413d-4b29-ab6f-4f93cfaad322" />


New Site for old browser:
<img width="1020" height="765" alt="Screenshot_7" src="https://github.com/user-attachments/assets/3e1c1a43-9906-4a4a-8439-76d4cfe4409b" />
