### PR TITLE
[Demonology] [Warlock] Tyrant analyzer and Guide Update

### DIFF
--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Katorri } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2026, 4, 3), "Overhaul Demonic Tyrant guide with weighted scoring, add Diabolist support, and improved resource/cooldown tracking in Tyrant windows.", Katorri),
   change(date(2026, 3, 20), "Add Demonic Healthstone Tracker, update guide structure, fix timestamp issues on Demonic Tyrant windows.", Katorri),
   change(date(2026, 3, 11), "Fix to show Soul Shard Graph again", Katorri),
   change(date(2026, 3, 7), <>Create <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT}></SpellLink> Analyzer to detail Demonic Tyrant windows.</>, Katorri),

--- a/src/analysis/retail/warlock/demonology/CONFIG.tsx
+++ b/src/analysis/retail/warlock/demonology/CONFIG.tsx
@@ -11,7 +11,7 @@ const config: Config = {
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '12.0.1',
-  supportLevel: SupportLevel.MaintainedPartial,
+  supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -72,7 +72,8 @@ const config: Config = {
     </>
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: "/report/hY6vg1LxqzmR94XG/126-Heroic+Broodtwister+Ovi'nax+-+Kill+(6:24)/Meurthe/",
+  exampleReport:
+    '/report/FHfng1KdRc98Z6VP/27-Mythic+Imperator+Averzian+-+Kill+(6:53)/1-Katorrí/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/warlock/demonology/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/demonology/CombatLogParser.ts
@@ -7,6 +7,7 @@ import CooldownThroughputTracker from './modules/features/CooldownThroughputTrac
 import LegionStrike from './modules/features/LegionStrike';
 import DemoPets from './modules/pets/DemoPets';
 import DemonicTyrant from './modules/features/DemonicTyrant';
+import SummonDoomguard from './modules/features/SummonDoomguard';
 import PetDamageHandler from './modules/pets/DemoPets/PetDamageHandler';
 import PetSummonHandler from './modules/pets/DemoPets/PetSummonHandler';
 import PowerSiphonHandler from './modules/pets/DemoPets/PowerSiphonHandler';
@@ -39,6 +40,7 @@ class CombatLogParser extends CoreCombatLogParser {
     cooldownThroughputTracker: CooldownThroughputTracker,
     legionStrike: LegionStrike,
     DemonicTyrant: DemonicTyrant,
+    summonDoomguard: SummonDoomguard,
 
     // Core
     soulShardTracker: SoulShardTracker,

--- a/src/analysis/retail/warlock/demonology/Guide.tsx
+++ b/src/analysis/retail/warlock/demonology/Guide.tsx
@@ -26,8 +26,12 @@ function CoreSection({ modules }: GuideProps<typeof CombatLogParser>) {
 function CooldownSection({ modules }: GuideProps<typeof CombatLogParser>) {
   return (
     <Section title="Cooldowns">
-      <CooldownSubsection />
-      <DemonicTyrantGuide />
+      <Section title="Cooldown Usage">
+        <CooldownSubsection />
+      </Section>
+      <Section title="Demonic Tyrant">
+        <DemonicTyrantGuide />
+      </Section>
     </Section>
   );
 }

--- a/src/analysis/retail/warlock/demonology/modules/features/Abilities.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/Abilities.ts
@@ -106,13 +106,6 @@ class Abilities extends SharedAbilities {
           base: 1500,
         },
       },
-      // TODO: figure which spell triggers this now
-      // {
-      //   spell: SPELLS.FELSTORM.id,
-      //   category: SPELL_CATEGORY.ROTATIONAL,
-      //   cooldown: 45,
-      //   gcd: null,
-      // },
       {
         spell: SPELLS.IMPLOSION_CAST.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
@@ -172,6 +165,21 @@ class Abilities extends SharedAbilities {
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: 120,
         enabled: combatant.hasTalent(TALENTS.GRIMOIRE_FEL_RAVAGER_TALENT),
+        gcd: {
+          base: 1500,
+        },
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.9,
+          averageIssueEfficiency: 0.8,
+          majorIssueEfficiency: 0.7,
+        },
+      },
+      {
+        spell: TALENTS.SUMMON_DOOMGUARD_TALENT.id,
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 120,
+        enabled: combatant.hasTalent(TALENTS.SUMMON_DOOMGUARD_TALENT),
         gcd: {
           base: 1500,
         },

--- a/src/analysis/retail/warlock/demonology/modules/features/CooldownThroughputTracker.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/CooldownThroughputTracker.ts
@@ -22,6 +22,11 @@ class CooldownThroughputTracker extends CoreCooldownThroughputTracker {
       duration: 20,
       summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
     },
+    {
+      spell: TALENTS.SUMMON_DOOMGUARD_TALENT.id,
+      duration: 12,
+      summary: [BUILT_IN_SUMMARY_TYPES.DAMAGE],
+    },
   ];
 }
 

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -9,6 +9,7 @@ import Events, {
   ApplyBuffStackEvent,
   CastEvent,
   FightEndEvent,
+  RemoveBuffEvent,
   ResourceChangeEvent,
 } from 'parser/core/Events';
 import SoulShardTracker from 'analysis/retail/warlock/shared/resources/SoulShardTracker';
@@ -16,7 +17,7 @@ import SoulShardTracker from 'analysis/retail/warlock/shared/resources/SoulShard
 const DREADSTALKERS_DURATION = 12000;
 const GRIMOIRE_DURATION = 20000;
 const DOOMGUARD_DURATION = 12000;
-export const TYRANT_WINDOW_MS = 25000; //adds 5 seconds to the end to account for Apex window
+export const TYRANT_WINDOW_MS = 25000;
 const DEMONIC_POWER_SPELL_ID = 1276788;
 
 export default class DemonicTyrant extends Analyzer {
@@ -33,8 +34,6 @@ export default class DemonicTyrant extends Analyzer {
   lastDreadstalkersCast = 0;
   lastGrimoireCast = 0;
   lastDoomguardCast = 0;
-  // Last known shard count from SoulShardTracker while inside a Tyrant window.
-  latestShardsInWindow = 0;
   // Tracks gains (in shards) after Tyrant cast to retroactively compute shardsOnCast from the first window spender.
   private gainsBeforeFirstWindowSpend = 0;
   private pendingRetroactiveShardsOnCast = false;
@@ -42,10 +41,23 @@ export default class DemonicTyrant extends Analyzer {
   constructor(options: Options) {
     super(options);
 
+    // Use the Apex talent buff (longer window) if the player has it, otherwise the base Tyrant buff.
+    const hasApex =
+      this.selectedCombatant.hasTalent(TALENTS.DOMINION_OF_ARGUS_1_DEMONOLOGY_TALENT) ||
+      this.selectedCombatant.hasTalent(TALENTS.DOMINION_OF_ARGUS_2_DEMONOLOGY_TALENT) ||
+      this.selectedCombatant.hasTalent(TALENTS.DOMINION_OF_ARGUS_3_DEMONOLOGY_TALENT);
+    const windowBuff = hasApex ? SPELLS.DOMINION_OF_ARGUS_BUFF : SPELLS.SUMMON_DEMONIC_TYRANT;
+
     // Tyrant cast
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.SUMMON_DEMONIC_TYRANT),
       this.onTyrantCast,
+    );
+
+    // Window end via buff removal
+    this.addEventListener(
+      Events.removebuff.to(SELECTED_PLAYER).spell(windowBuff),
+      this.onTyrantEnd,
     );
 
     // Hand of Gul'dan and Ruination (Diabolist) — both count as shard spender casts
@@ -78,9 +90,6 @@ export default class DemonicTyrant extends Analyzer {
 
     // Track shard gains — use to(SELECTED_PLAYER) since energize events target the player, not sourced by them.
     this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.onShardGain);
-
-    // Track shard costs for all player casts during the window
-    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onAnyPlayerCast);
 
     // Finalize last window at fight end
     this.addEventListener(Events.fightend, this.onFightEnd);
@@ -126,9 +135,6 @@ export default class DemonicTyrant extends Analyzer {
           event.timestamp - this.lastDoomguardCast <= DOOMGUARD_DURATION
         : null;
 
-    // Close the previous window before opening a new one.
-    this.tryFinalizeWindow(event.timestamp);
-    this.latestShardsInWindow = this.soulShardTracker.current;
     this.gainsBeforeFirstWindowSpend = 0;
     // Only needed before the first ever spend — after that the tracker has accurate absolute state.
     this.pendingRetroactiveShardsOnCast = this.soulShardTracker.spent === 0;
@@ -156,12 +162,18 @@ export default class DemonicTyrant extends Analyzer {
     this.currentTyrant = tyrant;
   }
 
+  // Called when the tracked window buff (Dominion of Argus or Summon Demonic Tyrant) expires.
+  onTyrantEnd(event: RemoveBuffEvent) {
+    if (!this.currentTyrant) return;
+    if (this.currentTyrant.shardsAtWindowEnd !== null) return;
+
+    this.currentTyrant.shardsAtWindowEnd = Math.round(Math.max(0, this.soulShardTracker.current));
+    this.currentTyrant.actualWindowDurationMs = event.timestamp - this.currentTyrant.cast;
+    this.currentTyrant = null;
+  }
+
   onSpenderCast(event: CastEvent) {
     if (!this.currentTyrant) return;
-
-    this.tryFinalizeWindow(event.timestamp);
-
-    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
 
     // Retroactively set shardsOnCast: first spender's pre-spend amount minus gains since Tyrant cast.
     if (this.pendingRetroactiveShardsOnCast) {
@@ -178,22 +190,11 @@ export default class DemonicTyrant extends Analyzer {
     this.currentTyrant.handOfGuldanCasts += 1;
   }
 
-  // Snapshots the shard count at window end once the window has expired.
-  tryFinalizeWindow(timestamp: number) {
-    if (!this.currentTyrant) return;
-    if (this.currentTyrant.shardsAtWindowEnd !== null) return;
-    if (timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) {
-      this.currentTyrant.shardsAtWindowEnd = Math.round(Math.max(0, this.latestShardsInWindow));
-    }
-  }
-
-  // Closes the active window early and flags it if the fight ends before the window naturally expires.
+  // Closes the active window if the fight ends before the buff naturally expires.
   onFightEnd(event: FightEndEvent) {
     if (!this.currentTyrant) return;
     if (this.currentTyrant.shardsAtWindowEnd === null) {
-      this.currentTyrant.shardsAtWindowEnd = Math.round(Math.max(0, this.latestShardsInWindow));
-    }
-    if (event.timestamp < this.currentTyrant.cast + TYRANT_WINDOW_MS) {
+      this.currentTyrant.shardsAtWindowEnd = Math.round(Math.max(0, this.soulShardTracker.current));
       this.currentTyrant.fightEndedDuringWindow = true;
       this.currentTyrant.actualWindowDurationMs = event.timestamp - this.currentTyrant.cast;
     }
@@ -201,11 +202,7 @@ export default class DemonicTyrant extends Analyzer {
 
   onDreadstalkersCast(event: CastEvent) {
     this.lastDreadstalkersCast = event.timestamp;
-    if (
-      this.currentTyrant &&
-      event.timestamp > this.currentTyrant.cast &&
-      event.timestamp <= this.currentTyrant.cast + TYRANT_WINDOW_MS
-    ) {
+    if (this.currentTyrant) {
       this.currentTyrant.dreadstalkersCastDuringWindow = true;
     }
   }
@@ -213,11 +210,7 @@ export default class DemonicTyrant extends Analyzer {
   // Records last Grimoire cast timestamp and flags if it fell inside the Tyrant window.
   onGrimoireCast(event: CastEvent) {
     this.lastGrimoireCast = event.timestamp;
-    if (
-      this.currentTyrant &&
-      event.timestamp > this.currentTyrant.cast &&
-      event.timestamp <= this.currentTyrant.cast + TYRANT_WINDOW_MS
-    ) {
+    if (this.currentTyrant) {
       this.currentTyrant.grimoireCastDuringWindow = true;
     }
   }
@@ -230,7 +223,6 @@ export default class DemonicTyrant extends Analyzer {
   onShardGain(event: ResourceChangeEvent) {
     if (event.resourceChangeType !== RESOURCE_TYPES.SOUL_SHARDS.id) return;
     if (!this.currentTyrant) return;
-    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
 
     // Accumulate effective gains (÷10 from ×10 log units) until the first window spender.
     if (this.pendingRetroactiveShardsOnCast) {
@@ -239,22 +231,11 @@ export default class DemonicTyrant extends Analyzer {
         this.gainsBeforeFirstWindowSpend += (lastUpdate.change ?? 0) / 10;
       }
     }
-
-    this.latestShardsInWindow = this.soulShardTracker.current;
-  }
-
-  onAnyPlayerCast(event: CastEvent) {
-    if (!this.currentTyrant) return;
-    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
-    this.latestShardsInWindow = this.soulShardTracker.current;
   }
 
   // Tracks the peak Demonic Power stack count reached during the Tyrant window (listens to all sources, not just SELECTED_PLAYER).
   onDemonicPower(event: ApplyBuffEvent | ApplyBuffStackEvent) {
     if (!this.currentTyrant) return;
-
-    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
-
     if (event.ability?.guid !== DEMONIC_POWER_SPELL_ID) return;
 
     let stacks = 1;

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -36,7 +36,11 @@ export default class DemonicTyrant extends Analyzer {
   lastGrimoireCast = 0;
   lastDoomguardCast = 0;
   demonicCoreStacks = 0;
-  shardDeltaInWindow = 0;
+  // Last known shard count from SoulShardTracker while inside a Tyrant window.
+  latestShardsInWindow = 0;
+  // Tracks gains (in shards) after Tyrant cast to retroactively compute shardsOnCast from the first window spender.
+  private gainsBeforeFirstWindowSpend = 0;
+  private pendingRetroactiveShardsOnCast = false;
 
   constructor(options: Options) {
     super(options);
@@ -142,9 +146,12 @@ export default class DemonicTyrant extends Analyzer {
           event.timestamp - this.lastDoomguardCast <= DOOMGUARD_DURATION
         : null;
 
-    // Close the previous window before opening a new one, then reset the shard delta accumulator.
+    // Close the previous window before opening a new one.
     this.tryFinalizeWindow(event.timestamp);
-    this.shardDeltaInWindow = 0;
+    this.latestShardsInWindow = this.soulShardTracker.current;
+    this.gainsBeforeFirstWindowSpend = 0;
+    // Only needed before the first ever spend — after that the tracker has accurate absolute state.
+    this.pendingRetroactiveShardsOnCast = this.soulShardTracker.spent === 0;
 
     const tyrant: TyrantCastData = {
       cast: event.timestamp,
@@ -176,6 +183,18 @@ export default class DemonicTyrant extends Analyzer {
 
     if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
 
+    // Retroactively set shardsOnCast: first spender's pre-spend amount minus gains since Tyrant cast.
+    if (this.pendingRetroactiveShardsOnCast) {
+      const resource = this.soulShardTracker.getResource(event);
+      if (resource !== undefined) {
+        this.currentTyrant.shardsOnCast = Math.max(
+          0,
+          Math.round(resource.amount - this.gainsBeforeFirstWindowSpend),
+        );
+      }
+      this.pendingRetroactiveShardsOnCast = false;
+    }
+
     this.currentTyrant.handOfGuldanCasts += 1;
   }
 
@@ -184,9 +203,7 @@ export default class DemonicTyrant extends Analyzer {
     if (!this.currentTyrant) return;
     if (this.currentTyrant.shardsAtWindowEnd !== null) return;
     if (timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) {
-      this.currentTyrant.shardsAtWindowEnd = Math.round(
-        Math.max(0, this.currentTyrant.shardsOnCast + this.shardDeltaInWindow),
-      );
+      this.currentTyrant.shardsAtWindowEnd = Math.round(Math.max(0, this.latestShardsInWindow));
     }
   }
 
@@ -194,9 +211,7 @@ export default class DemonicTyrant extends Analyzer {
   onFightEnd(event: FightEndEvent) {
     if (!this.currentTyrant) return;
     if (this.currentTyrant.shardsAtWindowEnd === null) {
-      this.currentTyrant.shardsAtWindowEnd = Math.round(
-        Math.max(0, this.currentTyrant.shardsOnCast + this.shardDeltaInWindow),
-      );
+      this.currentTyrant.shardsAtWindowEnd = Math.round(Math.max(0, this.latestShardsInWindow));
     }
     if (event.timestamp < this.currentTyrant.cast + TYRANT_WINDOW_MS) {
       this.currentTyrant.fightEndedDuringWindow = true;
@@ -236,20 +251,22 @@ export default class DemonicTyrant extends Analyzer {
     if (event.resourceChangeType !== RESOURCE_TYPES.SOUL_SHARDS.id) return;
     if (!this.currentTyrant) return;
     if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
-    // ResourceChangeEvent values are in raw units (×10); divide to get real shard counts.
-    this.shardDeltaInWindow += Math.round((event.resourceChange - (event.waste ?? 0)) / 10);
+
+    // Accumulate effective gains (÷10 from ×10 log units) until the first window spender.
+    if (this.pendingRetroactiveShardsOnCast) {
+      const lastUpdate = this.soulShardTracker.resourceUpdates.at(-1);
+      if (lastUpdate?.type === 'gain') {
+        this.gainsBeforeFirstWindowSpend += (lastUpdate.change ?? 0) / 10;
+      }
+    }
+
+    this.latestShardsInWindow = this.soulShardTracker.current;
   }
 
   onAnyPlayerCast(event: CastEvent) {
     if (!this.currentTyrant) return;
     if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
-    const shardResource = event.classResources?.find(
-      (r) => r.type === RESOURCE_TYPES.SOUL_SHARDS.id,
-    );
-    // SoulShardTracker.onCast already normalizes cost by /10 in-place before this fires.
-    if (shardResource?.cost) {
-      this.shardDeltaInWindow -= shardResource.cost;
-    }
+    this.latestShardsInWindow = this.soulShardTracker.current;
   }
 
   onDemonicCoreApply(_event: ApplyBuffEvent) {

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -8,6 +8,7 @@ import Events, {
   ApplyBuffEvent,
   ApplyBuffStackEvent,
   CastEvent,
+  EventType,
   FightEndEvent,
   RemoveBuffEvent,
   ResourceChangeEvent,
@@ -240,8 +241,8 @@ export default class DemonicTyrant extends Analyzer {
 
     let stacks = 1;
 
-    if ('stack' in event) {
-      stacks = (event as ApplyBuffStackEvent).stack ?? 1;
+    if (event.type === EventType.ApplyBuffStack) {
+      stacks = event.stack ?? 1;
     }
 
     if (stacks > this.currentTyrant.maxDemonicPowerStacks) {

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -1,16 +1,42 @@
 import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Analyzer from 'parser/core/Analyzer';
-import Events, { CastEvent, SummonEvent } from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import Events, {
+  ApplyBuffEvent,
+  ApplyBuffStackEvent,
+  CastEvent,
+  FightEndEvent,
+  RemoveBuffEvent,
+  RemoveBuffStackEvent,
+  ResourceChangeEvent,
+} from 'parser/core/Events';
+import SoulShardTracker from 'analysis/retail/warlock/shared/resources/SoulShardTracker';
 
 const DREADSTALKERS_DURATION = 12000;
-const TYRANT_WINDOW_MS = 20000;
+const GRIMOIRE_DURATION = 20000;
+const DOOMGUARD_DURATION = 12000;
+export const TYRANT_WINDOW_MS = 25000; //adds 5 seconds to the end to account for Apex window
+const DEMONIC_POWER_SPELL_ID = 1276788;
 
 export default class DemonicTyrant extends Analyzer {
+  static dependencies = {
+    soulShardTracker: SoulShardTracker,
+    spellUsable: SpellUsable,
+  };
+  protected soulShardTracker!: SoulShardTracker;
+  protected spellUsable!: SpellUsable;
+
   tyrantData: TyrantCastData[] = [];
   currentTyrant: TyrantCastData | null = null;
 
   lastDreadstalkersCast = 0;
+  lastGrimoireCast = 0;
+  lastDoomguardCast = 0;
+  demonicCoreStacks = 0;
+  shardDeltaInWindow = 0;
 
   constructor(options: Options) {
     super(options);
@@ -21,16 +47,10 @@ export default class DemonicTyrant extends Analyzer {
       this.onTyrantCast,
     );
 
-    // Hand of Gul'dan cast
+    // Hand of Gul'dan and Ruination (Diabolist) — both count as shard spender casts
     this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.HAND_OF_GULDAN_CAST),
-      this.onHandOfGuldanCast,
-    );
-
-    // Wild imp summons
-    this.addEventListener(
-      Events.summon.by(SELECTED_PLAYER).spell(SPELLS.WILD_IMP_HOG_SUMMON),
-      this.onImpSummon,
+      Events.cast.by(SELECTED_PLAYER).spell([SPELLS.HAND_OF_GULDAN_CAST, SPELLS.RUINATION_CAST]),
+      this.onSpenderCast,
     );
 
     // Dreadstalkers cast
@@ -38,6 +58,53 @@ export default class DemonicTyrant extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.CALL_DREADSTALKERS),
       this.onDreadstalkersCast,
     );
+
+    // Grimoire: Imp Lord / Fel Ravager cast tracking
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.GRIMOIRE_IMP_LORD_TALENT),
+      this.onGrimoireCast,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.GRIMOIRE_FEL_RAVAGER_TALENT),
+      this.onGrimoireCast,
+    );
+
+    // Doomguard cast tracking
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.SUMMON_DOOMGUARD_TALENT),
+      this.onDoomguardCast,
+    );
+
+    // Demonic Core stack tracking
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
+      this.onDemonicCoreApply,
+    );
+    this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
+      this.onDemonicCoreApplyStack,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
+      this.onDemonicCoreRemove,
+    );
+    this.addEventListener(
+      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
+      this.onDemonicCoreRemoveStack,
+    );
+
+    // Track shard gains — use to(SELECTED_PLAYER) since energize events target the player, not sourced by them.
+    this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.onShardGain);
+
+    // Track shard costs for all player casts during the window
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onAnyPlayerCast);
+
+    // Finalize last window at fight end
+    this.addEventListener(Events.fightend, this.onFightEnd);
+
+    // Demonic Power stack tracking (not filtered to SELECTED_PLAYER — Tyrant is a pet)
+    this.addEventListener(Events.applybuff, this.onDemonicPower);
+    this.addEventListener(Events.applybuffstack, this.onDemonicPower);
   }
 
   onTyrantCast(event: CastEvent) {
@@ -47,49 +114,200 @@ export default class DemonicTyrant extends Analyzer {
     const dreadstalkersTooEarly =
       dreadstalkersActive && timeSinceDreadstalkers > DREADSTALKERS_DURATION / 2;
 
+    const shardsOnCast = this.soulShardTracker.current;
+    const demonicCoresOnCast = this.demonicCoreStacks;
+
+    // Resolve which Grimoire talent the player has and whether it was cast before this Tyrant.
+    const grimoireTalent = this.selectedCombatant.hasTalent(TALENTS.GRIMOIRE_IMP_LORD_TALENT)
+      ? TALENTS.GRIMOIRE_IMP_LORD_TALENT
+      : this.selectedCombatant.hasTalent(TALENTS.GRIMOIRE_FEL_RAVAGER_TALENT)
+        ? TALENTS.GRIMOIRE_FEL_RAVAGER_TALENT
+        : null;
+    const grimoireAvailable = grimoireTalent
+      ? this.spellUsable.isAvailable(grimoireTalent.id)
+      : null;
+    const grimoireCast =
+      grimoireAvailable != null
+        ? this.lastGrimoireCast !== 0 &&
+          event.timestamp - this.lastGrimoireCast <= GRIMOIRE_DURATION
+        : null;
+
+    // Check if Doomguard was cast recently enough to still be active during this Tyrant window.
+    const doomguardAvailable = this.selectedCombatant.hasTalent(TALENTS.SUMMON_DOOMGUARD_TALENT)
+      ? this.spellUsable.isAvailable(TALENTS.SUMMON_DOOMGUARD_TALENT.id)
+      : null;
+    const doomguardCast =
+      doomguardAvailable != null
+        ? this.lastDoomguardCast !== 0 &&
+          event.timestamp - this.lastDoomguardCast <= DOOMGUARD_DURATION
+        : null;
+
+    // Close the previous window before opening a new one, then reset the shard delta accumulator.
+    this.tryFinalizeWindow(event.timestamp);
+    this.shardDeltaInWindow = 0;
+
     const tyrant: TyrantCastData = {
       cast: event.timestamp,
       handOfGuldanCasts: 0,
-      impsSummoned: 0,
+      maxDemonicPowerStacks: 0,
       dreadstalkersActive,
       dreadstalkersTooEarly,
+      shardsOnCast,
+      demonicCoresOnCast,
+      grimoireAvailable,
+      grimoireCast,
+      doomguardAvailable,
+      doomguardCast,
+      shardsAtWindowEnd: null,
+      fightEndedDuringWindow: false,
+      actualWindowDurationMs: TYRANT_WINDOW_MS,
+      dreadstalkersCastDuringWindow: false,
+      grimoireCastDuringWindow: false,
     };
 
     this.tyrantData.push(tyrant);
     this.currentTyrant = tyrant;
   }
 
-  onHandOfGuldanCast(event: CastEvent) {
+  onSpenderCast(event: CastEvent) {
     if (!this.currentTyrant) return;
 
-    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) {
-      this.currentTyrant = null;
-      return;
-    }
+    this.tryFinalizeWindow(event.timestamp);
+
+    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
 
     this.currentTyrant.handOfGuldanCasts += 1;
   }
 
-  onImpSummon(event: SummonEvent) {
+  // Snapshots the shard count at window end once the window has expired.
+  tryFinalizeWindow(timestamp: number) {
     if (!this.currentTyrant) return;
-
-    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) {
-      this.currentTyrant = null;
-      return;
+    if (this.currentTyrant.shardsAtWindowEnd !== null) return;
+    if (timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) {
+      this.currentTyrant.shardsAtWindowEnd = Math.round(
+        Math.max(0, this.currentTyrant.shardsOnCast + this.shardDeltaInWindow),
+      );
     }
+  }
 
-    this.currentTyrant.impsSummoned += 1;
+  // Closes the active window early and flags it if the fight ends before the window naturally expires.
+  onFightEnd(event: FightEndEvent) {
+    if (!this.currentTyrant) return;
+    if (this.currentTyrant.shardsAtWindowEnd === null) {
+      this.currentTyrant.shardsAtWindowEnd = Math.round(
+        Math.max(0, this.currentTyrant.shardsOnCast + this.shardDeltaInWindow),
+      );
+    }
+    if (event.timestamp < this.currentTyrant.cast + TYRANT_WINDOW_MS) {
+      this.currentTyrant.fightEndedDuringWindow = true;
+      this.currentTyrant.actualWindowDurationMs = event.timestamp - this.currentTyrant.cast;
+    }
   }
 
   onDreadstalkersCast(event: CastEvent) {
     this.lastDreadstalkersCast = event.timestamp;
+    if (
+      this.currentTyrant &&
+      event.timestamp > this.currentTyrant.cast &&
+      event.timestamp <= this.currentTyrant.cast + TYRANT_WINDOW_MS
+    ) {
+      this.currentTyrant.dreadstalkersCastDuringWindow = true;
+    }
+  }
+
+  // Records last Grimoire cast timestamp and flags if it fell inside the Tyrant window.
+  onGrimoireCast(event: CastEvent) {
+    this.lastGrimoireCast = event.timestamp;
+    if (
+      this.currentTyrant &&
+      event.timestamp > this.currentTyrant.cast &&
+      event.timestamp <= this.currentTyrant.cast + TYRANT_WINDOW_MS
+    ) {
+      this.currentTyrant.grimoireCastDuringWindow = true;
+    }
+  }
+
+  // Records last Doomguard cast timestamp for pre-Tyrant alignment checks.
+  onDoomguardCast(event: CastEvent) {
+    this.lastDoomguardCast = event.timestamp;
+  }
+
+  onShardGain(event: ResourceChangeEvent) {
+    if (event.resourceChangeType !== RESOURCE_TYPES.SOUL_SHARDS.id) return;
+    if (!this.currentTyrant) return;
+    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
+    // ResourceChangeEvent values are in raw units (×10); divide to get real shard counts.
+    this.shardDeltaInWindow += Math.round((event.resourceChange - (event.waste ?? 0)) / 10);
+  }
+
+  onAnyPlayerCast(event: CastEvent) {
+    if (!this.currentTyrant) return;
+    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
+    const shardResource = event.classResources?.find(
+      (r) => r.type === RESOURCE_TYPES.SOUL_SHARDS.id,
+    );
+    // SoulShardTracker.onCast already normalizes cost by /10 in-place before this fires.
+    if (shardResource?.cost) {
+      this.shardDeltaInWindow -= shardResource.cost;
+    }
+  }
+
+  onDemonicCoreApply(_event: ApplyBuffEvent) {
+    this.demonicCoreStacks = 1;
+  }
+
+  onDemonicCoreApplyStack(event: ApplyBuffStackEvent) {
+    this.demonicCoreStacks = event.stack;
+  }
+
+  onDemonicCoreRemove(_event: RemoveBuffEvent) {
+    this.demonicCoreStacks = 0;
+  }
+
+  onDemonicCoreRemoveStack(event: RemoveBuffStackEvent) {
+    this.demonicCoreStacks = event.stack;
+  }
+
+  // Tracks the peak Demonic Power stack count reached during the Tyrant window (listens to all sources, not just SELECTED_PLAYER).
+  onDemonicPower(event: ApplyBuffEvent | ApplyBuffStackEvent) {
+    if (!this.currentTyrant) return;
+
+    if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
+
+    if (event.ability?.guid !== DEMONIC_POWER_SPELL_ID) return;
+
+    let stacks = 1;
+
+    if ('stack' in event) {
+      stacks = (event as ApplyBuffStackEvent).stack ?? 1;
+    }
+
+    if (stacks > this.currentTyrant.maxDemonicPowerStacks) {
+      this.currentTyrant.maxDemonicPowerStacks = stacks;
+    }
   }
 }
 
 export interface TyrantCastData {
   cast: number;
   handOfGuldanCasts: number;
-  impsSummoned: number;
+  maxDemonicPowerStacks: number;
   dreadstalkersActive: boolean;
   dreadstalkersTooEarly: boolean;
+  shardsOnCast: number;
+  demonicCoresOnCast: number;
+  /** null if neither Grimoire: Imp Lord nor Grimoire: Fel Ravager is talented */
+  grimoireAvailable: boolean | null;
+  /** null if neither Grimoire: Imp Lord nor Grimoire: Fel Ravager is talented */
+  grimoireCast: boolean | null;
+  /** null if not talented */
+  doomguardAvailable: boolean | null;
+  /** null if not talented */
+  doomguardCast: boolean | null;
+  shardsAtWindowEnd: number | null;
+  fightEndedDuringWindow: boolean;
+  /** Actual window duration in ms — shorter than TYRANT_WINDOW_MS if the fight ended early */
+  actualWindowDurationMs: number;
+  dreadstalkersCastDuringWindow: boolean;
+  grimoireCastDuringWindow: boolean;
 }

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -240,8 +240,8 @@ export default class DemonicTyrant extends Analyzer {
 
     let stacks = 1;
 
-    if ('stack' in event) {
-      stacks = (event as ApplyBuffStackEvent).stack ?? 1;
+    if (event.type === EventType.ApplyBuffStack) {
+      stacks = event.stack ?? 1;
     }
 
     if (stacks > this.currentTyrant.maxDemonicPowerStacks) {

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonicTyrant.ts
@@ -9,8 +9,6 @@ import Events, {
   ApplyBuffStackEvent,
   CastEvent,
   FightEndEvent,
-  RemoveBuffEvent,
-  RemoveBuffStackEvent,
   ResourceChangeEvent,
 } from 'parser/core/Events';
 import SoulShardTracker from 'analysis/retail/warlock/shared/resources/SoulShardTracker';
@@ -35,7 +33,6 @@ export default class DemonicTyrant extends Analyzer {
   lastDreadstalkersCast = 0;
   lastGrimoireCast = 0;
   lastDoomguardCast = 0;
-  demonicCoreStacks = 0;
   // Last known shard count from SoulShardTracker while inside a Tyrant window.
   latestShardsInWindow = 0;
   // Tracks gains (in shards) after Tyrant cast to retroactively compute shardsOnCast from the first window spender.
@@ -79,24 +76,6 @@ export default class DemonicTyrant extends Analyzer {
       this.onDoomguardCast,
     );
 
-    // Demonic Core stack tracking
-    this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
-      this.onDemonicCoreApply,
-    );
-    this.addEventListener(
-      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
-      this.onDemonicCoreApplyStack,
-    );
-    this.addEventListener(
-      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
-      this.onDemonicCoreRemove,
-    );
-    this.addEventListener(
-      Events.removebuffstack.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
-      this.onDemonicCoreRemoveStack,
-    );
-
     // Track shard gains — use to(SELECTED_PLAYER) since energize events target the player, not sourced by them.
     this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.onShardGain);
 
@@ -119,7 +98,8 @@ export default class DemonicTyrant extends Analyzer {
       dreadstalkersActive && timeSinceDreadstalkers > DREADSTALKERS_DURATION / 2;
 
     const shardsOnCast = this.soulShardTracker.current;
-    const demonicCoresOnCast = this.demonicCoreStacks;
+    const demonicCoresOnCast =
+      this.selectedCombatant.getBuff(SPELLS.DEMONIC_CORE_BUFF.id)?.stacks ?? 0;
 
     // Resolve which Grimoire talent the player has and whether it was cast before this Tyrant.
     const grimoireTalent = this.selectedCombatant.hasTalent(TALENTS.GRIMOIRE_IMP_LORD_TALENT)
@@ -267,22 +247,6 @@ export default class DemonicTyrant extends Analyzer {
     if (!this.currentTyrant) return;
     if (event.timestamp > this.currentTyrant.cast + TYRANT_WINDOW_MS) return;
     this.latestShardsInWindow = this.soulShardTracker.current;
-  }
-
-  onDemonicCoreApply(_event: ApplyBuffEvent) {
-    this.demonicCoreStacks = 1;
-  }
-
-  onDemonicCoreApplyStack(event: ApplyBuffStackEvent) {
-    this.demonicCoreStacks = event.stack;
-  }
-
-  onDemonicCoreRemove(_event: RemoveBuffEvent) {
-    this.demonicCoreStacks = 0;
-  }
-
-  onDemonicCoreRemoveStack(event: RemoveBuffStackEvent) {
-    this.demonicCoreStacks = event.stack;
   }
 
   // Tracks the peak Demonic Power stack count reached during the Tyrant window (listens to all sources, not just SELECTED_PLAYER).

--- a/src/analysis/retail/warlock/demonology/modules/features/SummonDoomguard.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/SummonDoomguard.ts
@@ -1,10 +1,5 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, {
-  ApplyBuffEvent,
-  ApplyBuffStackEvent,
-  CastEvent,
-  RemoveBuffEvent,
-} from 'parser/core/Events';
+import Events, { CastEvent } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
@@ -18,8 +13,6 @@ class SummonDoomguard extends Analyzer.withDependencies({
   effectiveCdrMs = 0;
   wastedCdrMs = 0;
 
-  currentDemonicCoreStacks = 0;
-
   constructor(options: Options) {
     super(options);
 
@@ -29,39 +22,13 @@ class SummonDoomguard extends Analyzer.withDependencies({
     }
 
     this.addEventListener(
-      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
-      this.onCoreApply,
-    );
-    this.addEventListener(
-      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
-      this.onCoreStack,
-    );
-    this.addEventListener(
-      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
-      this.onCoreRemove,
-    );
-    this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(SPELLS.DEMONBOLT),
       this.onDemonboltCast,
     );
   }
 
-  onCoreApply(_event: ApplyBuffEvent) {
-    this.currentDemonicCoreStacks = 1;
-  }
-
-  onCoreStack(event: ApplyBuffStackEvent) {
-    this.currentDemonicCoreStacks = event.stack;
-  }
-
-  onCoreRemove(_event: RemoveBuffEvent) {
-    this.currentDemonicCoreStacks = 0;
-  }
-
   onDemonboltCast(_event: CastEvent) {
-    if (this.currentDemonicCoreStacks <= 0) return;
-
-    this.currentDemonicCoreStacks -= 1;
+    if (!this.selectedCombatant.getBuff(SPELLS.DEMONIC_CORE_BUFF.id)) return;
 
     const actualReduction = this.deps.spellUsable.reduceCooldown(
       TALENTS.SUMMON_DOOMGUARD_TALENT.id,

--- a/src/analysis/retail/warlock/demonology/modules/features/SummonDoomguard.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/SummonDoomguard.ts
@@ -1,0 +1,76 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  ApplyBuffEvent,
+  ApplyBuffStackEvent,
+  CastEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
+
+// Each Demonic Core consumed by Demonbolt reduces Summon Doomguard's cooldown by 3 seconds
+const CDR_PER_CORE_MS = 3000;
+
+class SummonDoomguard extends Analyzer.withDependencies({
+  spellUsable: SpellUsable,
+}) {
+  effectiveCdrMs = 0;
+  wastedCdrMs = 0;
+
+  currentDemonicCoreStacks = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS.SUMMON_DOOMGUARD_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
+      this.onCoreApply,
+    );
+    this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
+      this.onCoreStack,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.DEMONIC_CORE_BUFF),
+      this.onCoreRemove,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.DEMONBOLT),
+      this.onDemonboltCast,
+    );
+  }
+
+  onCoreApply(_event: ApplyBuffEvent) {
+    this.currentDemonicCoreStacks = 1;
+  }
+
+  onCoreStack(event: ApplyBuffStackEvent) {
+    this.currentDemonicCoreStacks = event.stack;
+  }
+
+  onCoreRemove(_event: RemoveBuffEvent) {
+    this.currentDemonicCoreStacks = 0;
+  }
+
+  onDemonboltCast(_event: CastEvent) {
+    if (this.currentDemonicCoreStacks <= 0) return;
+
+    this.currentDemonicCoreStacks -= 1;
+
+    const actualReduction = this.deps.spellUsable.reduceCooldown(
+      TALENTS.SUMMON_DOOMGUARD_TALENT.id,
+      CDR_PER_CORE_MS,
+    );
+
+    this.effectiveCdrMs += actualReduction;
+    this.wastedCdrMs += CDR_PER_CORE_MS - actualReduction;
+  }
+}
+
+export default SummonDoomguard;

--- a/src/analysis/retail/warlock/demonology/modules/guide/CooldownsSubsection.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/CooldownsSubsection.tsx
@@ -29,6 +29,10 @@ const cooldowns: Cooldown[] = [
     spell: TALENTS.GRIMOIRE_FEL_RAVAGER_TALENT,
     isActive: (c) => c.hasTalent(TALENTS.GRIMOIRE_FEL_RAVAGER_TALENT),
   },
+  {
+    spell: TALENTS.SUMMON_DOOMGUARD_TALENT,
+    isActive: (c) => c.hasTalent(TALENTS.SUMMON_DOOMGUARD_TALENT),
+  },
 ];
 
 function CooldownSubsection() {

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -446,52 +446,52 @@ function DemonicTyrantGuide(): JSX.Element | null {
           scoreBreakdown.maxExpectedCasts,
         ),
         // Splits casts into in-window and post-window groups, ghosting post-window entries.
-        additionalContent: sequenceEntry
-          ? (() => {
-              const tyrantWindowEnd = cast.cast + TYRANT_WINDOW_MS;
-              const inWindowCasts = sequenceEntry.casts.filter(
-                (c) => c.timestamp <= tyrantWindowEnd,
-              );
-              const postWindowCasts = sequenceEntry.casts
-                .filter((c) => c.timestamp > tyrantWindowEnd)
-                .map((c) => ({
-                  ...c,
-                  ghosted: true as const,
-                  tooltip: (
-                    <div>
-                      <strong>{c.spellName}</strong>
-                      <p>
-                        <em>Cast after the Tyrant window ended</em>
-                      </p>
-                    </div>
-                  ),
-                }));
-              return {
-                title: 'Cast Sequence',
-                content: (
-                  <>
-                    <SpellSequence casts={inWindowCasts} iconSize={40} />
-                    {postWindowCasts.length > 0 && (
-                      <>
-                        <div
-                          style={{
-                            fontSize: '1.1rem',
-                            color: 'rgba(255, 255, 255, 0.4)',
-                            marginTop: 4,
-                            marginBottom: 2,
-                            fontStyle: 'italic',
-                          }}
-                        >
-                          cast after the tyrant window ended
-                        </div>
-                        <SpellSequence casts={postWindowCasts} iconSize={40} />
-                      </>
-                    )}
-                  </>
+        additionalContent: (() => {
+          let additionalContent = undefined;
+          if (sequenceEntry) {
+            const tyrantWindowEnd = cast.cast + TYRANT_WINDOW_MS;
+            const inWindowCasts = sequenceEntry.casts.filter((c) => c.timestamp <= tyrantWindowEnd);
+            const postWindowCasts = sequenceEntry.casts
+              .filter((c) => c.timestamp > tyrantWindowEnd)
+              .map((c) => ({
+                ...c,
+                ghosted: true as const,
+                tooltip: (
+                  <div>
+                    <strong>{c.spellName}</strong>
+                    <p>
+                      <em>Cast after the Tyrant window ended</em>
+                    </p>
+                  </div>
                 ),
-              };
-            })()
-          : undefined,
+              }));
+            additionalContent = {
+              title: 'Cast Sequence',
+              content: (
+                <>
+                  <SpellSequence casts={inWindowCasts} iconSize={40} />
+                  {postWindowCasts.length > 0 && (
+                    <>
+                      <div
+                        style={{
+                          fontSize: '1.1rem',
+                          color: 'rgba(255, 255, 255, 0.4)',
+                          marginTop: 4,
+                          marginBottom: 2,
+                          fontStyle: 'italic',
+                        }}
+                      >
+                        cast after the tyrant window ended
+                      </div>
+                      <SpellSequence casts={postWindowCasts} iconSize={40} />
+                    </>
+                  )}
+                </>
+              ),
+            };
+          }
+          return additionalContent;
+        })(),
       };
     });
   }, [demonicTyrant, eventHistory, tyrantSequenceEvents, isDialobist, hasPowerSiphon]);

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -353,6 +353,50 @@ function DemonicTyrantGuide(): JSX.Element | null {
         scoreBreakdown.totalSpenderCasts,
         scoreBreakdown.maxExpectedCasts,
       );
+      let additionalContent;
+      if (sequenceEntry) {
+        const tyrantWindowEnd = cast.cast + TYRANT_WINDOW_MS;
+        const inWindowCasts = sequenceEntry.casts.filter((c) => c.timestamp <= tyrantWindowEnd);
+        const postWindowCasts = sequenceEntry.casts
+          .filter((c) => c.timestamp > tyrantWindowEnd)
+          .map((c) => ({
+            ...c,
+            ghosted: true as const,
+            tooltip: (
+              <div>
+                <strong>{c.spellName}</strong>
+                <p>
+                  <em>Cast after the Tyrant window ended</em>
+                </p>
+              </div>
+            ),
+          }));
+        additionalContent = {
+          title: 'Cast Sequence',
+          content: (
+            <>
+              <SpellSequence casts={inWindowCasts} iconSize={40} />
+              {postWindowCasts.length > 0 && (
+                <>
+                  <div
+                    style={{
+                      fontSize: '1.1rem',
+                      color: 'rgba(255, 255, 255, 0.4)',
+                      marginTop: 4,
+                      marginBottom: 2,
+                      fontStyle: 'italic',
+                    }}
+                  >
+                    cast after the tyrant window ended
+                  </div>
+                  <SpellSequence casts={postWindowCasts} iconSize={40} />
+                </>
+              )}
+            </>
+          ),
+        };
+      }
+
       return {
         performance: perf,
         timestamp: `${formatTimestampMs(cast.cast - fightStart)} – ${formatTimestampMs(cast.cast + cast.actualWindowDurationMs - fightStart)}`,
@@ -435,53 +479,7 @@ function DemonicTyrantGuide(): JSX.Element | null {
           perf,
           scoreBreakdown.maxExpectedCasts,
         ),
-        // Splits casts into in-window and post-window groups, ghosting post-window entries.
-        additionalContent: (() => {
-          let additionalContent = undefined;
-          if (sequenceEntry) {
-            const tyrantWindowEnd = cast.cast + TYRANT_WINDOW_MS;
-            const inWindowCasts = sequenceEntry.casts.filter((c) => c.timestamp <= tyrantWindowEnd);
-            const postWindowCasts = sequenceEntry.casts
-              .filter((c) => c.timestamp > tyrantWindowEnd)
-              .map((c) => ({
-                ...c,
-                ghosted: true as const,
-                tooltip: (
-                  <div>
-                    <strong>{c.spellName}</strong>
-                    <p>
-                      <em>Cast after the Tyrant window ended</em>
-                    </p>
-                  </div>
-                ),
-              }));
-            additionalContent = {
-              title: 'Cast Sequence',
-              content: (
-                <>
-                  <SpellSequence casts={inWindowCasts} iconSize={40} />
-                  {postWindowCasts.length > 0 && (
-                    <>
-                      <div
-                        style={{
-                          fontSize: '1.1rem',
-                          color: 'rgba(255, 255, 255, 0.4)',
-                          marginTop: 4,
-                          marginBottom: 2,
-                          fontStyle: 'italic',
-                        }}
-                      >
-                        cast after the tyrant window ended
-                      </div>
-                      <SpellSequence casts={postWindowCasts} iconSize={40} />
-                    </>
-                  )}
-                </>
-              ),
-            };
-          }
-          return additionalContent;
-        })(),
+        additionalContent,
       };
     });
   }, [demonicTyrant, eventHistory, tyrantSequenceEvents, isDialobist, hasPowerSiphon]);

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -41,106 +41,91 @@ function scoreTyrantWindow(cast: TyrantCastData, isDialobist: boolean): ScoreBre
   const maxExpectedCasts = cast.fightEndedDuringWindow
     ? Math.max(1, Math.round(8 * windowFraction))
     : 8;
-  const dreadstalkerScore = cast.dreadstalkersActive
-    ? cast.dreadstalkersTooEarly
-      ? 11 // active but summoned in the first half of their duration (too early)
-      : 15 // active and timed well
-    : cast.dreadstalkersCastDuringWindow
-      ? 7 // cast inside the window (wastes a GCD)
-      : 0; // not active at all
+
+  let dreadstalkerScore: number;
+  if (cast.dreadstalkersActive) {
+    dreadstalkerScore = cast.dreadstalkersTooEarly ? 11 : 15;
+  } else if (cast.dreadstalkersCastDuringWindow) {
+    dreadstalkerScore = 7; // cast inside the window wastes a GCD
+  } else {
+    dreadstalkerScore = 0;
+  }
+
   // If the fight ended early, leftover shards aren't the player's fault — full points.
   const missedCasts =
     cast.fightEndedDuringWindow || cast.shardsAtWindowEnd === null
       ? 0
       : Math.floor(cast.shardsAtWindowEnd / 3);
-  const shardsEndScore = missedCasts === 0 ? 15 : missedCasts === 1 ? 8 : missedCasts === 2 ? 3 : 0; // penalizes leftover shards that could have been spender casts
+  let shardsEndScore: number;
+  if (missedCasts === 0) shardsEndScore = 15;
+  else if (missedCasts === 1) shardsEndScore = 8;
+  else if (missedCasts === 2) shardsEndScore = 3;
+  else shardsEndScore = 0;
+
   // If grimoire was on CD when Tyrant was cast but used during the window, it came off CD naturally — full points.
   const grimoireCameOffCdDuringWindow = cast.grimoireCastDuringWindow && !cast.grimoireAvailable;
-  const grimoireScore =
-    cast.grimoireAvailable === null
-      ? null // not talented — excluded from scoring
-      : cast.grimoireAvailable && !cast.grimoireCast && !cast.grimoireCastDuringWindow
-        ? 0 // available but never cast
-        : cast.grimoireCastDuringWindow && !grimoireCameOffCdDuringWindow
-          ? 2 // was available before Tyrant but cast during window instead (wastes a GCD)
-          : 5; // cast before the window, or came off CD during the window (both ideal)
-  const doomguardScore =
-    cast.doomguardAvailable === null
-      ? null // not talented — excluded from scoring
-      : cast.doomguardAvailable && !cast.doomguardCast
-        ? 0 // available but skipped
-        : 5;
+  let grimoireScore: number | null;
+  if (cast.grimoireAvailable === null) {
+    grimoireScore = null; // not talented — excluded from scoring
+  } else if (cast.grimoireAvailable && !cast.grimoireCast && !cast.grimoireCastDuringWindow) {
+    grimoireScore = 0; // available but never cast
+  } else if (cast.grimoireCastDuringWindow && !grimoireCameOffCdDuringWindow) {
+    grimoireScore = 2; // was available before Tyrant but cast during window instead (wastes a GCD)
+  } else {
+    grimoireScore = 5; // cast before the window, or came off CD during the window (both ideal)
+  }
+
+  let doomguardScore: number | null;
+  if (cast.doomguardAvailable === null) {
+    doomguardScore = null; // not talented — excluded from scoring
+  } else if (cast.doomguardAvailable && !cast.doomguardCast) {
+    doomguardScore = 0; // available but skipped
+  } else {
+    doomguardScore = 5;
+  }
+
   // Diabolist: 1 point per shard, capped at 5.
-  // Non-Diabolist: Tyrant grants 3 shards on cast, so 2 is ideal. 0–1 is ok/good, 3 is ok, 4 is poor, 5 is bad.
-  const shardsOnCastScore = isDialobist
-    ? Math.min(cast.shardsOnCast, 5)
-    : cast.shardsOnCast === 2
-      ? 5
-      : cast.shardsOnCast <= 1
-        ? 4
-        : cast.shardsOnCast === 3
-          ? 3
-          : cast.shardsOnCast === 4
-            ? 1
-            : 0; // 5 shards
+  // Non-Diabolist: Tyrant grants 3 shards on cast, so 2 is ideal — each shard above 2 is wasted (overcaps on cast), costing 2 points.
+  let shardsOnCastScore: number;
+  if (isDialobist) {
+    shardsOnCastScore = Math.min(cast.shardsOnCast, 5);
+  } else {
+    const wastedShards = Math.max(0, cast.shardsOnCast - 2);
+    shardsOnCastScore = Math.max(0, 5 - wastedShards * 2);
+  }
 
-  // Optional talents take a fixed 5pts each; shardsOnCast is also fixed at 5 (raw score is already 0–5).
-  // The remaining pool is split proportionally among hog, dreadstalkers, and shardsEnd.
-  const grimoireMax = grimoireScore !== null ? 5 : 0;
-  const doomguardMax = doomguardScore !== null ? 5 : 0;
-  const shardsOnCastMax = 5;
-  const basePool = 100 - grimoireMax - doomguardMax - shardsOnCastMax;
+  // Fixed weights per component. Each raw score is already in range 0..weight, so raw scores
+  // are used directly as contributions. Absent talents are excluded and the sum normalizes to 100.
+  const grimoireWeight = grimoireScore !== null ? 5 : 0;
+  const doomguardWeight = doomguardScore !== null ? 5 : 0;
+  const totalWeight = 50 + 15 + 15 + grimoireWeight + doomguardWeight + 5;
 
-  // Raw relative weights for the three proportionally-scaled base components.
-  const BASE_WEIGHTS = { hog: 50, dreadstalkers: 15, shardsEnd: 15 };
-  const BASE_WEIGHT_TOTAL = Object.values(BASE_WEIGHTS).reduce((a, b) => a + b, 0);
-  const w = (weight: number) => Math.round((weight / BASE_WEIGHT_TOTAL) * basePool);
+  const hogRatio = Math.min(totalSpenderCasts, maxExpectedCasts) / maxExpectedCasts;
+  const rawScore =
+    hogRatio * 50 +
+    dreadstalkerScore +
+    shardsEndScore +
+    (grimoireScore ?? 0) +
+    (doomguardScore ?? 0) +
+    shardsOnCastScore;
+  const total = Math.round((rawScore / totalWeight) * 100);
 
-  const hogMax = w(BASE_WEIGHTS.hog);
-  const dreadstalkerMax = w(BASE_WEIGHTS.dreadstalkers);
-  const shardsEndMax = w(BASE_WEIGHTS.shardsEnd);
-
-  const scaledHog = Math.round(
-    (Math.min(totalSpenderCasts, maxExpectedCasts) / maxExpectedCasts) * hogMax,
-  );
-  const scaledDreadstalker = Math.round((dreadstalkerScore / 15) * dreadstalkerMax);
-  const scaledShardsEnd = Math.round((shardsEndScore / 15) * shardsEndMax);
-  const scaledGrimoire = grimoireScore !== null ? Math.round((grimoireScore / 5) * grimoireMax) : 0;
-  const scaledDoomguard =
-    doomguardScore !== null ? Math.round((doomguardScore / 5) * doomguardMax) : 0;
-  const scaledShardsOnCast = shardsOnCastScore; // raw score is already 0–5, max is fixed at 5
+  const spenderLabel = isDialobist
+    ? `HoG / Ruination casts (${totalSpenderCasts} / ${maxExpectedCasts})`
+    : `Hand of Gul'dan casts (${totalSpenderCasts} / ${maxExpectedCasts})`;
 
   const components: ScoreBreakdown['components'] = [
-    {
-      label: isDialobist
-        ? `HoG / Ruination casts (${totalSpenderCasts} / ${maxExpectedCasts})`
-        : `Hand of Gul'dan casts (${totalSpenderCasts} / ${maxExpectedCasts})`,
-      score: scaledHog,
-      max: hogMax,
-    },
-    { label: 'Dreadstalkers timing', score: scaledDreadstalker, max: dreadstalkerMax },
-    { label: 'Shards at window end', score: scaledShardsEnd, max: shardsEndMax },
+    { label: spenderLabel, score: Math.round(hogRatio * 50), max: 50 },
+    { label: 'Dreadstalkers timing', score: dreadstalkerScore, max: 15 },
+    { label: 'Shards at window end', score: shardsEndScore, max: 15 },
   ];
   if (grimoireScore !== null) {
-    components.push({ label: 'Grimoire cast', score: scaledGrimoire, max: grimoireMax });
+    components.push({ label: 'Grimoire cast', score: grimoireScore, max: 5 });
   }
   if (doomguardScore !== null) {
-    components.push({ label: 'Doomguard cast', score: scaledDoomguard, max: doomguardMax });
+    components.push({ label: 'Doomguard cast', score: doomguardScore, max: 5 });
   }
-  components.push({
-    label: 'Soul Shards at cast',
-    score: scaledShardsOnCast,
-    max: shardsOnCastMax,
-  });
-
-  const rawScore =
-    scaledHog +
-    scaledDreadstalker +
-    scaledShardsEnd +
-    scaledGrimoire +
-    scaledDoomguard +
-    scaledShardsOnCast;
-  const total = Math.min(100, rawScore);
+  components.push({ label: 'Soul Shards at cast', score: shardsOnCastScore, max: 5 });
 
   return { total, totalSpenderCasts, maxExpectedCasts, components };
 }
@@ -433,6 +418,11 @@ function DemonicTyrantGuide(): JSX.Element | null {
                     </span>
                   </div>
                 ))}
+                {(cast.grimoireAvailable === null || cast.doomguardAvailable === null) && (
+                  <div style={{ marginTop: 6, opacity: 0.6, fontStyle: 'italic' }}>
+                    Untalented cooldowns excluded; total normalized to 100.
+                  </div>
+                )}
               </div>
             ),
           },

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -12,17 +12,153 @@ import {
   type CastSequenceEntry,
   type CastInSequence,
 } from 'interface/guide/components/CastSequence';
-import DemonicTyrant, { TyrantCastData } from '../features/DemonicTyrant';
+import DemonicTyrant, { TyrantCastData, TYRANT_WINDOW_MS } from '../features/DemonicTyrant';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import { useAnalyzer } from 'interface/guide';
+import { useAnalyzer, useInfo } from 'interface/guide';
 
 const TYRANT_PRE_WINDOW = 7000;
-const TYRANT_POST_WINDOW = 20000;
+const TYRANT_POST_BUFFER = 3000;
 
-function rateTyrantWindow(handOfGuldanCasts: number): QualitativePerformance {
-  if (handOfGuldanCasts >= 6) return QualitativePerformance.Perfect;
-  if (handOfGuldanCasts === 5) return QualitativePerformance.Good;
-  if (handOfGuldanCasts >= 3) return QualitativePerformance.Ok;
+interface ScoreBreakdown {
+  total: number;
+  totalSpenderCasts: number;
+  maxExpectedCasts: number;
+  components: {
+    label: string;
+    score: number;
+    max: number;
+    displayScore?: number;
+    displayMax?: number;
+  }[];
+}
+
+// Computes a weighted 0–100 score for a single Tyrant window across spender casts, cooldown usage, and resource management.
+function scoreTyrantWindow(cast: TyrantCastData, isDialobist: boolean): ScoreBreakdown {
+  const totalSpenderCasts = cast.handOfGuldanCasts;
+
+  // Pro-rate the max HoG cast expectation based on how much of the window actually occurred.
+  const windowFraction = cast.actualWindowDurationMs / TYRANT_WINDOW_MS;
+  const maxExpectedCasts = cast.fightEndedDuringWindow
+    ? Math.max(1, Math.round(8 * windowFraction))
+    : 8;
+  const dreadstalkerScore = cast.dreadstalkersActive
+    ? cast.dreadstalkersTooEarly
+      ? 11 // active but summoned in the first half of their duration (too early)
+      : 15 // active and timed well
+    : cast.dreadstalkersCastDuringWindow
+      ? 7 // cast inside the window (wastes a GCD)
+      : 0; // not active at all
+  // If the fight ended early, leftover shards aren't the player's fault — full points.
+  const missedCasts =
+    cast.fightEndedDuringWindow || cast.shardsAtWindowEnd === null
+      ? 0
+      : Math.floor(cast.shardsAtWindowEnd / 3);
+  const shardsEndScore = missedCasts === 0 ? 15 : missedCasts === 1 ? 8 : missedCasts === 2 ? 3 : 0; // penalizes leftover shards that could have been spender casts
+  // If grimoire was on CD when Tyrant was cast but used during the window, it came off CD naturally — full points.
+  const grimoireCameOffCdDuringWindow = cast.grimoireCastDuringWindow && !cast.grimoireAvailable;
+  const grimoireScore =
+    cast.grimoireAvailable === null
+      ? null // not talented — excluded from scoring
+      : cast.grimoireAvailable && !cast.grimoireCast && !cast.grimoireCastDuringWindow
+        ? 0 // available but never cast
+        : cast.grimoireCastDuringWindow && !grimoireCameOffCdDuringWindow
+          ? 2 // was available before Tyrant but cast during window instead (wastes a GCD)
+          : 5; // cast before the window, or came off CD during the window (both ideal)
+  const doomguardScore =
+    cast.doomguardAvailable === null
+      ? null // not talented — excluded from scoring
+      : cast.doomguardAvailable && !cast.doomguardCast
+        ? 0 // available but skipped
+        : 5;
+  // Diabolist wants 5 shards to fuel HoG casts; Soul Harvester only needs 2.
+  const shardsOnCastScore = isDialobist
+    ? cast.shardsOnCast >= 5
+      ? 5
+      : cast.shardsOnCast >= 3
+        ? 3
+        : cast.shardsOnCast >= 1
+          ? 1
+          : 0
+    : cast.shardsOnCast >= 2
+      ? 5
+      : cast.shardsOnCast === 1
+        ? 3
+        : 0;
+
+  // Optional talents take a fixed 5pts each; the remaining pool is split proportionally among base components.
+  // This means base component weights shift depending on which optional talents are taken.
+  const grimoireMax = grimoireScore !== null ? 5 : 0;
+  const doomguardMax = doomguardScore !== null ? 5 : 0;
+  const basePool = 100 - grimoireMax - doomguardMax;
+
+  // Raw relative weights for base components (must sum to a consistent total for scaling).
+  const BASE_WEIGHTS = { hog: 50, dreadstalkers: 15, shardsEnd: 15, shardsOnCast: 5 };
+  const BASE_WEIGHT_TOTAL = Object.values(BASE_WEIGHTS).reduce((a, b) => a + b, 0);
+  const w = (weight: number) => Math.round((weight / BASE_WEIGHT_TOTAL) * basePool);
+
+  const hogMax = w(BASE_WEIGHTS.hog);
+  const dreadstalkerMax = w(BASE_WEIGHTS.dreadstalkers);
+  const shardsEndMax = w(BASE_WEIGHTS.shardsEnd);
+  const shardsOnCastMax = w(BASE_WEIGHTS.shardsOnCast);
+
+  const scaledHog = Math.round(
+    (Math.min(totalSpenderCasts, maxExpectedCasts) / maxExpectedCasts) * hogMax,
+  );
+  const scaledDreadstalker = Math.round((dreadstalkerScore / 15) * dreadstalkerMax);
+  const scaledShardsEnd = Math.round((shardsEndScore / 15) * shardsEndMax);
+  const scaledGrimoire = grimoireScore !== null ? Math.round((grimoireScore / 5) * grimoireMax) : 0;
+  const scaledDoomguard =
+    doomguardScore !== null ? Math.round((doomguardScore / 5) * doomguardMax) : 0;
+  const scaledShardsOnCast = Math.round((shardsOnCastScore / 5) * shardsOnCastMax);
+
+  const components: ScoreBreakdown['components'] = [
+    {
+      label: isDialobist
+        ? `HoG / Ruination casts (${totalSpenderCasts} / ${maxExpectedCasts})`
+        : `Hand of Gul'dan casts (${totalSpenderCasts} / ${maxExpectedCasts})`,
+      score: scaledHog,
+      max: hogMax,
+    },
+    { label: 'Dreadstalkers timing', score: scaledDreadstalker, max: dreadstalkerMax },
+    { label: 'Shards at window end', score: scaledShardsEnd, max: shardsEndMax },
+  ];
+  if (grimoireScore !== null) {
+    components.push({ label: 'Grimoire cast', score: scaledGrimoire, max: grimoireMax });
+  }
+  if (doomguardScore !== null) {
+    components.push({ label: 'Doomguard cast', score: scaledDoomguard, max: doomguardMax });
+  }
+  components.push({
+    label: 'Soul Shards at cast',
+    score: scaledShardsOnCast,
+    max: shardsOnCastMax,
+    displayScore: shardsOnCastScore,
+    displayMax: 5,
+  });
+
+  const rawScore =
+    scaledHog +
+    scaledDreadstalker +
+    scaledShardsEnd +
+    scaledGrimoire +
+    scaledDoomguard +
+    scaledShardsOnCast;
+  const total = Math.min(100, rawScore);
+
+  return { total, totalSpenderCasts, maxExpectedCasts, components };
+}
+
+// Maps a numeric window score to a performance rating, requiring ≥ maxExpectedCasts spender casts to qualify for Perfect.
+function scoreToPerf(
+  score: number,
+  totalSpenderCasts?: number,
+  maxExpectedCasts = 8,
+): QualitativePerformance {
+  const spenderRequirementMet =
+    totalSpenderCasts === undefined || totalSpenderCasts >= maxExpectedCasts;
+  if (score >= 95 && spenderRequirementMet) return QualitativePerformance.Perfect;
+  if (score >= 70) return QualitativePerformance.Good;
+  if (score >= 50) return QualitativePerformance.Ok;
   return QualitativePerformance.Fail;
 }
 
@@ -34,42 +170,74 @@ function formatTimestampMs(ms: number) {
 }
 
 function getTyrantFeedback(
-  handOfGuldanCasts: number,
-  impsSummoned: number,
-  dreadstalkersActive: boolean,
-  dreadstalkersTooEarly: boolean,
+  cast: TyrantCastData,
+  isDialobist: boolean,
   casts: CastInSequence[],
-  tyrantTimestamp: number,
+  isFirstWindow: boolean,
+  perf: QualitativePerformance,
+  maxExpectedCasts: number,
 ): JSX.Element {
+  const {
+    handOfGuldanCasts,
+    maxDemonicPowerStacks,
+    dreadstalkersActive,
+    dreadstalkersTooEarly,
+    dreadstalkersCastDuringWindow,
+    grimoireAvailable,
+    grimoireCast,
+    grimoireCastDuringWindow,
+    doomguardAvailable,
+    doomguardCast,
+    shardsOnCast,
+    demonicCoresOnCast,
+    shardsAtWindowEnd,
+    fightEndedDuringWindow,
+  } = cast;
   const feedback: string[] = [];
-  const preTyrantCasts = casts.filter((cast) => cast.timestamp < tyrantTimestamp);
+  const preTyrantCasts = casts.filter((c) => c.timestamp < cast.cast);
+  const spenderLabel = isDialobist ? 'HoG / Ruination' : "Hand of Gul'dan";
+  const grimoireCameOffCdDuringWindow = grimoireCastDuringWindow && !grimoireAvailable;
 
-  if (handOfGuldanCasts >= 6) {
+  if (fightEndedDuringWindow) {
     feedback.push(
-      "Perfect Tyrant window. You maximized Hand of Gul'dan casts during the Tyrant duration.",
-    );
-  } else if (handOfGuldanCasts === 5) {
-    feedback.push(
-      "Great Tyrant window. One additional Hand of Gul'dan cast would make this perfect.",
-    );
-  } else if (handOfGuldanCasts >= 3) {
-    feedback.push(
-      "Try to cast Hand of Gul'dan more often during Tyrant by saving Demonic Cores for your Tyrant window.",
-    );
-  } else {
-    feedback.push(
-      "Too few Hand of Gul'dan casts. Either try pooling Soul Shards or Demonic Core charges before casting Tyrant.",
+      `The fight ended during this Tyrant window — score is pro-rated to ${maxExpectedCasts} expected ${spenderLabel} cast${maxExpectedCasts === 1 ? '' : 's'}.`,
     );
   }
 
-  const castedImplosion = preTyrantCasts.some((cast) => cast.spellId === SPELLS.IMPLOSION_CAST.id);
+  if (handOfGuldanCasts >= maxExpectedCasts && perf === QualitativePerformance.Perfect) {
+    feedback.push(
+      `Perfect Tyrant window. You maximized ${spenderLabel} casts during the Tyrant duration.`,
+    );
+  } else if (handOfGuldanCasts >= maxExpectedCasts) {
+    feedback.push(
+      `Good ${spenderLabel} count, but other issues prevented a perfect window — see below.`,
+    );
+  } else if (handOfGuldanCasts >= Math.round(maxExpectedCasts * 0.75)) {
+    feedback.push(
+      `${handOfGuldanCasts} ${spenderLabel} casts — good window. Aim for ${maxExpectedCasts} for a perfect window.`,
+    );
+  } else if (handOfGuldanCasts >= Math.round(maxExpectedCasts * 0.6)) {
+    feedback.push(
+      `Only ${handOfGuldanCasts} ${spenderLabel} cast${handOfGuldanCasts === 1 ? '' : 's'} during Tyrant. Aim for at least ${maxExpectedCasts}.`,
+    );
+  } else {
+    feedback.push(
+      `Only ${handOfGuldanCasts} ${spenderLabel} cast${handOfGuldanCasts === 1 ? '' : 's'} during Tyrant — this window was significantly underpowered.`,
+    );
+  }
+
   const castedPowerSiphon = preTyrantCasts.some(
     (cast) => cast.spellId === TALENTS.POWER_SIPHON_TALENT.id,
   );
 
-  if (!dreadstalkersActive) {
+  if (!dreadstalkersActive && !dreadstalkersCastDuringWindow) {
     feedback.push(
-      'Cast Call Dreadstalkers before summoning Demonic Tyrant so they benefit from the damage bonus.',
+      "Cast Call Dreadstalkers before Demonic Tyrant to ensure you can immediately begin Hand of Gul'dan casts without wasting GCDs.",
+    );
+  } else if (dreadstalkersCastDuringWindow && !dreadstalkersActive) {
+    // Only flag if there was no pre-Tyrant cast — an in-window cast alongside a pre-cast is a legitimate re-cast on cooldown.
+    feedback.push(
+      "Call Dreadstalkers was cast during the Tyrant window instead of before it, wasting GCDs you could have used on Hand of Gul'dan.",
     );
   } else if (dreadstalkersTooEarly) {
     feedback.push(
@@ -77,18 +245,52 @@ function getTyrantFeedback(
     );
   }
 
-  if (castedImplosion)
-    feedback.push(
-      'Avoid casting Implosion before Tyrant, as it removes imps that Tyrant could extend.',
-    );
-
   if (castedPowerSiphon)
     feedback.push('Power Siphon before Tyrant sacrifices imps that could increase Tyrant damage.');
 
-  if (impsSummoned < 8)
+  if (maxDemonicPowerStacks < 8)
     feedback.push(
       'Entering Tyrant with more imps already active will significantly increase its damage.',
     );
+
+  if (grimoireAvailable && !grimoireCast && !grimoireCastDuringWindow)
+    feedback.push(
+      "Cast your Grimoire cooldown before Tyrant so you don't waste GCDs during the window.",
+    );
+  else if (grimoireAvailable && grimoireCastDuringWindow)
+    // Only flag if Grimoire was available before Tyrant — if it came off CD during the window, the in-window cast is correct.
+    feedback.push(
+      'Your Grimoire cooldown was cast during the Tyrant window instead of before it, wasting a GCD.',
+    );
+  else if (grimoireCameOffCdDuringWindow)
+    feedback.push(
+      'Your Grimoire cooldown became available during the Tyrant window and was cast — good use.',
+    );
+
+  if (doomguardAvailable && !doomguardCast)
+    feedback.push("Cast Summon Doomguard before Tyrant so you don't waste GCDs during the window.");
+
+  const shardsThreshold = isDialobist ? 5 : 2;
+  if (shardsOnCast < shardsThreshold)
+    feedback.push(
+      `You entered the Tyrant window with ${shardsOnCast} Soul Shard${shardsOnCast === 1 ? '' : 's'}. Try to pool at least ${shardsThreshold} Soul Shards before casting Tyrant${isDialobist ? ' to fuel Ruination casts' : ''}.`,
+    );
+
+  if (demonicCoresOnCast === 0 && !isFirstWindow)
+    feedback.push(
+      "You had no Demonic Core charges when casting Tyrant. Save Demonic Cores before your Tyrant window to fuel Hand of Gul'dan casts.",
+    );
+  else if (demonicCoresOnCast === 1 && !isFirstWindow)
+    feedback.push(
+      'You had only 1 Demonic Core when casting Tyrant. Try to save more charges before the window.',
+    );
+
+  if (!fightEndedDuringWindow && shardsAtWindowEnd !== null && shardsAtWindowEnd >= 3) {
+    const missedCasts = Math.floor(shardsAtWindowEnd / 3);
+    feedback.push(
+      `You ended the Tyrant window with ${shardsAtWindowEnd} Soul Shards — that's ${missedCasts} missed Hand of Gul'dan cast${missedCasts === 1 ? '' : 's'}.`,
+    );
+  }
 
   return (
     <ul>
@@ -102,12 +304,16 @@ function getTyrantFeedback(
 function DemonicTyrantGuide(): JSX.Element | null {
   const demonicTyrant = useAnalyzer(DemonicTyrant);
   const eventHistory = useAnalyzer(EventHistory);
+  const info = useInfo();
+  // Used to relabel spender casts and conditionally show the Demonic Cores stat.
+  const isDialobist = info?.combatant.hasTalent(TALENTS.RUINATION_TALENT) ?? false;
+  const hasPowerSiphon = info?.combatant.hasTalent(TALENTS.POWER_SIPHON_TALENT) ?? false;
 
   const tyrantSequenceEvents = useMemo((): CastSequenceEntry<TyrantCastData>[] => {
     if (!demonicTyrant || !eventHistory) return [];
     return demonicTyrant.tyrantData.map((cast) => {
       const windowStart = cast.cast - TYRANT_PRE_WINDOW;
-      const windowEnd = cast.cast + TYRANT_POST_WINDOW;
+      const windowEnd = cast.cast + TYRANT_WINDOW_MS + TYRANT_POST_BUFFER;
 
       const castEvents = eventHistory.getEvents([EventType.Cast], {
         searchBackwards: false,
@@ -142,38 +348,139 @@ function DemonicTyrantGuide(): JSX.Element | null {
     return demonicTyrant.tyrantData.map((cast, index) => {
       const sequenceEntry = tyrantSequenceEvents[index];
 
+      const scoreBreakdown = scoreTyrantWindow(cast, isDialobist);
+      const score = scoreBreakdown.total;
+      const perf = scoreToPerf(
+        score,
+        scoreBreakdown.totalSpenderCasts,
+        scoreBreakdown.maxExpectedCasts,
+      );
       return {
-        performance: rateTyrantWindow(cast.handOfGuldanCasts),
-        timestamp: formatTimestampMs(cast.cast - fightStart),
+        performance: perf,
+        timestamp: `${formatTimestampMs(cast.cast - fightStart)} – ${formatTimestampMs(cast.cast + cast.actualWindowDurationMs - fightStart)}`,
         stats: [
           {
-            label: "Hand of Gul'dan Casts",
+            label: isDialobist ? 'HoG / Ruination Casts' : "Hand of Gul'dan Casts",
             value: cast.handOfGuldanCasts,
-            tooltip: "Number of Hand of Gul'dan casts during the Tyrant window",
+            tooltip: isDialobist
+              ? "Number of Hand of Gul'dan and Ruination casts during the Tyrant window"
+              : "Number of Hand of Gul'dan casts during the Tyrant window",
           },
           {
-            label: 'Imps Summoned',
-            value: cast.impsSummoned,
-            tooltip: 'Wild Imps generated during the Tyrant window',
+            label: 'Max Demonic Power Stacks',
+            value: cast.maxDemonicPowerStacks,
+            tooltip: 'Highest stacks of Demonic Power the Tyrant had during the window',
+          },
+          {
+            label: 'Soul Shards at Cast',
+            value: Math.round(cast.shardsOnCast),
+            tooltip:
+              'Soul Shards available when Demonic Tyrant was cast. Aim for 2+ (Soul Harvester) or 5 (Diabolist).',
+          },
+          ...(index > 0 || hasPowerSiphon
+            ? [
+                {
+                  label: 'Demonic Cores at Cast',
+                  value: cast.demonicCoresOnCast,
+                  tooltip: 'Demonic Core stacks available when Demonic Tyrant was cast (max 4).',
+                },
+              ]
+            : []),
+          ...(cast.shardsAtWindowEnd !== null
+            ? [
+                {
+                  label: 'Soul Shards at Window End',
+                  value: cast.shardsAtWindowEnd,
+                  tooltip:
+                    "Soul Shards remaining when the Tyrant window ended. Aim for fewer than 3 — leftover shards could have been another Hand of Gul'dan.",
+                },
+              ]
+            : []),
+          {
+            label: 'Score',
+            value: `${score} / 100`,
+            performance: perf,
+            tooltip: (
+              <div>
+                <div style={{ marginBottom: 4, fontWeight: 700 }}>Score breakdown</div>
+                {scoreBreakdown.components.map((c, i) => (
+                  <div
+                    key={i}
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      gap: 16,
+                      opacity: c.score === 0 ? 0.5 : 1,
+                    }}
+                  >
+                    <span>{c.label}</span>
+                    <span>
+                      {c.displayScore ?? c.score} / {c.displayMax ?? c.max}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ),
           },
         ],
         details: getTyrantFeedback(
-          cast.handOfGuldanCasts,
-          cast.impsSummoned,
-          cast.dreadstalkersActive,
-          cast.dreadstalkersTooEarly,
+          cast,
+          isDialobist,
           sequenceEntry?.casts ?? [],
-          cast.cast,
+          index === 0,
+          perf,
+          scoreBreakdown.maxExpectedCasts,
         ),
+        // Splits casts into in-window and post-window groups, ghosting post-window entries.
         additionalContent: sequenceEntry
-          ? {
-              title: 'Cast Sequence',
-              content: <SpellSequence casts={sequenceEntry.casts} iconSize={40} />,
-            }
+          ? (() => {
+              const tyrantWindowEnd = cast.cast + TYRANT_WINDOW_MS;
+              const inWindowCasts = sequenceEntry.casts.filter(
+                (c) => c.timestamp <= tyrantWindowEnd,
+              );
+              const postWindowCasts = sequenceEntry.casts
+                .filter((c) => c.timestamp > tyrantWindowEnd)
+                .map((c) => ({
+                  ...c,
+                  ghosted: true as const,
+                  tooltip: (
+                    <div>
+                      <strong>{c.spellName}</strong>
+                      <p>
+                        <em>Cast after the Tyrant window ended</em>
+                      </p>
+                    </div>
+                  ),
+                }));
+              return {
+                title: 'Cast Sequence',
+                content: (
+                  <>
+                    <SpellSequence casts={inWindowCasts} iconSize={40} />
+                    {postWindowCasts.length > 0 && (
+                      <>
+                        <div
+                          style={{
+                            fontSize: '1.1rem',
+                            color: 'rgba(255, 255, 255, 0.4)',
+                            marginTop: 4,
+                            marginBottom: 2,
+                            fontStyle: 'italic',
+                          }}
+                        >
+                          cast after the tyrant window ended
+                        </div>
+                        <SpellSequence casts={postWindowCasts} iconSize={40} />
+                      </>
+                    )}
+                  </>
+                ),
+              };
+            })()
           : undefined,
       };
     });
-  }, [demonicTyrant, eventHistory, tyrantSequenceEvents]);
+  }, [demonicTyrant, eventHistory, tyrantSequenceEvents, isDialobist, hasPowerSiphon]);
 
   if (!demonicTyrant || !eventHistory) return null;
 

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -70,36 +70,35 @@ function scoreTyrantWindow(cast: TyrantCastData, isDialobist: boolean): ScoreBre
       : cast.doomguardAvailable && !cast.doomguardCast
         ? 0 // available but skipped
         : 5;
-  // Diabolist wants 5 shards to fuel HoG casts; Soul Harvester only needs 2.
+  // Diabolist: 1 point per shard, capped at 5.
+  // Non-Diabolist: Tyrant grants 3 shards on cast, so 2 is ideal. 0–1 is ok/good, 3 is ok, 4 is poor, 5 is bad.
   const shardsOnCastScore = isDialobist
-    ? cast.shardsOnCast >= 5
+    ? Math.min(cast.shardsOnCast, 5)
+    : cast.shardsOnCast === 2
       ? 5
-      : cast.shardsOnCast >= 3
-        ? 3
-        : cast.shardsOnCast >= 1
-          ? 1
-          : 0
-    : cast.shardsOnCast >= 2
-      ? 5
-      : cast.shardsOnCast === 1
-        ? 3
-        : 0;
+      : cast.shardsOnCast <= 1
+        ? 4
+        : cast.shardsOnCast === 3
+          ? 3
+          : cast.shardsOnCast === 4
+            ? 1
+            : 0; // 5 shards
 
-  // Optional talents take a fixed 5pts each; the remaining pool is split proportionally among base components.
-  // This means base component weights shift depending on which optional talents are taken.
+  // Optional talents take a fixed 5pts each; shardsOnCast is also fixed at 5 (raw score is already 0–5).
+  // The remaining pool is split proportionally among hog, dreadstalkers, and shardsEnd.
   const grimoireMax = grimoireScore !== null ? 5 : 0;
   const doomguardMax = doomguardScore !== null ? 5 : 0;
-  const basePool = 100 - grimoireMax - doomguardMax;
+  const shardsOnCastMax = 5;
+  const basePool = 100 - grimoireMax - doomguardMax - shardsOnCastMax;
 
-  // Raw relative weights for base components (must sum to a consistent total for scaling).
-  const BASE_WEIGHTS = { hog: 50, dreadstalkers: 15, shardsEnd: 15, shardsOnCast: 5 };
+  // Raw relative weights for the three proportionally-scaled base components.
+  const BASE_WEIGHTS = { hog: 50, dreadstalkers: 15, shardsEnd: 15 };
   const BASE_WEIGHT_TOTAL = Object.values(BASE_WEIGHTS).reduce((a, b) => a + b, 0);
   const w = (weight: number) => Math.round((weight / BASE_WEIGHT_TOTAL) * basePool);
 
   const hogMax = w(BASE_WEIGHTS.hog);
   const dreadstalkerMax = w(BASE_WEIGHTS.dreadstalkers);
   const shardsEndMax = w(BASE_WEIGHTS.shardsEnd);
-  const shardsOnCastMax = w(BASE_WEIGHTS.shardsOnCast);
 
   const scaledHog = Math.round(
     (Math.min(totalSpenderCasts, maxExpectedCasts) / maxExpectedCasts) * hogMax,
@@ -109,7 +108,7 @@ function scoreTyrantWindow(cast: TyrantCastData, isDialobist: boolean): ScoreBre
   const scaledGrimoire = grimoireScore !== null ? Math.round((grimoireScore / 5) * grimoireMax) : 0;
   const scaledDoomguard =
     doomguardScore !== null ? Math.round((doomguardScore / 5) * doomguardMax) : 0;
-  const scaledShardsOnCast = Math.round((shardsOnCastScore / 5) * shardsOnCastMax);
+  const scaledShardsOnCast = shardsOnCastScore; // raw score is already 0–5, max is fixed at 5
 
   const components: ScoreBreakdown['components'] = [
     {
@@ -132,8 +131,6 @@ function scoreTyrantWindow(cast: TyrantCastData, isDialobist: boolean): ScoreBre
     label: 'Soul Shards at cast',
     score: scaledShardsOnCast,
     max: shardsOnCastMax,
-    displayScore: shardsOnCastScore,
-    displayMax: 5,
   });
 
   const rawScore =
@@ -148,7 +145,8 @@ function scoreTyrantWindow(cast: TyrantCastData, isDialobist: boolean): ScoreBre
   return { total, totalSpenderCasts, maxExpectedCasts, components };
 }
 
-// Maps a numeric window score to a performance rating, requiring ≥ maxExpectedCasts spender casts to qualify for Perfect.
+// Maps a numeric window score to a performance rating.
+// Perfect requires ≥ maxExpectedCasts spender casts; Good requires ≥ 6.
 function scoreToPerf(
   score: number,
   totalSpenderCasts?: number,
@@ -156,8 +154,9 @@ function scoreToPerf(
 ): QualitativePerformance {
   const spenderRequirementMet =
     totalSpenderCasts === undefined || totalSpenderCasts >= maxExpectedCasts;
+  const goodSpenderRequirementMet = totalSpenderCasts === undefined || totalSpenderCasts >= 6;
   if (score >= 95 && spenderRequirementMet) return QualitativePerformance.Perfect;
-  if (score >= 70) return QualitativePerformance.Good;
+  if (score >= 80 && goodSpenderRequirementMet) return QualitativePerformance.Good;
   if (score >= 50) return QualitativePerformance.Ok;
   return QualitativePerformance.Fail;
 }
@@ -255,7 +254,7 @@ function getTyrantFeedback(
 
   if (grimoireAvailable && !grimoireCast && !grimoireCastDuringWindow)
     feedback.push(
-      "Cast your Grimoire cooldown before Tyrant so you don't waste GCDs during the window.",
+      "Grimoire was available but wasn't used this window. If you're holding it for a burn phase that's fine, otherwise cast it before Tyrant to avoid wasting GCDs during the window.",
     );
   else if (grimoireAvailable && grimoireCastDuringWindow)
     // Only flag if Grimoire was available before Tyrant — if it came off CD during the window, the in-window cast is correct.
@@ -270,11 +269,18 @@ function getTyrantFeedback(
   if (doomguardAvailable && !doomguardCast)
     feedback.push("Cast Summon Doomguard before Tyrant so you don't waste GCDs during the window.");
 
-  const shardsThreshold = isDialobist ? 5 : 2;
-  if (shardsOnCast < shardsThreshold)
-    feedback.push(
-      `You entered the Tyrant window with ${shardsOnCast} Soul Shard${shardsOnCast === 1 ? '' : 's'}. Try to pool at least ${shardsThreshold} Soul Shards before casting Tyrant${isDialobist ? ' to fuel Ruination casts' : ''}.`,
-    );
+  if (isDialobist) {
+    if (shardsOnCast < 5)
+      feedback.push(
+        `You entered the Tyrant window with ${shardsOnCast} Soul Shard${shardsOnCast === 1 ? '' : 's'}. Try to pool at least 5 Soul Shards before casting Tyrant to fuel Hand of Gul'dan casts.`,
+      );
+  } else {
+    // Tyrant grants 3 shards on cast — 2 is ideal, 0–1 is fine, 4+ is wasteful.
+    if (shardsOnCast >= 4)
+      feedback.push(
+        `You entered the Tyrant window with ${shardsOnCast} Soul Shard${shardsOnCast === 1 ? '' : 's'}. Aim for around 2 — Tyrant grants 3 shards on cast, so higher counts cap your shards and waste resources.`,
+      );
+  }
 
   if (demonicCoresOnCast === 0 && !isFirstWindow)
     feedback.push(
@@ -292,12 +298,19 @@ function getTyrantFeedback(
     );
   }
 
+  const [summary, ...details] = feedback;
+
   return (
-    <ul>
-      {feedback.map((line, i) => (
-        <p key={i}>{line}</p>
-      ))}
-    </ul>
+    <div>
+      <p>{summary}</p>
+      {details.length > 0 && (
+        <ul style={{ paddingLeft: 20, margin: 0 }}>
+          {details.map((line, i) => (
+            <li key={i}>{line}</li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }
 
@@ -375,7 +388,7 @@ function DemonicTyrantGuide(): JSX.Element | null {
             label: 'Soul Shards at Cast',
             value: Math.round(cast.shardsOnCast),
             tooltip:
-              'Soul Shards available when Demonic Tyrant was cast. Aim for 2+ (Soul Harvester) or 5 (Diabolist).',
+              'Soul Shards available when Demonic Tyrant was cast. Aim for ~2 (Soul Harvester) — Tyrant grants 3 shards on cast, so 0–2 is fine while 4+ is wasteful. Diabolist should aim for 5.',
           },
           ...(index > 0 || hasPowerSiphon
             ? [

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -382,7 +382,8 @@ function DemonicTyrantGuide(): JSX.Element | null {
           {
             label: 'Max Demonic Power Stacks',
             value: cast.maxDemonicPowerStacks,
-            tooltip: 'Highest stacks of Demonic Power the Tyrant had during the window',
+            tooltip:
+              'Highest stacks of Demonic Power during the window. Each active demon (Wild Imps, Dreadstalkers, Felguard) grants one stack.',
           },
           {
             label: 'Soul Shards at Cast',

--- a/src/analysis/retail/warlock/shared/resources/SoulShardTracker.tsx
+++ b/src/analysis/retail/warlock/shared/resources/SoulShardTracker.tsx
@@ -7,6 +7,7 @@ class SoulShardTracker extends ResourceTracker {
   constructor(options: Options) {
     super(options);
     this.resource = RESOURCE_TYPES.SOUL_SHARDS;
+    this.maxResource = 5;
   }
 
   onCast(event: CastEvent) {

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -388,6 +388,12 @@ const spells = {
     name: 'Summon Demonic Tyrant',
     icon: 'inv_summondemonictyrant',
   },
+  // Buff applied to the player while the Demonic Tyrant is active (Apex talent); ~25s duration
+  DOMINION_OF_ARGUS_BUFF: {
+    id: 1276166,
+    name: 'Dominion of Argus',
+    icon: 'inv12_apextalent_warlock_dominionofargus',
+  },
   GRIMOIRE_IMP_LORD: {
     id: 1276452,
     name: 'Grimoire: Imp Lord',


### PR DESCRIPTION
## Summary

- **Demonic Tyrant analyzer overhaul**: tracks Demonic Power stacks, Soul Shards at cast and window end, Dreadstalker timing, Grimoire (Imp Lord / Fel Ravager), and Doomguard alignment
- **Weighted 0–100 scoring system**: score pool adjusts dynamically based on talented cooldowns — Grimoire, Doomguard, and Shards at end each take 5pts from the pool; base components (HoG/Ruination, Dreadstalkers, Shards at cast) redistribute proportionally. Score is capped at 100
- **Scoring thresholds**: Soul Shards at Cast thresholds differ by spec (Diabolist vs Soul Harvester). Perfect requires ≥95 and ≥8 (updated from ≥6) spender casts
- **Cast sequence filmstrip**: shows spells cast during the Tyrant window, with post-window casts shown desaturated for context
- **Score breakdown tooltip**: per-factor contribution shown on the Score stat card
- **Timestamps**: update the Cast Details timestamp to show the entire Tyrant/Apex window and not just the start time
- **Fight-ended window handling**: pro-rates the score based on how far into the window the fight ended; suppresses leftover-shard penalties and misleading feedback messages for those windows
- **Grimoire leeway**: no penalty if Grimoire came off cooldown during the Tyrant window; positive feedback message shown
- **Dreadstalkers timing**: accounts for pre-cast Dreadstalkers that become available again during the 25s window; feedback wording updated
- **Imp Wording**: remove incorrect wording regarding extending Imps
- **Soul Shards tracking fixes**: corrected `resourcechange` listener (`to` vs `by(SELECTED_PLAYER)`), fixed NaN/float display, rounded shard values for display, restored `soulShardTracker.current` for accurate cast-time shard counts. Initialized `SoulShardTracker.maxResource` to `5` to prevent NaN when the first log event is an energize with no classResources. Retroactively derives `shardsOnCast` from the first window spender's pre-spend amount minus gains since Tyrant cast, since combat logs report stale shard counts on free spells
- **Guide feedback improvements**: feedback items below the HoG/Ruination cast summary now render as a bulleted list; Grimoire "available but unused" feedback acknowledges intentional burn phase holds
- **Ruination (Diabolist) support**: casts folded into HoG cast count; labels adjust via `hasTalent`
- **Doomguard CDR analyzer**: tracks cooldown reduction granted by Doomguard
- **Guide restructure**: Demonic Tyrant guide moved into a nested subsection within Cooldowns, matching the Defensives section pattern
- **Support Level and Example Report**: Changed support level to Full and updated example report

- Comments were added to new code to briefly explain the purpose that code does  (mostly for me)

### Testing
- Test report URL: 
- `/report/wN3fvbZyQr7GgcJ2/9-Heroic+Imperator+Averzian+-+Kill+(3:49)/537-Katorrí/standard`
- `/report/FHfng1KdRc98Z6VP/27-Mythic+Imperator+Averzian+-+Kill+(6:53)/1-Katorrí/standard`
- `/report/FHfng1KdRc98Z6VP/9-Heroic+Belo'ren,+Child+of+Al'ar+-+Kill+(4:31)/1-Katorrí/standard`
- Screenshot(s):
<img width="741" height="624" alt="image" src="https://github.com/user-attachments/assets/a4ce447b-8345-4110-87be-4ed46d9deae3" />
<img width="718" height="650" alt="image" src="https://github.com/user-attachments/assets/fb12f74e-282a-4072-94c2-3771c430978e" />
<img width="715" height="752" alt="image" src="https://github.com/user-attachments/assets/4df2a699-3f5b-4203-9473-fd96236a1229" />

<img width="720" height="599" alt="image" src="https://github.com/user-attachments/assets/6ccf66e3-91d8-4fb8-9745-76f4bc0cbfec" />
<img width="1487" height="451" alt="image" src="https://github.com/user-attachments/assets/941a3f5f-74a3-41e6-9213-200b26006d36" />