### PR TITLE
Vdh frailty buffs

### DIFF
--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 19), <>Fix <SpellLink spell={SPELLS.FRAILTY} /> uptime analysis activation and <SpellLink spell={TALENTS.FIERY_DEMISE_TALENT} /> target checks for Midnight behavior.</>, Guminator),
   change(date(2026, 4, 18), <>Fix <SpellLink spell={SPELLS.DEMON_SPIKES} /> usage segmentation in the major defensive breakdown.</>, Guminator),
   change(date(2026, 4, 18), <>Update <SpellLink spell={SPELLS.FRACTURE} />, <SpellLink spell={SPELLS.DEMON_SPIKES} />, <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT} />, and <SpellLink spell={SPELLS.INFERNAL_STRIKE} /> spellbook values for Midnight.</>, Guminator),
   change(date(2026, 4, 12), <>Bump Vengeance to partial support</>, Quaarkz),

--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,7 +7,7 @@ import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
-  change(date(2026, 4, 19), <>Fix <SpellLink spell={SPELLS.FRAILTY} /> uptime analysis activation and <SpellLink spell={TALENTS.FIERY_DEMISE_TALENT} /> target checks for Midnight behavior.</>, Guminator),
+  change(date(2026, 4, 19), <>Fix <SpellLink spell={SPELLS.FRAILTY} /> uptime analysis activation, <SpellLink spell={TALENTS.FIERY_DEMISE_TALENT} /> target checks, and <SpellLink spell={TALENTS.SOUL_BARRIER_TALENT} /> cooldown/statistic display for Midnight behavior.</>, Guminator),
   change(date(2026, 4, 18), <>Fix <SpellLink spell={SPELLS.DEMON_SPIKES} /> usage segmentation in the major defensive breakdown.</>, Guminator),
   change(date(2026, 4, 18), <>Update <SpellLink spell={SPELLS.FRACTURE} />, <SpellLink spell={SPELLS.DEMON_SPIKES} />, <SpellLink spell={TALENTS.SPIRIT_BOMB_TALENT} />, and <SpellLink spell={SPELLS.INFERNAL_STRIKE} /> spellbook values for Midnight.</>, Guminator),
   change(date(2026, 4, 12), <>Bump Vengeance to partial support</>, Quaarkz),

--- a/src/analysis/retail/demonhunter/vengeance/Guide.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/Guide.tsx
@@ -147,10 +147,6 @@ const cooldowns: Cooldown[] = [
     isActive: (c) => c.hasTalent(TALENTS_DEMON_HUNTER.SIGIL_OF_SPITE_TALENT),
   },
   {
-    spell: TALENTS_DEMON_HUNTER.SOUL_BARRIER_TALENT,
-    isActive: (c) => c.hasTalent(TALENTS_DEMON_HUNTER.SOUL_BARRIER_TALENT),
-  },
-  {
     spell: TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT,
     isActive: (c) =>
       c.hasTalent(TALENTS_DEMON_HUNTER.FIERY_BRAND_TALENT) &&

--- a/src/analysis/retail/demonhunter/vengeance/modules/Buffs.ts
+++ b/src/analysis/retail/demonhunter/vengeance/modules/Buffs.ts
@@ -46,7 +46,7 @@ class Buffs extends CoreAuras {
         triggeredBySpellId: SPELLS.SIGIL_OF_FLAME.id,
       },
       {
-        spellId: TALENTS_DEMON_HUNTER.SOUL_BARRIER_TALENT.id,
+        spellId: SPELLS.SOUL_BARRIER_BUFF.id,
         triggeredBySpellId: TALENTS_DEMON_HUNTER.SPIRIT_BOMB_TALENT.id,
         enabled: combatant.hasTalent(TALENTS_DEMON_HUNTER.SOUL_BARRIER_TALENT),
       },

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/FelDevastation.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/FelDevastation.tsx
@@ -150,7 +150,7 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
     if (!enemy) {
       return false;
     }
-    return enemy.hasBuff(SPELLS.FRAILTY.id, event.timestamp);
+    return enemy.hasBuff(SPELLS.FIERY_BRAND_DOT.id, event.timestamp);
   }
 
   private fieryDemisePerformance(cast: FelDevastationCooldownCast): UsageInfo | undefined {

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/FrailtyDebuff.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/FrailtyDebuff.tsx
@@ -20,7 +20,6 @@ class FrailtyDebuff extends Analyzer {
   constructor(options: Options) {
     super(options);
     this.active =
-      this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.SPIRIT_BOMB_TALENT) ||
       this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.FRAILTY_TALENT) ||
       this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.VOID_REAVER_TALENT) ||
       this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.SOULCRUSH_TALENT);

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/SoulBarrier.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/SoulBarrier.tsx
@@ -1,4 +1,5 @@
 import { formatNumber, formatPercentage } from 'common/format';
+import SPELLS from 'common/SPELLS/demonhunter';
 import { TALENTS_DEMON_HUNTER } from 'common/TALENTS/demonhunter';
 import Uptime from 'interface/icons/Uptime';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
@@ -29,23 +30,22 @@ class SoulBarrier extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.SOUL_BARRIER_TALENT);
     this.addEventListener(
-      Events.applybuff.to(SELECTED_PLAYER).spell(TALENTS_DEMON_HUNTER.SOUL_BARRIER_TALENT),
+      Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.SOUL_BARRIER_BUFF),
       this.onApplyBuff,
     );
     this.addEventListener(
-      Events.absorbed.to(SELECTED_PLAYER).spell(TALENTS_DEMON_HUNTER.SOUL_BARRIER_TALENT),
+      Events.absorbed.to(SELECTED_PLAYER).spell(SPELLS.SOUL_BARRIER_BUFF),
       this.onAbsorb,
     );
     this.addEventListener(
-      Events.removebuff.to(SELECTED_PLAYER).spell(TALENTS_DEMON_HUNTER.SOUL_BARRIER_TALENT),
+      Events.removebuff.to(SELECTED_PLAYER).spell(SPELLS.SOUL_BARRIER_BUFF),
       this.onRemoveBuff,
     );
   }
 
   get uptime() {
     return (
-      this.selectedCombatant.getBuffUptime(TALENTS_DEMON_HUNTER.SOUL_BARRIER_TALENT.id) /
-      this.owner.fightDuration
+      this.selectedCombatant.getBuffUptime(SPELLS.SOUL_BARRIER_BUFF.id) / this.owner.fightDuration
     );
   }
 
@@ -71,7 +71,7 @@ class SoulBarrier extends Analyzer {
   }
 
   onRemoveBuff(event: RemoveBuffEvent) {
-    if (event.ability.guid !== TALENTS_DEMON_HUNTER.SOUL_BARRIER_TALENT.id) {
+    if (event.ability.guid !== SPELLS.SOUL_BARRIER_BUFF.id) {
       return;
     }
     this.buffRemoved = event.timestamp;

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/SoulCarver.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/SoulCarver.tsx
@@ -121,7 +121,7 @@ export default class SoulCarver extends MajorCooldown<SoulCarverCooldownCast> {
     if (!enemy) {
       return false;
     }
-    return enemy.hasBuff(SPELLS.FRAILTY.id, event.timestamp);
+    return enemy.hasBuff(SPELLS.FIERY_BRAND_DOT.id, event.timestamp);
   }
 
   private fieryDemisePerformance(cast: SoulCarverCooldownCast): UsageInfo | undefined {

--- a/src/common/SPELLS/demonhunter.ts
+++ b/src/common/SPELLS/demonhunter.ts
@@ -318,6 +318,11 @@ const spells = {
     name: 'Spirit Bomb',
     icon: 'inv_icon_shadowcouncilorb_purple',
   },
+  SOUL_BARRIER_BUFF: {
+    id: 263648,
+    name: 'Soul Barrier',
+    icon: 'spell_shadow_soulleech',
+  },
   COLLECTIVE_ANGUISH_EYE_BEAM: {
     id: 391058,
     name: 'Collective Anguish',


### PR DESCRIPTION
## Description
- Fixed Frailty uptime analysis activation for Midnight talent behavior
- Removed Spirit Bomb talent as a standalone activation condition for the Frailty uptime analyzer
- Fixed Fiery Demise target checks in Fel Devastation and Soul Carver to check for Fiery Brand instead of Frailty
- Removed Soul Barrier from the cooldown graph, since it no longer fits that model after the Midnight redesign
- Fixed Soul Barrier talent analysis to track the actual buff/log spell instead of the talent spell
- Added a Vengeance changelog entry

## Testing
- `pnpm run typecheck`
- Manually reviewed the updated Frailty and Fiery Demise logic against Midnight 12.0.0 talent behavior and patch notes
- Verified locally that Fel Devastation / Fiery Demise evaluation now lines up with Fiery Brand windows rather than Frailty presence
- Verified Soul Barrier no longer appears in the cooldown graph
- Verified Soul Barrier uptime in the talent statistic now matches the logged buff uptime