### PR TITLE
feat(combatant): Refactor `itemMap` to load in parseGear instead of lazy load

### DIFF
--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -229,6 +229,7 @@ class Combatant extends Entity {
 
   // region Gear
   private gearItemsBySlotId: Record<number, Item> = {};
+  private gearItemsById = new Map<number, Item>();
 
   protected parseGear(gear: Item[]) {
     const equipedSets: number[][] = [];
@@ -250,6 +251,7 @@ class Combatant extends Entity {
       }
 
       this.gearItemsBySlotId[index] = equippedItem;
+      this.gearItemsById.set(equippedItem.id, equippedItem);
     });
   }
 
@@ -297,18 +299,8 @@ class Combatant extends Entity {
     return this.getTrinket(itemId) !== undefined;
   }
 
-  private itemMap = new Map<number, Item>();
-  private scannedForItems = false;
-
-  getItem(itemId: number) {
-    if (!this.scannedForItems && this.itemMap.size === 0) {
-      Object.values(this.gearItemsBySlotId).forEach((item) => {
-        this.itemMap.set(item.id, item);
-      });
-      this.scannedForItems = true;
-    }
-
-    return this.itemMap.get(itemId);
+  getItem(itemId: number): Item | undefined {
+    return this.gearItemsById.get(itemId);
   }
 
   // endregion


### PR DESCRIPTION
### Description

This PR intends to refactor the `itemMap` to be a part of `parseGear` instead of doing it's own lazy loading on the first function call and eliminate the need to loop over all the gear twice

Closes #7781 

### Testing

- Test report URL: `/report/GTXbLVZt3H6jYxJD/37-Mythic+Lightblinded+Vanguard+-+Wipe+26+(6:23)/8-Thiasvoker/standard/character`
