### PR TITLE
[Vengeance] Fix Demon Spikes usage segmentation

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2908,5 +2908,17 @@ export const Biggerbits: Contributor = {
 export const Guminator: Contributor = {
   nickname: 'Guminator',
   github: 'DanielVagner',
-  discord: 'Guminator',
+  discord: 'guminatorr',
+  mains: [
+    {
+      name: 'Guuminator',
+      spec: SPECS.VENGEANCE_DEMON_HUNTER,
+      link: 'https://worldofwarcraft.blizzard.com/en-gb/character/eu/drakthul/guuminator/',
+    },
+    {
+      name: 'Guuminator',
+      spec: SPECS.BREWMASTER_MONK,
+      link: 'https://worldofwarcraft.blizzard.com/en-gb/character/eu/drakthul/guminnator/',
+    },
+  ],
 };

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,10 +7,11 @@ import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 18), <>Fix <SpellLink spell={SPELLS.DEMON_SPIKES} /> usage segmentation in the major defensive breakdown.</>, Guminator),
   change(date(2026, 4, 18), <>Update <SpellLink spell={SPELLS.FRACTURE} />, <SpellLink spell={SPELLS.DEMON_SPIKES} />, <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT} />, and <SpellLink spell={SPELLS.INFERNAL_STRIKE} /> spellbook values for Midnight.</>, Guminator),
   change(date(2026, 4, 12), <>Bump Vengeance to partial support</>, Quaarkz),
-  change(date(2026, 4, 12), <>Delete <SpellLink spell={SPELLS.SOUL_CLEAVE}/> analysis and update <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT}/></>, Quaarkz),
-  change(date(2026, 4, 11), <>Corrected behaviour of MID1 4PC proc rate calculation and updated <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT}/> analysis to Midnight use cases</>, Quaarkz),
+  change(date(2026, 4, 12), <>Delete <SpellLink spell={SPELLS.SOUL_CLEAVE} /> analysis and update <SpellLink spell={TALENTS.FEL_DEVASTATION_TALENT} /></>, Quaarkz),
+  change(date(2026, 4, 11), <>Corrected behaviour of MID1 4PC proc rate calculation and updated <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT} /> analysis to Midnight use cases</>, Quaarkz),
   change(date(2026, 3, 28), <>Vengeance <SpellLink spell={SPELLS.FRACTURE} /> soul and fury thresholds updated to Midnight values.</>, Quaarkz),
   change(date(2026, 1, 25), <><SpellLink spell={TALENTS.CALCIFIED_SPIKES_TALENT} /> DR added to <SpellLink spell={SPELLS.DEMON_SPIKES} /> mitigation.</>, Quaarkz),
   change(date(2025, 12, 21), <>Update value of MID1 2PC and delete Demonic for VDH.</>, Quaarkz),

--- a/src/analysis/retail/demonhunter/vengeance/CONFIG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CONFIG.tsx
@@ -1,5 +1,5 @@
 import SPELLS from 'common/SPELLS/demonhunter';
-import { Quaarkz, Topple } from 'CONTRIBUTORS';
+import { Quaarkz, Topple, Guminator } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import { SpellLink } from 'interface';
@@ -14,7 +14,7 @@ const textAlignStyle: CSSProperties = {
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Topple, Quaarkz],
+  contributors: [Topple, Quaarkz, Guminator],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '12.0.1',

--- a/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/DemonSpikes.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/core/MajorDefensives/DemonSpikes.tsx
@@ -1,6 +1,6 @@
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/demonhunter';
-import Events, { DamageEvent } from 'parser/core/Events';
+import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import MAGIC_SCHOOLS from 'game/MAGIC_SCHOOLS';
 import { SpellLink } from 'interface';
 import { ReactNode } from 'react';
@@ -9,13 +9,20 @@ import { getArmorMitigationForEvent } from 'parser/retail/armorMitigation';
 import {
   buff,
   MajorDefensiveBuff,
+  Mitigation,
+  MitigationRow,
+  MitigationRowContainer,
 } from 'interface/guide/components/MajorDefensives/MajorDefensiveAnalyzer';
 import MajorDefensiveStatistic from 'interface/MajorDefensiveStatistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import { TALENTS_DEMON_HUNTER } from 'common/TALENTS';
 import { CALCIFIED_SPIKES_DR } from '../../../constants';
+import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
+import { PerformanceMark } from 'interface/guide';
+import { PerformanceUsageRow } from 'parser/core/SpellUsage/core';
 
 const BASE_DURATION = 12000;
+const CAST_MATCH_BUFFER_MS = 1000;
 
 export default class DemonSpikes extends MajorDefensiveBuff {
   static dependencies = {
@@ -25,6 +32,7 @@ export default class DemonSpikes extends MajorDefensiveBuff {
 
   private spikesDurationPerCast = BASE_DURATION;
   private maximumUptime = 0;
+  private demonSpikesCasts: CastEvent[] = [];
   private hasCalcifiedSpikes = this.selectedCombatant.hasTalent(
     TALENTS_DEMON_HUNTER.CALCIFIED_SPIKES_TALENT,
   );
@@ -51,6 +59,10 @@ export default class DemonSpikes extends MajorDefensiveBuff {
 
   get wastedUptimeInMilliseconds() {
     return this.maximumUptimeInMilliseconds - this.uptimeInMilliseconds;
+  }
+
+  override get mitigations() {
+    return super.mitigations.flatMap((mit) => this.splitMitigationByCast(mit));
   }
 
   description(): ReactNode {
@@ -90,7 +102,78 @@ export default class DemonSpikes extends MajorDefensiveBuff {
     }
   }
 
-  private onDemonSpikesCast() {
+  override mitigationPerformance(maxValue: number): BoxRowEntry[] {
+    return this.mitigations.map((mit) => {
+      const { perf, explanation } = this.explainPerformance(mit);
+      return {
+        value: perf,
+        tooltip: (
+          <>
+            <PerformanceUsageRow>
+              <PerformanceMark perf={perf} /> {explanation ?? 'Good Usage'}
+            </PerformanceUsageRow>
+            <div>
+              <MitigationRowContainer>
+                <strong>Time</strong>
+                <strong>Mit.</strong>
+              </MitigationRowContainer>
+              <MitigationRow
+                mitigation={mit}
+                segments={this.mitigationSegments(mit)}
+                fightStart={this.owner.fight.start_time}
+                maxValue={maxValue}
+                key={mit.start.timestamp}
+              />
+            </div>
+          </>
+        ),
+      };
+    });
+  }
+
+  private splitMitigationByCast(mit: Mitigation) {
+    const castTimestamps = [
+      ...new Set(
+        this.demonSpikesCasts
+          .filter(
+            (event) =>
+              event.timestamp >= mit.start.timestamp - CAST_MATCH_BUFFER_MS &&
+              event.timestamp <= mit.end.timestamp,
+          )
+          .map((event) => event.timestamp)
+          .sort((a, b) => a - b),
+      ),
+    ];
+
+    if (castTimestamps.length <= 1) {
+      return [mit];
+    }
+
+    return castTimestamps.map((castTimestamp, index) => {
+      const startTimestamp = index === 0 ? mit.start.timestamp : castTimestamp;
+      const endTimestamp =
+        index === castTimestamps.length - 1 ? mit.end.timestamp : castTimestamps[index + 1];
+      const mitigated = mit.mitigated.filter(({ event }) =>
+        index === castTimestamps.length - 1
+          ? event.timestamp >= startTimestamp && event.timestamp <= endTimestamp
+          : event.timestamp >= startTimestamp && event.timestamp < endTimestamp,
+      );
+
+      return {
+        ...mit,
+        start:
+          startTimestamp === mit.start.timestamp
+            ? mit.start
+            : { ...mit.start, timestamp: startTimestamp },
+        end: endTimestamp === mit.end.timestamp ? mit.end : { ...mit.end, timestamp: endTimestamp },
+        mitigated,
+        amount: mitigated.reduce((total, event) => total + event.mitigatedAmount, 0),
+      };
+    });
+  }
+
+  private onDemonSpikesCast(event: CastEvent) {
+    this.demonSpikesCasts.push(event);
     this.maximumUptime += this.spikesDurationPerCast;
   }
 }


### PR DESCRIPTION
## Description
- Fixed Demon Spikes usage segmentation in the major defensive breakdown
- Split continuous Demon Spikes mitigation windows by actual cast timestamps
- Added a Vengeance changelog entry
- Added Guminator to the Vengeance contributor list

## Testing
- `pnpm run typecheck`
- Verified Demon Spikes usage bars and cast breakdown now align much better with actual casts in a log where the live analyzer was showing many incorrect red unused boxes

