### PR TITLE
fix(typing): Limit usage of ts-ignore

### DIFF
--- a/src/analysis/retail/priest/holy/modules/core/EchoOfLightMastery.tsx
+++ b/src/analysis/retail/priest/holy/modules/core/EchoOfLightMastery.tsx
@@ -18,7 +18,8 @@ import { ABILITIES_THAT_TRIGGER_MASTERY } from '../../constants';
  * UNTIL THEN, JUST THE FRONT END IS DISABLED.
  */
 
-const DEBUG = false;
+// widened to boolean so TS doesn't narrow to literal `false` and flag DEBUG && ... as unreachable
+const DEBUG = false as boolean;
 const CUTOFF_PERCENT = 0.01;
 
 interface EoLHealEvent extends HealEvent {
@@ -191,8 +192,6 @@ class EchoOfLightMastery extends Analyzer {
 
     // As far as I can tell, this happens when the combat log is out of order. You shouldn't receive a tick of EoL without a target having a buff apply event.
     if (!this.targetMasteryPool[targetId]) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       DEBUG &&
         console.warn(
           `[${event.timestamp}] There was a mastery tick for ${
@@ -205,8 +204,6 @@ class EchoOfLightMastery extends Analyzer {
     }
 
     if (this.targetMasteryPool[targetId].remainingTicks < 1) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       DEBUG &&
         console.warn(
           `[${event.timestamp}] There was a mastery tick for ${
@@ -306,8 +303,6 @@ class EchoOfLightMastery extends Analyzer {
       // This code compensates for that.
       if (this.targetMasteryPool[targetId]) {
         if (event.timestamp === this.targetMasteryPool[targetId].applicationTime) {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
           DEBUG &&
             console.warn(
               `[${event.timestamp}] There was a double application of EoL tick on target ${

--- a/src/analysis/retail/priest/holy/modules/core/EchoOfLightMastery.tsx
+++ b/src/analysis/retail/priest/holy/modules/core/EchoOfLightMastery.tsx
@@ -18,8 +18,7 @@ import { ABILITIES_THAT_TRIGGER_MASTERY } from '../../constants';
  * UNTIL THEN, JUST THE FRONT END IS DISABLED.
  */
 
-// widened to boolean so TS doesn't narrow to literal `false` and flag DEBUG && ... as unreachable
-const DEBUG = false as boolean;
+const DEBUG = false;
 const CUTOFF_PERCENT = 0.01;
 
 interface EoLHealEvent extends HealEvent {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,6 @@ import 'interface/static/bootstrap/css/bootstrap.css';
 
 import { createRoot } from 'react-dom/client';
 
-// @ts-expect-error types/core-js doesn't include the type for this i guess
 import at from 'core-js/actual/array/at';
 
 import Root from './Root';

--- a/src/interface/report/Results/Timeline/Casts.tsx
+++ b/src/interface/report/Results/Timeline/Casts.tsx
@@ -208,8 +208,6 @@ const Casts = ({
     return renderIcon(event, {
       className,
       style: {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         '--level': level > 0 ? level : undefined,
       },
       children: lower ? <div className="time-indicator" /> : undefined,
@@ -371,8 +369,6 @@ const Casts = ({
           style={{
             left,
             width: (duration / 1000) * secondWidth,
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
             '--rate-height': actualMovementDurationEstimate,
           }}
         />
@@ -385,8 +381,6 @@ const Casts = ({
       className="casts"
       {...others}
       style={{
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         '--levels': hasLowered ? _maxLevel : 0,
         '--has-levels': hasLowered ? 1 : 0,
         ...others.style,

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -318,13 +318,9 @@ class CombatLogParser {
     this.characterProfile = characterProfile;
     this._timestamp = selectedFight.start_time;
     this.boss = findByBossId(selectedFight.boss);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore populated dynamically but object keys still strongly typed
-    this.disabledModules = {};
-    //initialize disabled modules for each state
-    Object.values(ModuleError).forEach((key) => {
-      this.disabledModules[key] = [];
-    });
+    this.disabledModules = Object.fromEntries(
+      Object.values(ModuleError).map((key) => [key, [] as ModuleErrorDetails[]]),
+    ) as Record<ModuleError, ModuleErrorDetails[]>;
     const ctor = this.constructor as typeof CombatLogParser;
     this.initializeModules({
       ...ctor.internalModules,

--- a/src/parser/core/Module.ts
+++ b/src/parser/core/Module.ts
@@ -42,14 +42,12 @@ class Module {
     // as we move towards a `this.deps` world, this ceases to be a problem.
     //
     // See https://github.com/Microsoft/TypeScript/issues/6110, https://github.com/microsoft/TypeScript/issues/37640 for more info
-    Object.keys(options)
-      // i don't like listing these out by name, but it prevents a TON of existing tests from breaking
-      .filter((key) => key !== 'priority' && key !== 'owner')
-      .forEach((key) => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        instance[key] = options[key];
-      });
+    Object.assign(
+      instance,
+      Object.fromEntries(
+        Object.entries(options).filter(([key]) => key !== 'priority' && key !== 'owner'),
+      ),
+    );
   }
 
   get consoleMeta() {

--- a/src/parser/core/modules/EventEmitter.ts
+++ b/src/parser/core/modules/EventEmitter.ts
@@ -255,10 +255,7 @@ class EventEmitter extends Module {
     }
     this._isHandlingEvent = false;
 
-    // TODO fix
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    this.owner.eventHistory.push(event);
+    this.owner.eventHistory.push(event as AnyEvent);
     // Some modules need to have a primitive value to cause re-renders
     // TODO: This can probably be removed since we only render upon completion now
     this.owner.eventCount += 1;

--- a/src/parser/shared/modules/resources/mana/ManaLevelChartComponent.tsx
+++ b/src/parser/shared/modules/resources/mana/ManaLevelChartComponent.tsx
@@ -83,10 +83,7 @@ class ManaLevelChartComponent extends PureComponent<Props, State> {
       }),
     );
 
-    // oxlint-disable-next-line typescript-eslint/no-explicit-any -- Baseline suppression. Try to fix if you edit this code.
-    const bossData = this.state.bossHealth.series.map((series: any) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+    const bossData = this.state.bossHealth.series.map((series) => {
       const data = series.data.map(([timestamp, health]) => ({ x: timestamp - start, y: health }));
 
       return {

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -32,6 +32,4 @@ beforeEach(() => {
 afterEach(cleanup);
 
 // make jest things think vitest is jest
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- Uhhh
-// @ts-ignore
-global.jest = vi;
+(globalThis as Record<string, unknown>).jest = vi;

--- a/types/core-js.d.ts
+++ b/types/core-js.d.ts
@@ -1,0 +1,4 @@
+declare module 'core-js/actual/array/at' {
+  function at<T>(this: T[], index: number): T | undefined;
+  export default at;
+}

--- a/types/css-custom-properties.d.ts
+++ b/types/css-custom-properties.d.ts
@@ -1,0 +1,8 @@
+import 'react';
+
+declare module 'react' {
+  interface CSSProperties {
+    // oxlint-disable-next-line consistent-indexed-object-style -- template literal pattern keys cannot use Record syntax
+    [key: `--${string}`]: string | number | undefined;
+  }
+}


### PR DESCRIPTION
### Description

This PR intends to limit the usage of ts-ignore by fixing typing of multiple files.

I've had to keep the ignore for CSSProperties as the solution marked as accepted on the package repo simply didnt work anymore and I couldn't find a better solution that wouldn't require big changes

### Testing

- Test report URL: `/report/2ygv3QaYBfnRA14c/22-Mythic+Vaelgor+&+Ezzorak+-+Kill+(6:57)/70-Tabbìe/standard`
