### PR TITLE
[Mistweaver] Fix Zen Pulse analysis when Sheilun's Gift is Talented

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 15), <>Fixed a bug with <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT} /> statistic and guide subsection analysis when <SpellLink spell={TALENTS_MONK.SHEILUNS_GIFT_TALENT} /> is talented.</>, Vohrr),
   change(date(2026, 3, 29), <>Updated Celestial analysis, APL checks, and general healing cooldowns updates.</>, swirl),
   change(date(2026, 3, 24), <>Fixed <SpellLink spell={TALENTS_MONK.MISTY_COALESCENCE_TALENT} /> to correctly cap scaling at 20 players.</>, swirl),
   change(date(2026, 3, 21), <>Added <SpellLink spell={TALENTS_MONK.MORNING_BREEZE_TALENT} /> module.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/constants.ts
+++ b/src/analysis/retail/monk/mistweaver/constants.ts
@@ -188,6 +188,12 @@ export function getCurrentCelestialTalent(player: Combatant): Talent {
     : TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT;
 }
 
+export function getSelectedPrimaryHeal(player: Combatant): Talent | Spell {
+  return player.hasTalent(TALENTS_MONK.SHEILUNS_GIFT_TALENT)
+    ? TALENTS_MONK.SHEILUNS_GIFT_TALENT
+    : SPELLS.VIVIFY;
+}
+
 export function getCurrentAncientTeachingsTransferCoefficient(player: Combatant): number {
   let coefficient = AT_TRANSFER_COEFFICIENT;
 

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ZenPulse.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ZenPulse.tsx
@@ -19,7 +19,11 @@ import { TooltipElement } from 'interface/Tooltip';
 import { formatNumber, formatPercentage } from 'common/format';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
-import { ZEN_PULSE_INCREASE_PER_STACK, ZEN_PULSE_MAX_HITS_FOR_BOOST } from '../../constants';
+import {
+  getSelectedPrimaryHeal,
+  ZEN_PULSE_INCREASE_PER_STACK,
+  ZEN_PULSE_MAX_HITS_FOR_BOOST,
+} from '../../constants';
 import Abilities from '../features/Abilities';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
@@ -55,7 +59,10 @@ class ZenPulse extends Analyzer {
       this.onHeal,
     );
 
-    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.VIVIFY), this.onViv);
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell([SPELLS.VIVIFY, TALENTS_MONK.SHEILUNS_GIFT_TALENT]),
+      this.onCast,
+    );
 
     this.addEventListener(
       Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.ZEN_PULSE_BUFF),
@@ -160,7 +167,7 @@ class ZenPulse extends Analyzer {
     return { overheal: avgOverhealing, perf: QualitativePerformance.Good };
   }
 
-  private onViv(event: HealEvent) {
+  private onCast(event: HealEvent) {
     const zenPulseHits = getZenPulseHitsPerCast(event);
     if (!zenPulseHits.length) {
       return;
@@ -195,8 +202,9 @@ class ZenPulse extends Analyzer {
             <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT} />
           </b>{' '}
           is a buff that procs off of <SpellLink spell={SPELLS.RENEWING_MIST_CAST} /> that makes
-          your next <SpellLink spell={SPELLS.VIVIFY} /> cast do additional healing on your target
-          and all targets with <SpellLink spell={SPELLS.RENEWING_MIST_CAST} />. The healing done by{' '}
+          your next <SpellLink spell={getSelectedPrimaryHeal(this.selectedCombatant)} /> cast do
+          additional healing on your target and all targets with{' '}
+          <SpellLink spell={SPELLS.RENEWING_MIST_CAST} />. The healing done by{' '}
           <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT} /> is increased by 6% per target with{' '}
           <SpellLink spell={SPELLS.RENEWING_MIST_CAST} /> up to 30%, so it is important to have at
           least 5 ReMs active before consuming the buff.
@@ -273,7 +281,7 @@ class ZenPulse extends Analyzer {
           <hr />
           {this.avgHitsPerConsume.toFixed(2)}{' '}
           <small>
-            Average hits per <SpellLink spell={SPELLS.VIVIFY} />
+            Average hits per <SpellLink spell={getSelectedPrimaryHeal(this.selectedCombatant)} />
           </small>
           <div></div>
           <TooltipElement

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -41,7 +41,7 @@ import {
   CRANE_STYLE_SCK,
   VIVACIOUS_VIVIFICATION,
   ZEN_PULSE_CONSUME,
-  ZEN_PULSE_VIVIFY,
+  ZEN_PULSE_CAST,
   STRENGTH_OF_THE_BLACK_OX,
   SPIRITFONT_CONSUMED,
   JADE_BOND_ENVM,
@@ -277,7 +277,7 @@ export function isVivaciousVivification(event: HealEvent) {
 }
 
 export function getZenPulseHitsPerCast(event: HealEvent): HealEvent[] {
-  return GetRelatedEvents<HealEvent>(event, ZEN_PULSE_VIVIFY);
+  return GetRelatedEvents<HealEvent>(event, ZEN_PULSE_CAST);
 }
 
 export function isZenPulseConsumed(event: RemoveBuffEvent | RemoveBuffStackEvent) {

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants.ts
@@ -31,7 +31,7 @@ export const CRANE_STYLE_SCK = 'CraneStyleSCK';
 // Vivify
 export const VIVIFY = 'Vivify';
 export const VIVACIOUS_VIVIFICATION = 'VivaciousVivification';
-export const ZEN_PULSE_VIVIFY = 'ZenPulseVivify';
+export const ZEN_PULSE_CAST = 'ZenPulseCast';
 export const ZEN_PULSE_CONSUME = 'ZenPulseConsume';
 export const CHI_WAVE_VIVIFY = 'ChiWaveVivify';
 export const SHEILUNS_GIFT = 'SheilunsGift';

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/VivifyEventLinks.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/VivifyEventLinks.ts
@@ -4,7 +4,7 @@ import { EventType } from 'parser/core/Events';
 import {
   VIVIFY,
   CAST_BUFFER_MS,
-  ZEN_PULSE_VIVIFY,
+  ZEN_PULSE_CAST,
   VIVACIOUS_VIVIFICATION,
   ZEN_PULSE_CONSUME,
   SHEILUNS_GIFT_MAIN_TARGET,
@@ -24,8 +24,8 @@ export const VIVIFY_EVENT_LINKS: EventLink[] = [
     anyTarget: true,
   },
   {
-    linkRelation: ZEN_PULSE_VIVIFY,
-    linkingEventId: [SPELLS.VIVIFY.id],
+    linkRelation: ZEN_PULSE_CAST,
+    linkingEventId: [SPELLS.VIVIFY.id, TALENTS_MONK.SHEILUNS_GIFT_TALENT.id],
     linkingEventType: [EventType.Heal],
     referencedEventId: [SPELLS.ZEN_PULSE_HEAL.id],
     referencedEventType: [EventType.Heal],


### PR DESCRIPTION
### Description
Updated Zen Pulse event links and verbiage so that the statistic and guide subsection provide accurate analysis when Sheilun's Gift is talented 

### Testing
Manual

- Test report URL: `/report/cYXgAQx3VwCfB2zN/65-Mythic+Fallen-King+Salhadaar+-+Wipe+13+(1:11)/14-Vohrr/standard/overview`

### Screenshot(s):
Guide subsection before/after
<img width="2481" height="296" alt="image" src="https://github.com/user-attachments/assets/5cc081a2-6c63-4148-afeb-01b9356cd052" />

Statistic before/after 
<img width="2145" height="475" alt="image" src="https://github.com/user-attachments/assets/d1c1bead-e5fc-4c8c-a4c2-62614eada15f" />
