### PR TITLE
fix(mage): HeatShimmer Guide crash due to buff timestamp

### DIFF
--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -2,10 +2,11 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/mage';
 import SpellLink from 'interface/SpellLink';
 import { change, date } from 'common/changelog';
-import { Sharrq } from 'CONTRIBUTORS';
+import { Thias, Sharrq } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 17), <>Fixed an issue where <SpellLink spell={TALENTS.HEAT_SHIMMER_TALENT} /> procs were not being correctly evaluated.</>, Thias),
   change(date(2026, 3, 20), <>Fixed an issue that prevented <SpellLink spell={TALENTS.FLAMESTRIKE_2_FIRE_TALENT} /> from being detected as a <SpellLink spell={SPELLS.HOT_STREAK} /> spender if the player chose the talent to cast <SpellLink spell={TALENTS.FLAMESTRIKE_2_FIRE_TALENT} /> at your target instead of your cursor.</>, Sharrq),
   change(date(2026, 3, 20), <>Fixed an issue that caused some <SpellLink spell={SPELLS.FIRE_BLAST.id} /> casts to not detect that <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> was active.</>, Sharrq),
   change(date(2026, 3, 6), <>Removed Searing Touch and Feel the Burn modules.</>, Sharrq),

--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -6,7 +6,7 @@ import { Thias, Sharrq } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
-  change(date(2026, 4, 17), <>Fixed an issue where <SpellLink spell={TALENTS.HEAT_SHIMMER_TALENT} /> procs were not being correctly evaluated.</>, Thias),
+  change(date(2026, 4, 17), <>Temporarily fix crash of <SpellLink spell={SPELLS.HEAT_SHIMMER_BUFF} /> by extending the buffer</>, Thias),
   change(date(2026, 3, 20), <>Fixed an issue that prevented <SpellLink spell={TALENTS.FLAMESTRIKE_2_FIRE_TALENT} /> from being detected as a <SpellLink spell={SPELLS.HOT_STREAK} /> spender if the player chose the talent to cast <SpellLink spell={TALENTS.FLAMESTRIKE_2_FIRE_TALENT} /> at your target instead of your cursor.</>, Sharrq),
   change(date(2026, 3, 20), <>Fixed an issue that caused some <SpellLink spell={SPELLS.FIRE_BLAST.id} /> casts to not detect that <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> was active.</>, Sharrq),
   change(date(2026, 3, 6), <>Removed Searing Touch and Feel the Burn modules.</>, Sharrq),

--- a/src/analysis/retail/mage/fire/guide/HeatShimmer.tsx
+++ b/src/analysis/retail/mage/fire/guide/HeatShimmer.tsx
@@ -41,7 +41,7 @@ class HeatShimmerGuide extends Analyzer {
     // FAIL CONDITIONS
     if (!hs.spender) {
       return {
-        timestamp: hs.buffApply!.timestamp,
+        timestamp: hs.buffRemove.timestamp,
         performance: QualitativePerformance.Fail,
         reason: 'Heat Shimmer proc expired.',
       };
@@ -50,15 +50,14 @@ class HeatShimmerGuide extends Analyzer {
     // GOOD CONDITIONS
     if (hs.spender) {
       return {
-        timestamp: hs.buffApply!.timestamp,
+        timestamp: hs.buffRemove.timestamp,
         performance: QualitativePerformance.Good,
         reason: 'Heat Shimmer proc spent.',
       };
     }
 
-    // DEFAULT
     return {
-      timestamp: hs.buffApply!.timestamp,
+      timestamp: hs.buffRemove.timestamp,
       performance: QualitativePerformance.Fail,
       reason: 'Unknown Performance Condition (Please report this)',
     };

--- a/src/analysis/retail/mage/fire/guide/HeatShimmer.tsx
+++ b/src/analysis/retail/mage/fire/guide/HeatShimmer.tsx
@@ -41,7 +41,7 @@ class HeatShimmerGuide extends Analyzer {
     // FAIL CONDITIONS
     if (!hs.spender) {
       return {
-        timestamp: hs.buffRemove.timestamp,
+        timestamp: hs.buffApply!.timestamp,
         performance: QualitativePerformance.Fail,
         reason: 'Heat Shimmer proc expired.',
       };
@@ -50,14 +50,15 @@ class HeatShimmerGuide extends Analyzer {
     // GOOD CONDITIONS
     if (hs.spender) {
       return {
-        timestamp: hs.buffRemove.timestamp,
+        timestamp: hs.buffApply!.timestamp,
         performance: QualitativePerformance.Good,
         reason: 'Heat Shimmer proc spent.',
       };
     }
 
+    // DEFAULT
     return {
-      timestamp: hs.buffRemove.timestamp,
+      timestamp: hs.buffApply!.timestamp,
       performance: QualitativePerformance.Fail,
       reason: 'Unknown Performance Condition (Please report this)',
     };

--- a/src/analysis/retail/mage/fire/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/fire/normalizers/CastLinkNormalizer.ts
@@ -212,7 +212,7 @@ const EVENT_LINKS = createEventLinks(
     spell: SPELLS.HEAT_SHIMMER_BUFF.id,
     parentType: EventType.RemoveBuff,
     links: [
-      link(EventType.ApplyBuff, { backwardBuffer: 15_000, maxLinks: 1 }),
+      link(EventType.ApplyBuff, { backwardBuffer: 90_000, maxLinks: 1 }),
       link(CustomType.CONSUME, {
         id: TALENTS.SCORCH_TALENT.id,
         type: EventType.Cast,


### PR DESCRIPTION
### Description

This PR intends to fix an issue in the mage guide where `HeatShimmer` could cause a crash when the buffApply timestamp was undefined. This is fixed by changing to `hs.buffRemove.timestamp` similar to what is implemented in `HotStreak.tsx`

Closes #7828 

### Testing

- Test report URL: `/report/Nzbptj9F6A41XnmV/10-Unknown+difficulty+Gladius+Slaurna+-+Kill+(4:33)/12-Sageflame/standard`
