### PR TITLE
[Interface] Allow deselecting an open defensives cast breakdown entry

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -37,6 +37,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 10), 'Allow deselecting an open defensives cast breakdown entry by clicking it again.', Hezaerd),
   change(date(2026, 4, 7), "Fix typing of `get tierPieces`", Thias),
   change(date(2026, 4, 6), "Allow deselecting an open spell usage entry by clicking it again.", Hezaerd),
   change(date(2026, 4, 6), <>Improve visuals for close calls in pull selection</>, Thias),

--- a/src/interface/guide/components/MajorDefensives/AllCooldownUsagesList.tsx
+++ b/src/interface/guide/components/MajorDefensives/AllCooldownUsagesList.tsx
@@ -316,13 +316,13 @@ const CooldownUsage = <Apply extends EventType, Remove extends EventType>({
 
   const onClickBox = useCallback(
     (index: number) => {
-      if (index >= mitigations.length) {
+      if (selectedMit === index || index >= mitigations.length) {
         setSelectedMit(undefined);
       } else {
         setSelectedMit(index);
       }
     },
-    [mitigations.length],
+    [mitigations.length, selectedMit],
   );
 
   return (


### PR DESCRIPTION
### Description

Very simple change to match with #7784 and let user close an open defensives cast breakdown entry

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/kaTFdMBHA74vLP8m/25-Heroic+Chimaerus,+the+Undreamt+God+-+Kill+(8:44)/309-Hezaerd/standard`
- Screenshot(s):
![castbreakdownclose](https://github.com/user-attachments/assets/f78b03cd-31c0-415d-9edf-55ed1e15b701)
