### PR TITLE
Add HP plot to Brew stagger graph

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2839,3 +2839,9 @@ export const MarchingCube: Contributor = {
   nickname: 'MarchingCube',
   github: 'MarchingCube',
 };
+
+export const NotStirred: Contributor = {
+  nickname: 'NotStirred',
+  github: 'NotStirred',
+  discord: 'NotStirred',
+};

--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
-import { emallson } from 'CONTRIBUTORS';
+import { emallson, NotStirred } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 import SPELLS from './spell-list_Monk_Brewmaster.retail';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 4), <>Add hit points graph to stagger plot.</>, NotStirred),
   change(date(2026, 3, 29), <>Fix handling of pre-pull <SpellLink spell={SPELLS.CHI_BURST_TALENT} /> casts.</>, emallson),
   change(date(2026, 3, 24), <>Add cast breakdowns and <SpellLink spell={SPELLS.BLACKOUT_COMBO_TALENT} /> breakdown to Rotation section.</>, emallson),
   change(date(2026, 3, 24), <>Allow using <SpellLink spell={SPELLS.BREATH_OF_FIRE_TALENT} /> before combo <SpellLink spell={SPELLS.TIGER_PALM} /> in the APL in some cases.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/features/StaggerPoolGraph.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/features/StaggerPoolGraph.tsx
@@ -3,7 +3,7 @@ import talents from 'common/TALENTS/monk';
 import { SpellLink } from 'interface';
 import { Panel } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DeathEvent } from 'parser/core/Events';
+import Events, { DamageEvent, DeathEvent, HealEvent } from 'parser/core/Events';
 import BaseChart, { formatTime } from 'parser/ui/BaseChart';
 import { VisualizationSpec } from 'react-vega';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -29,6 +29,7 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
   stagger: StaggerPool,
   pb: PurifyingBrew,
 }) {
+  _hpEvents: (HealEvent | DamageEvent)[] = [];
   _deathEvents: DeathEvent[] = [];
   _lastHp: number | null = null;
   _lastMaxHp: number | null = null;
@@ -36,6 +37,8 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
   constructor(options: Options) {
     super(options);
 
+    this.addEventListener(Events.damage.to(SELECTED_PLAYER), this._damage);
+    this.addEventListener(Events.heal.to(SELECTED_PLAYER), this._heal);
     this.addEventListener(Events.death.to(SELECTED_PLAYER), this._death);
   }
 
@@ -81,6 +84,50 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
         ],
       },
       layer: [
+        {
+          data: {
+            name: 'hp',
+          },
+          mark: {
+            type: 'area',
+            color: 'rgb(38, 62, 41)',
+            interpolate: 'step',
+          },
+          transform: [
+            {
+              calculate: `datum.timestamp - ${startTime}`,
+              as: 'timestamp_shifted',
+            },
+          ],
+          encoding: {
+            x: {
+              field: 'x',
+              type: 'quantitative' as const,
+              axis: {
+                labelExpr: formatTime('datum.value'),
+                tickCount: 25,
+                grid: false,
+              },
+              scale: {
+                nice: false,
+              },
+              title: null,
+            },
+            y: {
+              field: 'hitPoints',
+              type: 'quantitative' as const,
+              title: null,
+            },
+            tooltip: [
+              {
+                field: 'hitPoints',
+                type: 'quantitative' as const,
+                title: 'Hit Points',
+                format: '.3~s',
+              },
+            ],
+          },
+        },
         {
           mark: {
             type: 'line' as const,
@@ -164,6 +211,15 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
           }) satisfies StaggerEvent,
       );
 
+      let hpEvents = this._hpEvents
+        .filter((event) => event.hitPoints !== undefined)
+        .map(({ timestamp, hitPoints }) => {
+          return {
+            x: timestamp - startTime,
+            hitPoints: hitPoints!!, // !! filtered above
+          };
+        });
+
       return (
         <div
           className="graph-container"
@@ -180,6 +236,7 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
                   combined: staggerEvents,
                   purifies: this.deps.pb.purifies,
                   deaths: this._deathEvents,
+                  hp: hpEvents,
                 }}
                 width={width}
                 height={height}
@@ -191,6 +248,14 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
     } else {
       return null;
     }
+  }
+
+  _damage(event: DamageEvent) {
+    this._hpEvents.push(event);
+  }
+
+  _heal(event: HealEvent) {
+    this._hpEvents.push(event);
   }
 
   _death(event: DeathEvent) {

--- a/src/analysis/retail/monk/brewmaster/modules/features/StaggerPoolGraph.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/features/StaggerPoolGraph.tsx
@@ -3,7 +3,14 @@ import talents from 'common/TALENTS/monk';
 import { SpellLink } from 'interface';
 import { Panel } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, DeathEvent, HealEvent } from 'parser/core/Events';
+import Events, {
+  DamageEvent,
+  DeathEvent,
+  EventType,
+  HasHitpoints,
+  HealEvent,
+  HitpointsEvent,
+} from 'parser/core/Events';
 import BaseChart, { formatTime } from 'parser/ui/BaseChart';
 import { VisualizationSpec } from 'react-vega';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -29,7 +36,7 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
   stagger: StaggerPool,
   pb: PurifyingBrew,
 }) {
-  _hpEvents: (HealEvent | DamageEvent)[] = [];
+  _hpEvents: HitpointsEvent<EventType>[] = [];
   _deathEvents: DeathEvent[] = [];
   _lastHp: number | null = null;
   _lastMaxHp: number | null = null;
@@ -100,19 +107,7 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
             },
           ],
           encoding: {
-            x: {
-              field: 'x',
-              type: 'quantitative' as const,
-              axis: {
-                labelExpr: formatTime('datum.value'),
-                tickCount: 25,
-                grid: false,
-              },
-              scale: {
-                nice: false,
-              },
-              title: null,
-            },
+            x: xAxis,
             y: {
               field: 'hitPoints',
               type: 'quantitative' as const,
@@ -211,14 +206,12 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
           }) satisfies StaggerEvent,
       );
 
-      let hpEvents = this._hpEvents
-        .filter((event) => event.hitPoints !== undefined)
-        .map(({ timestamp, hitPoints }) => {
-          return {
-            x: timestamp - startTime,
-            hitPoints: hitPoints!!, // !! filtered above
-          };
-        });
+      let hpEvents = this._hpEvents.map(({ timestamp, hitPoints }) => {
+        return {
+          timestamp: timestamp,
+          hitPoints: hitPoints,
+        };
+      });
 
       return (
         <div
@@ -251,10 +244,16 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
   }
 
   _damage(event: DamageEvent) {
+    if (!HasHitpoints(event)) {
+      return;
+    }
     this._hpEvents.push(event);
   }
 
   _heal(event: HealEvent) {
+    if (!HasHitpoints(event)) {
+      return;
+    }
     this._hpEvents.push(event);
   }
 


### PR DESCRIPTION
### Description
Adds player HP to the stagger graph, which is useful to understand why Purifying Brew was cast at a specific moment.

I would like to have the HP graph as a % of max which requires having independent scale, but I don't know how to do that without also forcing the purify casts to have their own independent scale.

### Testing
- Test report URL: `/report/cVTwyWK2fn1FvB8L/1-Mythic++Algeth'ar+Academy+-+Kill+(26:24)/5-Bluefists/standard/stagger`
<img width="1230" height="222" alt="image" src="https://github.com/user-attachments/assets/441c1bb5-38b4-46c9-8703-e8770101df1f" />

