### PR TITLE
[Vengeance] Update core spellbook values for Midnight

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2896,3 +2896,9 @@ export const Biggerbits: Contributor = {
   github: 'zprobinson',
   discord: 'msrobinson',
 };
+
+export const Guminator: Contributor = {
+  nickname: 'Guminator',
+  github: 'DanielVagner',
+  discord: 'Guminator',
+};

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -1,5 +1,5 @@
 import { change, date } from 'common/changelog';
-import { Quaarkz, Topple, Vollmer } from 'CONTRIBUTORS';
+import { Guminator, Quaarkz, Topple, Vollmer } from 'CONTRIBUTORS';
 import SHARED_CHANGELOG from 'analysis/retail/demonhunter/shared/CHANGELOG';
 import SpellLink from 'interface/SpellLink';
 import SPELLS from 'common/SPELLS/demonhunter';
@@ -7,6 +7,7 @@ import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 18), <>Update <SpellLink spell={SPELLS.FRACTURE} />, <SpellLink spell={SPELLS.DEMON_SPIKES} />, <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT} />, and <SpellLink spell={SPELLS.INFERNAL_STRIKE} /> spellbook values for Midnight.</>, Guminator),
   change(date(2026, 4, 12), <>Delete <SpellLink spell={SPELLS.SOUL_CLEAVE}/> analysis and update <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT}/></>, Quaarkz),
   change(date(2026, 4, 11), <>Corrected behaviour of MID1 4PC proc rate calculation and updated <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT}/> analysis to Midnight use cases</>, Quaarkz),
   change(date(2026, 3, 28), <>Vengeance <SpellLink spell={SPELLS.FRACTURE} /> soul and fury thresholds updated to Midnight values.</>, Quaarkz),

--- a/src/analysis/retail/demonhunter/vengeance/modules/Abilities.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/Abilities.tsx
@@ -50,7 +50,7 @@ class Abilities extends SharedAbilities {
         spell: SPELLS.FRACTURE.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         cooldown: (haste) =>
-          (5 -
+          (6 -
             PERFECTLY_BALANCED_GLAIVE_SCALING_FRACTURE[
               combatant.getTalentRank(TALENTS.PERFECTLY_BALANCED_GLAIVE_TALENT)
             ]) /
@@ -131,7 +131,7 @@ class Abilities extends SharedAbilities {
         spell: SPELLS.DEMON_SPIKES.id,
         category: SPELL_CATEGORY.DEFENSIVE,
         cooldown: (haste) => 20 / (1 + haste),
-        charges: 2,
+        charges: combatant.hasTalent(TALENTS_DEMON_HUNTER.DEMONIC_RESILIENCE_TALENT) ? 2 : 1,
         isDefensive: true,
       },
 
@@ -176,6 +176,7 @@ class Abilities extends SharedAbilities {
         spell: TALENTS.SPIRIT_BOMB_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         enabled: combatant.hasTalent(TALENTS.SPIRIT_BOMB_TALENT),
+        cooldown: (haste) => 25 / (1 + haste),
         gcd: {
           base: 1500,
         },
@@ -272,7 +273,7 @@ class Abilities extends SharedAbilities {
       {
         spell: SPELLS.INFERNAL_STRIKE.id,
         category: SPELL_CATEGORY.UTILITY,
-        cooldown: getInfernalStrikeCooldown(combatant),
+        cooldown: (haste) => getInfernalStrikeCooldown(combatant, haste),
         charges: 1 + (combatant.hasTalent(TALENTS.BLAZING_PATH_TALENT) ? 1 : 0),
         enabled: false, // TODO: change this to true, when infernal strike logging is working, see infernalstrike module for more details.
       },

--- a/src/analysis/retail/demonhunter/vengeance/modules/spells/InfernalStrike.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/spells/InfernalStrike.tsx
@@ -5,12 +5,15 @@ import Combatant from 'parser/core/Combatant';
 import { TALENTS_DEMON_HUNTER } from 'common/TALENTS';
 import { ERRATIC_FELHEART_SCALING } from 'analysis/retail/demonhunter/shared';
 
-export function getInfernalStrikeCooldown(combatant: Combatant) {
-  const baseCooldown = 20;
+export function getInfernalStrikeBaseCooldown(combatant: Combatant) {
+  const baseCooldown = 15;
   const erraticFelheartReduction =
     ERRATIC_FELHEART_SCALING[combatant.getTalentRank(TALENTS_DEMON_HUNTER.ERRATIC_FELHEART_TALENT)];
-  const flatReduced = baseCooldown;
-  return flatReduced - flatReduced * erraticFelheartReduction;
+  return baseCooldown - erraticFelheartReduction;
+}
+
+export function getInfernalStrikeCooldown(combatant: Combatant, haste = 0) {
+  return getInfernalStrikeBaseCooldown(combatant) / (1 + haste);
 }
 
 /*  When considering Infernal Strike, it is worth tracking how much time is spent overcapped on charges.
@@ -18,7 +21,9 @@ export function getInfernalStrikeCooldown(combatant: Combatant) {
     or shortly after gaining a second use. */
 export default class InfernalStrike extends Analyzer {
   infernalCasts = 0;
-  infernalCharges = 2;
+  infernalCharges = this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.BLAZING_PATH_TALENT)
+    ? 2
+    : 1;
   lastCastTimestamp = 0;
   currentCastTimestamp = 0;
   castsAtCap = 0;
@@ -56,21 +61,27 @@ export default class InfernalStrike extends Analyzer {
 
   onCast(event: CastEvent) {
     this.currentCastTimestamp = event.timestamp;
+    const rechargeMs = getInfernalStrikeBaseCooldown(this.selectedCombatant) * 1000;
 
     // Track recharge
-    if (this.currentCastTimestamp > this.lastCastTimestamp + 12000) {
+    if (this.currentCastTimestamp > this.lastCastTimestamp + rechargeMs) {
       this.infernalCharges += 1;
     }
     this.infernalCasts += 1;
 
     // Track overcapped data
-    if (this.infernalCharges === 2) {
+    const maxCharges = this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.BLAZING_PATH_TALENT)
+      ? 2
+      : 1;
+    if (this.infernalCharges === maxCharges) {
       this.castsAtCap += 1;
       if (this.lastCastTimestamp > 0) {
-        this.secsOverCap += (this.currentCastTimestamp - this.lastCastTimestamp - 1200) / 1000;
+        this.secsOverCap +=
+          (this.currentCastTimestamp - this.lastCastTimestamp - rechargeMs) / 1000;
       }
     }
 
     this.infernalCharges -= 1;
+    this.lastCastTimestamp = this.currentCastTimestamp;
   }
 }


### PR DESCRIPTION
## Description
- Updated core Vengeance spellbook values for Midnight
- Fracture: 6s base cooldown
- Demon Spikes: 1 base charge, 2 with Demonic Resilience
- Spirit Bomb: 25s cooldown, affected by haste
- Infernal Strike: 15s base cooldown, affected by haste
- Erratic Felheart now uses flat cooldown reduction
- Added changelog and contributor entries

## Testing
- `pnpm run typecheck`
- Verified Demon Spikes 2-charge behavior in timeline with Demonic Resilience talented
- Verified Fracture cooldown matches Midnight values with Perfectly Balanced Glaive and haste
- Verified Spirit Bomb cooldown matches Midnight values with haste