### PR TITLE
feat(combatant/stattracker): Refactor `pullStats` to be immutable

### DIFF
--- a/src/analysis/retail/paladin/protection/modules/talents/Redoubt.tsx
+++ b/src/analysis/retail/paladin/protection/modules/talents/Redoubt.tsx
@@ -32,11 +32,11 @@ class Redoubt extends Analyzer {
   }
 
   bonusStaminaGain(statTracker: StatTracker) {
-    return statTracker.startingStaminaRating * STAT_MODIFIER;
+    return statTracker.startingStats.stamina * STAT_MODIFIER;
   }
 
   bonusStrenghGain(statTracker: StatTracker) {
-    return statTracker.startingStrengthRating * STAT_MODIFIER;
+    return statTracker.startingStats.strength * STAT_MODIFIER;
   }
 
   get averageStacks() {

--- a/src/interface/report/Results/CharacterStats.tsx
+++ b/src/interface/report/Results/CharacterStats.tsx
@@ -11,74 +11,68 @@ import STAT, {
 import StatTracker from 'parser/shared/modules/StatTracker';
 
 const getStatRating = (statTracker: StatTracker, stat: STAT) => {
+  const stats = statTracker.startingStats;
   switch (stat) {
     case STAT.STRENGTH:
-      return statTracker.startingStrengthRating;
+      return stats.strength;
     case STAT.AGILITY:
-      return statTracker.startingAgilityRating;
+      return stats.agility;
     case STAT.INTELLECT:
-      return statTracker.startingIntellectRating;
+      return stats.intellect;
     case STAT.STAMINA:
-      return statTracker.startingStaminaRating;
+      return stats.stamina;
     case STAT.CRITICAL_STRIKE:
-      return statTracker.startingCritRating;
+      return stats.crit;
     case STAT.HASTE:
-      return statTracker.startingHasteRating;
+      return stats.haste;
     case STAT.MASTERY:
-      return statTracker.startingMasteryRating;
+      return stats.mastery;
     case STAT.VERSATILITY:
-      return statTracker.startingVersatilityRating;
+      return stats.versatility;
     case STAT.LEECH:
-      return statTracker.startingLeechRating;
+      return stats.leech;
     case STAT.AVOIDANCE:
-      return statTracker.startingAvoidanceRating;
+      return stats.avoidance;
     case STAT.SPEED:
-      return statTracker.startingSpeedRating;
+      return stats.speed;
     default:
       return 0;
   }
 };
 
 const getStatPercentage = (statTracker: StatTracker, stat: STAT) => {
+  const stats = statTracker.startingStats;
   switch (stat) {
     case STAT.CRITICAL_STRIKE:
-      return statTracker.critPercentage(statTracker.startingCritRating, true);
+      return statTracker.critPercentage(stats.crit, true);
     case STAT.HASTE:
-      return statTracker.hastePercentage(statTracker.startingHasteRating, true);
+      return statTracker.hastePercentage(stats.haste, true);
     case STAT.MASTERY:
       return statTracker.hasMasteryCoefficient
-        ? statTracker.masteryPercentage(statTracker.startingMasteryRating, true)
+        ? statTracker.masteryPercentage(stats.mastery, true)
         : null;
     case STAT.VERSATILITY:
-      return statTracker.versatilityPercentage(statTracker.startingVersatilityRating, true);
+      return statTracker.versatilityPercentage(stats.versatility, true);
     case STAT.LEECH:
-      return statTracker.leechPercentage(statTracker.startingLeechRating, true);
+      return statTracker.leechPercentage(stats.leech, true);
     case STAT.AVOIDANCE:
-      return statTracker.avoidancePercentage(statTracker.startingAvoidanceRating, true);
+      return statTracker.avoidancePercentage(stats.avoidance, true);
     case STAT.SPEED:
-      return statTracker.speedPercentage(statTracker.startingSpeedRating, true);
+      return statTracker.speedPercentage(stats.speed, true);
     default:
       return null;
   }
 };
 
 const getPrimaryStat = (statTracker: StatTracker) => {
-  if (
-    statTracker.startingStrengthRating > statTracker.startingAgilityRating &&
-    statTracker.startingStrengthRating > statTracker.startingIntellectRating
-  ) {
+  const { strength, agility, intellect } = statTracker.startingStats;
+  if (strength > agility && strength > intellect) {
     return STAT.STRENGTH;
   }
-  if (
-    statTracker.startingAgilityRating > statTracker.startingStrengthRating &&
-    statTracker.startingAgilityRating > statTracker.startingIntellectRating
-  ) {
+  if (agility > strength && agility > intellect) {
     return STAT.AGILITY;
   }
-  if (
-    statTracker.startingIntellectRating > statTracker.startingStrengthRating &&
-    statTracker.startingIntellectRating > statTracker.startingAgilityRating
-  ) {
+  if (intellect > strength && intellect > agility) {
     return STAT.INTELLECT;
   }
   return STAT.UNKNOWN;

--- a/src/parser/core/Combatant.test.jsx
+++ b/src/parser/core/Combatant.test.jsx
@@ -2,7 +2,7 @@ import COMBATANTINFO from 'parser/core/tests/COMBATANTINFO.json';
 
 import { FullCombatant } from './Combatant';
 
-function getCombatant(parser = null, combatantInfo = null) {
+function getCombatant(parser = null, combatantInfo = null, config = {}) {
   const parserStub = {
     players: [
       {
@@ -13,6 +13,7 @@ function getCombatant(parser = null, combatantInfo = null) {
     fight: {
       start_time: 0,
     },
+    config,
   };
   return new FullCombatant(
     parser || parserStub,
@@ -123,6 +124,41 @@ describe('Combatant', () => {
     it('returns false when neither weapon carries the enchant', () => {
       // mainhand 128868 has no permanentEnchant in the fixture
       expect(getCombatant().hasWeaponEnchant({ effectId: 99999 })).toBe(false);
+    });
+  });
+
+  describe('pullStats', () => {
+    it('returns raw stats from combatantInfo when no statMultipliers are configured', () => {
+      const stats = getCombatant().pullStats;
+      expect(stats.strength).toBe(5932);
+      expect(stats.armor).toBe(2000);
+      expect(stats.intellect).toBe(51633);
+      expect(stats.crit).toBe(6122);
+      expect(stats.haste).toBe(8962);
+    });
+
+    it('applies configured spec statMultipliers', () => {
+      const stats = getCombatant(null, null, { statMultipliers: { armor: 1.25 } }).pullStats;
+      expect(stats.armor).toBe(2500);
+      // unrelated stats are unaffected
+      expect(stats.strength).toBe(5932);
+      expect(stats.intellect).toBe(51633);
+    });
+
+    it('ignores statMultiplier entries whose value is undefined', () => {
+      const stats = getCombatant(null, null, {
+        statMultipliers: { armor: undefined, strength: 1.5 },
+      }).pullStats;
+      expect(stats.armor).toBe(2000);
+      expect(stats.strength).toBe(5932 * 1.5);
+    });
+
+    it('is frozen so callers cannot mutate the shared snapshot', () => {
+      const stats = getCombatant().pullStats;
+      expect(Object.isFrozen(stats)).toBe(true);
+      expect(() => {
+        stats.armor = 9999;
+      }).toThrow();
     });
   });
 });

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -92,12 +92,14 @@ class Combatant extends Entity {
     return factionFromWclId(this.combatantInfo.faction);
   }
 
-  get pullStats(): Stats | undefined {
-    const info = this.combatantInfo;
-    if (!info) {
-      return undefined;
-    }
-    return {
+  /**
+   * Player stats at the start of the pull, with any spec-specific `statMultipliers` applied.
+   * Frozen at construction; safe to share without copying.
+   */
+  readonly pullStats: Readonly<Stats> | undefined;
+
+  protected buildPullStats(info: CombatantInfoEvent): Readonly<Stats> {
+    const stats: Stats = {
       strength: info.strength,
       agility: info.agility,
       intellect: info.intellect,
@@ -113,6 +115,15 @@ class Combatant extends Entity {
       speed: info.speed,
       armor: info.armor,
     };
+    const modifiers = this.owner.config.statMultipliers;
+    if (modifiers) {
+      for (const [stat, multiplier] of Object.entries(modifiers)) {
+        if (multiplier !== undefined) {
+          stats[stat as keyof Stats] *= multiplier;
+        }
+      }
+    }
+    return Object.freeze(stats);
   }
 
   readonly ilvl: number | undefined;
@@ -386,15 +397,12 @@ export default Combatant;
  */
 export class FullCombatant extends Combatant {
   protected override combatantInfo: CombatantInfoEvent;
+  override readonly pullStats: Readonly<Stats>;
   override readonly ilvl: number | undefined;
   readonly specId: number;
 
   override get faction(): Faction {
     return super.faction!;
-  }
-
-  override get pullStats(): Stats {
-    return super.pullStats!;
   }
 
   constructor(parser: CombatLogParser, player: PlayerDetails, combatantInfo: CombatantInfoEvent) {
@@ -414,6 +422,8 @@ export class FullCombatant extends Combatant {
     this.importTalentTree(combatantInfo.talentTree);
     this.parseGear(combatantInfo.gear);
     this.parsePrepullBuffs(combatantInfo.auras);
+
+    this.pullStats = this.buildPullStats(combatantInfo);
 
     this.ilvl =
       this.gear.length > 0

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -121,8 +121,6 @@ class StatTracker extends Analyzer {
 
   // all known stat buffs
   statBuffs: StatBuffsByGuid;
-  // the player's stat ratings at pull
-  _pullStats: PlayerStats;
   // the player's 'current' stat ratings
   _currentStats: PlayerStats;
 
@@ -247,20 +245,18 @@ class StatTracker extends Analyzer {
 
   constructor(options: Options) {
     super(options);
-    this._pullStats = this.selectedCombatant.pullStats;
 
     if (wclGameVersionToBranch(options.owner.report.gameVersion) === GameBranch.Classic) {
       this.isClassic = true;
     }
 
-    this.applySpecModifiers();
-
     this.statBuffs = {
       ...StatTracker.DEFAULT_BUFFS,
     };
 
+    // Copy: pullStats is frozen, but _currentStats is mutated by buff event handlers.
     this._currentStats = {
-      ...this._pullStats,
+      ...this.selectedCombatant.pullStats,
     };
 
     // Really hoping people don't run around with wrong armor types
@@ -391,65 +387,11 @@ class StatTracker extends Analyzer {
     changeCurrentStats && this.forceChangeStats(delta, null, true);
   }
 
-  applySpecModifiers(): void {
-    const modifiers: StatMultiplier = this.config.statMultipliers || {};
-    Object.entries(modifiers).forEach(([stat, multiplier]: [string, number | undefined]) => {
-      if (multiplier !== undefined) {
-        this._pullStats[stat as keyof Stats] *= multiplier;
-      }
-    });
-  }
-
-  /*
-   * Stat rating at pull.
-   * Should be identical to what you get from Combatant.
+  /**
+   * Stat ratings at pull, with any spec `statMultipliers` applied.
    */
-  get startingStrengthRating(): number {
-    return this._pullStats.strength;
-  }
-
-  get startingAgilityRating(): number {
-    return this._pullStats.agility;
-  }
-
-  get startingIntellectRating(): number {
-    return this._pullStats.intellect;
-  }
-
-  get startingStaminaRating(): number {
-    return this._pullStats.stamina;
-  }
-
-  get startingCritRating(): number {
-    return this._pullStats.crit;
-  }
-
-  get startingHasteRating(): number {
-    return this._pullStats.haste;
-  }
-
-  get startingMasteryRating(): number {
-    return this._pullStats.mastery;
-  }
-
-  get startingVersatilityRating(): number {
-    return this._pullStats.versatility;
-  }
-
-  get startingAvoidanceRating(): number {
-    return this._pullStats.avoidance;
-  }
-
-  get startingLeechRating(): number {
-    return this._pullStats.leech;
-  }
-
-  get startingSpeedRating(): number {
-    return this._pullStats.speed;
-  }
-
-  get startingArmorRating(): number {
-    return this._pullStats.armor;
+  get startingStats(): Readonly<Stats> {
+    return this.selectedCombatant.pullStats;
   }
 
   /*


### PR DESCRIPTION
### Description

This PR Intends to reactor the existing `_pullStats` since it's indicated to be private but is being modified by external sources. 

This implementation turns it into `readonly pullStats: Readonly<Stats> | undefined` which ensures immutability and to achieve that I've included the `statMultipliers` directly where we build pullStats.

It also removes all the duplicate getters for it in StatTracker and turns it into a single getter `get startingStats(): Readonly<Stats>`

Closes #7775 

### Testing

- Test report URL: `/report/GTXbLVZt3H6jYxJD/37-Mythic+Lightblinded+Vanguard+-+Wipe+26+(6:23)/8-Thiasvoker/standard/character`
