### PR TITLE
feat(pulls): Improve selection for close calls

### DIFF
--- a/e2e/report-selection.spec.ts
+++ b/e2e/report-selection.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from './fixtures';
 
 const reportCode = 'VqRJyj1fx3DCwHnb';
 const reportTitle = 'HoF / ToES';
-const fightLinkName = 'Kill 3:31';
+const fightLinkName = 'Kill #1 3:31';
 const fightUrlPart = '5-Heroic+Lei+Shi+-+Kill+(3:31)';
 const bossTitle = `Heroic Lei Shi - Kill (3:31)`;
 const fightPageTitle = `${bossTitle} in ${reportTitle}`;

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -28,12 +28,14 @@ import {
   squided,
   Gambyt,
   MarchingCube,
+  Thias,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 6), <>Improve visuals for close calls in pull selection</>, Thias),
   change(date(2026, 4, 2), <>Link out-dated browsers to a functional website alternative</>, Vetyst),
   change(date(2026, 3, 31), <>Convert ReportHistory to TypeScript.</>, Vetyst),
   change(date(2026, 3, 24), <>Add <SpellLink spell={ITEMS.DARKMOON_SIGIL_HUNT} /> embellishment analyzer with stat buff tracking.</>, MarchingCube),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2849,3 +2849,9 @@ export const NotStirred: Contributor = {
   github: 'NotStirred',
   discord: 'NotStirred',
 };
+
+export const Thias: Contributor = {
+  nickname: 'Thias',
+  github: 'math280h',
+  discord: 'thias.',
+};

--- a/src/interface/report/FightSelection.scss
+++ b/src/interface/report/FightSelection.scss
@@ -38,6 +38,8 @@
       .icon {
         font-size: 1.22em;
         margin-right: 2px;
+      }
+      .icon:not(.ProgressBar) {
         vertical-align: -0.18em;
       }
     }

--- a/src/interface/report/FightSelection.scss
+++ b/src/interface/report/FightSelection.scss
@@ -38,6 +38,7 @@
       .icon {
         font-size: 1.22em;
         margin-right: 2px;
+        vertical-align: -0.18em;
       }
     }
   }

--- a/src/interface/report/FightSelection.scss
+++ b/src/interface/report/FightSelection.scss
@@ -21,7 +21,7 @@
 
     .pull {
       margin: 5px;
-      padding: 7px 10px;
+      padding: 9px 10px;
       background: rgba(255, 255, 255, 0.05);
       border-radius: 4px;
       color: Theme.$primaryColor;

--- a/src/interface/report/FightSelectionPanelList.tsx
+++ b/src/interface/report/FightSelectionPanelList.tsx
@@ -68,6 +68,10 @@ class FightSelectionPanelList extends PureComponent<Props> {
                     {pulls.map((pull) => {
                       const duration = Math.round(pull.end_time - pull.start_time);
                       const Icon = pull.kill ? SkullIcon : CancelIcon;
+                      // pull.fightPercentage is in 1/100ths of a percent (10000 = 100% HP remaining).
+                      const bossHpRemaining = pull.kill ? 0 : pull.fightPercentage! / 100;
+                      // Flag wipes where the boss had less than 2% HP left as a close call.
+                      const isCloseCall = !pull.kill && bossHpRemaining > 0 && bossHpRemaining < 2;
 
                       return (
                         <Link
@@ -90,11 +94,38 @@ class FightSelectionPanelList extends PureComponent<Props> {
                             </div>
                             <div className="flex-sub">
                               <small>{formatDuration(duration)}</small>{' '}
-                              <ProgressBar
-                                percentage={pull.kill ? 100 : (10000 - pull.fightPercentage!) / 100}
-                                width={100}
-                                height={8}
-                              />
+                              <span style={{ position: 'relative', display: 'inline-block' }}>
+                                <ProgressBar
+                                  percentage={
+                                    pull.kill ? 100 : (10000 - pull.fightPercentage!) / 100
+                                  }
+                                  width={100}
+                                  height={8}
+                                  tooltip={
+                                    pull.kill
+                                      ? 'Kill'
+                                      : `Boss had ${bossHpRemaining.toFixed(2)}% HP remaining`
+                                  }
+                                />
+                                {isCloseCall && (
+                                  <div
+                                    style={{
+                                      position: 'absolute',
+                                      left: '50%',
+                                      top: '100%',
+                                      transform: 'translateX(-50%)',
+                                      marginTop: -3,
+                                      color: '#ffd100',
+                                      fontSize: 10,
+                                      lineHeight: 1,
+                                      pointerEvents: 'none',
+                                      whiteSpace: 'nowrap',
+                                    }}
+                                  >
+                                    Close Call: {bossHpRemaining.toFixed(2)}%
+                                  </div>
+                                )}
+                              </span>
                             </div>
                           </div>
                         </Link>

--- a/src/interface/report/FightSelectionPanelList.tsx
+++ b/src/interface/report/FightSelectionPanelList.tsx
@@ -68,10 +68,7 @@ class FightSelectionPanelList extends PureComponent<Props> {
                     {pulls.map((pull) => {
                       const duration = Math.round(pull.end_time - pull.start_time);
                       const Icon = pull.kill ? SkullIcon : CancelIcon;
-                      // pull.fightPercentage is in 1/100ths of a percent (10000 = 100% HP remaining).
-                      const bossHpRemaining = pull.kill ? 0 : pull.fightPercentage! / 100;
-                      // Flag wipes where the boss had less than 2% HP left as a close call.
-                      const isCloseCall = !pull.kill && bossHpRemaining > 0 && bossHpRemaining < 2;
+                      const bossHpRemaining = (pull.fightPercentage! / 100).toFixed(2);
 
                       return (
                         <Link
@@ -82,50 +79,29 @@ class FightSelectionPanelList extends PureComponent<Props> {
                           <div className="flex">
                             <div className="flex-main">
                               <Icon />{' '}
-                              {pull.kill ? (
-                                <Trans id="interface.report.fightSelectionPanelList.kill">
-                                  Kill
-                                </Trans>
-                              ) : (
-                                <Trans id="interface.report.fightSelectionPanelList.wipe">
-                                  Wipe {getWipeCount(fights, pull)}
-                                </Trans>
-                              )}
+                              <span style={{ whiteSpace: 'nowrap' }}>
+                                {pull.kill ? (
+                                  <Trans id="interface.report.fightSelectionPanelList.kill">
+                                    Kill
+                                  </Trans>
+                                ) : (
+                                  `${bossHpRemaining}%`
+                                )}{' '}
+                                <small style={{ opacity: 0.65 }}>
+                                  #{getWipeCount(fights, pull)}
+                                </small>
+                              </span>
                             </div>
                             <div className="flex-sub">
                               <small>{formatDuration(duration)}</small>{' '}
-                              <span style={{ position: 'relative', display: 'inline-block' }}>
-                                <ProgressBar
-                                  percentage={
-                                    pull.kill ? 100 : (10000 - pull.fightPercentage!) / 100
-                                  }
-                                  width={100}
-                                  height={8}
-                                  tooltip={
-                                    pull.kill
-                                      ? 'Kill'
-                                      : `Boss had ${bossHpRemaining.toFixed(2)}% HP remaining`
-                                  }
-                                />
-                                {isCloseCall && (
-                                  <div
-                                    style={{
-                                      position: 'absolute',
-                                      left: '50%',
-                                      top: '100%',
-                                      transform: 'translateX(-50%)',
-                                      marginTop: -3,
-                                      color: '#ffd100',
-                                      fontSize: 10,
-                                      lineHeight: 1,
-                                      pointerEvents: 'none',
-                                      whiteSpace: 'nowrap',
-                                    }}
-                                  >
-                                    Close Call: {bossHpRemaining.toFixed(2)}%
-                                  </div>
-                                )}
-                              </span>
+                              <ProgressBar
+                                percentage={pull.kill ? 100 : (10000 - pull.fightPercentage!) / 100}
+                                width={100}
+                                height={8}
+                                tooltip={
+                                  pull.kill ? 'Kill' : `Boss had ${bossHpRemaining}% HP remaining`
+                                }
+                              />
                             </div>
                           </div>
                         </Link>

--- a/src/interface/report/FightSelectionPanelList.tsx
+++ b/src/interface/report/FightSelectionPanelList.tsx
@@ -98,9 +98,6 @@ class FightSelectionPanelList extends PureComponent<Props> {
                                 percentage={pull.kill ? 100 : (10000 - pull.fightPercentage!) / 100}
                                 width={100}
                                 height={8}
-                                tooltip={
-                                  pull.kill ? 'Kill' : `Boss had ${bossHpRemaining}% HP remaining`
-                                }
                               />
                             </div>
                           </div>

--- a/src/interface/report/ProgressBar.tsx
+++ b/src/interface/report/ProgressBar.tsx
@@ -1,10 +1,13 @@
+import Tooltip from 'interface/Tooltip';
+
 interface Props {
   width: number;
   height: number;
   percentage: number;
+  tooltip?: string;
 }
 
-const ProgressBar = ({ width, height, percentage }: Props) => {
+const ProgressBar = ({ width, height, percentage, tooltip }: Props) => {
   const backgroundColor = 'rgba(0,0,0,.6)';
   const wipeFillColor = '#fb6d35';
   const killFillColor = '#1d9c07';
@@ -12,7 +15,7 @@ const ProgressBar = ({ width, height, percentage }: Props) => {
   // Remove the height(radius of the bar) from the width to make sure the bars presented at the correct width.
   const adjustedWidth = width - 2 * height;
   const fillColor = percentage === 100 ? killFillColor : wipeFillColor;
-  return (
+  const svg = (
     <svg className="ProgressBar icon" style={{ width, height }}>
       <path
         strokeWidth={height}
@@ -34,6 +37,14 @@ const ProgressBar = ({ width, height, percentage }: Props) => {
       )}
     </svg>
   );
+  if (tooltip) {
+    return (
+      <Tooltip content={tooltip}>
+        <span style={{ display: 'inline-block', lineHeight: 0 }}>{svg}</span>
+      </Tooltip>
+    );
+  }
+  return svg;
 };
 
 export default ProgressBar;

--- a/src/interface/report/ProgressBar.tsx
+++ b/src/interface/report/ProgressBar.tsx
@@ -1,13 +1,10 @@
-import Tooltip from 'interface/Tooltip';
-
 interface Props {
   width: number;
   height: number;
   percentage: number;
-  tooltip?: string;
 }
 
-const ProgressBar = ({ width, height, percentage, tooltip }: Props) => {
+const ProgressBar = ({ width, height, percentage }: Props) => {
   const backgroundColor = 'rgba(0,0,0,.6)';
   const wipeFillColor = '#fb6d35';
   const killFillColor = '#1d9c07';
@@ -15,7 +12,7 @@ const ProgressBar = ({ width, height, percentage, tooltip }: Props) => {
   // Remove the height(radius of the bar) from the width to make sure the bars presented at the correct width.
   const adjustedWidth = width - 2 * height;
   const fillColor = percentage === 100 ? killFillColor : wipeFillColor;
-  const svg = (
+  return (
     <svg className="ProgressBar icon" style={{ width, height }}>
       <path
         strokeWidth={height}
@@ -37,14 +34,6 @@ const ProgressBar = ({ width, height, percentage, tooltip }: Props) => {
       )}
     </svg>
   );
-  if (tooltip) {
-    return (
-      <Tooltip content={tooltip}>
-        <span style={{ display: 'inline-block', lineHeight: 0 }}>{svg}</span>
-      </Tooltip>
-    );
-  }
-  return svg;
 };
 
 export default ProgressBar;


### PR DESCRIPTION
### Description

This PR Aims to improve the visual language around close calls as they can be hard to see with the current progress bar in pull selection.

Replace the "Wipe x" text with the remaining boss HP% on wipes as the wipe is implied by the boss not being killed, moved the pull count to a small text after the boss HP

It makes the boxes slightly taller to make space for the new text but only by a few px

Closes #6266 

### Testing

- Test report URL: `/report/xZmqapzPBVMfvTbk`
- Screenshot(s):
<img width="1248" height="127" alt="image" src="https://github.com/user-attachments/assets/9c9ba004-16c5-44a2-ba5d-e27924c32275" />
<img width="284" height="72" alt="image" src="https://github.com/user-attachments/assets/f76e7fd3-7f9f-47a3-9ffa-8d8b847b7781" />


Prod:
<img width="1115" height="101" alt="image" src="https://github.com/user-attachments/assets/c60549e7-7993-47ae-b619-bd96c895f8d6" />
