### PR TITLE
[Interface] Introduce toaster to better display errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "redux": "5.0.1",
     "redux-thunk": "3.1.0",
     "sass-text-stroke": "1.2.0",
+    "sonner": "2.0.7",
     "spin-delay": "2.0.1",
     "swr": "2.3.6",
     "universal-cookie": "^4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       sass-text-stroke:
         specifier: 1.2.0
         version: 1.2.0
+      sonner:
+        specifier: 2.0.7
+        version: 2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       spin-delay:
         specifier: 2.0.1
         version: 2.0.1(react@19.2.0)
@@ -2823,11 +2826,13 @@ packages:
   glob@11.0.0:
     resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3884,6 +3889,12 @@ packages:
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -4424,6 +4435,7 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -8000,6 +8012,11 @@ snapshots:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.6.2
+
+  sonner@2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   source-map-js@1.2.1: {}
 

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 11), 'Add toaster system to display alerts and errors.', Hezaerd),
   change(date(2026, 4, 10), 'Allow deselecting an open defensives cast breakdown entry by clicking it again.', Hezaerd),
   change(date(2026, 4, 8), "Refactor gear `getters` in Combatant class", Thias),
   change(date(2026, 4, 8), <>Replace external usages of <code>Combatant._combatantInfo</code> with proper public getters and introduce a <code>Faction</code> enum.</>, Thias),

--- a/src/interface/DebugAnnotationsTab.tsx
+++ b/src/interface/DebugAnnotationsTab.tsx
@@ -9,6 +9,7 @@ import { Ability, AnyEvent, HasAbility, HasSource, HasTarget } from 'parser/core
 import { useMemo, useState, useCallback } from 'react';
 import { useCombatLogParser } from './report/CombatLogParserContext';
 import { formatDuration } from 'common/format';
+import { toast } from 'sonner';
 import SpellLink from './SpellLink';
 
 export default function DebugAnnotationsTab({ parser }: { parser: CombatLogParser }) {
@@ -270,7 +271,7 @@ function CopySpellData({ ability }: { ability: Ability }) {
       const text = `${key}: ${data},`;
       await navigator.clipboard.writeText(text);
     } catch {
-      alert('Unable to copy data to clipboard');
+      toast.error('Unable to copy data to clipboard');
     }
   }, [ability]);
   return <CopyTextLink onClick={copy}>(copy definition)</CopyTextLink>;

--- a/src/interface/NameSearch.tsx
+++ b/src/interface/NameSearch.tsx
@@ -7,6 +7,7 @@ import { REALM_LIST, CLASSIC_REALM_LIST } from 'game/RealmList';
 import { FormEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import SelectSearch from 'react-select-search';
+import { toast } from 'sonner';
 import { useLingui } from '@lingui/react';
 import { RETAIL_EXPANSION_NAME, CLASSIC_EXPANSION_NAME } from 'game/Expansion';
 
@@ -43,7 +44,7 @@ const NameSearch = ({ type }: Props) => {
       const makePageUrl = type === SearchType.CHARACTER ? makeCharacterPageUrl : makeGuildPageUrl;
 
       if (!game || !region || !realm || !name) {
-        alert(
+        toast.warning(
           i18n._(
             defineMessage({
               id: 'interface.nameSearch.pleaseSelect',
@@ -56,7 +57,7 @@ const NameSearch = ({ type }: Props) => {
 
       // Checking for guild-exists here makes it more user-friendly and saves WCL-requests when guild doesn't exist
       if (loading) {
-        alert(
+        toast.info(
           i18n._(
             defineMessage({
               id: 'interface.nameSearch.stillWorking',
@@ -76,7 +77,7 @@ const NameSearch = ({ type }: Props) => {
           response = await fetch(makeCharacterApiUrl(undefined, region, realm, name));
         }
         if (response.status === 500) {
-          alert(
+          toast.error(
             i18n._(
               defineMessage({
                 id: 'interface.nameSearch.noResponse',
@@ -87,7 +88,7 @@ const NameSearch = ({ type }: Props) => {
           setLoading(false);
           return;
         } else if (response.status === 404) {
-          alert(
+          toast.error(
             i18n._(
               defineMessage({
                 id: 'interface.nameSearch.nameNotFound',
@@ -98,7 +99,7 @@ const NameSearch = ({ type }: Props) => {
           setLoading(false);
           return;
         } else if (!response.ok) {
-          alert(
+          toast.error(
             i18n._(
               defineMessage({
                 id: 'interface.nameSearch.noAPIResponse',

--- a/src/interface/ReportSelecter.tsx
+++ b/src/interface/ReportSelecter.tsx
@@ -1,6 +1,7 @@
 import { Trans, t } from '@lingui/macro';
 import { FormEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import REGION_CODES from './REGION_CODES';
 import Tooltip from './Tooltip';
@@ -157,7 +158,9 @@ const ReportSelecter = () => {
     e.preventDefault();
 
     if (!reportCode) {
-      alert('Enter a report first.');
+      toast.warning(
+        defineMessage({ id: 'interface.reportSelecter.enterReport', message: `Enter a report first.` }),
+      );
       return;
     }
 

--- a/src/interface/ReportSelecter.tsx
+++ b/src/interface/ReportSelecter.tsx
@@ -158,9 +158,7 @@ const ReportSelecter = () => {
     e.preventDefault();
 
     if (!reportCode) {
-      toast.warning(
-        defineMessage({ id: 'interface.reportSelecter.enterReport', message: `Enter a report first.` }),
-      );
+      toast.warning('Enter a report first.');
       return;
     }
 

--- a/src/interface/RootErrorBoundary.tsx
+++ b/src/interface/RootErrorBoundary.tsx
@@ -4,54 +4,13 @@ import ErrorBoundary from 'interface/ErrorBoundary';
 import FullscreenError from 'interface/FullscreenError';
 import ApiDownBackground from 'interface/images/api-down-background.gif';
 import { PureComponent, ErrorInfo, ReactNode } from 'react';
+import { toast } from 'sonner';
 
+import { classifyUiError, type ClassifiedUiError, type ErrorSource } from './errorHandling';
 import { EventsParseError } from './report/hooks/useEventParser';
 
-interface HandledError {
-  message: string;
-  stack?: string;
-  filename?: string;
-}
-
-// Some errors are triggered by third party scripts, such as browser plug-ins.
-// These errors should generally not affect the application, so we can safely ignore them for
-// our error handling. If a plug-in like Google Translate messes with the DOM and that breaks the
-// app, that triggers a different error so those third party issues are still handled.
-const isTriggeredByExternalScript = (error: HandledError) => {
-  if (!error || error.message === 'Script error.') {
-    return true;
-  }
-
-  // The stack trace includes links to each script involved in the error. Find
-  // the first relevant link and check if it was one of our scripts.
-  if (!error.stack) {
-    return true;
-  }
-  const paths = error.stack
-    .split('\n')
-    // The first line may point to the page the error occurred on rather than
-    // the script that caused it, so ignore that to avoid false positives.
-    .splice(1)
-    .map((line) => line.match(/(https?:\/\/[^/]+)\//))
-    .filter((line) => line);
-  const firstPath = paths[0];
-  if (!firstPath) {
-    return true;
-  }
-  if (firstPath[1] !== window.location.origin) {
-    return true;
-  }
-  // Sometimes the second line can cause it (relevant for ads).
-  const secondPath = paths[1];
-  if (!secondPath) {
-    return true;
-  }
-  if (secondPath[1] !== window.location.origin) {
-    return true;
-  }
-
-  return false;
-};
+const NON_FATAL_ERROR_TOAST_DURATION = 10000;
+const NON_FATAL_ERROR_TOAST_DEDUPE_MS = 10000;
 
 interface Props {
   children: ReactNode;
@@ -62,6 +21,8 @@ interface State {
 }
 
 class RootErrorBoundary extends PureComponent<Props, State> {
+  private recentNonFatalToasts = new Map<string, number>();
+
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -84,7 +45,7 @@ class RootErrorBoundary extends PureComponent<Props, State> {
   componentDidCatch(error: Error, { componentStack }: ErrorInfo) {
     // we don't call captureException here because it will be called by the child ErrorBoundary
     // this boundary exists primarily for dev mode.
-    this.error(error, componentStack);
+    this.handleCaughtError(error, componentStack, 'componentDidCatch');
   }
 
   handleErrorEvent(event: ErrorEvent) {
@@ -95,27 +56,75 @@ class RootErrorBoundary extends PureComponent<Props, State> {
       return;
     }
     console.log('Caught a global error');
-    this.error(error, 'error');
+    this.handleCaughtError(error, 'error', 'window-error');
   }
   handleUnhandledrejectionEvent(event: PromiseRejectionEvent) {
     console.log('Caught a global unhandledrejection');
-    this.error(event.reason, 'unhandledrejection');
+    this.handleCaughtError(event.reason, 'unhandledrejection', 'unhandledrejection');
   }
 
-  error(error: Error | undefined, details?: string | null) {
-    if (!error) {
+  private shouldSkipNonFatalToast(classifiedError: ClassifiedUiError) {
+    const now = Date.now();
+    const lastShown = this.recentNonFatalToasts.get(classifiedError.fingerprint);
+
+    for (const [fingerprint, timestamp] of this.recentNonFatalToasts.entries()) {
+      if (now - timestamp >= NON_FATAL_ERROR_TOAST_DEDUPE_MS) {
+        this.recentNonFatalToasts.delete(fingerprint);
+      }
+    }
+
+    if (lastShown && now - lastShown < NON_FATAL_ERROR_TOAST_DEDUPE_MS) {
+      return true;
+    }
+
+    this.recentNonFatalToasts.set(classifiedError.fingerprint, now);
+    return false;
+  }
+
+  private showNonFatalErrorToast(classifiedError: ClassifiedUiError) {
+    if (this.shouldSkipNonFatalToast(classifiedError)) {
       return;
     }
-    // NOTE: These filters only prevent the error state from being triggered. Sentry automatically logs them regardless.
-    if (isTriggeredByExternalScript(error)) {
+
+    if (import.meta.env.DEV) {
+      console.error('Caught a recoverable global error', classifiedError.error);
+    }
+
+    toast.error(
+      <Trans id="interface.rootErrorBoundary.nonFatalErrorTitle">
+        Something went wrong, but the page can keep working.
+      </Trans>,
+      {
+        description: classifiedError.message,
+        duration: NON_FATAL_ERROR_TOAST_DURATION,
+        action: {
+          label: 'Reload',
+          onClick: () => window.location.reload(),
+        },
+      },
+    );
+  }
+
+  private handleCaughtError(
+    error: unknown,
+    details?: string | null,
+    source: ErrorSource = 'window-error',
+  ) {
+    const classifiedError = classifyUiError(error, source);
+    if (!classifiedError) {
       console.log('Ignored because it looks like a third party error.');
       return;
     }
 
-    (window.errors = window.errors || []).push(error);
+    (window.errors = window.errors || []).push(classifiedError.error);
+
+    if (classifiedError.severity === 'nonFatal') {
+      this.showNonFatalErrorToast(classifiedError);
+      return;
+    }
 
     this.setState({
-      error: error,
+      error: classifiedError.error,
       errorDetails: details,
     });
   }
@@ -138,7 +147,6 @@ class RootErrorBoundary extends PureComponent<Props, State> {
         );
       }
 
-      // TODO: Instead of hiding the entire app, show a small toaster instead. Not all uncaught errors are fatal.
       return (
         <FullscreenError
           error={<Trans id="interface.rootErrorBoundary.errorOccurred">An error occurred.</Trans>}

--- a/src/interface/RouterErrorBoundary.tsx
+++ b/src/interface/RouterErrorBoundary.tsx
@@ -3,10 +3,12 @@ import FullscreenError from 'interface/FullscreenError';
 import ApiDownBackground from 'interface/images/api-down-background.gif';
 import { useRouteError } from 'react-router-dom';
 
+import { normalizeThrownError } from './errorHandling';
 import { EventsParseError } from './report/hooks/useEventParser';
 
 const RouterErrorBoundary = () => {
-  const error = useRouteError();
+  const routeError = useRouteError();
+  const error = normalizeThrownError(routeError);
 
   if (error instanceof EventsParseError) {
     return (
@@ -24,7 +26,6 @@ const RouterErrorBoundary = () => {
     );
   }
 
-  // TODO: Instead of hiding the entire app, show a small toaster instead. Not all uncaught errors are fatal.
   return (
     <FullscreenError
       error={<Trans id="interface.rootErrorBoundary.errorOccurred">An error occurred.</Trans>}
@@ -35,14 +36,12 @@ const RouterErrorBoundary = () => {
       }
       background={ApiDownBackground}
       errorDetails={
-        error instanceof Error ? (
-          <>
-            <p>{error.message}</p>
-            <pre style={{ color: 'red', backgroundColor: 'rgba(255, 255, 255, 0.8)' }}>
-              {error.stack}
-            </pre>
-          </>
-        ) : undefined
+        <>
+          <p>{error.message}</p>
+          <pre style={{ color: 'red', backgroundColor: 'rgba(255, 255, 255, 0.8)' }}>
+            {error.stack}
+          </pre>
+        </>
       }
     >
       <div className="text-muted">

--- a/src/interface/errorHandling.ts
+++ b/src/interface/errorHandling.ts
@@ -1,0 +1,159 @@
+import { EventsParseError } from './report/hooks/useEventParser';
+
+export type ErrorSource = 'componentDidCatch' | 'router' | 'window-error' | 'unhandledrejection';
+export type ErrorSeverity = 'fatal' | 'nonFatal';
+
+interface ErrorLike {
+  message?: unknown;
+  stack?: unknown;
+  name?: unknown;
+  filename?: unknown;
+  fatal?: unknown;
+  severity?: unknown;
+  status?: unknown;
+  statusText?: unknown;
+}
+
+export interface ClassifiedUiError {
+  error: Error;
+  severity: ErrorSeverity;
+  source: ErrorSource;
+  message: string;
+  stack?: string;
+  fingerprint: string;
+}
+
+const UNKNOWN_ERROR_MESSAGE = 'An unknown error occurred.';
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const safeStringify = (value: unknown) => {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+};
+
+const getObjectErrorMessage = (value: Record<string, unknown>) => {
+  if (typeof value.message === 'string' && value.message.trim()) {
+    return value.message;
+  }
+
+  if (typeof value.status === 'number') {
+    const suffix =
+      typeof value.statusText === 'string' && value.statusText.trim() ? ` ${value.statusText}` : '';
+    return `Request failed with status ${value.status}${suffix}.`;
+  }
+
+  const serialized = safeStringify(value);
+  if (serialized && serialized !== '{}') {
+    return `Unexpected error payload: ${serialized}`;
+  }
+
+  return UNKNOWN_ERROR_MESSAGE;
+};
+
+export const normalizeThrownError = (thrown: unknown): Error => {
+  if (thrown instanceof Error) {
+    return thrown;
+  }
+
+  if (typeof thrown === 'string') {
+    return new Error(thrown);
+  }
+
+  if (isObject(thrown)) {
+    const errorLike = thrown as ErrorLike;
+    const error = new Error(getObjectErrorMessage(thrown));
+    if (typeof errorLike.name === 'string' && errorLike.name.trim()) {
+      error.name = errorLike.name;
+    }
+    if (typeof errorLike.stack === 'string' && errorLike.stack.trim()) {
+      error.stack = errorLike.stack;
+    }
+    if (typeof errorLike.filename === 'string' && errorLike.filename.trim()) {
+      (error as Error & { filename?: string }).filename = errorLike.filename;
+    }
+    return error;
+  }
+
+  return new Error(UNKNOWN_ERROR_MESSAGE);
+};
+
+const getErrorFingerprint = (error: Error, source: ErrorSource) => {
+  const firstStackLine = error.stack?.split('\n')[1]?.trim() ?? '';
+  return `${source}:${error.name}:${error.message}:${firstStackLine}`;
+};
+
+const hasCrossOriginStack = (stack: string) => {
+  const paths = stack
+    .split('\n')
+    // The first line may point to the page the error occurred on rather than
+    // the script that caused it, so ignore that to avoid false positives.
+    .splice(1)
+    .map((line) => line.match(/(https?:\/\/[^/]+)\//))
+    .filter((line): line is RegExpMatchArray => Boolean(line));
+
+  if (paths.length === 0) {
+    return false;
+  }
+
+  return paths.some((path) => path[1] !== window.location.origin);
+};
+
+const shouldIgnoreGlobalError = (error: Error) => {
+  if (error.message === 'Script error.') {
+    return true;
+  }
+
+  if (!error.stack) {
+    return false;
+  }
+
+  return hasCrossOriginStack(error.stack);
+};
+
+const isExplicitlyFatalError = (thrown: unknown) => {
+  if (!isObject(thrown)) {
+    return false;
+  }
+
+  return thrown.fatal === true || thrown.severity === 'fatal';
+};
+
+const getErrorSeverity = (error: Error, thrown: unknown, source: ErrorSource): ErrorSeverity => {
+  if (error instanceof EventsParseError || isExplicitlyFatalError(thrown)) {
+    return 'fatal';
+  }
+
+  switch (source) {
+    case 'componentDidCatch':
+    case 'router':
+      return 'fatal';
+    case 'window-error':
+    case 'unhandledrejection':
+      return 'nonFatal';
+  }
+};
+
+export const classifyUiError = (thrown: unknown, source: ErrorSource): ClassifiedUiError | null => {
+  const error = normalizeThrownError(thrown);
+
+  if (
+    (source === 'window-error' || source === 'unhandledrejection') &&
+    shouldIgnoreGlobalError(error)
+  ) {
+    return null;
+  }
+
+  return {
+    error,
+    severity: getErrorSeverity(error, thrown, source),
+    source,
+    message: error.message || UNKNOWN_ERROR_MESSAGE,
+    stack: error.stack,
+    fingerprint: getErrorFingerprint(error, source),
+  };
+};

--- a/src/interface/layouts/AppLayout.tsx
+++ b/src/interface/layouts/AppLayout.tsx
@@ -69,7 +69,7 @@ export function AppLayout() {
       <Hotkeys />
       <ScrollRestoration />
       <ProgressBar />
-      <Toaster theme="dark" position="top-center" richColors />
+      <Toaster theme="dark" position="top-center" richColors closeButton />
     </>
   );
 }

--- a/src/interface/layouts/AppLayout.tsx
+++ b/src/interface/layouts/AppLayout.tsx
@@ -9,6 +9,7 @@ import { Outlet, ScrollRestoration } from 'react-router-dom';
 import Footer from 'interface/Footer';
 import PortalTarget from 'interface/PortalTarget';
 import Hotkeys from 'interface/Hotkeys';
+import { Toaster } from 'sonner';
 import 'react-toggle/style.css';
 
 import '../App.scss';
@@ -68,6 +69,7 @@ export function AppLayout() {
       <Hotkeys />
       <ScrollRestoration />
       <ProgressBar />
+      <Toaster theme="dark" position="top-center" richColors />
     </>
   );
 }

--- a/src/interface/report/PlayerLoader.tsx
+++ b/src/interface/report/PlayerLoader.tsx
@@ -21,6 +21,7 @@ import DocumentTitle from 'interface/DocumentTitle';
 import PlayerSelection from './PlayerSelection';
 import { getPlayerIdFromParam } from 'interface/selectors/url/report/getPlayerId';
 import { i18n } from '@lingui/core';
+import { toast } from 'sonner';
 import useSWR from 'swr';
 import { PlayerDetails } from 'parser/core/Player';
 import makeApiUrl from 'common/makeApiUrl';
@@ -152,7 +153,7 @@ const PlayerLoader = ({ children }: Props) => {
 
   if (playerId && (!player || !config)) {
     if (!player) {
-      alert(
+      toast.error(
         i18n._(
           defineMessage({
             id: 'interface.report.render.dataNotAvailable',
@@ -161,7 +162,7 @@ const PlayerLoader = ({ children }: Props) => {
         ),
       );
     } else if (!config) {
-      alert(
+      toast.error(
         i18n._(
           defineMessage({
             id: 'interface.report.render.notSupported',

--- a/src/interface/report/PlayerTile.tsx
+++ b/src/interface/report/PlayerTile.tsx
@@ -3,6 +3,7 @@ import { getClassName } from 'game/ROLES';
 import Icon from 'interface/Icon';
 import { getCharacterById } from 'interface/selectors/characters';
 import SpecIcon from 'interface/SpecIcon';
+import Tooltip from 'interface/Tooltip';
 import Config from 'parser/Config';
 import { PlayerDetails } from 'parser/core/Player';
 import { ReactNode, useEffect } from 'react';
@@ -26,14 +27,11 @@ interface BlockLoadingProps {
   message: string;
 }
 const BlockLoading = ({ children, message }: BlockLoadingProps) => (
-  <span
-    className="player"
-    onClick={() => {
-      alert(message);
-    }}
-  >
-    {children}
-  </span>
+  <Tooltip content={message}>
+    <span className="player" style={{ cursor: 'not-allowed', opacity: 0.6 }}>
+      {children}
+    </span>
+  </Tooltip>
 );
 
 interface BasicBlockLoadingProps extends Omit<BlockLoadingProps, 'children'> {


### PR DESCRIPTION
### Description

- Introduce [Sonner](https://sonner.emilkowal.ski/getting-started) as a lightweight and unstyled library for toasts (~4kb).
- Split fatal and non-fatal uncaught errors in the app shell.
- Replace blocking browser alerts with toasts.
- Replace blocking non-fatal error window with toasts.

#### Notes
- Will probably need better styling
- Will definitely need better phrasing
- Resolve [this todo](https://github.com/WoWAnalyzer/WoWAnalyzer/blob/927d46c09d786157adc14d009beea6421c79077f/src/interface/RootErrorBoundary.tsx#L141) about displaying a toast to user instead of hiding the entire app and that all errors aren't fatal ones

### Testing

- Check report selector, name search, debug annotations, and player loading flows for Sonner toasts instead of browser alerts.
- Check blocked player tiles now explain the state with a tooltip.
- Trigger a recoverable global error and confirm the app stays interactive while showing a toast.
- Trigger a fatal render/analysis error and confirm the fullscreen error state still appears.

### Screenshots:
![empty-report-toast](https://github.com/user-attachments/assets/a7456637-9145-448d-b26a-dc8e2f59612e)
![manual-error-toast1](https://github.com/user-attachments/assets/cfec3f4e-d8fa-4b7f-a26a-cbde2dbbf81a)
![manual-error-toast2](https://github.com/user-attachments/assets/bd0e5a74-f239-430f-a6c4-f8661adf9e14)
<img width="304" height="310" alt="{DC30C03E-21CF-440C-9EF4-69B598695113}" src="https://github.com/user-attachments/assets/57c7a807-3113-4c76-9279-4d4aed225d25" />
