### PR TITLE
[Warrior] [Fury] Update Fury APL + buffStacks condition bugfix

### DIFF
--- a/src/analysis/retail/warrior/arms/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/arms/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { Nevdok } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2026, 4, 3), 'Fix apex talent CS cdr', Nevdok),
   change(date(2026, 3, 14), 'Midnight season 1 APL updates', Nevdok),
   change(date(2026, 1, 19), 'Midnight cleanup before prepatch', Nevdok),
   change(date(2026, 1, 12), 'Prepare Arms for Midnight. Update talents, spells and cooldowns. Migrate to Guide', Nevdok),

--- a/src/analysis/retail/warrior/arms/modules/talents/ColossusSmash.tsx
+++ b/src/analysis/retail/warrior/arms/modules/talents/ColossusSmash.tsx
@@ -4,7 +4,7 @@ import TALENTS from 'common/TALENTS/warrior';
 import { SpellLink } from 'interface';
 import Analyzer, { SELECTED_PLAYER, Options } from 'parser/core/Analyzer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
-import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
+import Events, { DamageEvent } from 'parser/core/Events';
 import Enemies from 'parser/shared/modules/Enemies';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
@@ -16,7 +16,6 @@ import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
  */
 
 const COLOSSUS_SMASH_BONUS_DAMAGE = 0.3;
-const ARMS_WARRIOR_APEX4_COLOSSUS_SMASH_CDR = 2000;
 
 class ColossusSmash extends Analyzer.withDependencies({
   spellUsable: SpellUsable,
@@ -34,19 +33,6 @@ class ColossusSmash extends Analyzer.withDependencies({
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.COLOSSUS_SMASH_TALENT);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this._onDamage);
-    if (this.selectedCombatant.hasTalent(TALENTS.MASTER_OF_WARFARE_3_ARMS_TALENT)) {
-      this.addEventListener(
-        Events.cast.by(SELECTED_PLAYER).spell(SPELLS.HEROIC_STRIKE),
-        this.onHeroicStrikeCast,
-      );
-    }
-  }
-
-  onHeroicStrikeCast(event: CastEvent) {
-    this.deps.spellUsable.reduceCooldown(
-      SPELLS.COLOSSUS_SMASH.id,
-      ARMS_WARRIOR_APEX4_COLOSSUS_SMASH_CDR,
-    );
   }
 
   _onDamage(event: DamageEvent) {

--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { Gambyt, Nevdok } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2026, 4, 3), 'More midnight season 1 APL updates', Nevdok),
   change(date(2026, 3, 26), 'Fix Statistics for Sudden Death Procs', Gambyt),
   change(date(2026, 3, 25), 'Update spellbook. Fix cooldown reset issues', Gambyt),
   change(date(2026, 3, 14), 'Midnight season 1 APL updates', Nevdok),

--- a/src/analysis/retail/warrior/fury/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/warrior/fury/modules/core/AplCheck.tsx
@@ -34,9 +34,25 @@ export const apl = (info: PlayerInfo): Apl => {
   // threshold below which builders are still better than spending (115 rage)
   // in the future this will probably be based on talents
 
+  const apexRampageRageReduction =
+    info.combatant.getTalentRank(TALENTS.RAMPAGING_BERSERKER_2_FURY_TALENT) * 150;
+  // fury apex reduces rampage rage cost by 15 rage per rank
+
   return info.combatant.hasTalent(TALENTS.SLAYERS_DOMINANCE_TALENT)
-    ? buildSlayerApl(executeThreshold, executeUsable, executeSpell, rampageRageThreshold)
-    : buildThaneApl(executeThreshold, executeUsable, executeSpell, rampageRageThreshold);
+    ? buildSlayerApl(
+        executeThreshold,
+        executeUsable,
+        executeSpell,
+        rampageRageThreshold,
+        apexRampageRageReduction,
+      )
+    : buildThaneApl(
+        executeThreshold,
+        executeUsable,
+        executeSpell,
+        rampageRageThreshold,
+        apexRampageRageReduction,
+      );
 };
 
 export const buildSlayerApl = (
@@ -44,19 +60,23 @@ export const buildSlayerApl = (
   executeUsable: Condition<boolean>,
   executeSpell: Spell,
   rampageRageThreshold: number,
+  apexRampageRageReduction: number,
 ): Apl => {
   return build([
     // Enrage
     {
       spell: SPELLS.RAMPAGE,
       condition: cnd.and(
-        cnd.buffMissing(SPELLS.ENRAGE),
         cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 }),
+        cnd.or(
+          cnd.buffMissing(SPELLS.ENRAGE),
+          cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
+        ),
       ),
       description: (
         <>
-          Cast <SpellLink spell={SPELLS.RAMPAGE} /> to apply <SpellLink spell={SPELLS.ENRAGE} /> if
-          it is missing
+          Cast <SpellLink spell={SPELLS.RAMPAGE} /> above {rampageRageThreshold / 10} rage, or to
+          apply <SpellLink spell={SPELLS.ENRAGE} /> if it is missing
         </>
       ),
     },
@@ -78,7 +98,10 @@ export const buildSlayerApl = (
     // rampage during reck
     {
       spell: SPELLS.RAMPAGE,
-      condition: cnd.buffPresent(SPELLS.RECKLESSNESS),
+      condition: cnd.and(
+        cnd.buffPresent(SPELLS.RECKLESSNESS),
+        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 - apexRampageRageReduction }),
+      ),
       description: (
         <>
           Cast <SpellLink spell={SPELLS.RAMPAGE} /> during <SpellLink spell={SPELLS.RECKLESSNESS} />
@@ -93,6 +116,20 @@ export const buildSlayerApl = (
       description: (
         <>
           Cast <SpellLink spell={executeSpell} />
+        </>
+      ),
+    },
+
+    // CB regardless of rage
+    {
+      spell: SPELLS.CRUSHING_BLOW,
+      condition: cnd.and(
+        cnd.spellAvailable(SPELLS.RAGING_BLOW),
+        cnd.buffPresent(SPELLS.RECKLESSNESS),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.CRUSHING_BLOW} />
         </>
       ),
     },
@@ -120,20 +157,6 @@ export const buildSlayerApl = (
       ),
     },
 
-    // CB regardless of rage
-    {
-      spell: SPELLS.CRUSHING_BLOW,
-      condition: cnd.and(
-        cnd.spellAvailable(SPELLS.RAGING_BLOW),
-        cnd.buffPresent(SPELLS.RECKLESSNESS),
-      ),
-      description: (
-        <>
-          Cast <SpellLink spell={SPELLS.CRUSHING_BLOW} />
-        </>
-      ),
-    },
-
     // RB below rage threshold
     {
       spell: SPELLS.RAGING_BLOW,
@@ -152,6 +175,7 @@ export const buildThaneApl = (
   executeUsable: Condition<boolean>,
   executeSpell: Spell,
   rampageRageThreshold: number,
+  apexRampageRageReduction: number,
 ): Apl => {
   return build([
     // Enrage
@@ -165,18 +189,6 @@ export const buildThaneApl = (
         <>
           Cast <SpellLink spell={SPELLS.RAMPAGE} /> to apply <SpellLink spell={SPELLS.ENRAGE} /> if
           it is missing
-        </>
-      ),
-    },
-
-    // high rage rampage
-    {
-      spell: SPELLS.RAMPAGE,
-      condition: cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
-      description: (
-        <>
-          Cast <SpellLink spell={SPELLS.RAMPAGE} /> above {rampageRageThreshold / 10} rage to avoid
-          overcapping
         </>
       ),
     },
@@ -195,6 +207,18 @@ export const buildThaneApl = (
       ),
     },
 
+    // high rage rampage
+    {
+      spell: SPELLS.RAMPAGE,
+      condition: cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.RAMPAGE} /> above {rampageRageThreshold / 10} rage to avoid
+          overcapping
+        </>
+      ),
+    },
+
     // BB regardless of rage
     {
       spell: SPELLS.BLOODBATH,
@@ -209,14 +233,16 @@ export const buildThaneApl = (
       ),
     },
 
-    // BT below rage threshold
+    // rampage during reck
     {
-      spell: SPELLS.BLOODTHIRST,
-      condition: cnd.spellAvailable(SPELLS.BLOODTHIRST),
-
+      spell: SPELLS.RAMPAGE,
+      condition: cnd.and(
+        cnd.buffPresent(SPELLS.RECKLESSNESS),
+        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 - apexRampageRageReduction }),
+      ),
       description: (
         <>
-          Cast <SpellLink spell={SPELLS.BLOODTHIRST} />
+          Cast <SpellLink spell={SPELLS.RAMPAGE} /> during <SpellLink spell={SPELLS.RECKLESSNESS} />
         </>
       ),
     },
@@ -237,6 +263,18 @@ export const buildThaneApl = (
       ),
     },
 
+    // BT below rage threshold
+    {
+      spell: SPELLS.BLOODTHIRST,
+      condition: cnd.spellAvailable(SPELLS.BLOODTHIRST),
+
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.BLOODTHIRST} />
+        </>
+      ),
+    },
+
     // Exe conditions
     {
       spell: executeSpell,
@@ -244,6 +282,20 @@ export const buildThaneApl = (
       description: (
         <>
           Cast <SpellLink spell={executeSpell} /> if specced into its respective talents
+        </>
+      ),
+    },
+
+    // CB regardless of rage
+    {
+      spell: SPELLS.CRUSHING_BLOW,
+      condition: cnd.and(
+        cnd.spellAvailable(SPELLS.RAGING_BLOW),
+        cnd.buffPresent(SPELLS.RECKLESSNESS),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.CRUSHING_BLOW} />
         </>
       ),
     },
@@ -269,20 +321,6 @@ export const buildThaneApl = (
       description: (
         <>
           Cast <SpellLink spell={SPELLS.RAMPAGE} />
-        </>
-      ),
-    },
-
-    // CB regardless of rage
-    {
-      spell: SPELLS.CRUSHING_BLOW,
-      condition: cnd.and(
-        cnd.spellAvailable(SPELLS.RAGING_BLOW),
-        cnd.buffPresent(SPELLS.RECKLESSNESS),
-      ),
-      description: (
-        <>
-          Cast <SpellLink spell={SPELLS.CRUSHING_BLOW} />
         </>
       ),
     },

--- a/src/analysis/retail/warrior/shared/modules/talents/Executioner.tsx
+++ b/src/analysis/retail/warrior/shared/modules/talents/Executioner.tsx
@@ -11,7 +11,6 @@ class Executioner extends Analyzer.withDependencies({
 }) {
   constructor(options: Options) {
     super(options);
-    console.log(this.selectedCombatant.hasTalent(talents.BLADESTORM_TALENT));
     this.active = this.selectedCombatant.hasTalent(talents.BLADESTORM_TALENT);
 
     this.addEventListener(

--- a/src/parser/shared/metrics/apl/conditions/buffStacks.tsx
+++ b/src/parser/shared/metrics/apl/conditions/buffStacks.tsx
@@ -7,7 +7,7 @@ import { Range, formatRange } from './index';
 
 export default function buffStacks(spell: Spell, range: Range): Condition<number> {
   return {
-    key: `buffPresent-${spell.id}`,
+    key: `buffStacks-${spell.id}`,
     init: () => 0,
     update: (state, event) => {
       switch (event.type) {


### PR DESCRIPTION
### Description

- Update Fury APLs (both slayer and thane hero specs) to reflect more recent theorycrafting
- Minor cleanup of Arms to reflect change to their apex talents
- Update key used by `buffStacks` condition for AplCheck to prevent a collision with the `buffPresent` condition; this was causing buff stacks to not be correctly tracked when AplChecks were running in cases where the same buff was being passed into both conditions

### Testing

- Test report URL: `/report/6XL1ZWkc2DTdCbRB/41-Mythic+Vorasius+-+Kill+(6:18)/472-Bigbowwl/standard`, `/report/PQyp1r8gAWxkDBGC/25/205`
- Screenshot(s):
<img width="1271" height="659" alt="image" src="https://github.com/user-attachments/assets/d6d54b8c-c83d-4e7a-8b65-d765223151e1" />
<img width="1297" height="587" alt="image" src="https://github.com/user-attachments/assets/99257a48-10dc-483a-bccb-0cd9b8a92d94" />
