### PR TITLE
[Resto Druid] fix bug in strategic infusion

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2026, 4, 10), <>Fixed bug in statistic for <SpellLink spell={TALENTS_DRUID.STRATEGIC_INFUSION_TALENT}/>.</>, squided),
   change(date(2026, 3, 31), <>Remove recent tranquility check from convoke guide. Fix Abundancy module to account for Intensity crit bonus. Add Intensity module.</>, squided),
   change(date(2026, 3, 23), <>Update mana efficiency calculations and cooldowns tab for Midnight.</>, squided),
   change(date(2026, 3, 22), <>Implement liveliness talent statistic. Fix bug in lifebloom guide's cast analysis.</>, squided),

--- a/src/analysis/retail/druid/restoration/modules/spells/Wildstalker/StrategicInfusion.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Wildstalker/StrategicInfusion.tsx
@@ -9,6 +9,7 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import StatTracker from 'parser/shared/modules/StatTracker';
+import HIT_TYPES from 'game/HIT_TYPES';
 
 const STRATEGIC_INFUSION_INCREASED_CRIT_CHANCE = 0.04;
 
@@ -35,7 +36,7 @@ export default class StrategicInfusion extends Analyzer {
   }
 
   private onHeal(event: HealEvent) {
-    if (!event.tick) {
+    if (!event.tick || event.hitType !== HIT_TYPES.CRIT) {
       return;
     }
 


### PR DESCRIPTION
### Description

Current strategic infusion module has a bug where it is over-attributing by not filtering out for specifically crit events. 

### Testing


- Test report URL:  https://www.warcraftlogs.com/reports/7g4p8FfNy3Pd1kCq?fight=1&type=healing
- Screenshot(s):
<img width="314" height="119" alt="image" src="https://github.com/user-attachments/assets/ca260014-f735-4b23-b85e-74acb95e8304" />

