### PR TITLE
Precise Shots Update

### DIFF
--- a/src/analysis/retail/hunter/marksmanship/constants.ts
+++ b/src/analysis/retail/hunter/marksmanship/constants.ts
@@ -47,8 +47,10 @@ export const LONE_WOLF_AFFECTED_SPELLS = [
 export const WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS = 2;
 //Precise Shots procs without Windrunner talents
 export const PRECISE_SHOTS_ASSUMED_PROCS = 1;
-//Precise Shots increase damage of Arcane or Multi-Shot by 100%
-export const PRECISE_SHOTS_MODIFIER = 1;
+//Precise Shots increase damage of Arcane or Multi-Shot by 180% per stack with Windrunner
+export const WINDRUNNER_PRECISE_SHOTS_MODIFIER = 1.8;
+//Precise Shots increase damage of Arcane or Multi-Shot by 200% per stack without Windrunner
+export const PRECISE_SHOTS_MODIFIER = 2;
 //Because the spells have traveltime we need to take it into account
 export const ARCANE_SHOT_MAX_TRAVEL_TIME = 500;
 /** Steady Shot */

--- a/src/analysis/retail/hunter/marksmanship/modules/Abilities.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/Abilities.tsx
@@ -93,7 +93,7 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS.VOLLEY_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 45,
+        cooldown: 45 - (combatant.hasTalent(TALENTS.BULLET_HELL_TALENT) ? 15 : 0),
         enabled: combatant.hasTalent(TALENTS.VOLLEY_TALENT),
         gcd: {
           base: 1500,
@@ -137,7 +137,10 @@ class Abilities extends CoreAbilities {
         buffSpellId: SPELLS.ASPECT_OF_THE_TURTLE.id,
         category: SPELL_CATEGORY.DEFENSIVE,
         isDefensive: true,
-        cooldown: 180 - (combatant.hasTalent(TALENTS.BORN_TO_BE_WILD_TALENT) ? 30 : 0),
+        cooldown:
+          180 -
+          (combatant.hasTalent(TALENTS.IMPROVED_ASPECT_OF_THE_TURTLE_TALENT) ? 30 : 0) -
+          combatant.getTalentRank(TALENTS.BORN_TO_BE_WILD_TALENT) * 15,
         gcd: {
           static: 0,
         },
@@ -200,7 +203,11 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.ASPECT_OF_THE_CHEETAH.id,
         category: SPELL_CATEGORY.UTILITY,
-        cooldown: 180 - (combatant.getTalentRank(TALENTS.BORN_TO_BE_WILD_TALENT) ? 30 : 0),
+        cooldown:
+          150 -
+          (combatant.hasTalent(TALENTS.IMPROVED_ASPECT_OF_THE_CHEETAH_TALENT) ? 30 : 0) -
+          combatant.getTalentRank(TALENTS.BORN_TO_BE_WILD_TALENT) * 15 -
+          (combatant.hasTalent(TALENTS.CONDITIONING_TALENT) ? 30 : 0),
         gcd: {
           static: 0,
         },
@@ -236,6 +243,28 @@ class Abilities extends CoreAbilities {
           base: 1000,
         },
       },
+      {
+        spell: SPELLS.WING_CLIP.id,
+        category: SPELL_CATEGORY.UTILITY,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.TRANQUILIZING_SHOT.id,
+        category: SPELL_CATEGORY.UTILITY,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.HARRIERS_CRY.id,
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 360,
+        gcd: {
+          static: 0,
+        },
+      },
       //endregion
 
       //region Pets
@@ -256,7 +285,14 @@ class Abilities extends CoreAbilities {
           static: 0,
         },
       },
-
+      {
+        spell: SPELLS.INTIMIDATION_MM.id,
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 60,
+        gcd: {
+          base: 1500,
+        },
+      },
       {
         spell: SPELLS.INTIMIDATION.id,
         category: SPELL_CATEGORY.UTILITY,

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/PreciseShots.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/PreciseShots.tsx
@@ -92,20 +92,21 @@ class PreciseShots extends Analyzer {
   }
 
   onRFPreciseShotsApplication() {
-    if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.NO_SCOPE_TALENT)) {
-      if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.WINDRUNNER_QUIVER_TALENT)) {
-        if (this.buffsActive == WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS) {
-          this.overwrittenProcs += 1;
-        }
-        if (this.buffsActive != WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS) {
-          this.buffsActive += 1;
-        }
-      } else {
-        if (this.buffsActive == PRECISE_SHOTS_ASSUMED_PROCS) {
-          this.overwrittenProcs += 1;
-        }
-        this.buffsActive = PRECISE_SHOTS_ASSUMED_PROCS;
+    if (!this.selectedCombatant.hasTalent(TALENTS_HUNTER.NO_SCOPE_TALENT)) {
+      return;
+    }
+    if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.WINDRUNNER_QUIVER_TALENT)) {
+      if (this.buffsActive == WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS) {
+        this.overwrittenProcs += 1;
       }
+      if (this.buffsActive != WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS) {
+        this.buffsActive += 1;
+      }
+    } else {
+      if (this.buffsActive == PRECISE_SHOTS_ASSUMED_PROCS) {
+        this.overwrittenProcs += 1;
+      }
+      this.buffsActive = PRECISE_SHOTS_ASSUMED_PROCS;
     }
   }
 

--- a/src/analysis/retail/hunter/marksmanship/modules/talents/PreciseShots.tsx
+++ b/src/analysis/retail/hunter/marksmanship/modules/talents/PreciseShots.tsx
@@ -2,6 +2,7 @@ import {
   ARCANE_SHOT_MAX_TRAVEL_TIME,
   WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS,
   PRECISE_SHOTS_ASSUMED_PROCS,
+  WINDRUNNER_PRECISE_SHOTS_MODIFIER,
   PRECISE_SHOTS_MODIFIER,
 } from 'analysis/retail/hunter/marksmanship/constants';
 import SPELLS from 'common/SPELLS';
@@ -31,8 +32,8 @@ class PreciseShots extends Analyzer {
   damage = 0;
   buffsActive = 0;
   buffsSpent = 0;
-  minOverwrittenProcs = 0;
-  maxOverwrittenProcs = 0;
+  inFlightStacks = 0;
+  overwrittenProcs = 0;
   buffedShotInFlight: number | null = null;
 
   protected spellUsable!: SpellUsable;
@@ -41,8 +42,12 @@ class PreciseShots extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_HUNTER.PRECISE_SHOTS_TALENT);
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.PRECISE_SHOTS_BUFF),
-      this.onPreciseShotsApplication,
+      Events.cast.by(SELECTED_PLAYER).spell([TALENTS_HUNTER.AIMED_SHOT_TALENT]),
+      this.onASPreciseShotsApplication,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell([TALENTS_HUNTER.RAPID_FIRE_TALENT]),
+      this.onRFPreciseShotsApplication,
     );
     this.addEventListener(
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.PRECISE_SHOTS_BUFF),
@@ -60,7 +65,7 @@ class PreciseShots extends Analyzer {
   }
 
   get preciseShotsUtilizationPercentage() {
-    return this.buffsSpent / (this.buffsSpent + this.minOverwrittenProcs);
+    return this.buffsSpent / (this.buffsSpent + this.overwrittenProcs);
   }
 
   get preciseShotsWastedThreshold() {
@@ -75,7 +80,10 @@ class PreciseShots extends Analyzer {
     };
   }
 
-  onPreciseShotsApplication() {
+  onASPreciseShotsApplication() {
+    if (this.buffsActive != 0) {
+      this.overwrittenProcs += 1;
+    }
     if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.WINDRUNNER_QUIVER_TALENT)) {
       this.buffsActive = WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS;
     } else {
@@ -83,14 +91,27 @@ class PreciseShots extends Analyzer {
     }
   }
 
-  onPreciseShotsRemoval() {
-    if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.WINDRUNNER_QUIVER_TALENT)) {
-      this.buffsSpent += 2;
-      this.buffsActive = 0;
-    } else {
-      this.buffsSpent += 1;
-      this.buffsActive = 0;
+  onRFPreciseShotsApplication() {
+    if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.NO_SCOPE_TALENT)) {
+      if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.WINDRUNNER_QUIVER_TALENT)) {
+        if (this.buffsActive == WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS) {
+          this.overwrittenProcs += 1;
+        }
+        if (this.buffsActive != WINDRUNNER_PRECISE_SHOTS_ASSUMED_PROCS) {
+          this.buffsActive += 1;
+        }
+      } else {
+        if (this.buffsActive == PRECISE_SHOTS_ASSUMED_PROCS) {
+          this.overwrittenProcs += 1;
+        }
+        this.buffsActive = PRECISE_SHOTS_ASSUMED_PROCS;
+      }
     }
+  }
+
+  onPreciseShotsRemoval() {
+    this.buffsSpent += this.buffsActive;
+    this.buffsActive = 0;
   }
 
   onPreciseCast(event: CastEvent) {
@@ -98,6 +119,7 @@ class PreciseShots extends Analyzer {
       return;
     }
     this.buffedShotInFlight = event.timestamp;
+    this.inFlightStacks = this.buffsActive;
   }
 
   onPreciseDamage(event: DamageEvent) {
@@ -106,7 +128,14 @@ class PreciseShots extends Analyzer {
       return;
     }
     if (this.buffedShotInFlight < event.timestamp + ARCANE_SHOT_MAX_TRAVEL_TIME) {
-      this.damage += calculateEffectiveDamage(event, PRECISE_SHOTS_MODIFIER);
+      if (this.selectedCombatant.hasTalent(TALENTS_HUNTER.WINDRUNNER_QUIVER_TALENT)) {
+        this.damage += calculateEffectiveDamage(
+          event,
+          WINDRUNNER_PRECISE_SHOTS_MODIFIER * this.inFlightStacks,
+        );
+      } else {
+        this.damage += calculateEffectiveDamage(event, PRECISE_SHOTS_MODIFIER);
+      }
     }
     if (event.ability.guid === SPELLS.ARCANE_SHOT.id) {
       this.buffedShotInFlight = null;
@@ -129,8 +158,11 @@ class PreciseShots extends Analyzer {
         size="flexible"
         tooltip={
           <>
-            You wasted between {this.minOverwrittenProcs} and {this.maxOverwrittenProcs} Precise
-            Shots procs by casting Aimed Shot when you already had Precise Shots active
+            You wasted {this.overwrittenProcs} Precise Shots procs by casting{' '}
+            {this.selectedCombatant.hasTalent(TALENTS_HUNTER.WINDRUNNER_QUIVER_TALENT)
+              ? 'Aimed Shot or Rapid Fire'
+              : 'Aimed Shot'}{' '}
+            when you already had Precise Shots active.
           </>
         }
       >

--- a/src/common/SPELLS/hunter.ts
+++ b/src/common/SPELLS/hunter.ts
@@ -582,6 +582,11 @@ const spells = {
     name: 'Intimidation',
     icon: 'ability_devour',
   },
+  INTIMIDATION_MM: {
+    id: 474421,
+    name: 'Intimidation',
+    icon: 'artifactability_survivalhunter_eaglesbite',
+  },
   CHIMAERA_SHOT_FOCUS: {
     id: 204304,
     name: 'Chimaera Shot',


### PR DESCRIPTION
- Updated Precise Shots to track buff stacks from both Aimed Shot and Rapid Fire as necessary (No Scope/Windrunner Quiver/etc).
- Added WINDRUNNER_PRECISE_SHOTS_MODIFIER and updated PRECISE_SHOTS_MODIFIER to correct calculateEffectiveDamage output.
- Fixed tracking of wasted Precise Shots procs.
- Added some abilities to spellbook, updated cooldown calculations for some.
