### PR TITLE
windwalker: fix rushing wind kick proc handling and fof guidance

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -6,6 +6,16 @@ import SpellLink from 'interface/SpellLink';
 
 export default [
   change(
+    date(2026, 4, 12),
+    <>
+      Gated <SpellLink spell={SPELLS.RUSHING_WIND_KICK_CAST} /> priority and chi reservation on
+      the proc buff actually being active in both Windwalker hero-spec APLs, and expanded the{' '}
+      <SpellLink spell={SPELLS.FISTS_OF_FURY_CAST} /> guide to call out how{' '}
+      <SpellLink spell={TALENTS.MOMENTUM_BOOST_TALENT} /> makes late ticks especially valuable.
+    </>,
+    Durpn,
+  ),
+  change(
     date(2026, 4, 3),
     <>
       Fixed cooldown availability for{' '}

--- a/src/analysis/retail/monk/windwalker/modules/apl/ConduitOfTheCelestialsApl.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/apl/ConduitOfTheCelestialsApl.tsx
@@ -91,7 +91,10 @@ export default function conduitOfTheCelestialsApl(combatant: Combatant): Apl {
     },
     TALENTS.STRIKE_OF_THE_WINDLORD_TALENT,
     TALENTS.FISTS_OF_FURY_TALENT,
-    TALENTS.RUSHING_WIND_KICK_WINDWALKER_TALENT,
+    {
+      spell: SPELLS.RUSHING_WIND_KICK_CAST,
+      condition: buffPresent(SPELLS.RUSHING_WIND_KICK_BUFF),
+    },
     {
       spell: SPELLS.SPINNING_CRANE_KICK,
       condition: describe(
@@ -119,7 +122,8 @@ export default function conduitOfTheCelestialsApl(combatant: Combatant): Apl {
           ),
           and(
             hasTalent(TALENTS.RUSHING_WIND_KICK_WINDWALKER_TALENT),
-            spellCooldownRemaining(TALENTS.RUSHING_WIND_KICK_WINDWALKER_TALENT, { atMost: 1 }),
+            buffPresent(SPELLS.RUSHING_WIND_KICK_BUFF),
+            spellCooldownRemaining(SPELLS.RUSHING_WIND_KICK_CAST, { atMost: 1 }),
             hasResource(RESOURCE_TYPES.CHI, { atMost: 1 }),
           ),
           and(danceOfChiJiExpiring, hasResource(RESOURCE_TYPES.CHI, { atMost: 1 })),

--- a/src/analysis/retail/monk/windwalker/modules/apl/ShadoPanApl.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/apl/ShadoPanApl.tsx
@@ -53,7 +53,10 @@ export default function shadoPanApl(combatant: Combatant): Apl {
     },
     TALENTS.STRIKE_OF_THE_WINDLORD_TALENT,
     TALENTS.FISTS_OF_FURY_TALENT,
-    TALENTS.RUSHING_WIND_KICK_WINDWALKER_TALENT,
+    {
+      spell: SPELLS.RUSHING_WIND_KICK_CAST,
+      condition: buffPresent(SPELLS.RUSHING_WIND_KICK_BUFF),
+    },
     {
       spell: SPELLS.SPINNING_CRANE_KICK,
       condition: describe(
@@ -81,7 +84,8 @@ export default function shadoPanApl(combatant: Combatant): Apl {
           ),
           and(
             hasTalent(TALENTS.RUSHING_WIND_KICK_WINDWALKER_TALENT),
-            spellCooldownRemaining(TALENTS.RUSHING_WIND_KICK_WINDWALKER_TALENT, { atMost: 1 }),
+            buffPresent(SPELLS.RUSHING_WIND_KICK_BUFF),
+            spellCooldownRemaining(SPELLS.RUSHING_WIND_KICK_CAST, { atMost: 1 }),
             hasResource(RESOURCE_TYPES.CHI, { atMost: 1 }),
           ),
           and(danceOfChiJiExpiring, hasResource(RESOURCE_TYPES.CHI, { atMost: 1 })),

--- a/src/analysis/retail/monk/windwalker/modules/spells/FistsofFury.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/spells/FistsofFury.tsx
@@ -168,14 +168,22 @@ class FistsofFury extends Analyzer {
 
   get guideSubsection(): JSX.Element {
     const explanation = (
-      <p>
-        <b>
-          <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} />
-        </b>{' '}
-        is one of your primary dps skills, and should be channeled to completion. It ticks{' '}
-        {BASE_FISTS_OF_FURY_TICKS} times by default, or {CRASHING_FISTS_FISTS_OF_FURY_TICKS} times
-        with <SpellLink spell={TALENTS_MONK.CRASHING_FISTS_TALENT} />.
-      </p>
+      <>
+        <p>
+          <b>
+            <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} />
+          </b>{' '}
+          is one of your primary dps skills, and should be channeled to completion. It ticks{' '}
+          {BASE_FISTS_OF_FURY_TICKS} times by default, or {CRASHING_FISTS_FISTS_OF_FURY_TICKS} times
+          with <SpellLink spell={TALENTS_MONK.CRASHING_FISTS_TALENT} />.
+        </p>
+        <p>
+          With <SpellLink spell={TALENTS_MONK.MOMENTUM_BOOST_TALENT} />, each tick of{' '}
+          <SpellLink spell={TALENTS_MONK.FISTS_OF_FURY_TALENT} /> ramps the damage of the next tick.
+          That means the back half of the channel is worth significantly more than the front half,
+          so clipping it early is especially punishing.
+        </p>
+      </>
     );
 
     const data = (


### PR DESCRIPTION
## Description

Fix Rushing Wind Kick priority handling so the proc is only treated as available when its buff is actually active in both Windwalker hero-spec APLs.

Also update the Fists of Fury guide text to explain that Momentum Boost ramps damage across the channel, which makes clipping late ticks especially costly.

### Testing

- Test report URL: `/report/HtbTKjMpvQy6NmZY/32-Mythic+Vorasius+-+Kill+(6:01)/222-Joriso/standard`
- Screenshot(s):

<img width="1312" height="544" alt="image" src="https://github.com/user-attachments/assets/35647298-3c9b-4830-af1d-c210768b038e" />