### PR TITLE
[Fury] Add Thunder Blast Execute Helper

### DIFF
--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { Gambyt, Nevdok } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2026, 4, 9), 'Fix max casts for Thunder Blast', Gambyt),
   change(date(2026, 4, 3), 'More midnight season 1 APL updates', Nevdok),
   change(date(2026, 4, 2), 'Remove old talents. Fix Anger Management Statistics', Gambyt),
   change(date(2026, 3, 26), 'Fix Statistics for Sudden Death Procs', Gambyt),

--- a/src/analysis/retail/warrior/fury/CombatLogParser.ts
+++ b/src/analysis/retail/warrior/fury/CombatLogParser.ts
@@ -41,6 +41,7 @@ import AplCheck from './modules/core/AplCheck';
 import Executioner from '../shared/modules/talents/Executioner';
 import AvatarOfTheStorm from './modules/talents/AvatarOfTheStorm';
 import BurstOfPower from './modules/talents/BurstOfPower';
+import ThunderBlast from './modules/spells/ThunderBlast';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -95,6 +96,7 @@ class CombatLogParser extends CoreCombatLogParser {
     executioner: Executioner,
     avatarOfTheStorm: AvatarOfTheStorm,
     burstOfPower: BurstOfPower,
+    thunderBlast: ThunderBlast,
 
     // Debuggers
     rageCountDebugger: RageCountDebugger,

--- a/src/analysis/retail/warrior/fury/modules/Abilities.ts
+++ b/src/analysis/retail/warrior/fury/modules/Abilities.ts
@@ -106,15 +106,6 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
       },
-      {
-        spell: SPELLS.THUNDER_BLAST.id,
-        enabled: combatant.hasTalent(TALENTS.THUNDER_BLAST_TALENT),
-        category: SPELL_CATEGORY.OTHERS,
-        cooldown: (haste: number) => 6 / (1 + haste),
-        gcd: {
-          base: 1500,
-        },
-      },
       // Cooldown
       {
         spell: SPELLS.RECKLESSNESS.id,

--- a/src/analysis/retail/warrior/fury/modules/spells/ThunderBlast.tsx
+++ b/src/analysis/retail/warrior/fury/modules/spells/ThunderBlast.tsx
@@ -5,7 +5,9 @@ import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 import ExecuteHelper from 'parser/shared/modules/helpers/ExecuteHelper';
 import TALENTS from 'common/TALENTS/warrior';
 import Spell from 'common/SPELLS/Spell';
-import Events from 'parser/core/Events';
+import Events, { ApplyBuffEvent, CastEvent } from 'parser/core/Events';
+
+const MS_BUFFER_100 = 100;
 
 export default class ThunderBlast extends ExecuteHelper.withDependencies({
   abilities: Abilities,
@@ -16,6 +18,9 @@ export default class ThunderBlast extends ExecuteHelper.withDependencies({
 
   static executeSpells = [SPELLS.THUNDER_BLAST];
   static countCooldownAsExecuteTime = true;
+
+  private lastAvatarCast = 0;
+  private hasAvatarOfTheStorm = false;
 
   private maxCasts = 0;
 
@@ -28,14 +33,21 @@ export default class ThunderBlast extends ExecuteHelper.withDependencies({
       return;
     }
 
+    this.hasAvatarOfTheStorm = this.selectedCombatant.hasTalent(TALENTS.AVATAR_OF_THE_STORM_TALENT);
+
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.THUNDER_BLAST_BUFF),
-      this.onThunderBlastBuff,
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.AVATAR_TALENT),
+      this.onAvatarCast,
     );
 
     this.addEventListener(
-      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.THUNDER_BLAST_BUFF),
-      this.onThunderBlastBuff,
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.THUNDER_BLAST_BUFF),
+      this.onThunderBlastApply,
+    );
+
+    this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.THUNDER_BLAST_BUFF),
+      this.onThunderBlastApplyStack,
     );
 
     this.deps.abilities.add({
@@ -51,7 +63,20 @@ export default class ThunderBlast extends ExecuteHelper.withDependencies({
     });
   }
 
-  private onThunderBlastBuff() {
+  private onAvatarCast(event: CastEvent) {
+    this.lastAvatarCast = event.timestamp;
+  }
+
+  private onThunderBlastApply(event: ApplyBuffEvent) {
+    // if you cast avatar you gain 2 stacks of the buff with avatar of the storm talent
+    if (this.hasAvatarOfTheStorm && event.timestamp - this.lastAvatarCast < MS_BUFFER_100) {
+      this.maxCasts += 2;
+    } else {
+      this.maxCasts += 1;
+    }
+  }
+
+  private onThunderBlastApplyStack() {
     this.maxCasts += 1;
   }
 }

--- a/src/analysis/retail/warrior/fury/modules/spells/ThunderBlast.tsx
+++ b/src/analysis/retail/warrior/fury/modules/spells/ThunderBlast.tsx
@@ -1,0 +1,57 @@
+import SPELLS from 'common/SPELLS';
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Abilities from 'parser/core/modules/Abilities';
+import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+import ExecuteHelper from 'parser/shared/modules/helpers/ExecuteHelper';
+import TALENTS from 'common/TALENTS/warrior';
+import Spell from 'common/SPELLS/Spell';
+import Events from 'parser/core/Events';
+
+export default class ThunderBlast extends ExecuteHelper.withDependencies({
+  abilities: Abilities,
+}) {
+  static executeSources = SELECTED_PLAYER;
+  static lowerThreshold = -1;
+  static executeOutsideRangeEnablers: Spell[] = [SPELLS.THUNDER_BLAST_BUFF];
+
+  static executeSpells = [SPELLS.THUNDER_BLAST];
+  static countCooldownAsExecuteTime = true;
+
+  private maxCasts = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS.THUNDER_BLAST_TALENT);
+
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.THUNDER_BLAST_BUFF),
+      this.onThunderBlastBuff,
+    );
+
+    this.addEventListener(
+      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.THUNDER_BLAST_BUFF),
+      this.onThunderBlastBuff,
+    );
+
+    this.deps.abilities.add({
+      spell: SPELLS.THUNDER_BLAST.id,
+      category: SPELL_CATEGORY.ROTATIONAL,
+      gcd: {
+        base: 1500,
+      },
+      cooldown: (haste) => 6 / (1 + haste),
+      castEfficiency: {
+        maxCasts: () => this.maxCasts,
+      },
+    });
+  }
+
+  private onThunderBlastBuff() {
+    this.maxCasts += 1;
+  }
+}


### PR DESCRIPTION
### Description

Move Thunder blast into an ExecuteHelper to accurately track max casts.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/bHMXxYWcKRPD4FT6/40-Heroic+Imperator+Averzian+-+Kill+(4:05)/30-Gambyt/standard/statistics`
- Screenshot(s):
Before:
<img width="909" height="30" alt="image" src="https://github.com/user-attachments/assets/5cddef31-87a6-48aa-8673-f79db191f1f4" />

After:
<img width="1015" height="55" alt="image" src="https://github.com/user-attachments/assets/ca4b0636-5d8c-417d-ab88-ec1f0d0e9137" />

