### PR TITLE
[RDruid] fix bug in power of nature

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2026, 4, 14), <>Fixed bug in statistic for <SpellLink spell={TALENTS_DRUID.POWER_OF_NATURE_TALENT}/>.</>, squided),
   change(date(2026, 4, 10), <>Fixed bug in statistic for <SpellLink spell={TALENTS_DRUID.STRATEGIC_INFUSION_TALENT}/>.</>, squided),
   change(date(2026, 3, 31), <>Remove recent tranquility check from convoke guide. Fix Abundancy module to account for Intensity crit bonus. Add Intensity module.</>, squided),
   change(date(2026, 3, 23), <>Update mana efficiency calculations and cooldowns tab for Midnight.</>, squided),

--- a/src/analysis/retail/druid/restoration/modules/spells/KeeperOfTheGrove/PowerOfNature.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/KeeperOfTheGrove/PowerOfNature.tsx
@@ -34,6 +34,8 @@ export default class PowerOfNature extends Analyzer {
           SPELLS.EFFLORESCENCE_HEAL,
           SPELLS.LIFEBLOOM_HOT_HEAL,
           SPELLS.LIFEBLOOM_BLOOM_HEAL,
+          SPELLS.THRIVING_VEGETATION,
+          SPELLS.EVERBLOOM_SPLASH_HEAL,
         ]),
       this.onHeal,
     );


### PR DESCRIPTION
### Description

Power of Nature is not accounting for everbloom splash healing or Thriving Vegetation healing when it should.

### Testing


- Test report URL: /reports/PQ9WRfcCbmpKFAx4?fight=31&type=healing&source=7
- Screenshot(s):
<img width="303" height="130" alt="image" src="https://github.com/user-attachments/assets/02e23c6d-0488-45e1-a88d-0257ba235876" />
