### PR TITLE
Sudden Ambush spell ID fix and adjustments to how we're tracking dot …

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import {  Drowzen } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2026, 4, 12), "Fixed Sudden Ambush spell ID issues + tracking updates, updated tracking for DOTs", Drowzen),
   change(date(2026, 3, 15), "Added initial Chomp and Frantic Frenzy Support", Drowzen),
   change(date(2026, 3, 7,), "Initial Midnight update to activate Feral", Drowzen),
 ];

--- a/src/analysis/retail/druid/feral/constants.ts
+++ b/src/analysis/retail/druid/feral/constants.ts
@@ -182,6 +182,7 @@ export function getTigersFuryDamageBonus(c: Combatant): number {
 export const BLOODTALONS_DAMAGE_BONUS = 0.25;
 export const LIONS_STRENGTH_DAMAGE_BONUS = 0.15;
 export const PROWL_RAKE_DAMAGE_BONUS = 0.6;
+export const SUDDEN_ABUSH_DAMAGE_BONUS = 0.5;
 
 /** Max time left on a DoT for us to not yell if snapshot is downgraded */
 export const SNAPSHOT_DOWNGRADE_BUFFER = 2000;
@@ -206,10 +207,18 @@ export function cdSpell(c: Combatant): Spell {
 // MISC
 //
 
-/** Minimum acceptable number of CPs to use with a finisher (currently always 5, leaving as function in case this changes again) */
-export function getAcceptableCps(_: Combatant): number {
-  return ACCEPTABLE_CPS;
+/** Minimum acceptable number of CPs to use with a finisher.
+ *  During Berserk/Incarnation, 5 CPs are required. Otherwise 4 CPs is acceptable.
+ *  This might change in the 12.0.5 patch */
+export function getAcceptableCps(c: Combatant, atTimestamp?: number): number {
+  const inBerserk =
+    c.hasBuff(SPELLS.BERSERK_CAT.id, atTimestamp) ||
+    c.hasBuff(TALENTS_DRUID.INCARNATION_AVATAR_OF_ASHAMANE_TALENT.id, atTimestamp);
+  return inBerserk ? MAX_CPS : MIN_ACCEPTABLE_CPS;
 }
+/** Minimum acceptable CPs for a finisher outside of Berserk */
+export const MIN_ACCEPTABLE_CPS = 4;
+/** Maximum CPs - required for finishers during Berserk */
 export const ACCEPTABLE_CPS = 5;
 
 /** Effective combo points used by a Convoke'd Ferocious Bite */

--- a/src/analysis/retail/druid/feral/modules/core/Snapshots.ts
+++ b/src/analysis/retail/druid/feral/modules/core/Snapshots.ts
@@ -210,6 +210,17 @@ abstract class Snapshots extends Analyzer {
     return this.applicableSnapshots.filter((as) => as.isPresent(this.selectedCombatant, timestamp));
   }
 
+  /** Combined uptime periods derived from snapshot tracking data.
+   *  Use this for the primary uptime bar to ensure consistency with snapshot sub-bars.
+   *  This is to fix an issue where because the time metrics used are slightly different you can result in values
+   *  over 100% which from an analysis perspective isn't exactly helpful */
+  get combinedUptimeHistory(): ClosedTimePeriod[] {
+    return mergeTimePeriods(
+      Object.values(this.snapshotsByTarget).flatMap((uptimes) => uptimes),
+      this.owner.currentTimestamp,
+    );
+  }
+
   get snapshotUptimes(): UptimeBarSpec[] {
     return this.applicableSnapshots.map((as) => this._getSnapshotUptimesForBuff(as));
   }

--- a/src/analysis/retail/druid/feral/modules/core/combopoints/FinisherUse.tsx
+++ b/src/analysis/retail/druid/feral/modules/core/combopoints/FinisherUse.tsx
@@ -40,8 +40,8 @@ class FinisherUse extends Analyzer {
     }
 
     this.totalFinisherCasts += 1;
-
-    if (cpsSpent < getAcceptableCps(this.selectedCombatant)) {
+    /** Added time stamps to allow us to buff track at the time of casts for performance metrics */
+    if (cpsSpent < getAcceptableCps(this.selectedCombatant, event.timestamp)) {
       if (
         event.ability.guid === SPELLS.RIP.id ||
         event.ability.guid === TALENTS_DRUID.PRIMAL_WRATH_TALENT.id

--- a/src/analysis/retail/druid/feral/modules/core/energy/EnergyDetails.tsx
+++ b/src/analysis/retail/druid/feral/modules/core/energy/EnergyDetails.tsx
@@ -28,13 +28,15 @@ class EnergyDetails extends Analyzer {
         label="Time with capped energy"
         tooltip={
           <>
-            Although it can be beneficial to wait and let your energy pool ready to be used at the
-            right time, you should still avoid letting it reach the cap.
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-            You spent <b>{formatPercentage(percentAtCap)}%</b> of the fight at capped energy,
-            causing you to miss out on <b>{this.owner.getPerMinute(gainWaste).toFixed(0)}</b> energy
-            per minute from regeneration.
+            <p>
+              Although it can be beneficial to wait and let your energy pool ready to be used at the
+              right time, you should still avoid letting it reach the cap.
+            </p>
+            <p>
+              You spent <b>{formatPercentage(percentAtCap)}%</b> of the fight at capped energy,
+              causing you to miss out on <b>{this.owner.getPerMinute(gainWaste).toFixed(0)}</b>{' '}
+              energy per minute from regeneration.
+            </p>
           </>
         }
         footer={

--- a/src/analysis/retail/druid/feral/modules/spells/ApexPredatorsCraving.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/ApexPredatorsCraving.tsx
@@ -142,6 +142,13 @@ class ApexPredatorsCraving extends Analyzer {
     return this.biteDamage + this.rampantFerocityDamage;
   }
 
+  get buffUptime() {
+    return (
+      this.selectedCombatant.getBuffUptime(SPELLS.APEX_PREDATORS_CRAVING_BUFF.id) /
+      this.owner.fightDuration
+    );
+  }
+
   statistic() {
     return (
       <Statistic
@@ -228,15 +235,20 @@ class ApexPredatorsCraving extends Analyzer {
         }
       >
         <BoringSpellValueText spell={TALENTS_DRUID.APEX_PREDATORS_CRAVING_TALENT}>
-          <ItemPercentDamageDone amount={this.totalDamage} />
-          {this.hasSotf && (
-            <>
-              {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-              <br />
-              <SpellIcon spell={SPELLS.SOUL_OF_THE_FOREST_FERAL_ENERGY} />{' '}
-              {this.sotfEnergyEffectivePerMinute.toFixed(0)} <small>energy per minute</small>
-            </>
-          )}
+          <div>
+            <ItemPercentDamageDone amount={this.totalDamage} />
+          </div>
+          <div>
+            <UptimeIcon /> {formatPercentage(this.buffUptime, 1)}% <small>buff uptime</small>
+          </div>
+          <div>
+            {this.hasSotf && (
+              <>
+                <SpellIcon spell={SPELLS.SOUL_OF_THE_FOREST_FERAL_ENERGY} />{' '}
+                {this.sotfEnergyEffectivePerMinute.toFixed(0)} <small>energy per minute</small>
+              </>
+            )}
+          </div>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/analysis/retail/druid/feral/modules/spells/ApexPredatorsCraving.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/ApexPredatorsCraving.tsx
@@ -241,14 +241,13 @@ class ApexPredatorsCraving extends Analyzer {
           <div>
             <UptimeIcon /> {formatPercentage(this.buffUptime, 1)}% <small>buff uptime</small>
           </div>
-          <div>
-            {this.hasSotf && (
-              <>
-                <SpellIcon spell={SPELLS.SOUL_OF_THE_FOREST_FERAL_ENERGY} />{' '}
-                {this.sotfEnergyEffectivePerMinute.toFixed(0)} <small>energy per minute</small>
-              </>
-            )}
-          </div>
+
+          {this.hasSotf && (
+            <div>
+              <SpellIcon spell={SPELLS.SOUL_OF_THE_FOREST_FERAL_ENERGY} />{' '}
+              {this.sotfEnergyEffectivePerMinute.toFixed(0)} <small>energy per minute</small>
+            </div>
+          )}
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/analysis/retail/druid/feral/modules/spells/ConvokeSpiritsFeral.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/ConvokeSpiritsFeral.tsx
@@ -12,19 +12,10 @@ import CooldownExpandable, {
 } from 'interface/guide/components/CooldownExpandable';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { ApplyBuffEvent } from 'parser/core/Events';
-import { PassFailCheckmark, PerformanceMark } from 'interface/guide';
-import { TALENTS_DRUID } from 'common/TALENTS';
+import { PassFailCheckmark } from 'interface/guide';
 import { cdSpell } from 'analysis/retail/druid/feral/constants';
-import EnergyTracker from 'analysis/retail/druid/feral/modules/core/energy/EnergyTracker';
 
 class ConvokeSpiritsFeral extends ConvokeSpirits {
-  static dependencies = {
-    ...ConvokeSpirits.dependencies,
-    energyTracker: EnergyTracker,
-  };
-
-  protected energyTracker!: EnergyTracker;
-
   /** Mapping from convoke cast number to a tracker for that cast - note that index zero will always be empty */
   feralConvokeTracker: FeralConvokeCast[] = [];
 
@@ -33,12 +24,10 @@ class ConvokeSpiritsFeral extends ConvokeSpirits {
 
     const tfOnCast = this.selectedCombatant.hasBuff(SPELLS.TIGERS_FURY.id);
     const berserkOnCast = this.selectedCombatant.hasBuff(cdSpell(this.selectedCombatant));
-    const energyOnCast = this.energyTracker.current;
 
     this.feralConvokeTracker[this.cast] = {
       tfOnCast,
       berserkOnCast,
-      energyOnCast,
     };
   }
 
@@ -79,25 +68,15 @@ class ConvokeSpiritsFeral extends ConvokeSpirits {
 
   /** Guide fragment showing a breakdown of each Convoke cast */
   get guideCastBreakdown() {
-    const hasHotL = this.selectedCombatant.hasTalent(
-      TALENTS_DRUID.BERSERK_HEART_OF_THE_LION_TALENT,
-    );
     const explanation = (
       <>
         <p>
           <strong>
             <SpellLink spell={SPELLS.CONVOKE_SPIRITS} />
           </strong>{' '}
-          is a powerful but somewhat random burst of damage. It's best used immediately on cooldown.
-          Always pair it with <SpellLink spell={SPELLS.TIGERS_FURY} />
-          {hasHotL && (
-            <>
-              {' '}
-              and <SpellLink spell={cdSpell(this.selectedCombatant)} />
-            </>
-          )}{' '}
-          to benefit from the damage boost. If possible, spend down your energy before starting the
-          channel (this may not be possible with abundant procs and/or high haste)
+          is a powerful but somewhat random burst of damage. Always pair it with{' '}
+          <SpellLink spell={SPELLS.TIGERS_FURY} /> and{' '}
+          <SpellLink spell={cdSpell(this.selectedCombatant)} /> to maximize damage.
         </p>
       </>
     );
@@ -116,13 +95,6 @@ class ConvokeSpiritsFeral extends ConvokeSpirits {
             </>
           );
 
-          let energyPerf = QualitativePerformance.Good;
-          if (feralCast.energyOnCast >= 100) {
-            energyPerf = QualitativePerformance.Fail;
-          } else if (feralCast.energyOnCast >= 50) {
-            energyPerf = QualitativePerformance.Ok;
-          }
-
           let overallPerf = QualitativePerformance.Good;
 
           const checklistItems: CooldownExpandableItem[] = [];
@@ -138,30 +110,17 @@ class ConvokeSpiritsFeral extends ConvokeSpirits {
             overallPerf = QualitativePerformance.Fail;
           }
 
-          if (hasHotL) {
-            checklistItems.push({
-              label: (
-                <>
-                  <SpellLink spell={cdSpell(this.selectedCombatant)} /> active
-                </>
-              ),
-              result: <PassFailCheckmark pass={feralCast.berserkOnCast} />,
-            });
-            if (!feralCast.berserkOnCast) {
-              overallPerf = QualitativePerformance.Fail;
-            }
-          }
-
           checklistItems.push({
-            label: 'Energy on cast',
-            result: <PerformanceMark perf={energyPerf} />,
-            details: <>({feralCast.energyOnCast} Energy)</>,
+            label: (
+              <>
+                <SpellLink spell={cdSpell(this.selectedCombatant)} /> active
+              </>
+            ),
+            result: <PassFailCheckmark pass={feralCast.berserkOnCast} />,
           });
-          overallPerf =
-            overallPerf === QualitativePerformance.Good &&
-            energyPerf !== QualitativePerformance.Good
-              ? QualitativePerformance.Ok
-              : overallPerf;
+          if (!feralCast.berserkOnCast) {
+            overallPerf = QualitativePerformance.Fail;
+          }
 
           return (
             <CooldownExpandable
@@ -183,7 +142,6 @@ class ConvokeSpiritsFeral extends ConvokeSpirits {
 interface FeralConvokeCast {
   tfOnCast: boolean;
   berserkOnCast: boolean;
-  energyOnCast: number;
 }
 
 export default ConvokeSpiritsFeral;

--- a/src/analysis/retail/druid/feral/modules/spells/ConvokeSpiritsFeral.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/ConvokeSpiritsFeral.tsx
@@ -41,17 +41,15 @@ class ConvokeSpiritsFeral extends ConvokeSpirits {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            <strong>
-              Damage amount listed considers only the direct damage and non-refreshable DoT damage
-              done by convoked abilities!{' '}
-            </strong>
-            (Non-refreshable DoTs are Starfall and Feral Frenzy) Refreshable DoTs, heals, and the
-            energy and damage boost from Tiger's Fury are all not considered by this number, making
-            it almost certainly an undercount of Convoke's true value.
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
+            <p>
+              <strong>
+                Damage amount listed considers only the direct damage and non-refreshable DoT damage
+                done by convoked abilities!{' '}
+              </strong>
+              (Non-refreshable DoTs are Starfall and Feral Frenzy) Refreshable DoTs, heals, and the
+              energy and damage boost from Tiger's Fury are all not considered by this number,
+              making it almost certainly an undercount of Convoke's true value.
+            </p>
             {this.baseTooltip}
           </>
         }
@@ -59,8 +57,6 @@ class ConvokeSpiritsFeral extends ConvokeSpirits {
       >
         <BoringSpellValueText spell={SPELLS.CONVOKE_SPIRITS}>
           <ItemPercentDamageDone greaterThan amount={this.totalDamage} />
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/analysis/retail/druid/feral/modules/spells/DoubleClawedRake.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/DoubleClawedRake.tsx
@@ -78,16 +78,16 @@ class DoubleClawedRake extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            This is the damage from Rake DoTs applied by Double-Clawed Rake. It is at best an
-            approximation of this talent's impact because of opportunity cost factors (Without DCR
-            you might have tab-Raked the 2nd target, with it you cast Swipe instead)
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-            Over the course of this encounter, <strong>{this.extraRakes}</strong> extra Rake DoTs
-            were created by this talent, or{' '}
-            <strong>{this.owner.getPerMinute(this.extraRakes).toFixed(1)} per minute</strong>.
+            <p>
+              This is the damage from Rake DoTs applied by Double-Clawed Rake. It is at best an
+              approximation of this talent's impact because of opportunity cost factors (Without DCR
+              you might have tab-Raked the 2nd target, with it you cast Swipe instead)
+            </p>
+            <p>
+              Over the course of this encounter, <strong>{this.extraRakes}</strong> extra Rake DoTs
+              were created by this talent, or{' '}
+              <strong>{this.owner.getPerMinute(this.extraRakes).toFixed(1)} per minute</strong>.
+            </p>
           </>
         }
       >

--- a/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
@@ -87,7 +87,7 @@ export default class FeralFrenzy extends Analyzer {
     const talent = this.talent;
 
     const explanation = (
-      <>
+      <div>
         <p>
           <strong>
             <SpellLink spell={talent} />
@@ -96,15 +96,15 @@ export default class FeralFrenzy extends Analyzer {
           it's best used at 2 or fewer combo points in order not to waste them.
           {this.isFrantic &&
             ' Should be used within as large of packs as possible for you to gain the most benefit out of it.'}
-          {this.isFocused && (
-            <>
-              {' '}
-              With <SpellLink spell={TALENTS_DRUID.FOCUSED_FRENZY_TALENT} />, always use it during{' '}
-              <SpellLink spell={SPELLS.TIGERS_FURY} />.
-            </>
-          )}
         </p>
-      </>
+        {this.isFocused && (
+          <p>
+            {' '}
+            With <SpellLink spell={TALENTS_DRUID.FOCUSED_FRENZY_TALENT} />, always use it during{' '}
+            <SpellLink spell={SPELLS.TIGERS_FURY} />.
+          </p>
+        )}
+      </div>
     );
 
     const data = (

--- a/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
@@ -10,7 +10,7 @@ import { getLowestPerf, QualitativePerformance } from 'parser/ui/QualitativePerf
 import CooldownExpandable, {
   CooldownExpandableItem,
 } from 'interface/guide/components/CooldownExpandable';
-import { PerformanceMark } from 'interface/guide';
+import { PassFailCheckmark, PerformanceMark } from 'interface/guide';
 import EnergyTracker from 'analysis/retail/druid/feral/modules/core/energy/EnergyTracker';
 import { getDamageHits } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
 
@@ -32,6 +32,7 @@ export default class FeralFrenzy extends Analyzer {
   protected energyTracker!: EnergyTracker;
   protected enemies!: Enemies;
   isFrantic = false;
+  isFocused = false;
 
   /** Tracker for each Feral Frenzy cast */
   ffTrackers: FeralFrenzyCast[] = [];
@@ -41,6 +42,7 @@ export default class FeralFrenzy extends Analyzer {
 
     this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.FERAL_FRENZY_TALENT);
     this.isFrantic = this.selectedCombatant.hasTalent(TALENTS_DRUID.FRANTIC_FRENZY_TALENT);
+    this.isFocused = this.selectedCombatant.hasTalent(TALENTS_DRUID.FOCUSED_FRENZY_TALENT);
 
     if (!this.isFrantic) {
       this.addEventListener(
@@ -73,16 +75,16 @@ export default class FeralFrenzy extends Analyzer {
     });
   }
 
+  get talent() {
+    if (this.isFrantic) {
+      return TALENTS_DRUID.FRANTIC_FRENZY_TALENT;
+    }
+    return TALENTS_DRUID.FERAL_FRENZY_TALENT;
+  }
+
   /** Guide fragment showing a breakdown of each Feral Frenzy cast */
   get guideCastBreakdown() {
-    const isFrantic = this.isFrantic;
-    let talent = TALENTS_DRUID.FERAL_FRENZY_TALENT;
-    let addition = '';
-    if (isFrantic) {
-      talent = TALENTS_DRUID.FRANTIC_FRENZY_TALENT;
-      addition =
-        'Should be used within as large of packs as possible for you to gain the most benefit out of it.';
-    }
+    const talent = this.talent;
 
     const explanation = (
       <>
@@ -91,7 +93,16 @@ export default class FeralFrenzy extends Analyzer {
             <SpellLink spell={talent} />
           </strong>{' '}
           is a brief but extremely powerful bleed. Use it on cooldown. As it gives 5 combo points,
-          it's best used at low combo points in order not to waste them. {addition}
+          it's best used at 2 or fewer combo points in order not to waste them.
+          {this.isFrantic &&
+            ' Should be used within as large of packs as possible for you to gain the most benefit out of it.'}
+          {this.isFocused && (
+            <>
+              {' '}
+              With <SpellLink spell={TALENTS_DRUID.FOCUSED_FRENZY_TALENT} />, always use it during{' '}
+              <SpellLink spell={SPELLS.TIGERS_FURY} />.
+            </>
+          )}
         </p>
       </>
     );
@@ -110,31 +121,36 @@ export default class FeralFrenzy extends Analyzer {
           let cpsPerf = QualitativePerformance.Good;
           if (cast.cpsOnCast > 4) {
             cpsPerf = QualitativePerformance.Fail;
-          } else if (cast.cpsOnCast > 1) {
+          } else if (cast.cpsOnCast > 2) {
             cpsPerf = QualitativePerformance.Ok;
           }
 
           let overallPerf = QualitativePerformance.Good;
           overallPerf = getLowestPerf([overallPerf, cpsPerf]);
-          // TODO: We should add back in the Tiger's fury overlap now. Snapshotting may be gone, but
-          // talented correctly Tiger's fury and Feral Frenzy will always overlap.
+
           const checklistItems: CooldownExpandableItem[] = [];
-          // FF is desynced with TF cooldown, and sims say send both on CD, so in proper use
-          // only half of FF uses will have TF active. Leaving code in in case that changes.
-          // checklistItems.push({
-          //   label: (
-          //     <>
-          //       <SpellLink spell={SPELLS.TIGERS_FURY} /> active
-          //     </>
-          //   ),
-          //   result: <PassFailCheckmark pass={cast.tfOnCast} />,
-          // });
+
+          if (this.isFocused) {
+            checklistItems.push({
+              label: (
+                <>
+                  <SpellLink spell={SPELLS.TIGERS_FURY} /> active
+                </>
+              ),
+              result: <PassFailCheckmark pass={cast.tfOnCast} />,
+            });
+            if (!cast.tfOnCast) {
+              overallPerf = QualitativePerformance.Fail;
+            }
+          }
+
           checklistItems.push({
             label: 'Combo Points on cast',
             result: <PerformanceMark perf={cpsPerf} />,
             details: (
               <>
-                ({cast.cpsOnCast} CPs) ({cast.hitCount} Targets hit ){' '}
+                ({cast.cpsOnCast} CPs)
+                {this.isFrantic && <> ({cast.hitCount} Targets hit)</>}
               </>
             ),
           });

--- a/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
@@ -4,20 +4,15 @@ import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, DamageEvent, EventType, TargettedEvent } from 'parser/core/Events';
 
-import { getAdditionalEnergyUsed } from '../../normalizers/FerociousBiteDrainLinkNormalizer';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
 import RipUptimeAndSnapshots from 'analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { SpellLink } from 'interface';
 import {
-  ACCEPTABLE_CPS,
-  cdSpell,
   FB_SPELLS,
-  FEROCIOUS_BITE_ENERGY,
-  FEROCIOUS_BITE_MAX_DRAIN,
+  MIN_ACCEPTABLE_CPS,
   getAcceptableCps,
-  getFerociousBiteMaxDrain,
 } from 'analysis/retail/druid/feral/constants';
 import getResourceSpent from 'parser/core/getResourceSpent';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
@@ -39,14 +34,10 @@ class FerociousBite extends Analyzer {
 
   protected rip!: RipUptimeAndSnapshots;
 
-  hasSotf: boolean;
-
   castEntries: BoxRowEntry[] = [];
 
   constructor(options: Options) {
     super(options);
-
-    this.hasSotf = this.selectedCombatant.hasTalent(TALENTS_DRUID.SOUL_OF_THE_FOREST_FERAL_TALENT);
 
     this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(FB_SPELLS), this.onFbCast);
   }
@@ -63,23 +54,6 @@ class FerociousBite extends Analyzer {
       return; // parried FBs don't drain and don't cost CPs - shouldn't evaluate
     }
 
-    const duringBerserkAndSotf =
-      this.hasSotf &&
-      (this.selectedCombatant.hasBuff(SPELLS.BERSERK_CAT.id) ||
-        this.selectedCombatant.hasBuff(TALENTS_DRUID.INCARNATION_AVATAR_OF_ASHAMANE_TALENT.id));
-    const extraEnergyUsed = getAdditionalEnergyUsed(event);
-    const maxExtraEnergy = getFerociousBiteMaxDrain(this.selectedCombatant);
-    const usedMax = extraEnergyUsed >= maxExtraEnergy;
-
-    if (!duringBerserkAndSotf && usedMax) {
-      addInefficientCastReason(
-        event,
-        `Used with low energy, causing only ${extraEnergyUsed}
-        extra energy to be turned in to bonus damage. You should always cast Ferocious Bite with
-        the full extra energy available in order to maximize damage`,
-      );
-    }
-
     // fill out cast entry
     let timeLeftOnRip = 0;
     // target is optional in cast event, but we know FB cast will always have it
@@ -87,11 +61,11 @@ class FerociousBite extends Analyzer {
       timeLeftOnRip = this.rip.getTimeRemaining(event as TargettedEvent<EventType>);
     }
     const cpsUsed = getResourceSpent(event, RESOURCE_TYPES.COMBO_POINTS);
+    const currAcceptableCps = getAcceptableCps(this.selectedCombatant, event.timestamp);
     const acceptableTimeLeftOnRip = timeLeftOnRip >= MIN_ACCEPTABLE_TIME_LEFT_ON_RIP_MS;
 
     let value: QualitativePerformance = QualitativePerformance.Good;
     let perfExplanation: React.ReactNode = undefined;
-    const currAcceptableCps = getAcceptableCps(this.selectedCombatant);
     if (cpsUsed < currAcceptableCps) {
       value = QualitativePerformance.Fail;
       perfExplanation = (
@@ -101,14 +75,9 @@ class FerociousBite extends Analyzer {
           <br />
         </h5>
       );
-    } else if (!usedMax && !duringBerserkAndSotf) {
-      value = QualitativePerformance.Fail;
-      perfExplanation = (
-        <h5 style={{ color: BadColor }}>
-          Bad because you cast at too low energy
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
-        </h5>
+      addInefficientCastReason(
+        event,
+        `Used with only ${cpsUsed} CPs (need at least ${currAcceptableCps})`,
       );
     } else if (!acceptableTimeLeftOnRip) {
       value = QualitativePerformance.Ok;
@@ -125,13 +94,6 @@ class FerociousBite extends Analyzer {
       <>
         {perfExplanation}@ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> targetting{' '}
         <strong>{this.owner.getTargetName(event)}</strong> using <strong>{cpsUsed} CPs</strong>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
-        Extra energy used:{' '}
-        <strong>
-          {extraEnergyUsed} / {maxExtraEnergy}
-        </strong>{' '}
-        {duringBerserkAndSotf && '(during Berserk)'}
         {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
         <br />
         {timeLeftOnRip === 0 ? (
@@ -161,19 +123,9 @@ class FerociousBite extends Analyzer {
         <strong>
           <SpellLink spell={SPELLS.FEROCIOUS_BITE} />
         </strong>{' '}
-        is your direct damage finisher. Use it when you've already applied Rip to enemies. Always
-        use Bite with at least {ACCEPTABLE_CPS} CPs. Bite can consume up to{' '}
-        {FEROCIOUS_BITE_MAX_DRAIN} extra energy to do increased damage - this boost is very
-        efficient and you should always wait until{' '}
-        {FEROCIOUS_BITE_MAX_DRAIN + FEROCIOUS_BITE_ENERGY} energy to use Bite.{' '}
-        {this.hasSotf && (
-          <>
-            One exception: because you have{' '}
-            <SpellLink spell={TALENTS_DRUID.SOUL_OF_THE_FOREST_FERAL_TALENT} />, it is acceptable to
-            use low energy bites during <SpellLink spell={cdSpell(this.selectedCombatant)} /> in
-            order to get extra finishers in.
-          </>
-        )}
+        is your direct damage finisher. Use it when you've already applied Rip to enemies. Use Bite
+        with at least {MIN_ACCEPTABLE_CPS} CPs, or {MIN_ACCEPTABLE_CPS + 1}+ during{' '}
+        <SpellLink spell={SPELLS.BERSERK_CAT} />.
       </p>
     );
 
@@ -192,7 +144,7 @@ class FerociousBite extends Analyzer {
           spell={SPELLS.FEROCIOUS_BITE}
           castEntries={this.castEntries}
           okExtraExplanation={<>used on target with low duration Rip</>}
-          badExtraExplanation={<>&lt;25 extra energy + not during Berserk, or low CPs</>}
+          badExtraExplanation={<>low CPs</>}
         />
       </div>
     );

--- a/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FerociousBite.tsx
@@ -69,11 +69,7 @@ class FerociousBite extends Analyzer {
     if (cpsUsed < currAcceptableCps) {
       value = QualitativePerformance.Fail;
       perfExplanation = (
-        <h5 style={{ color: BadColor }}>
-          Bad because you used less than {currAcceptableCps} CPs
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
-        </h5>
+        <h5 style={{ color: BadColor }}>Bad because you used less than {currAcceptableCps} CPs</h5>
       );
       addInefficientCastReason(
         event,
@@ -84,27 +80,26 @@ class FerociousBite extends Analyzer {
       perfExplanation = (
         <h5 style={{ color: OkColor }}>
           Questionable because you cast when Rip was close to expiring
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
         </h5>
       );
     }
 
     const tooltip = (
       <>
-        {perfExplanation}@ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> targetting{' '}
-        <strong>{this.owner.getTargetName(event)}</strong> using <strong>{cpsUsed} CPs</strong>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
-        {timeLeftOnRip === 0 ? (
-          <>
+        {perfExplanation}
+        <div>
+          @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> targetting{' '}
+          <strong>{this.owner.getTargetName(event)}</strong> using <strong>{cpsUsed} CPs</strong>
+        </div>
+        <div>
+          {timeLeftOnRip === 0 ? (
             <strong>No Rip on target!</strong>
-          </>
-        ) : (
-          <>
-            Time remaining on Rip: <strong>{(timeLeftOnRip / 1000).toFixed(1)}s</strong>
-          </>
-        )}
+          ) : (
+            <>
+              Time remaining on Rip: <strong>{(timeLeftOnRip / 1000).toFixed(1)}s</strong>
+            </>
+          )}
+        </div>
       </>
     );
 
@@ -132,13 +127,11 @@ class FerociousBite extends Analyzer {
     const data = (
       <div>
         {hasConvokeOrApex && (
-          <>
+          <p>
             The below cast evaluations consider only CP spending Bites -{' '}
             <SpellLink spell={TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT} /> and{' '}
             <SpellLink spell={TALENTS_DRUID.APEX_PREDATORS_CRAVING_TALENT} /> procs aren't included.
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-          </>
+          </p>
         )}
         <CastSummaryAndBreakdown
           spell={SPELLS.FEROCIOUS_BITE}

--- a/src/analysis/retail/druid/feral/modules/spells/MoonfireUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/MoonfireUptimeAndSnapshots.tsx
@@ -81,32 +81,27 @@ class MoonfireUptimeAndSnapshots extends Snapshots {
 
     const tooltip = (
       <>
-        @ <strong>{this.owner.formatTimestamp(cast.timestamp)}</strong> targetting{' '}
-        <strong>{targetName || 'unknown'}</strong>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
+        <div>
+          @ <strong>{this.owner.formatTimestamp(cast.timestamp)}</strong> targetting{' '}
+          <strong>{targetName || 'unknown'}</strong>
+        </div>
         {prevSnapshotNames !== null && (
-          <>
+          <div>
             Refreshed on target w/ {(remainingOnPrev / 1000).toFixed(1)}s remaining{' '}
-            {clipped > 0 && (
-              <>
-                <strong>- Clipped {(clipped / 1000).toFixed(1)}s!</strong>
-              </>
-            )}
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-          </>
+            {clipped > 0 && <strong>- Clipped {(clipped / 1000).toFixed(1)}s!</strong>}
+          </div>
         )}
-        Snapshots: <strong>{snapshotNames.length === 0 ? 'NONE' : snapshotNames.join(', ')}</strong>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
+        <div>
+          Snapshots:{' '}
+          <strong>{snapshotNames.length === 0 ? 'NONE' : snapshotNames.join(', ')}</strong>
+        </div>
         {prevSnapshotNames !== null && (
-          <>
+          <div>
             Prev Snapshots:{' '}
             <strong>
               {prevSnapshotNames.length === 0 ? 'NONE' : prevSnapshotNames.join(', ')}
             </strong>
-          </>
+          </div>
         )}
       </>
     );
@@ -136,21 +131,23 @@ class MoonfireUptimeAndSnapshots extends Snapshots {
 
     const data = (
       <div>
-        <RoundedPanel>
-          <div>
-            <strong>Moonfire uptime / snapshots</strong>
-            <small> - Try to get as close to 100% as the encounter allows!</small>
-          </div>
-          {this.subStatistic()}
-        </RoundedPanel>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
-        <CastSummaryAndBreakdown
-          spell={SPELLS.MOONFIRE_FERAL}
-          castEntries={this.castEntries}
-          okExtraExplanation={<>clipped duration but upgraded snapshot</>}
-          badExtraExplanation={<>clipped duration or downgraded snapshot w/ &gt;2s remaining</>}
-        />
+        <div>
+          <RoundedPanel>
+            <div>
+              <strong>Moonfire uptime / snapshots</strong>
+              <small> - Try to get as close to 100% as the encounter allows!</small>
+            </div>
+            {this.subStatistic()}
+          </RoundedPanel>
+        </div>
+        <div>
+          <CastSummaryAndBreakdown
+            spell={SPELLS.MOONFIRE_FERAL}
+            castEntries={this.castEntries}
+            okExtraExplanation={<>clipped duration but upgraded snapshot</>}
+            badExtraExplanation={<>clipped duration or downgraded snapshot w/ &gt;2s remaining</>}
+          />
+        </div>
       </div>
     );
 

--- a/src/analysis/retail/druid/feral/modules/spells/MoonfireUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/MoonfireUptimeAndSnapshots.tsx
@@ -15,11 +15,12 @@ import {
   SNAPSHOT_DOWNGRADE_BUFFER,
 } from 'analysis/retail/druid/feral/constants';
 import { SpellLink } from 'interface';
-import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
 import { getHardcast } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
 
 class MoonfireUptimeAndSnapshots extends Snapshots {
   static dependencies = {
@@ -117,7 +118,7 @@ class MoonfireUptimeAndSnapshots extends Snapshots {
   }
 
   get uptimeHistory() {
-    return this.enemies.getDebuffHistory(SPELLS.MOONFIRE_FERAL.id);
+    return this.combinedUptimeHistory;
   }
 
   /** Subsection explaining the use of Lunar Inspiration and providing performance statistics */
@@ -144,14 +145,12 @@ class MoonfireUptimeAndSnapshots extends Snapshots {
         </RoundedPanel>
         {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
         <br />
-        <strong>Moonfire casts</strong>
-        <small>
-          {' '}
-          - Green is a good cast, Yellow is an ok cast (clipped duration but upgraded snapshot), Red
-          is a bad cast (clipped duration or downgraded snapshot w/ &gt;2s remaining). Mouseover for
-          more details.
-        </small>
-        <PerformanceBoxRow values={this.castEntries} />
+        <CastSummaryAndBreakdown
+          spell={SPELLS.MOONFIRE_FERAL}
+          castEntries={this.castEntries}
+          okExtraExplanation={<>clipped duration but upgraded snapshot</>}
+          badExtraExplanation={<>clipped duration or downgraded snapshot w/ &gt;2s remaining</>}
+        />
       </div>
     );
 

--- a/src/analysis/retail/druid/feral/modules/spells/RakeUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RakeUptimeAndSnapshots.tsx
@@ -156,7 +156,7 @@ class RakeUptimeAndSnapshots extends Snapshots {
   }
 
   get uptimeHistory() {
-    return this.enemies.getDebuffHistory(SPELLS.RAKE_BLEED.id);
+    return this.combinedUptimeHistory;
   }
 
   /** Subsection explaining the use of Rake and providing performance statistics */

--- a/src/analysis/retail/druid/feral/modules/spells/RakeUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RakeUptimeAndSnapshots.tsx
@@ -79,11 +79,7 @@ class RakeUptimeAndSnapshots extends Snapshots {
     if (wasUnacceptableDowngrade) {
       value = QualitativePerformance.Fail;
       perfExplanation = (
-        <h5 style={{ color: BadColor }}>
-          Bad because you refreshed early with a weaker snapshot
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
-        </h5>
+        <h5 style={{ color: BadColor }}>Bad because you refreshed early with a weaker snapshot</h5>
       );
     } else if (clipped > CLIP_BUFFER) {
       if (wasUpgrade) {
@@ -91,59 +87,43 @@ class RakeUptimeAndSnapshots extends Snapshots {
         perfExplanation = (
           <h5 style={{ color: OkColor }}>
             You refreshed this too early, but upgraded the snapshot
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
           </h5>
         );
       } else {
         value = QualitativePerformance.Fail;
-        perfExplanation = (
-          <h5 style={{ color: BadColor }}>
-            Bad because you refreshed too early
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-          </h5>
-        );
+        perfExplanation = <h5 style={{ color: BadColor }}>Bad because you refreshed too early</h5>;
       }
     } else if (clipped > 0) {
       value = QualitativePerformance.Ok;
       perfExplanation = (
-        <h5 style={{ color: OkColor }}>
-          Careful, you refreshed this a little early
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
-        </h5>
+        <h5 style={{ color: OkColor }}>Careful, you refreshed this a little early</h5>
       );
     }
 
     const tooltip = (
       <>
-        {perfExplanation}@ <strong>{this.owner.formatTimestamp(cast.timestamp)}</strong> targetting{' '}
-        <strong>{targetName || 'unknown'}</strong>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
+        {perfExplanation}
+        <div>
+          @ <strong>{this.owner.formatTimestamp(cast.timestamp)}</strong> targetting{' '}
+          <strong>{targetName || 'unknown'}</strong>
+        </div>
         {prevSnapshotNames !== null && (
-          <>
+          <div>
             Refreshed on target w/ {(remainingOnPrev / 1000).toFixed(1)}s remaining{' '}
-            {clipped > 0 && (
-              <>
-                <strong>- Clipped {(clipped / 1000).toFixed(1)}s!</strong>
-              </>
-            )}
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-          </>
+            {clipped > 0 && <strong>- Clipped {(clipped / 1000).toFixed(1)}s!</strong>}
+          </div>
         )}
-        Snapshots: <strong>{snapshotNames.length === 0 ? 'NONE' : snapshotNames.join(', ')}</strong>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
+        <div>
+          Snapshots:{' '}
+          <strong>{snapshotNames.length === 0 ? 'NONE' : snapshotNames.join(', ')}</strong>
+        </div>
         {prevSnapshotNames !== null && (
-          <>
+          <div>
             Prev Snapshots:{' '}
             <strong>
               {prevSnapshotNames.length === 0 ? 'NONE' : prevSnapshotNames.join(', ')}
             </strong>
-          </>
+          </div>
         )}
       </>
     );
@@ -184,8 +164,6 @@ class RakeUptimeAndSnapshots extends Snapshots {
           </div>
           {this.subStatistic()}
         </RoundedPanel>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
         <CastSummaryAndBreakdown
           spell={SPELLS.RAKE}
           castEntries={this.castEntries}

--- a/src/analysis/retail/druid/feral/modules/spells/RampantFerocity.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RampantFerocity.tsx
@@ -103,12 +103,12 @@ class RampantFerocity extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            Average splash hits per Bite: <strong>{this.avgTargetsHit.toFixed(1)}</strong>
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
+            <div>
+              Average splash hits per Bite: <strong>{this.avgTargetsHit.toFixed(1)}</strong>
+            </div>
             {(hasApex || hasConvoke) && (
               <>
-                Breakdown per Bite source:
+                <div>Breakdown per Bite source:</div>
                 <ul>
                   <li>Hardcast: {this._formattedPercentDamage(this.hardcastRfDamage)}</li>
                   {hasApex && (

--- a/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
@@ -18,7 +18,6 @@ import {
   getPrimalWrath,
 } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
 import Snapshots, {
-  hasSpec,
   SnapshotSpec,
   TIGERS_FURY_SPEC,
 } from 'analysis/retail/druid/feral/modules/core/Snapshots';
@@ -90,82 +89,40 @@ class RipUptimeAndSnapshots extends Snapshots {
       const targetName = this.owner.getTargetName(ripCast);
       const cpsUsed = getResourceSpent(ripCast, RESOURCE_TYPES.COMBO_POINTS);
       const wasNewApplication = prevSnapshots === null;
-      const wasUpgrade = prevPower < power;
 
       /** Perf logic:
-       *  3 or 4 CPs, but is initial Rip -> Green
-       *  3 or 4 CPs, but  upgrades Snapshot -> Yellow
-       *  < 5 CPs without an excuse -> Red
-       *  Missing BT -> Red
-       *  Missing TF -> Yellow
-       *  Clip Duration (but upgrade Snapshot) -> Yellow
-       *  Clip Duration more than threshold duration -> Red
+       *  Low CPs, but is initial Rip -> Green (getting it up matters more)
+       *  Low CPs on refresh -> Red
+       *  Refreshed outside pandemic -> Red
+       *  Refreshed slightly early (within clip buffer) -> Ok
        *  None of the Above -> Green
        */
       let value: QualitativePerformance = QualitativePerformance.Good;
       let perfExplanation: React.ReactNode = undefined;
-      const currAcceptableCps = getAcceptableCps(this.selectedCombatant);
-      if (cpsUsed < 3) {
+      const currAcceptableCps = getAcceptableCps(this.selectedCombatant, ripCast.timestamp);
+      if (cpsUsed < currAcceptableCps && !wasNewApplication) {
         value = QualitativePerformance.Fail;
         perfExplanation = (
           <h5 style={{ color: BadColor }}>
-            Bad because you used only {cpsUsed} CPs
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-          </h5>
-        );
-      } else if (cpsUsed < currAcceptableCps && this.castEntries.length > 0 && !wasUpgrade) {
-        value = QualitativePerformance.Fail;
-        perfExplanation = (
-          <h5 style={{ color: BadColor }}>
-            Bad because you used less than {currAcceptableCps} CPs
+            Bad because you used only {cpsUsed} CPs (need at least {currAcceptableCps})
             {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
             <br />
           </h5>
         );
       } else if (clipped > CLIP_BUFFER) {
-        if (wasUpgrade) {
-          value = QualitativePerformance.Ok;
-          perfExplanation = (
-            <h5 style={{ color: OkColor }}>
-              You upgraded the snapshot at the cost of refreshing early
-              {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-              <br />
-            </h5>
-          );
-        } else {
-          value = QualitativePerformance.Fail;
-          perfExplanation = (
-            <h5 style={{ color: BadColor }}>
-              Bad because you refreshed too early
-              {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-              <br />
-            </h5>
-          );
-        }
+        value = QualitativePerformance.Fail;
+        perfExplanation = (
+          <h5 style={{ color: BadColor }}>
+            Bad because you refreshed too early
+            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
+            <br />
+          </h5>
+        );
       } else if (clipped > 0) {
         value = QualitativePerformance.Ok;
         perfExplanation = (
           <h5 style={{ color: OkColor }}>
             Careful, you refreshed this a little early
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-          </h5>
-        );
-      } else if (!hasSpec(snapshots, TIGERS_FURY_SPEC)) {
-        value = QualitativePerformance.Ok;
-        perfExplanation = (
-          <h5 style={{ color: OkColor }}>
-            Supoptimal because no Tiger's Fury snapshot
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-          </h5>
-        );
-      } else if (cpsUsed < currAcceptableCps && this.castEntries.length !== 0 && wasUpgrade) {
-        value = QualitativePerformance.Ok;
-        perfExplanation = (
-          <h5 style={{ color: OkColor }}>
-            Only {cpsUsed} CPs, but upgraded snapshot
             {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
             <br />
           </h5>
@@ -237,7 +194,7 @@ class RipUptimeAndSnapshots extends Snapshots {
             <SpellLink spell={TALENTS_DRUID.PRIMAL_WRATH_TALENT} />.
           </>
         )}{' '}
-        Don't refresh early, and try to always snapshot <SpellLink spell={SPELLS.TIGERS_FURY} />.
+        Only refresh in the pandemic window (last 30% of duration).
       </p>
     );
 
@@ -255,8 +212,8 @@ class RipUptimeAndSnapshots extends Snapshots {
         <CastSummaryAndBreakdown
           spell={SPELLS.RIP}
           castEntries={this.castEntries}
-          okExtraExplanation={<>clipped duration but upgraded snapshot or missing Tigers Fury</>}
-          badExtraExplanation={<>clipped duration</>}
+          okExtraExplanation={<>slightly early refresh</>}
+          badExtraExplanation={<>refreshed outside pandemic or low CPs</>}
         />
       </div>
     );
@@ -265,7 +222,7 @@ class RipUptimeAndSnapshots extends Snapshots {
   }
 
   get uptimeHistory() {
-    return this.enemies.getDebuffHistory(SPELLS.RIP.id);
+    return this.combinedUptimeHistory;
   }
 
   subStatistic() {

--- a/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/RipUptimeAndSnapshots.tsx
@@ -105,51 +105,34 @@ class RipUptimeAndSnapshots extends Snapshots {
         perfExplanation = (
           <h5 style={{ color: BadColor }}>
             Bad because you used only {cpsUsed} CPs (need at least {currAcceptableCps})
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
           </h5>
         );
       } else if (clipped > CLIP_BUFFER) {
         value = QualitativePerformance.Fail;
-        perfExplanation = (
-          <h5 style={{ color: BadColor }}>
-            Bad because you refreshed too early
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-          </h5>
-        );
+        perfExplanation = <h5 style={{ color: BadColor }}>Bad because you refreshed too early</h5>;
       } else if (clipped > 0) {
         value = QualitativePerformance.Ok;
         perfExplanation = (
-          <h5 style={{ color: OkColor }}>
-            Careful, you refreshed this a little early
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-          </h5>
+          <h5 style={{ color: OkColor }}>Careful, you refreshed this a little early</h5>
         );
       }
 
       const tooltip = (
         <>
-          {perfExplanation}@ <strong>{this.owner.formatTimestamp(timestamp)}</strong> targetting{' '}
-          <strong>{targetName || 'unknown'}</strong> using <strong>{cpsUsed} CPs</strong>
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
+          {perfExplanation}
+          <div>
+            @ <strong>{this.owner.formatTimestamp(timestamp)}</strong> targetting{' '}
+            <strong>{targetName || 'unknown'}</strong> using <strong>{cpsUsed} CPs</strong>
+          </div>
           {!wasNewApplication && (
-            <>
+            <div>
               Refreshed on target w/ {(remainingOnPrev / 1000).toFixed(1)}s remaining{' '}
-              {clipped > 0 && (
-                <>
-                  <strong>- Clipped {(clipped / 1000).toFixed(1)}s!</strong>
-                </>
-              )}
-              {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-              <br />
-            </>
+              {clipped > 0 && <strong>- Clipped {(clipped / 1000).toFixed(1)}s!</strong>}
+            </div>
           )}
-          Snapshots: <strong>{snapshots.map((ss) => ss.name).join(', ')}</strong>
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
+          <div>
+            Snapshots: <strong>{snapshots.map((ss) => ss.name).join(', ')}</strong>
+          </div>
         </>
       );
       this.castEntries.push({ value, tooltip });
@@ -207,8 +190,6 @@ class RipUptimeAndSnapshots extends Snapshots {
           </div>
           {this.subStatistic()}
         </RoundedPanel>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
         <CastSummaryAndBreakdown
           spell={SPELLS.RIP}
           castEntries={this.castEntries}

--- a/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
@@ -1,27 +1,16 @@
 import type { JSX } from 'react';
-import { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import { Options } from 'parser/core/Module';
 import SPELLS from 'common/SPELLS';
 import Events, {
   ApplyBuffEvent,
-  ApplyDebuffEvent,
-  DamageEvent,
+  CastEvent,
   RefreshBuffEvent,
-  RefreshDebuffEvent,
   RemoveBuffEvent,
 } from 'parser/core/Events';
-import {
-  getSuddenAmbushBoostedDamage,
-  isBoostedBySuddenAmbush,
-} from 'analysis/retail/druid/feral/normalizers/SuddenAmbushLinkNormalizer';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
-import {
-  getRakeDuration,
-  PANDEMIC_FRACTION,
-  PROWL_RAKE_DAMAGE_BONUS,
-} from 'analysis/retail/druid/feral/constants';
-import Enemies, { encodeEventTargetString } from 'parser/shared/modules/Enemies';
+import { SUDDEN_ABUSH_DAMAGE_BONUS } from 'analysis/retail/druid/feral/constants';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -33,15 +22,12 @@ import { formatPercentage } from 'common/format';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
-import { BadColor, OkColor } from 'interface/guide';
+import { BadColor } from 'interface/guide';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import Snapshots, {
-  PROWL_SPEC,
-  SnapshotSpec,
-  TIGERS_FURY_SPEC,
-} from 'analysis/retail/druid/feral/modules/core/Snapshots';
-import { getHardcast } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
 import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
+import { getDamageHits } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
+
+const SA_BUFF_BUFFER = 50;
 
 /**
  * **Sudden Ambush**
@@ -49,22 +35,23 @@ import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBr
  *
  * Finishing moves have a 6% chance per combo point spent to make your next Rake or Shred
  * deal damage as though you were stealthed.
+ *
+ * Detects SA usage by checking if the buff is active at the time of Shred/Swipe/Rake casts,
+ * which is more reliable than depending on RemoveBuff event linking.
  */
-class SuddenAmbush extends Snapshots {
-  static dependencies = {
-    ...Snapshots.dependencies,
-    enemies: Enemies,
-  };
-  protected enemies!: Enemies;
-
-  /** Number of shreads boosted by SA */
+class SuddenAmbush extends Analyzer {
+  /** Number of shreds boosted by SA */
   boostedShreds = 0;
   /** Number of rakes boosted by SA */
   boostedRakes = 0;
+  /** Number of swipes boosted by SA */
+  boostedSwipes = 0;
   /** Total damage added to Shred by SA boost */
   boostedShredDamage = 0;
   /** Total damage added to Rake by SA boost */
   boostedRakeDamage = 0;
+  /** Total damage added to Swipe by SA boost */
+  boostedSwipeDamage = 0;
 
   /** SA buffs gained */
   saGained = 0;
@@ -75,14 +62,11 @@ class SuddenAmbush extends Snapshots {
   /** SA buffs overwritten */
   saOverwritten = 0;
 
-  /** Set of targets for whom the last applied Rake was boosted by SA */
-  saBoostedRakeTargets: Set<string> = new Set<string>();
-
   /** Per use entries for the Guide */
   useEntries: BoxRowEntry[] = [];
 
   constructor(options: Options) {
-    super(SPELLS.RAKE, SPELLS.RAKE_BLEED, [TIGERS_FURY_SPEC, PROWL_SPEC], options);
+    super(options);
 
     this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.SUDDEN_AMBUSH_TALENT);
 
@@ -91,278 +75,115 @@ class SuddenAmbush extends Snapshots {
       this.onGainSa,
     );
     this.addEventListener(
-      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_AMBUSH_BUFF),
-      this.onUseSa,
-    );
-    this.addEventListener(
       Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_AMBUSH_BUFF),
       this.onOverwriteSa,
     );
-
-    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.SHRED), this.onSaShred);
-
     this.addEventListener(
-      Events.applydebuff.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
-      this.onApplyRake,
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.SUDDEN_AMBUSH_BUFF),
+      this.onRemoveSa,
     );
+
+    // Detect SA consumption by checking buff at cast time
     this.addEventListener(
-      Events.refreshdebuff.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
-      this.onApplyRake,
-    );
-    this.addEventListener(
-      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
-      this.onRakeBleedDamage,
+      Events.cast.by(SELECTED_PLAYER).spell([SPELLS.SHRED, SPELLS.SWIPE_CAT, SPELLS.RAKE]),
+      this.onSaConsumerCast,
     );
   }
 
-  // Uses the 'Snapshots' framework seprately from the RakeUptimeAndSnapshots module to capture SA specific info
-
-  getDotExpectedDuration(): number {
-    return getRakeDuration(this.selectedCombatant);
-  }
-
-  getDotFullDuration(): number {
-    return getRakeDuration(this.selectedCombatant);
-  }
-
-  getTotalDotUptime(): number {
-    return this.enemies.getBuffUptime(SPELLS.RAKE_BLEED.id);
-  }
-
-  handleApplication(
-    application: ApplyDebuffEvent | RefreshDebuffEvent,
-    snapshots: SnapshotSpec[],
-    prevSnapshots: SnapshotSpec[] | null,
-    power: number,
-    prevPower: number,
-    remainingOnPrev: number,
-    clipped: number,
-  ) {
-    const cast = getHardcast(application);
-    if (!cast) {
-      return; // no entry needed for 'uncontrolled' rakes from DCR or Convoke
-    }
-    if (!isBoostedBySuddenAmbush(application)) {
-      // most Rake handling is in RakeUptimeAndSnapshots module,
-      // here we only need to look at SA buffed Rakes
-      return;
-    }
-
-    const targetName = this.owner.getTargetName(cast);
-    const wasUpgrade = power > prevPower;
-
-    const isRakeOnTarget = prevSnapshots !== null;
-    const wasPrevRakeProwlBuffed =
-      prevSnapshots !== null &&
-      prevSnapshots.find((ss) => ss.name === PROWL_SPEC.name) !== undefined;
-
-    let value: QualitativePerformance = QualitativePerformance.Good;
-    let perfExplanation: React.ReactNode = undefined;
-
-    if (!wasUpgrade && clipped > 0) {
-      value = QualitativePerformance.Ok;
-      perfExplanation = (
-        <h5 style={{ color: OkColor }}>
-          Careful, you early overwrote an already strong Rake.
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
-        </h5>
-      );
-    }
-
-    const tooltip = (
-      <>
-        <strong>
-          Consumed with <SpellLink spell={SPELLS.RAKE} />
-        </strong>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
-        {perfExplanation}@ <strong>{this.owner.formatTimestamp(cast.timestamp)}</strong> targetting{' '}
-        <strong>{targetName || 'unknown'}</strong>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
-        {isRakeOnTarget ? (
-          <>
-            Previous rake on target had <strong>{(remainingOnPrev / 1000).toFixed(1)}s</strong> left
-            and{' '}
-            {wasPrevRakeProwlBuffed ? (
-              <strong>
-                <SpellLink spell={TALENTS_DRUID.POUNCING_STRIKES_TALENT} /> buff
-              </strong>
-            ) : (
-              <strong>no buff</strong>
-            )}
-          </>
-        ) : (
-          <>
-            <b>No Rake on target!</b>
-          </>
-        )}
-      </>
-    );
-
-    this.useEntries.push({
-      value,
-      tooltip,
-    });
-  }
-
-  onSaShred(event: DamageEvent) {
-    if (!isBoostedBySuddenAmbush(event)) {
-      return;
-    }
-    const cast = getHardcast(event);
-    if (!cast) {
-      return; // no entry needed for 'uncontrolled' shreds from Convoke
-    }
-
-    const latestUptime = this.getLatestUptimeForTarget(event);
-    const isRakeOnTarget = latestUptime !== undefined;
-    const timeLeftOnRake = this.getTimeRemaining(event);
-    const isRakeProwlBuffed = latestUptime
-      ? latestUptime.snapshots.find((ss) => ss.name === PROWL_SPEC.name) !== undefined
-      : false;
-    const targetName = this.owner.getTargetName(event);
-
-    let value: QualitativePerformance = QualitativePerformance.Good;
-    let perfExplanation: React.ReactNode = undefined;
-
-    if (!isRakeOnTarget) {
-      value = QualitativePerformance.Fail;
-      perfExplanation = (
-        <h5 style={{ color: BadColor }}>
-          Bad because there was no Rake on the target
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
-        </h5>
-      );
-    } else if (timeLeftOnRake <= getRakeDuration(this.selectedCombatant) * PANDEMIC_FRACTION) {
-      value = QualitativePerformance.Fail;
-      perfExplanation = (
-        <h5 style={{ color: BadColor }}>
-          Bad because the Rake on target was within the refresh window
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
-        </h5>
-      );
-    } else if (!isRakeProwlBuffed) {
-      value = QualitativePerformance.Fail;
-      perfExplanation = (
-        <h5 style={{ color: BadColor }}>
-          Bad because the Rake on target was weak
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
-        </h5>
-      );
-    }
-
-    const tooltip = (
-      <>
-        <strong>
-          Consumed with <SpellLink spell={SPELLS.SHRED} />
-        </strong>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
-        {perfExplanation}@ <strong>{this.owner.formatTimestamp(cast.timestamp)}</strong> targetting{' '}
-        <strong>{targetName || 'unknown'}</strong>
-        {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-        <br />
-        {isRakeOnTarget ? (
-          <>
-            Rake on target had <strong>{(timeLeftOnRake / 1000).toFixed(1)}s</strong> left and{' '}
-            {isRakeProwlBuffed ? (
-              <strong>
-                <SpellLink spell={TALENTS_DRUID.POUNCING_STRIKES_TALENT} /> buff
-              </strong>
-            ) : (
-              <strong>no buff</strong>
-            )}
-          </>
-        ) : (
-          <>
-            <b>No Rake on target!</b>
-          </>
-        )}
-      </>
-    );
-
-    this.useEntries.push({
-      value,
-      tooltip,
-    });
-  }
-
-  onGainSa(event: ApplyBuffEvent) {
+  onGainSa(_event: ApplyBuffEvent) {
     this.saGained += 1;
   }
 
-  onUseSa(event: RemoveBuffEvent) {
-    const boostedDamageEvents: DamageEvent[] = getSuddenAmbushBoostedDamage(event);
-    if (boostedDamageEvents.length === 0) {
-      this.saExpired += 1;
+  onOverwriteSa(_event: RefreshBuffEvent) {
+    this.saGained += 1;
+    this.saOverwritten += 1;
+  }
 
-      const value = QualitativePerformance.Fail;
-      const tooltip = (
-        <>
-          <h5 style={{ color: BadColor }}>
-            Bad because you let a proc expire
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-          </h5>
-          @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
-        </>
-      );
+  onRemoveSa(event: RemoveBuffEvent) {
+    // If the buff expired without being consumed by a cast, mark it as expired.
+    // Used procs are already tracked in onSaConsumerCast, so we only need to handle expirations.
+    // Since onSaConsumerCast fires on cast events (which happen before removebuff),
+    // if this removebuff wasn't preceded by a cast, it's an expiration.
+    const totalAccountedFor = this.saUsed + this.saExpired + this.saOverwritten;
+    if (totalAccountedFor < this.saGained) {
+      // This removal wasn't from a cast - it expired
+      this.saExpired += 1;
       this.useEntries.push({
-        value,
-        tooltip,
-      });
-    } else {
-      this.saUsed += 1;
-      // with Double Clawed Rake, possible more than one damage event is boosted
-      boostedDamageEvents.forEach((d) => {
-        if (d.ability.guid === SPELLS.SHRED.id) {
-          this.boostedShreds += 1;
-          this.boostedShredDamage += calculateEffectiveDamage(d, PROWL_RAKE_DAMAGE_BONUS);
-        } else if (d.ability.guid === SPELLS.RAKE.id) {
-          this.boostedRakes += 1;
-          this.boostedRakeDamage += calculateEffectiveDamage(d, PROWL_RAKE_DAMAGE_BONUS);
-        }
+        value: QualitativePerformance.Fail,
+        tooltip: (
+          <>
+            <h5 style={{ color: BadColor }}>
+              Bad because you let a proc expire
+              {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
+              <br />
+            </h5>
+            @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
+          </>
+        ),
       });
     }
   }
 
-  onOverwriteSa(event: RefreshBuffEvent) {
-    this.saOverwritten += 1;
+  onSaConsumerCast(event: CastEvent) {
+    if (
+      !this.selectedCombatant.hasBuff(SPELLS.SUDDEN_AMBUSH_BUFF.id, event.timestamp, SA_BUFF_BUFFER)
+    ) {
+      return;
+    }
 
-    const value = QualitativePerformance.Fail;
-    const tooltip = (
-      <>
-        <h5 style={{ color: BadColor }}>
-          Bad because you overwrote a proc
+    this.saUsed += 1;
+
+    const spellId = event.ability.guid;
+    const isRake = spellId === SPELLS.RAKE.id;
+    const spell =
+      spellId === SPELLS.SHRED.id
+        ? SPELLS.SHRED
+        : spellId === SPELLS.SWIPE_CAT.id
+          ? SPELLS.SWIPE_CAT
+          : SPELLS.RAKE;
+    const targetName = this.owner.getTargetName(event);
+
+    this.useEntries.push({
+      value: isRake ? QualitativePerformance.Fail : QualitativePerformance.Good,
+      tooltip: (
+        <>
+          <strong>
+            Consumed with <SpellLink spell={spell} />
+          </strong>
           {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
           <br />
-        </h5>
-        @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
-      </>
-    );
-    this.useEntries.push({
-      value,
-      tooltip,
+          {isRake && (
+            <h5 style={{ color: BadColor }}>
+              Sudden Ambush only buffs Rake's initial damage now, not the bleed. Prefer using it on{' '}
+              <SpellLink spell={SPELLS.SHRED} /> or <SpellLink spell={SPELLS.SWIPE_CAT} /> instead.
+              {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
+              <br />
+            </h5>
+          )}
+          @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> targetting{' '}
+          <strong>{targetName || 'unknown'}</strong>
+        </>
+      ),
     });
-  }
 
-  onApplyRake(event: ApplyDebuffEvent | RefreshDebuffEvent) {
-    if (isBoostedBySuddenAmbush(event)) {
-      this.saBoostedRakeTargets.add(encodeEventTargetString(event) || '');
-    } else {
-      this.saBoostedRakeTargets.delete(encodeEventTargetString(event) || '');
-    }
-  }
-
-  onRakeBleedDamage(event: DamageEvent) {
-    if (this.saBoostedRakeTargets.has(encodeEventTargetString(event) || '')) {
-      this.boostedRakeDamage += calculateEffectiveDamage(event, PROWL_RAKE_DAMAGE_BONUS);
-    }
+    // Track damage from linked hits
+    const damageHits = getDamageHits(event);
+    damageHits.forEach((d) => {
+      switch (d.ability.guid) {
+        case SPELLS.SHRED.id:
+          this.boostedShreds += 1;
+          this.boostedShredDamage += calculateEffectiveDamage(d, SUDDEN_ABUSH_DAMAGE_BONUS);
+          break;
+        case SPELLS.RAKE.id:
+          this.boostedRakes += 1;
+          this.boostedRakeDamage += calculateEffectiveDamage(d, SUDDEN_ABUSH_DAMAGE_BONUS);
+          break;
+        case SPELLS.SWIPE_CAT.id:
+          this.boostedSwipes += 1;
+          this.boostedSwipeDamage += calculateEffectiveDamage(d, SUDDEN_ABUSH_DAMAGE_BONUS);
+          break;
+      }
+    });
   }
 
   get saEnding() {
@@ -374,7 +195,7 @@ class SuddenAmbush extends Snapshots {
   }
 
   get totalDamage() {
-    return this.boostedRakeDamage + this.boostedShredDamage;
+    return this.boostedRakeDamage + this.boostedShredDamage + this.boostedSwipeDamage;
   }
 
   get guideSubsection(): JSX.Element {
@@ -383,10 +204,11 @@ class SuddenAmbush extends Snapshots {
         <strong>
           <SpellLink spell={TALENTS_DRUID.SUDDEN_AMBUSH_TALENT} />
         </strong>{' '}
-        buffs your next <SpellLink spell={SPELLS.SHRED} /> or <SpellLink spell={SPELLS.RAKE} />.
-        Consuming the proc with <SpellLink spell={SPELLS.RAKE} /> is almost always preferred - the
-        only time you should consume with <SpellLink spell={SPELLS.SHRED} /> is when your target
-        already has a high duration buffed <SpellLink spell={SPELLS.RAKE} />.
+        buffs your next <SpellLink spell={SPELLS.SHRED} />, <SpellLink spell={SPELLS.SWIPE_CAT} />,
+        or <SpellLink spell={SPELLS.RAKE} />. You should spend the proc on{' '}
+        <SpellLink spell={SPELLS.SHRED} /> (single target) or <SpellLink spell={SPELLS.SWIPE_CAT} />{' '}
+        (AoE). Avoid using it on <SpellLink spell={SPELLS.RAKE} /> as it only buffs the initial
+        damage, not the bleed.
       </p>
     );
 
@@ -405,17 +227,16 @@ class SuddenAmbush extends Snapshots {
   }
 
   statistic() {
-    const hasDcr = this.selectedCombatant.hasTalent(TALENTS_DRUID.DOUBLE_CLAWED_RAKE_TALENT);
     return (
       <Statistic
-        position={STATISTIC_ORDER.OPTIONAL(3)} // number based on talent row
+        position={STATISTIC_ORDER.OPTIONAL(6)} // number based on talent row
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            This is the damage from the increase to Shred and Rake damage caused by Sudden Ambush
-            procs. This underrates the total benefit of Sudden Ambush because it does not count the
-            increased crit chance and additional combo point from Shred.
+            This is the damage from the increase to Shred, Swipe, and Rake initial damage caused by
+            Sudden Ambush procs. This underrates the total benefit of Sudden Ambush because it does
+            not count the increased crit chance and additional combo point from Shred.
             {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
             <br />
             {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
@@ -440,14 +261,7 @@ class SuddenAmbush extends Snapshots {
             </ul>
             {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
             <br />
-            Breakdown by spell{' '}
-            {hasDcr && (
-              <>
-                (possibly more hits than uses due to{' '}
-                <SpellLink spell={TALENTS_DRUID.DOUBLE_CLAWED_RAKE_TALENT} />)
-              </>
-            )}
-            :
+            Breakdown by spell:
             <ul>
               <li>
                 <SpellLink spell={SPELLS.SHRED} />: Boosted <strong>{this.boostedShreds}</strong>{' '}
@@ -455,8 +269,13 @@ class SuddenAmbush extends Snapshots {
                 <strong>&gt;{this.owner.formatItemDamageDone(this.boostedShredDamage)}</strong>
               </li>
               <li>
+                <SpellLink spell={SPELLS.SWIPE_CAT} />: Boosted{' '}
+                <strong>{this.boostedSwipes}</strong> hits for{' '}
+                <strong>&gt;{this.owner.formatItemDamageDone(this.boostedSwipeDamage)}</strong>
+              </li>
+              <li>
                 <SpellLink spell={SPELLS.RAKE} />: Boosted <strong>{this.boostedRakes}</strong> hits
-                for <strong>{this.owner.formatItemDamageDone(this.boostedRakeDamage)}</strong>
+                for <strong>&gt;{this.owner.formatItemDamageDone(this.boostedRakeDamage)}</strong>
               </li>
             </ul>
           </>

--- a/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
@@ -112,12 +112,8 @@ class SuddenAmbush extends Analyzer {
         value: QualitativePerformance.Fail,
         tooltip: (
           <>
-            <h5 style={{ color: BadColor }}>
-              Bad because you let a proc expire
-              {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-              <br />
-            </h5>
-            @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
+            <h5 style={{ color: BadColor }}>Bad because you let a proc expire</h5>@{' '}
+            <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
           </>
         ),
       });
@@ -147,17 +143,15 @@ class SuddenAmbush extends Analyzer {
       value: isRake ? QualitativePerformance.Fail : QualitativePerformance.Good,
       tooltip: (
         <>
-          <strong>
-            Consumed with <SpellLink spell={spell} />
-          </strong>
-          {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-          <br />
+          <div>
+            <strong>
+              Consumed with <SpellLink spell={spell} />
+            </strong>
+          </div>
           {isRake && (
             <h5 style={{ color: BadColor }}>
               Sudden Ambush only buffs Rake's initial damage now, not the bleed. Prefer using it on{' '}
               <SpellLink spell={SPELLS.SHRED} /> or <SpellLink spell={SPELLS.SWIPE_CAT} /> instead.
-              {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-              <br />
             </h5>
           )}
           @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong> targetting{' '}
@@ -234,14 +228,14 @@ class SuddenAmbush extends Analyzer {
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
-            This is the damage from the increase to Shred, Swipe, and Rake initial damage caused by
-            Sudden Ambush procs. This underrates the total benefit of Sudden Ambush because it does
-            not count the increased crit chance and additional combo point from Shred.
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-            Buff Utilization: <strong>{formatPercentage(this.saUtil, 1)}%</strong>
+            <p>
+              This is the damage from the increase to Shred, Swipe, and Rake initial damage caused
+              by Sudden Ambush procs. This underrates the total benefit of Sudden Ambush because it
+              does not count the increased crit chance and additional combo point from Shred.
+            </p>
+            <div>
+              Buff Utilization: <strong>{formatPercentage(this.saUtil, 1)}%</strong>
+            </div>
             <ul>
               <li>
                 <SpellIcon spell={TALENTS_DRUID.SUDDEN_AMBUSH_TALENT} /> Used:{' '}
@@ -259,9 +253,7 @@ class SuddenAmbush extends Analyzer {
                 </li>
               )}
             </ul>
-            {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-            <br />
-            Breakdown by spell:
+            <div>Breakdown by spell:</div>
             <ul>
               <li>
                 <SpellLink spell={SPELLS.SHRED} />: Boosted <strong>{this.boostedShreds}</strong>{' '}

--- a/src/analysis/retail/druid/feral/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/druid/feral/normalizers/CastLinkNormalizer.ts
@@ -143,9 +143,24 @@ const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: HIT_TARGET,
     reverseLinkRelation: FROM_HARDCAST,
+    linkingEventId: TALENTS_DRUID.FERAL_FRENZY_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.FERAL_FRENZY_DEBUFF.id,
+    referencedEventType: EventType.Damage,
+    forwardBufferMs: 5000, // 5 flickers take time to play out
+    backwardBufferMs: 0,
+    anyTarget: true,
+    maximumLinks: 50,
+    isActive: (c) =>
+      c.hasTalent(TALENTS_DRUID.FERAL_FRENZY_TALENT) &&
+      !c.hasTalent(TALENTS_DRUID.FRANTIC_FRENZY_TALENT),
+  },
+  {
+    linkRelation: HIT_TARGET,
+    reverseLinkRelation: FROM_HARDCAST,
     linkingEventId: TALENTS_DRUID.FRANTIC_FRENZY_TALENT.id,
     linkingEventType: EventType.Cast,
-    referencedEventId: SPELLS.FRANTIC_FRENZY_DEBUFF.id, // the damage spell ID, not the talent
+    referencedEventId: SPELLS.FRANTIC_FRENZY_DEBUFF.id,
     referencedEventType: EventType.Damage,
     forwardBufferMs: 5000, // 5 flickers take time to play out
     backwardBufferMs: 0,

--- a/src/analysis/retail/druid/feral/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/druid/feral/normalizers/CastLinkNormalizer.ts
@@ -143,21 +143,6 @@ const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: HIT_TARGET,
     reverseLinkRelation: FROM_HARDCAST,
-    linkingEventId: TALENTS_DRUID.FERAL_FRENZY_TALENT.id,
-    linkingEventType: EventType.Cast,
-    referencedEventId: SPELLS.FERAL_FRENZY_DEBUFF.id,
-    referencedEventType: EventType.Damage,
-    forwardBufferMs: 5000, // 5 flickers take time to play out
-    backwardBufferMs: 0,
-    anyTarget: true,
-    maximumLinks: 50,
-    isActive: (c) =>
-      c.hasTalent(TALENTS_DRUID.FERAL_FRENZY_TALENT) &&
-      !c.hasTalent(TALENTS_DRUID.FRANTIC_FRENZY_TALENT),
-  },
-  {
-    linkRelation: HIT_TARGET,
-    reverseLinkRelation: FROM_HARDCAST,
     linkingEventId: TALENTS_DRUID.FRANTIC_FRENZY_TALENT.id,
     linkingEventType: EventType.Cast,
     referencedEventId: SPELLS.FRANTIC_FRENZY_DEBUFF.id,

--- a/src/analysis/retail/druid/feral/normalizers/SuddenAmbushLinkNormalizer.ts
+++ b/src/analysis/retail/druid/feral/normalizers/SuddenAmbushLinkNormalizer.ts
@@ -34,7 +34,7 @@ const EVENT_LINKS: EventLink[] = [
     reverseLinkRelation: BOOSTED_BY_SA,
     linkingEventId: SPELLS.SUDDEN_AMBUSH_BUFF.id,
     linkingEventType: EventType.RemoveBuff,
-    referencedEventId: [SPELLS.RAKE.id, SPELLS.SHRED.id],
+    referencedEventId: [SPELLS.RAKE.id, SPELLS.SHRED.id, SPELLS.SWIPE_CAT.id],
     referencedEventType: EventType.Damage,
     forwardBufferMs: CAST_BUFFER_MS,
     backwardBufferMs: CAST_BUFFER_MS,

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -1120,7 +1120,7 @@ const spells = {
   },
   // buff from Sudden Ambush talent
   SUDDEN_AMBUSH_BUFF: {
-    id: 391974,
+    id: 1244483,
     name: 'Sudden Ambush',
     icon: 'ability_hunter_catlikereflexes',
   },


### PR DESCRIPTION
…uptime history, feral frenzy TF tracking

There's a lot of changes in here based on feedback from the Feral theory crafting community and how the APL actually ends up running it. Some of these are subject to change in the 12.0.5 patch, but I think this is a clear place to cut before I start adding all the new module trackers. Ex. Hunger for Battle Energy tracking + damage gains, better infect wounds tracking, and basically everything with the Apex talents

<!-- A brief description of the changes made with this pull request.-->

I used my personal logs based on talent choices to make sure the reflected changes are functioning as expected. The analysis on alot of the dots now more closely reflects the reality expectations based on feedback from feral community. 

<!-- How can the reviewer test your changes (if applicable)? -->

https://www.warcraftlogs.com/reports/GW6qCN8x2MAm7tRF?fight=15&type=damage-done
https://www.warcraftlogs.com/reports/gvdKhMrFcDtRLC2m?fight=25&type=damage-done

- Screenshot(s):

Sudden Ambush fixed, currently it's just fully broken. 

<img width="1271" height="631" alt="image" src="https://github.com/user-attachments/assets/a515387a-23f7-4f19-a651-7d6e6d21d571" />
