### PR TITLE
windwalker: fix cooldown tracking for WW cooldown reducers

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -6,6 +6,24 @@ import SpellLink from 'interface/SpellLink';
 
 export default [
   change(
+    date(2026, 4, 3),
+    <>
+      Fixed cooldown availability for{' '}
+      <SpellLink spell={TALENTS.WHIRLING_DRAGON_PUNCH_TALENT} />,{' '}
+      <SpellLink spell={TALENTS.STRIKE_OF_THE_WINDLORD_TALENT} />,{' '}
+      <SpellLink spell={SPELLS.FISTS_OF_FURY_CAST} />,{' '}
+      <SpellLink spell={TALENTS.RISING_SUN_KICK_TALENT} />, and{' '}
+      <SpellLink spell={TALENTS.ZENITH_TALENT} /> by correcting Midnight
+      Season 1 set and <SpellLink spell={TALENTS.COMMUNION_WITH_WIND_TALENT} />{' '}
+      cooldown updates, adding missing haste sources, counting{' '}
+      <SpellLink spell={SPELLS.RUSHING_WIND_KICK_CAST} /> crits for{' '}
+      <SpellLink spell={TALENTS.XUENS_BATTLEGEAR_TALENT} />, and inferring
+      hidden <SpellLink spell={SPELLS.TEACHINGS_OF_THE_MONASTERY} />{' '}
+      bonus-strike cooldown reduction.
+    </>,
+    Durpn,
+  ),
+  change(
     date(2026, 3, 29),
     <>
       Updated Windwalker statistics for current talents and cooldowns: fixed{' '}

--- a/src/analysis/retail/monk/windwalker/CombatLogParser.ts
+++ b/src/analysis/retail/monk/windwalker/CombatLogParser.ts
@@ -48,11 +48,15 @@ import {
 import ComboBreakerCastLinkNormalizer from './normalizers/ComboBreakerCastLinkNormalizer';
 import DanceOfChiJiCastLinkNormalizer from './normalizers/DanceOfChiJiCastLinkNormalizer';
 import CelestialConduit from './modules/talents/CelestialConduit';
+import CyclonesDrift from './modules/talents/CyclonesDrift';
 import SlicingWinds from './modules/spells/SlicingWinds';
 import T34ConduitTier from '../shared/hero/ConduitOfTheCelestials/tier/T34Tier';
+import VeteransEye from '../shared/hero/ShadoPan/VeteransEye';
 import RushingWindKick from './modules/talents/RushingWindKick';
+import GloryOfTheDawnLinkNormalizer from './normalizers/GloryOfTheDawnLinkNormalizer';
 import RushingWindKickGenerationNormalizer from './normalizers/RushingWindKickGenerationNormalizer';
 import RushingWindKickCastLinkNormalizer from './normalizers/RushingWindKickCastLinkNormalizer';
+import XuensBattlegearNormalizer from './normalizers/XuensBattlegearNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -66,8 +70,10 @@ class CombatLogParser extends CoreCombatLogParser {
     cracklingJadeLightningNormalizer: CracklingJadeLightningNormalizer,
     cracklingJadeLightningLinkNormalizer: CracklingJadeLightningLinkNormalizer,
     comboBreakerLinkNormalizer: ComboBreakerCastLinkNormalizer,
+    gloryOfTheDawnLinkNormalizer: GloryOfTheDawnLinkNormalizer,
     rushingWindKickGenerationNormalizer: RushingWindKickGenerationNormalizer,
     rushingWindKickLinkNormalizer: RushingWindKickCastLinkNormalizer,
+    xuensBattlegearNormalizer: XuensBattlegearNormalizer,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,
@@ -88,6 +94,8 @@ class CombatLogParser extends CoreCombatLogParser {
     chiBurst: ChiBurst,
     heartOfTheJadeSerpent: HeartOfTheJadeSerpent,
     celestialConduit: CelestialConduit,
+    cyclonesDrift: CyclonesDrift,
+    veteransEye: VeteransEye,
     zenith: Zenith,
     rushingWindKick: RushingWindKick,
 

--- a/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
@@ -1,5 +1,6 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
+import { TIERS } from 'game/TIERS';
 import CoreAbilities from 'parser/core/modules/Abilities';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
@@ -7,6 +8,14 @@ import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 class Abilities extends CoreAbilities {
   spellbook(): SpellbookAbility[] {
     const combatant = this.selectedCombatant;
+    const hasMidnight4pc = combatant.has4PieceByTier(TIERS.MID1);
+    const windwalkerTierCooldownReduction = hasMidnight4pc ? 5 : 0;
+    const communionWithWindReduction = combatant.hasTalent(TALENTS_MONK.COMMUNION_WITH_WIND_TALENT)
+      ? 5
+      : 0;
+    const zenithCooldownReduction = combatant.hasTalent(TALENTS_MONK.EFFICIENT_TRAINING_TALENT)
+      ? 10
+      : 0;
     // Windwalker GCD is 1 second by default and static in almost all cases, 750 is lowest recorded GCD
     // Serenity's interaction with cooldowns is handled in the Serenity module
     return [
@@ -38,7 +47,7 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: (haste) => 24 / (1 + haste),
+        cooldown: 35 - communionWithWindReduction - windwalkerTierCooldownReduction,
         gcd: {
           static: 1000,
         },
@@ -109,6 +118,14 @@ class Abilities extends CoreAbilities {
           recommendedEfficiency: 0.95,
         },
       },
+      {
+        spell: SPELLS.RUSHING_WIND_KICK_CAST.id,
+        category: SPELL_CATEGORY.ROTATIONAL,
+        gcd: {
+          static: 750,
+        },
+        enabled: combatant.hasTalent(TALENTS_MONK.RUSHING_WIND_KICK_WINDWALKER_TALENT),
+      },
       // cooldowns
       {
         spell: SPELLS.TOUCH_OF_KARMA_CAST.id,
@@ -126,7 +143,7 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS_MONK.ZENITH_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 90,
+        cooldown: 90 - zenithCooldownReduction,
         charges: 2,
         gcd: null,
         enabled: combatant.hasTalent(TALENTS_MONK.ZENITH_TALENT),
@@ -154,7 +171,7 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: combatant.hasTalent(TALENTS_MONK.COMMUNION_WITH_WIND_TALENT) ? 30 : 40,
+        cooldown: 35 - communionWithWindReduction - windwalkerTierCooldownReduction,
         gcd: {
           static: 1000,
         },

--- a/src/analysis/retail/monk/windwalker/modules/core/SpellUsable.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/core/SpellUsable.tsx
@@ -1,10 +1,28 @@
 import SPELLS from 'common/SPELLS/monk';
 import TALENTS from 'common/TALENTS/monk';
+import HIT_TYPES from 'game/HIT_TYPES';
 import { SpellLink } from 'interface';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { AbilityEvent, CastEvent, EventType } from 'parser/core/Events';
+import Events, {
+  AbilityEvent,
+  CastEvent,
+  DamageEvent,
+  EventType,
+  RemoveBuffEvent,
+  RemoveBuffStackEvent,
+} from 'parser/core/Events';
 import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
 import { addEnhancedCastReason } from 'parser/core/EventMetaLib';
+import { triggeredGloryOfTheDawnFromRushingWindKick } from 'analysis/retail/monk/windwalker/normalizers/GloryOfTheDawnLinkNormalizer';
+import { getLateXuensBattlegearTriggers } from 'analysis/retail/monk/windwalker/normalizers/XuensBattlegearNormalizer';
+
+const TOTM_CONSUME_WINDOW_MS = 400;
+const XUENS_BATTLEGEAR_FOF_CDR_MS = 4000;
+const debug = false;
+
+type PreAppliedXuensBattlegearDamageEvent = DamageEvent & {
+  preAppliedXuensBattlegearReductionMs?: number;
+};
 
 // Override spell usable to handle CD resets on RSK from Teachings of the Monastery
 // There is no direct event to observe, so if we detect RSK being used earlier than its CD dictates,
@@ -15,6 +33,8 @@ class SpellUsable extends CoreSpellUsable {
   };
 
   lastPotentialTriggerForRskReset: CastEvent | null = null;
+  lastPotentialTriggerForMissingGotdCrit: CastEvent | DamageEvent | null = null;
+  lastBlackoutKickTimestamp = 0;
   constructor(options: Options) {
     super(options);
     this.addEventListener(
@@ -25,10 +45,78 @@ class SpellUsable extends CoreSpellUsable {
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.BLACKOUT_KICK_TOTM),
       this.onBlackoutKick,
     );
+    this.addEventListener(
+      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.TEACHINGS_OF_THE_MONASTERY),
+      this.onTotmConsumed,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.TEACHINGS_OF_THE_MONASTERY),
+      this.onTotmConsumed,
+    );
+    const tracksHiddenGotdCrit =
+      this.selectedCombatant.hasTalent(TALENTS.RUSHING_WIND_KICK_WINDWALKER_TALENT) &&
+      this.selectedCombatant.hasTalent(TALENTS.GLORY_OF_THE_DAWN_TALENT) &&
+      this.selectedCombatant.hasTalent(TALENTS.XUENS_BATTLEGEAR_TALENT);
+
+    if (tracksHiddenGotdCrit) {
+      this.addEventListener(
+        Events.cast.by(SELECTED_PLAYER).spell(SPELLS.RUSHING_WIND_KICK_CAST),
+        this.onRushingWindKickCast,
+      );
+      this.addEventListener(
+        Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RUSHING_WIND_KICK_DAMAGE),
+        this.onRushingWindKickDamage,
+      );
+    }
   }
 
   onBlackoutKick(event: CastEvent) {
+    this.lastBlackoutKickTimestamp = event.timestamp;
     this.lastPotentialTriggerForRskReset = event;
+  }
+
+  onTotmConsumed(event: RemoveBuffEvent | RemoveBuffStackEvent) {
+    if (event.timestamp - this.lastBlackoutKickTimestamp > TOTM_CONSUME_WINDOW_MS) {
+      return;
+    }
+
+    // Logs often omit a distinct BLACKOUT_KICK_TOTM cast event, so treat TotM
+    // consumption as another possible hidden RSK reset trigger.
+    if (this.lastPotentialTriggerForRskReset !== null) {
+      this.lastPotentialTriggerForRskReset = {
+        ...this.lastPotentialTriggerForRskReset,
+        timestamp: event.timestamp,
+      };
+    }
+  }
+
+  onRushingWindKickCast(event: CastEvent) {
+    // RWK's damage can land after a subsequent FoF cast, and the GoTD follow-up can be missing
+    // entirely if it procs beyond GoTD's shorter range.
+    this.lastPotentialTriggerForMissingGotdCrit = event;
+  }
+
+  onRushingWindKickDamage(event: DamageEvent) {
+    // Update the pending trigger to the actual damage timestamp once the hit lands.
+    this.lastPotentialTriggerForMissingGotdCrit = event;
+  }
+
+  private preApplyLateXuensBattlegearReductions(event: CastEvent) {
+    for (const triggerEvent of getLateXuensBattlegearTriggers(event)) {
+      const isCrit =
+        triggerEvent.hitType === HIT_TYPES.CRIT || triggerEvent.hitType === HIT_TYPES.BLOCKED_CRIT;
+      if (!isCrit) {
+        continue;
+      }
+
+      const reductionMs = this.reduceCooldown(
+        SPELLS.FISTS_OF_FURY_CAST.id,
+        XUENS_BATTLEGEAR_FOF_CDR_MS,
+        event.timestamp,
+      );
+      (triggerEvent as PreAppliedXuensBattlegearDamageEvent).preAppliedXuensBattlegearReductionMs =
+        reductionMs;
+    }
   }
 
   beginCooldown(triggerEvent: AbilityEvent<EventType>, _spellId: number) {
@@ -59,6 +147,35 @@ class SpellUsable extends CoreSpellUsable {
         );
       }
       this.lastPotentialTriggerForRskReset = null;
+    }
+    if (spellId === SPELLS.FISTS_OF_FURY_CAST.id) {
+      this.preApplyLateXuensBattlegearReductions(triggerEvent as CastEvent);
+
+      const missingGotdCritTrigger = this.lastPotentialTriggerForMissingGotdCrit;
+      if (
+        this.isOnCooldown(spellId) &&
+        this.chargesAvailable(spellId) === 0 &&
+        missingGotdCritTrigger !== null &&
+        !(
+          missingGotdCritTrigger.type === EventType.Damage &&
+          triggeredGloryOfTheDawnFromRushingWindKick(missingGotdCritTrigger)
+        )
+      ) {
+        // Apply only the hidden GoTD crit's 4s Xuen's Battlegear reduction. If FoF is still not
+        // available afterwards, let CoreSpellUsable continue to flag the remaining mismatch.
+        const reductionMs = this.reduceCooldown(
+          spellId,
+          XUENS_BATTLEGEAR_FOF_CDR_MS,
+          triggerEvent.timestamp,
+        );
+
+        debug &&
+          reductionMs > 0 &&
+          this.log(
+            `Applied hidden GoTD/Xuen FoF reduction of ${reductionMs}ms at ${this.owner.formatTimestamp(triggerEvent.timestamp, 1)}`,
+          );
+      }
+      this.lastPotentialTriggerForMissingGotdCrit = null;
     }
 
     super.beginCooldown(triggerEvent, spellId);

--- a/src/analysis/retail/monk/windwalker/modules/spells/BlackoutKick.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/BlackoutKick.tsx
@@ -2,7 +2,7 @@ import type { JSX } from 'react';
 import SPELLS from 'common/SPELLS';
 import { SpellIcon, SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, { CastEvent, RemoveBuffEvent, RemoveBuffStackEvent } from 'parser/core/Events';
 import { ThresholdStyle } from 'parser/core/ParseResults';
 import SpellUsable from 'analysis/retail/monk/windwalker/modules/core/SpellUsable';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
@@ -56,6 +56,9 @@ class BlackoutKick extends Analyzer {
   wastedRisingSunKickReductionMs = 0;
   effectiveFistsOfFuryReductionMs = 0;
   wastedFistsOfFuryReductionMs = 0;
+  lastBlackoutKickTimestamp = 0;
+
+  static TOTM_CONSUME_WINDOW_MS = 400;
 
   constructor(options: Options) {
     super(options);
@@ -67,6 +70,30 @@ class BlackoutKick extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell([SPELLS.BLACKOUT_KICK, SPELLS.BLACKOUT_KICK_TOTM]),
       this.onCast,
     );
+    this.addEventListener(
+      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.TEACHINGS_OF_THE_MONASTERY),
+      this.onTotmConsumed,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.TEACHINGS_OF_THE_MONASTERY),
+      this.onTotmConsumed,
+    );
+  }
+
+  onTotmConsumed(event: RemoveBuffEvent | RemoveBuffStackEvent) {
+    if (event.timestamp - this.lastBlackoutKickTimestamp > BlackoutKick.TOTM_CONSUME_WINDOW_MS) {
+      return;
+    }
+
+    // Warcraft Logs often omits a separate BLACKOUT_KICK_TOTM cast, but the buff
+    // consumption still implies the bonus strike and its matching cooldown reduction.
+    const [effectiveRsk, wastedRsk] = this.applyCdr(TALENTS_MONK.RISING_SUN_KICK_TALENT.id);
+    this.effectiveRisingSunKickReductionMs += effectiveRsk;
+    this.wastedRisingSunKickReductionMs += wastedRsk;
+
+    const [effectiveFoF, wastedFoF] = this.applyCdr(SPELLS.FISTS_OF_FURY_CAST.id);
+    this.effectiveFistsOfFuryReductionMs += effectiveFoF;
+    this.wastedFistsOfFuryReductionMs += wastedFoF;
   }
 
   applyCdr(spellId: number): [number, number] {
@@ -87,6 +114,7 @@ class BlackoutKick extends Analyzer {
   }
 
   onCast(event: CastEvent) {
+    this.lastBlackoutKickTimestamp = event.timestamp;
     const availableImportantCast = this.IMPORTANT_SPELLS.filter((spellId) =>
       this.spellUsable.isAvailable(spellId),
     );

--- a/src/analysis/retail/monk/windwalker/modules/talents/CyclonesDrift.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/CyclonesDrift.tsx
@@ -1,0 +1,21 @@
+import { TALENTS_MONK } from 'common/TALENTS';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import StatTracker from 'parser/shared/modules/StatTracker';
+
+class CyclonesDrift extends Analyzer.withDependencies({
+  statTracker: StatTracker,
+}) {
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.CYCLONES_DRIFT_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    // Cyclone's Drift scales haste from rating and future haste-giving stat effects.
+    this.deps.statTracker.addStatMultiplier({ haste: 1.1 }, false, 'CyclonesDrift');
+  }
+}
+
+export default CyclonesDrift;

--- a/src/analysis/retail/monk/windwalker/modules/talents/XuensBattlegear.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/XuensBattlegear.tsx
@@ -14,8 +14,13 @@ import { TALENTS_MONK } from 'common/TALENTS';
 const FISTS_OF_FURY_COOLDOWN_REDUCTION_MS = 4000;
 const XUENS_BATTLEGEAR_TRIGGER_SPELLS = [
   SPELLS.RISING_SUN_KICK_DAMAGE,
+  SPELLS.RUSHING_WIND_KICK_DAMAGE,
   SPELLS.GLORY_OF_THE_DAWN_DAMAGE,
 ];
+
+type PreAppliedXuensBattlegearDamageEvent = DamageEvent & {
+  preAppliedXuensBattlegearReductionMs?: number;
+};
 
 class XuensBattlegear extends Analyzer {
   static dependencies = {
@@ -43,6 +48,14 @@ class XuensBattlegear extends Analyzer {
   onTriggerDamage(event: DamageEvent) {
     const isCrit = event.hitType === HIT_TYPES.CRIT || event.hitType === HIT_TYPES.BLOCKED_CRIT;
     if (!isCrit) {
+      return;
+    }
+    const preAppliedReductionMs = (event as PreAppliedXuensBattlegearDamageEvent)
+      .preAppliedXuensBattlegearReductionMs;
+    if (preAppliedReductionMs !== undefined) {
+      this.effectiveFistsOfFuryReductionMs += preAppliedReductionMs;
+      this.wastedFistsOfFuryReductionMs +=
+        FISTS_OF_FURY_COOLDOWN_REDUCTION_MS - preAppliedReductionMs;
       return;
     }
     if (!this.spellUsable.isOnCooldown(SPELLS.FISTS_OF_FURY_CAST.id)) {

--- a/src/analysis/retail/monk/windwalker/modules/talents/Zenith.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/Zenith.tsx
@@ -6,7 +6,7 @@ import { SpellIcon, SpellLink } from 'interface';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, { CastEvent, RemoveBuffEvent, RemoveBuffStackEvent } from 'parser/core/Events';
 import ChiTracker from 'analysis/retail/monk/windwalker/modules/resources/ChiTracker';
 import SpellUsable from 'analysis/retail/monk/windwalker/modules/core/SpellUsable';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
@@ -15,6 +15,9 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+
+const ADDITIONAL_BLACKOUT_KICK_CDR_MS = 1000;
+const TOTM_CONSUME_WINDOW_MS = 400;
 
 class Zenith extends Analyzer.withDependencies({
   chi: ChiTracker,
@@ -26,6 +29,7 @@ class Zenith extends Analyzer.withDependencies({
   private chiGeneratedPotential = 0;
   private readonly hasObsidianSpiral: boolean = false;
   private readonly zenithDurationMs: number = 15000;
+  private lastBlackoutKickTimestamp = 0;
 
   constructor(options: Options) {
     super(options);
@@ -46,6 +50,14 @@ class Zenith extends Analyzer.withDependencies({
       Events.cast.by(SELECTED_PLAYER).spell([SPELLS.BLACKOUT_KICK, SPELLS.BLACKOUT_KICK_TOTM]),
       this.onBlackoutKick,
     );
+    this.addEventListener(
+      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.TEACHINGS_OF_THE_MONASTERY),
+      this.onTotmConsumed,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.TEACHINGS_OF_THE_MONASTERY),
+      this.onTotmConsumed,
+    );
   }
 
   private isZenithActive(timestamp: number) {
@@ -62,6 +74,19 @@ class Zenith extends Analyzer.withDependencies({
     if (!this.isZenithActive(event.timestamp)) {
       return;
     }
+
+    this.lastBlackoutKickTimestamp = event.timestamp;
+    this.deps.spellUsable.reduceCooldown(
+      TALENTS_MONK.RISING_SUN_KICK_TALENT.id,
+      ADDITIONAL_BLACKOUT_KICK_CDR_MS,
+      event.timestamp,
+    );
+    this.deps.spellUsable.reduceCooldown(
+      TALENTS_MONK.FISTS_OF_FURY_TALENT.id,
+      ADDITIONAL_BLACKOUT_KICK_CDR_MS,
+      event.timestamp,
+    );
+
     this.blackoutKicksDuringZenith += 1;
     this.chiGeneratedPotential += 1;
     if (this.hasObsidianSpiral) {
@@ -75,6 +100,28 @@ class Zenith extends Analyzer.withDependencies({
         event.timestamp,
       );
     }
+  }
+
+  private onTotmConsumed(event: RemoveBuffEvent | RemoveBuffStackEvent) {
+    if (!this.isZenithActive(event.timestamp)) {
+      return;
+    }
+    if (event.timestamp - this.lastBlackoutKickTimestamp > TOTM_CONSUME_WINDOW_MS) {
+      return;
+    }
+
+    // Match the inferred TotM bonus strike so Zenith grants its extra 1s CDR
+    // even when the bonus Blackout Kick is not logged as a separate cast.
+    this.deps.spellUsable.reduceCooldown(
+      TALENTS_MONK.RISING_SUN_KICK_TALENT.id,
+      ADDITIONAL_BLACKOUT_KICK_CDR_MS,
+      event.timestamp,
+    );
+    this.deps.spellUsable.reduceCooldown(
+      TALENTS_MONK.FISTS_OF_FURY_TALENT.id,
+      ADDITIONAL_BLACKOUT_KICK_CDR_MS,
+      event.timestamp,
+    );
   }
 
   get guideSubsection(): JSX.Element {

--- a/src/analysis/retail/monk/windwalker/normalizers/GloryOfTheDawnLinkNormalizer.ts
+++ b/src/analysis/retail/monk/windwalker/normalizers/GloryOfTheDawnLinkNormalizer.ts
@@ -1,0 +1,45 @@
+import SPELLS from 'common/SPELLS';
+import { Options } from 'parser/core/Analyzer';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { DamageEvent, EventType, GetRelatedEvent, HasRelatedEvent } from 'parser/core/Events';
+
+const GLORY_OF_THE_DAWN_TRIGGER = 'glory-of-the-dawn-trigger';
+const GLORY_OF_THE_DAWN_TRIGGER_BUFFER_MS = 1000;
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: GLORY_OF_THE_DAWN_TRIGGER,
+    reverseLinkRelation: GLORY_OF_THE_DAWN_TRIGGER,
+    linkingEventId: SPELLS.GLORY_OF_THE_DAWN_DAMAGE.id,
+    linkingEventType: EventType.Damage,
+    referencedEventId: [SPELLS.RISING_SUN_KICK_DAMAGE.id, SPELLS.RUSHING_WIND_KICK_DAMAGE.id],
+    referencedEventType: EventType.Damage,
+    backwardBufferMs: GLORY_OF_THE_DAWN_TRIGGER_BUFFER_MS,
+    anyTarget: true,
+    maximumLinks: 1,
+  },
+];
+
+class GloryOfTheDawnLinkNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export function gloryOfTheDawnTrigger(event: DamageEvent): DamageEvent | undefined {
+  return GetRelatedEvent<DamageEvent>(event, GLORY_OF_THE_DAWN_TRIGGER);
+}
+
+export function triggeredGloryOfTheDawnFromRushingWindKick(event: DamageEvent): boolean {
+  return (
+    HasRelatedEvent(event, GLORY_OF_THE_DAWN_TRIGGER) &&
+    event.ability.guid === SPELLS.RUSHING_WIND_KICK_DAMAGE.id
+  );
+}
+
+export function triggeredGloryOfTheDawnFromRisingSunKick(event: DamageEvent): boolean {
+  const triggerEvent = gloryOfTheDawnTrigger(event);
+  return triggerEvent?.ability.guid === SPELLS.RISING_SUN_KICK_DAMAGE.id;
+}
+
+export default GloryOfTheDawnLinkNormalizer;

--- a/src/analysis/retail/monk/windwalker/normalizers/XuensBattlegearNormalizer.ts
+++ b/src/analysis/retail/monk/windwalker/normalizers/XuensBattlegearNormalizer.ts
@@ -1,0 +1,42 @@
+import SPELLS from 'common/SPELLS';
+import { Options } from 'parser/core/Analyzer';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { CastEvent, DamageEvent, EventType, GetRelatedEvents } from 'parser/core/Events';
+
+const XUENS_BATTLEGEAR_FOF_TRIGGER = 'xuens-battlegear-fof-trigger';
+const XUENS_BATTLEGEAR_BUFFER_MS = 500;
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: XUENS_BATTLEGEAR_FOF_TRIGGER,
+    reverseLinkRelation: XUENS_BATTLEGEAR_FOF_TRIGGER,
+    linkingEventId: SPELLS.FISTS_OF_FURY_CAST.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: [
+      SPELLS.RISING_SUN_KICK_DAMAGE.id,
+      SPELLS.RUSHING_WIND_KICK_DAMAGE.id,
+      SPELLS.GLORY_OF_THE_DAWN_DAMAGE.id,
+    ],
+    referencedEventType: EventType.Damage,
+    forwardBufferMs: XUENS_BATTLEGEAR_BUFFER_MS,
+    backwardBufferMs: XUENS_BATTLEGEAR_BUFFER_MS,
+    anyTarget: true,
+  },
+];
+
+/**
+ * RSK / RWK / Glory of the Dawn damage can be logged just after a nearby Fists of Fury cast.
+ * Link those late hits back to the FoF cast so SpellUsable can apply any Xuen's Battlegear
+ * reduction before validating the cast's cooldown availability.
+ */
+class XuensBattlegearNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
+export function getLateXuensBattlegearTriggers(event: CastEvent): DamageEvent[] {
+  return GetRelatedEvents<DamageEvent>(event, XUENS_BATTLEGEAR_FOF_TRIGGER);
+}
+
+export default XuensBattlegearNormalizer;

--- a/src/common/SPELLS/others.ts
+++ b/src/common/SPELLS/others.ts
@@ -38,6 +38,11 @@ const spells = {
     name: 'Speed',
     icon: 'petbattle_speed',
   },
+  AKILZONS_CRY_OF_VICTORY: {
+    id: 1252818,
+    name: "Akil'zon's Cry of Victory",
+    icon: 'ability_hunter_pathfinding2',
+  },
   ANCIENT_HEALING_POTION: {
     id: 188016,
     name: 'Ancient Healing Potion',

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -66,6 +66,7 @@ class StatTracker extends Analyzer {
 
     //region Phials
     // TODO: Figure out how to make this work with multiple ranks of phials
+    [SPELLS.FLASK_OF_THE_BLOOD_KNIGHTS.id]: { haste: 152 },
     // endregion
 
     //region Food
@@ -96,6 +97,7 @@ class StatTracker extends Analyzer {
     // endregion
 
     // region Other
+    [SPELLS.AKILZONS_CRY_OF_VICTORY.id]: { haste: 75, speed: 24 },
     // endregion
 
     // region Racials
@@ -350,7 +352,7 @@ class StatTracker extends Analyzer {
   /**
    * Adds a stat multiplier to tracking
    */
-  addStatMultiplier(statMult: StatMultiplier, changeCurrentStats = false): void {
+  addStatMultiplier(statMult: StatMultiplier, changeCurrentStats = false, source?: string): void {
     const delta: StatBuff = {};
     Object.entries(statMult).forEach(([stat, multiplier]: [string, number | undefined]) => {
       if (multiplier === undefined) {
@@ -363,7 +365,7 @@ class StatTracker extends Analyzer {
 
       debug &&
         console.log(
-          `StatTracker: ${stat} multiplier change (${before.toFixed(2)} -> ${this.playerMultipliers[
+          `${source ? `StatTracker[${source}]` : 'StatTracker'}: ${stat} multiplier change (${before.toFixed(2)} -> ${this.playerMultipliers[
             statKey
           ].toFixed(2)}) @ ${formatMilliseconds(this.owner.fightDuration)}`,
         );


### PR DESCRIPTION
### Description

Correct Windwalker cooldown availability in the Midnight analyzer by fixing several missing or incomplete cooldown inputs.

- update Whirling Dragon Punch and Strike of the Windlord cooldowns for Communion with Wind and the Midnight Season 1 four-piece
- add missing haste sources that affected shared cooldown math, including Cyclone's Drift scaling, Veteran's Eye wiring, Flask of the Blood Knights, and Akil'zon's Cry of Victory
- treat Rushing Wind Kick crits as valid Xuen's Battlegear reducers and reorder nearby damage events so those reductions land before adjacent Fists of Fury casts
- infer the hidden Teachings of the Monastery bonus strike for Blackout Kick and Zenith cooldown reduction when Warcraft Logs omits a distinct bonus-cast event

Together these fixes remove several false positives around FoF, RSK, Zenith, WDP, and SotWL availability.

### Testing

- Test report URL: `/report/63JNKRnYc4MvGZ8x/7-Mythic+Imperator+Averzian+-+Kill+(6:45)/66-Durpn/standard/overview`
- Screenshot(s):
