### PR TITLE
Adjust cooldown value for DRW  in Abilities module

### DIFF
--- a/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+    change(date(2026, 4, 5), <>Updated cooldown of <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT} />.</>, Badkad),
     change(date(2026, 4, 1), "Added basic support for Midnight", Badkad),
   change(date(2025, 9, 29), <>Updated cooldown and CDR of <SpellLink spell={talents.ANTI_MAGIC_ZONE_TALENT} />.</>, Arlie),
   change(date(2024, 11, 20), <>Add basic support for San'layn abilities.</>, emallson),

--- a/src/analysis/retail/deathknight/blood/modules/Abilities.ts
+++ b/src/analysis/retail/deathknight/blood/modules/Abilities.ts
@@ -102,7 +102,7 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
-        cooldown: 120,
+        cooldown: 90,
         castEfficiency: {
           suggestion: true,
           recommendedEfficiency: 0.9,

--- a/src/analysis/retail/deathknight/blood/modules/Abilities.ts
+++ b/src/analysis/retail/deathknight/blood/modules/Abilities.ts
@@ -53,7 +53,7 @@ class Abilities extends CoreAbilities {
         isDefensive: true,
       },
       {
-        spell: SPELLS.LICHBORNE.id,
+        spell: SPELLS.LICHBORNE.id, //NOTE: No longer defensive
         enabled: combatant.hasTalent(TALENTS.UNHOLY_ENDURANCE_TALENT), //Provides 15% DR if you take this talent
         category: SPELL_CATEGORY.DEFENSIVE,
         cooldown: 120 - combatant.getTalentRank(TALENTS.DEATHS_MESSENGER_TALENT) * 30,
@@ -74,7 +74,7 @@ class Abilities extends CoreAbilities {
         cooldown: 30,
         gcd: {
           base: 1500,
-        },
+        }, //NOTE: Need to implement new CONSUMPTION_TALENT with empowerment
         timelineSortIndex: 5,
       },
       //Rotational

--- a/src/analysis/retail/deathknight/blood/modules/features/BoneShieldTimesByStacks.ts
+++ b/src/analysis/retail/deathknight/blood/modules/features/BoneShieldTimesByStacks.ts
@@ -15,7 +15,6 @@ import SpellUsable from 'parser/shared/modules/SpellUsable';
 
 const MAX_BONE_SHIELD_STACKS = 15;
 const BONE_SHIELD_DURATION_MS = 30 * 1000;
-const DRW_COOLDOWN_REDUCTION_MS = 5000;
 /**
  boneShieldTimesByStacks() returns an array with the durations of each BS charge
  */
@@ -80,11 +79,6 @@ class BoneShieldStacksBySeconds extends Analyzer {
       return;
     }
     this.lastBoneShieldUpdate = event.timestamp;
-    const nextStacks = currentStacks(event);
-    const didExpire = nextStacks === 0 ? this.didExpire(event) : false;
-    if (nextStacks < this.lastBoneShieldStack && !didExpire) {
-      this.reduceDRWCooldown(nextStacks - this.lastBoneShieldStack);
-    }
     this.lastBoneShieldStack = currentStacks(event);
   }
 
@@ -122,24 +116,6 @@ class BoneShieldStacksBySeconds extends Analyzer {
       avgStacks += (durations.reduce((a, b) => a + b, 0) / this.owner.fightDuration) * index;
     });
     return avgStacks;
-  }
-
-  reduceDRWCooldown(stackDiff: number) {
-    if (!this.selectedCombatant.hasTalent(TALENTS.INSATIABLE_BLADE_TALENT)) {
-      return;
-    }
-    if (stackDiff >= 0) {
-      return;
-    }
-    const reduction = -stackDiff * DRW_COOLDOWN_REDUCTION_MS;
-    const reducedSpellID = TALENTS.DANCING_RUNE_WEAPON_TALENT.id;
-    if (!this.spellUsable.isOnCooldown(reducedSpellID)) {
-      this.totalDRWCooldownReductionWasted += reduction;
-    } else {
-      const effectiveReduction = this.spellUsable.reduceCooldown(reducedSpellID, reduction);
-      this.totalDRWCooldownReduction += effectiveReduction;
-      this.totalDRWCooldownReductionWasted += reduction - effectiveReduction;
-    }
   }
 }
 


### PR DESCRIPTION
### Description

Adjusted DRW cooldown from 120 seconds to 90 seconds and removed Boneshield Stack CDR logic

### Testing

Compare report with and withotu change for DRW usage

- Test report URL: `/reports/zm4gjZVNJ7YatwCf?fight=6&type=summary&source=474`
- Screenshot(s):
Before fix:
<img width="715" height="32" alt="image" src="https://github.com/user-attachments/assets/1163fa7f-71fe-4d31-868a-0fe9c61b2453" />

After fix:
<img width="1788" height="98" alt="image" src="https://github.com/user-attachments/assets/65cbff5e-51ca-4379-ab57-0d24d0ae5024" />



