### PR TITLE
feat(combatant): Refactor private/protected fields

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 11), 'Refactor Combatant to use proper private/protected types instead of `_` named fields', Thias),
   change(date(2026, 4, 10), 'Allow deselecting an open defensives cast breakdown entry by clicking it again.', Hezaerd),
   change(date(2026, 4, 8), "Refactor gear `getters` in Combatant class", Thias),
   change(date(2026, 4, 8), <>Replace external usages of <code>Combatant._combatantInfo</code> with proper public getters and introduce a <code>Faction</code> enum.</>, Thias),

--- a/src/analysis/classic/warlock/affliction/modules/spells/DrainSoul.tsx
+++ b/src/analysis/classic/warlock/affliction/modules/spells/DrainSoul.tsx
@@ -69,7 +69,7 @@ class DrainSoul extends Analyzer {
     const allEnemies = this.enemies.getEntities();
     this.totalNumOfAdds = Object.values(allEnemies)
       .filter((enemy) => enemy.subType === 'NPC')
-      .reduce((count, enemy) => count + enemy._baseInfo.fights[0].instances, 0);
+      .reduce((count, enemy) => count + enemy.fights[0].instances, 0);
   }
 
   statistic() {

--- a/src/analysis/retail/warlock/affliction/modules/analyzers/DrainSoul.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/analyzers/DrainSoul.tsx
@@ -86,7 +86,7 @@ class DrainSoul extends Analyzer {
     const allEnemies = this.enemies.getEntities();
     this.totalNumOfAdds = Object.values(allEnemies)
       .filter((enemy) => enemy.subType === 'NPC')
-      .reduce((count, enemy) => count + enemy._baseInfo.fights[0].instances, 0);
+      .reduce((count, enemy) => count + enemy.fights[0].instances, 0);
     this._shardsGained =
       this.soulShardTracker.getGeneratedBySpell(SPELLS.DRAIN_SOUL_KILL_SHARD_GEN.id) -
       this._subtractBossShards;

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -31,9 +31,8 @@ export type SlotMap<T> = Partial<Record<GearSlotName, T>>;
 class Combatant extends Entity {
   readonly player: PlayerInfo;
 
-  private _name: string;
-  public get name() {
-    return this._name;
+  override get name() {
+    return this.player.name;
   }
 
   get id() {
@@ -116,15 +115,10 @@ class Combatant extends Entity {
     };
   }
 
-  _ilvl: number | undefined;
-  public get ilvl() {
-    return this._ilvl;
-  }
+  readonly ilvl: number | undefined;
 
   constructor(parser: CombatLogParser, player: PlayerDetails) {
     super(parser);
-
-    this._name = player.name;
 
     this.player = this.owner.players.find((info) => info.id === player.id)!;
     this.specId =
@@ -139,16 +133,16 @@ class Combatant extends Entity {
   }
 
   // region Talents
-  _classicTalentPoints: Set<number> = new Set<number>();
+  private classicTalentPoints: Set<number> = new Set<number>();
 
-  _parseTalents(talents: Spell[]) {
+  protected parseTalents(talents: Spell[]) {
     talents?.forEach(({ id }) => {
-      this._classicTalentPoints.add(id);
+      this.classicTalentPoints.add(id);
     });
   }
 
   private treeTalentsByEntryId = new Map<number, TalentEntry>();
-  protected _importTalentTree(talents: TalentEntry[]) {
+  protected importTalentTree(talents: TalentEntry[]) {
     talents?.forEach((talent) => {
       this.treeTalentsByEntryId.set(talent.id, talent);
     });
@@ -160,7 +154,7 @@ class Combatant extends Entity {
 
   hasClassicTalent(spell: number | { id: number }): boolean {
     const id = typeof spell === 'number' ? spell : spell.id;
-    return this._classicTalentPoints.has(id);
+    return this.classicTalentPoints.has(id);
   }
 
   /** Returns true if this combatant has the specified talent. Will be true for any number of
@@ -219,7 +213,7 @@ class Combatant extends Entity {
 
   private glyphIds?: Set<number>;
 
-  private _importGlyphs(event: CombatantInfoEvent) {
+  private importGlyphs(event: CombatantInfoEvent) {
     if (this.glyphIds === undefined && event.customPowerSet) {
       this.glyphIds = new Set(event.customPowerSet.map((power) => power.traitID));
     }
@@ -230,7 +224,7 @@ class Combatant extends Entity {
       return false;
     }
 
-    this._importGlyphs(this.combatantInfo);
+    this.importGlyphs(this.combatantInfo);
     return this.glyphIds?.has(id) ?? false;
   }
 
@@ -246,7 +240,7 @@ class Combatant extends Entity {
   // region Gear
   private gearItemsBySlotId: Record<number, Item> = {};
 
-  _parseGear(gear: Item[]) {
+  protected parseGear(gear: Item[]) {
     const equipedSets: number[][] = [];
 
     gear
@@ -367,7 +361,7 @@ class Combatant extends Entity {
 
   // endregion
 
-  _parsePrepullBuffs(buffs: Buff[]) {
+  protected parsePrepullBuffs(buffs: Buff[]) {
     // TODO: We only apply prepull buffs in the `auras` prop of combatantinfo,
     // but not all prepull buffs are in there and ApplyBuff finds more. We
     // should update ApplyBuff to add the other buffs to the auras prop of the
@@ -402,6 +396,7 @@ export default Combatant;
  */
 export class FullCombatant extends Combatant {
   protected override combatantInfo: CombatantInfoEvent;
+  override readonly ilvl: number | undefined;
   readonly specId: number;
 
   override get faction(): Faction {
@@ -425,12 +420,12 @@ export class FullCombatant extends Combatant {
       ...combatantInfo,
     };
 
-    this._parseTalents(combatantInfo.talents);
-    this._importTalentTree(combatantInfo.talentTree);
-    this._parseGear(combatantInfo.gear);
-    this._parsePrepullBuffs(combatantInfo.auras);
+    this.parseTalents(combatantInfo.talents);
+    this.importTalentTree(combatantInfo.talentTree);
+    this.parseGear(combatantInfo.gear);
+    this.parsePrepullBuffs(combatantInfo.auras);
 
-    this._ilvl =
+    this.ilvl =
       this.gear.length > 0
         ? this.gear.map((item) => item.itemLevel).reduce((sum, val) => sum + val, 0) /
           this.gear.length

--- a/src/parser/core/Enemy.ts
+++ b/src/parser/core/Enemy.ts
@@ -13,39 +13,39 @@ export interface EnemyInfo extends Unit {
 }
 
 class Enemy extends Entity {
-  get name() {
-    return this._baseInfo.name;
+  private readonly baseInfo: EnemyInfo;
+  readonly instanceID: number;
+
+  override get name() {
+    return this.baseInfo.name;
   }
 
   /** Generally "NPC" */
   get type() {
-    return this._baseInfo.type;
+    return this.baseInfo.type;
   }
 
   /** Generally "Boss" or "NPC" */
   get subType() {
-    return this._baseInfo.subType;
+    return this.baseInfo.subType;
   }
 
   get guid() {
-    return this._baseInfo.guid;
+    return this.baseInfo.guid;
   }
 
   get id() {
-    return this._baseInfo.id;
+    return this.baseInfo.id;
   }
 
-  get instanceID() {
-    return this._instanceID;
+  get fights() {
+    return this.baseInfo.fights;
   }
-
-  _baseInfo: EnemyInfo;
-  _instanceID: number;
 
   constructor(owner: CombatLogParser, baseInfo: EnemyInfo, instanceID = 0) {
     super(owner);
-    this._baseInfo = baseInfo;
-    this._instanceID = instanceID;
+    this.baseInfo = baseInfo;
+    this.instanceID = instanceID;
   }
 }
 

--- a/src/parser/core/EnemyInstance.ts
+++ b/src/parser/core/EnemyInstance.ts
@@ -2,16 +2,12 @@ import CombatLogParser from './CombatLogParser';
 import { default as Enemy, EnemyInfo } from './Enemy';
 
 class EnemyInstance extends Enemy {
-  _instanceID: number;
-
-  get instanceID() {
-    return this._instanceID;
-  }
+  override readonly instanceID: number;
 
   constructor(owner: CombatLogParser, baseInfo: EnemyInfo, instanceID = 0) {
     super(owner, baseInfo);
 
-    this._instanceID = instanceID;
+    this.instanceID = instanceID;
   }
 }
 

--- a/src/parser/core/Entity.ts
+++ b/src/parser/core/Entity.ts
@@ -15,7 +15,7 @@ export interface TrackedBuffEvent extends BuffEvent<any> {
   stacks: number;
 }
 
-class Entity {
+abstract class Entity {
   owner: CombatLogParser;
   constructor(owner: CombatLogParser) {
     this.owner = owner;
@@ -51,10 +51,7 @@ class Entity {
     return (buff: TrackedBuffEvent) => HasSource(buff) && buff.sourceID === sourceID;
   }
 
-  // Override in extended classes
-  get name(): string {
-    throw new Error('attempted to access name of unimplemented Entity');
-  }
+  abstract get name(): string;
 
   activeBuffs(forTimestamp: number | null = null, bufferTime = 0, minimalActiveTime = 0) {
     const currentTimestamp = forTimestamp !== null ? forTimestamp : this.owner.currentTimestamp;

--- a/src/parser/core/Pet.ts
+++ b/src/parser/core/Pet.ts
@@ -13,23 +13,23 @@ export interface PetInfo extends Unit {
 }
 
 class Pet extends Entity {
-  get name() {
-    return this._baseInfo.name;
+  private readonly baseInfo: PetInfo;
+
+  override get name() {
+    return this.baseInfo.name;
   }
 
   get type() {
-    return this._baseInfo.type;
+    return this.baseInfo.type;
   }
 
   get guid() {
-    return this._baseInfo.guid;
+    return this.baseInfo.guid;
   }
-
-  _baseInfo: PetInfo;
 
   constructor(owner: CombatLogParser, baseInfo: PetInfo) {
     super(owner);
-    this._baseInfo = baseInfo;
+    this.baseInfo = baseInfo;
   }
 }
 


### PR DESCRIPTION
### Description

This PR intends to refactor part of Combatant to use proper private/protected fields instead of `_`. 

I've also turned Entity into an abstract class so you can no longer create a new instance of it directly (which would just throw errors before) and also forcing you to implement certain functions in the children such as `get name()`

For the future we should consider forcing `noImplicitOverride` however it would require us to do a LOT of changes across the app and I think it's better done in stages.

Closes #7777 

### Testing

- Test report URL: `/report/MVTXgZFnpWmx7wyd/61-Mythic+Vorasius+-+Kill+(5:30)/524-Evapriest/standard/character`
