### PR TITLE
[Unholy] Add Active Time section to guide

### DIFF
--- a/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/deathknight';
 
 export default [
+  change(date(2026, 4, 10), <>Added Active Time section to the guide with ability uptime, melee uptime, and downtime tracking.</>, MarchingCube),
   change(date(2026, 4, 2), <>Add <SpellLink spell={TALENTS.UNHOLY_AURA_TALENT} /> haste tracking per active Magus of the Dead.</>, MarchingCube),
   change(date(2026, 4, 2), <>Reworked <SpellLink spell={TALENTS.SUDDEN_DOOM_TALENT} /> tracking with stack support, fixed false overwrites from simultaneous procs, and fixed multi-stack expiration counting.</>, MarchingCube),
   change(date(2026, 3, 24), <>Fix <SpellLink spell={SPELLS.ANTI_MAGIC_SHELL} /> cooldown with <SpellLink spell={TALENTS.ANTI_MAGIC_BARRIER_TALENT} /> and <SpellLink spell={SPELLS.DEATH_CHARGE} /> charges with <SpellLink spell={TALENTS.DEATHS_ECHO_TALENT} />.</>, MarchingCube),

--- a/src/analysis/retail/deathknight/unholy/modules/Guide.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/Guide.tsx
@@ -5,11 +5,16 @@ import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS/deathknight';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
 import Cooldowns from './guide/CooldownSection';
+import { FoundationDowntimeSection } from 'interface/guide/foundation/FoundationDowntimeSection';
 
 export default function Guide({ modules }: GuideProps<typeof CombatLogParser>) {
   return (
     <>
       <IntroSection />
+
+      <Section title="Active Time">
+        <FoundationDowntimeSection />
+      </Section>
 
       <Section title="Cooldown Tracking">
         <Cooldowns />


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->
Add FoundationDowntimeSection to the Unholy DK guide, providing ability uptime, melee uptime, and downtime tracking consistent with other melee specs.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: /report/62j3A8rtfDcMamXW/47-Mythic+Vorasius+-+Kill+(6:20)/56-Scharfer/standard
- Screenshot(s):
<img width="1252" height="741" alt="image" src="https://github.com/user-attachments/assets/dd7f2ec3-9707-41e0-84f2-7f696bc1a49d" />
