### PR TITLE
feat(errors): Remove es6-error as it's natively supported now

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@wowanalyzer/react-tooltip-lite": "github:ToppleTheNun/react-tooltip-lite#react-19",
     "clsx": "2.1.1",
     "core-js": "3.36.1",
-    "es6-error": "^4.1.1",
     "prop-types": "^15.8.1",
     "rc-slider": "^10.5.0",
     "react": "19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,6 @@ importers:
       core-js:
         specifier: 3.36.1
         version: 3.36.1
-      es6-error:
-        specifier: ^4.1.1
-        version: 4.1.1
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -2603,9 +2600,6 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
-
-  es6-error@4.1.1:
-    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esbuild@0.25.1:
     resolution: {integrity: sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==}
@@ -6642,8 +6636,6 @@ snapshots:
       isarray: 2.0.5
 
   es-module-lexer@1.7.0: {}
-
-  es6-error@4.1.1: {}
 
   esbuild@0.25.1:
     optionalDependencies:

--- a/src/common/fetchWclApi.ts
+++ b/src/common/fetchWclApi.ts
@@ -1,5 +1,4 @@
 import { captureException } from 'common/errorLogger';
-import ExtendableError from 'es6-error';
 import { AnyEvent } from 'parser/core/Events';
 
 import { QueryParams } from './makeApiUrl';
@@ -12,23 +11,23 @@ import {
   WCLEventsResponse,
 } from './WCL_TYPES';
 
-export class ApiDownError extends ExtendableError {}
-export class LogNotFoundError extends ExtendableError {}
-export class CharacterNotFoundError extends ExtendableError {}
-export class GuildNotFoundError extends ExtendableError {}
-export class UnauthorizedError extends ExtendableError {}
-export class JsonParseError extends ExtendableError {
-  originalError?: ExtendableError;
+export class ApiDownError extends Error {}
+export class LogNotFoundError extends Error {}
+export class CharacterNotFoundError extends Error {}
+export class GuildNotFoundError extends Error {}
+export class UnauthorizedError extends Error {}
+export class JsonParseError extends Error {
+  originalError?: Error;
   raw?: string;
-  constructor(originalError?: ExtendableError, raw?: string) {
+  constructor(originalError?: Error, raw?: string) {
     super();
     this.originalError = originalError;
     this.raw = raw;
   }
 }
-export class WclApiError extends ExtendableError {}
-export class UnknownApiError extends ExtendableError {}
-export class CorruptResponseError extends ExtendableError {}
+export class WclApiError extends Error {}
+export class UnknownApiError extends Error {}
+export class CorruptResponseError extends Error {}
 
 const HTTP_CODES = {
   OK: 200,

--- a/src/interface/report/hooks/useEventParser.ts
+++ b/src/interface/report/hooks/useEventParser.ts
@@ -1,6 +1,5 @@
 import { captureException } from 'common/errorLogger';
 import { uploadServerMetrics, type Selection } from 'common/server-metrics';
-import ExtendableError from 'es6-error';
 import Config, { configName, SupportLevel } from 'parser/Config';
 import CharacterProfile from 'parser/core/CharacterProfile';
 import CombatLogParser from 'parser/core/CombatLogParser';
@@ -19,12 +18,11 @@ const MAX_BATCH_DURATION = 66.67; // ms
 const bench = (id: string) => console.time(id);
 const benchEnd = (id: string) => console.timeEnd(id);
 
-export class EventsParseError extends ExtendableError {
-  reason?: ExtendableError;
-  constructor(reason: ExtendableError) {
-    super();
+export class EventsParseError extends Error {
+  reason?: Error;
+  constructor(reason: Error) {
+    super(`An error occurred while parsing events: ${reason.message}`);
     this.reason = reason;
-    this.message = `An error occurred while parsing events: ${reason.message}`;
   }
 }
 


### PR DESCRIPTION
### Description

This PR intends to remove the `es6-error` package as what it does has been natively supported since 2015 via `Error`

### Testing

- Test report URL: `/report/2ygv3QaYBfnRA14c/22-Mythic+Vaelgor+&+Ezzorak+-+Kill+(6:57)/70-Tabbìe/standard`
