### PR TITLE
[Havoc] Blur defensive analysis

### DIFF
--- a/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
@@ -3,9 +3,11 @@ import { Topple, Vollmer, Hezaerd } from 'CONTRIBUTORS';
 import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/demonhunter';
+import SPELLS from 'common/SPELLS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 10), <>Add <SpellLink spell={SPELLS.BLUR} /> analysis to Havoc analysis.</>, Hezaerd),
   change(date(2026, 4, 2), <>Add initial Havoc analysis for <SpellLink spell={TALENTS.INERTIA_TALENT} /> and clean up outdated guide talent references.</>, Hezaerd),
   change(date(2025, 4, 21), <>Update example log.</>, Vollmer),
   change(date(2024, 9, 23), <>Improve handling of <SpellLink spell={TALENTS.EYE_BEAM_TALENT} /> in preparation for Demonsurge.</>, Topple),

--- a/src/analysis/retail/demonhunter/havoc/CONFIG.tsx
+++ b/src/analysis/retail/demonhunter/havoc/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Topple } from 'CONTRIBUTORS';
+import { Topple, Hezaerd } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
@@ -7,7 +7,7 @@ import CHANGELOG from './CHANGELOG';
 
 const CONFIG: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Topple],
+  contributors: [Topple, Hezaerd],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '12.0.1',

--- a/src/analysis/retail/demonhunter/havoc/Guide.tsx
+++ b/src/analysis/retail/demonhunter/havoc/Guide.tsx
@@ -1,6 +1,8 @@
-import { GuideProps, Section, SubSection } from 'interface/guide';
+import { GoodColor, GuideProps, Section, SubSection, useAnalyzers } from 'interface/guide';
 import TALENTS from 'common/TALENTS/demonhunter';
+import SPELLS from 'common/SPELLS/demonhunter';
 import { ResourceLink, SpellLink } from 'interface';
+import { Highlight } from 'interface/Highlight';
 import PreparationSection from 'interface/guide/components/Preparation/PreparationSection';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { HideExplanationsToggle } from 'interface/guide/components/HideExplanationsToggle';
@@ -18,6 +20,9 @@ import { HideGoodCastsToggle } from 'interface/guide/components/HideGoodCastsTog
 import { PerformanceStrong } from 'analysis/retail/priest/shadow/modules/guide/ExtraComponents';
 import { formatPercentage } from 'common/format';
 import ActiveTimeGraph from 'parser/ui/ActiveTimeGraph';
+import Blur from './modules/spells/Blur';
+import Timeline from 'interface/guide/components/MajorDefensives/Timeline';
+import AllCooldownUsageList from 'interface/guide/components/MajorDefensives/AllCooldownUsagesList';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -25,6 +30,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
       <ResourceUsageSection modules={modules} events={events} info={info} />
       <CooldownSection modules={modules} events={events} info={info} />
       <RotationSection modules={modules} events={events} info={info} />
+      <DefensivesSection modules={modules} events={events} info={info} />
       <PreparationSection />
     </>
   );
@@ -124,6 +130,51 @@ function RotationSection({ modules, info }: GuideProps<typeof CombatLogParser>) 
           </div>,
           <></>,
         )}
+    </Section>
+  );
+}
+
+function DefensivesSection({ modules }: GuideProps<typeof CombatLogParser>) {
+  const defensiveAnalyzers = useAnalyzers([Blur]);
+
+  return (
+    <Section title="Defensives">
+      <p>
+        <SpellLink spell={SPELLS.BLUR} /> is Havoc's primary personal defensive. Using it well helps
+        you survive dangerous moments more reliably and reduces avoidable pressure on your healers.
+      </p>
+      <p>
+        Because Blur has a relatively short cooldown, it should usually be used proactively for
+        meaningful incoming damage rather than held too long waiting for a perfect emergency.
+      </p>
+      <p>When reviewing your Blur usage, focus on two questions:</p>
+      <ol>
+        <li>
+          Did Blur cover dangerous spikes or other high-pressure damage windows?
+          <p>
+            <small>
+              In the damage chart below, a spike highlighted in{' '}
+              <Highlight color={GoodColor} textColor="black">
+                green
+              </Highlight>{' '}
+              was covered by Blur.
+            </small>
+          </p>
+        </li>
+        <li>
+          Was Blur used often enough across the fight, or was it held long enough to lose value?
+          <p>
+            <small>
+              The cooldown timeline below shows whether casts were timed around threatening damage
+              and whether long gaps may have cost you additional uses.
+            </small>
+          </p>
+        </li>
+      </ol>
+      <SubSection title="Damage Taken">
+        <Timeline analyzers={defensiveAnalyzers} />
+      </SubSection>
+      <AllCooldownUsageList analyzers={defensiveAnalyzers} />
     </Section>
   );
 }

--- a/src/analysis/retail/demonhunter/havoc/modules/spells/Blur.tsx
+++ b/src/analysis/retail/demonhunter/havoc/modules/spells/Blur.tsx
@@ -1,42 +1,48 @@
-import Analyzer from 'parser/core/Analyzer';
-import { NumberThreshold, ThresholdStyle } from 'parser/core/ParseResults';
-import { formatDuration, formatPercentage } from 'common/format';
-import Statistic from 'parser/ui/Statistic';
-import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
-import UptimeIcon from 'interface/icons/Uptime';
 import SPELLS from 'common/SPELLS/demonhunter';
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import {
+  absoluteMitigation,
+  buff,
+  MajorDefensiveBuff,
+} from 'interface/guide/components/MajorDefensives/MajorDefensiveAnalyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+import { ReactNode } from 'react';
+import SpellLink from 'interface/SpellLink';
+import MajorDefensiveStatistic from 'interface/MajorDefensiveStatistic';
 
-export default class Blur extends Analyzer {
-  get uptime() {
-    return this.selectedCombatant.getBuffUptime(SPELLS.BLUR_BUFF.id) / this.owner.fightDuration;
+const BASE_MITIGATION = 0.25; // https://www.wowhead.com/spell=198589/blur
+
+export default class Blur extends MajorDefensiveBuff {
+  mitigation = BASE_MITIGATION;
+
+  constructor(options: Options) {
+    super(SPELLS.BLUR, buff(SPELLS.BLUR_BUFF), options);
+
+    this.addEventListener(Events.damage.to(SELECTED_PLAYER), this.onDamageTaken);
   }
 
-  get uptimeSuggestionThresholds(): NumberThreshold {
-    return {
-      actual: this.uptime,
-      isLessThan: {
-        minor: 0.6,
-        average: 0.55,
-        major: 0.5,
-      },
-      style: ThresholdStyle.PERCENTAGE,
-    };
+  private onDamageTaken(event: DamageEvent) {
+    if (!this.defensiveActive(event)) {
+      return;
+    }
+
+    this.recordMitigation({
+      event,
+      mitigatedAmount: absoluteMitigation(event, this.mitigation),
+    });
   }
 
-  statistic() {
+  description(): ReactNode {
     return (
-      <Statistic
-        position={STATISTIC_ORDER.CORE(5)}
-        category={STATISTIC_CATEGORY.GENERAL}
-        size="flexible"
-        tooltip={<>Total uptime was {formatDuration(this.uptime)}.</>}
-      >
-        <BoringSpellValueText spell={SPELLS.BLUR}>
-          <UptimeIcon /> {formatPercentage(this.uptime)}% <small>uptime</small>
-        </BoringSpellValueText>
-      </Statistic>
+      <p>
+        <SpellLink spell={SPELLS.BLUR} /> reduces the damage you take by{' '}
+        {Math.round(this.mitigation * 100)}%.
+      </p>
     );
+  }
+
+  statistic(): ReactNode {
+    return <MajorDefensiveStatistic analyzer={this} category={STATISTIC_CATEGORY.GENERAL} />;
   }
 }


### PR DESCRIPTION
### Description

Add a simple analysis of the [Blur](https://www.wowhead.com/spell=198589/blur) defensive cooldown, with a breakdown matching the existing Frost Mage and Devour Demon Hunter defensive analyses.

### Testing

- Test report URL: `/report/kaTFdMBHA74vLP8m/25-Heroic+Chimaerus,+the+Undreamt+God+-+Kill+(8:44)/309-Hezaerd/standard`
- Screenshot(s):
<img width="1270" height="748" alt="{A83DA930-3763-4FEC-A350-66FF8909C3F6}" src="https://github.com/user-attachments/assets/c60e48c3-251e-4086-b957-1dea7c14ee34" />