### PR TITLE
[Survival] 0.5 Changes

### DIFF
--- a/src/analysis/retail/hunter/survival/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/survival/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import { Kivlov,
  } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2026,4,20), 'Update for 12.0.5', Kivlov),
   change(date(2026,3,31), 'Better Tip of the Spear Analysis', Kivlov),
   change(date(2026,3,25), 'Add Takedown, Raptor Swipe Analysers', Kivlov),
   change(date(2026, 3, 18), 'Update Survival for launch', Kivlov),

--- a/src/analysis/retail/hunter/survival/CONFIG.tsx
+++ b/src/analysis/retail/hunter/survival/CONFIG.tsx
@@ -9,7 +9,7 @@ const config: Config = {
   contributors: [Kivlov],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.1',
+  patchCompatibility: '12.0.5',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/hunter/survival/modules/Abilities.tsx
+++ b/src/analysis/retail/hunter/survival/modules/Abilities.tsx
@@ -48,8 +48,7 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS.WILDFIRE_BOMB_TALENT),
         category: SPELL_CATEGORY.ROTATIONAL,
         charges: combatant.hasTalent(TALENTS.GUERRILLA_TACTICS_TALENT) ? 2 : 1,
-        cooldown: (haste) =>
-          hastedCooldown(18 - (combatant.hasTalent(TALENTS.LUNGE_TALENT) ? 1 : 0), haste),
+        cooldown: (haste) => hastedCooldown(18, haste),
         gcd: {
           base: 1500,
         },

--- a/src/analysis/retail/hunter/survival/modules/guide/sections/resources/ResourceUseSection.tsx
+++ b/src/analysis/retail/hunter/survival/modules/guide/sections/resources/ResourceUseSection.tsx
@@ -8,7 +8,7 @@ import {
 import TALENTS from 'common/TALENTS/hunter';
 import { formatNumber, formatPercentage } from 'common/format';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
-import { ResourceLink, TooltipElement } from 'interface';
+import { ResourceLink } from 'interface';
 import { ModulesOf, PerformanceMark, Section, SubSection } from 'interface/guide';
 import PerformanceStrongWithTooltip from 'interface/PerformanceStrongWithTooltip';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
@@ -33,24 +33,6 @@ export default function ResourceUseSection(modules: ModulesOf<typeof CombatLogPa
           avoid most issues with focus and waste will be minimal to non-existant. It will
           occasionally be impossible to avoid capping <ResourceLink id={RESOURCE_TYPES.FOCUS.id} />
           {'. '}
-          As Pack Leader, it is occasionally impossible to avoid running out of focus. Sentinel does
-          not have this issue.{' '}
-          <TooltipElement
-            content={
-              <>
-                Sentinel gains 5 extra focus per{' '}
-                <SpellLink spell={TALENTS.KILL_COMMAND_SURVIVAL_TALENT} /> and uses{' '}
-                <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} /> more often than Pack Leader,
-                which only costs 10 focus. Pack Leader largely ignores Bomb in favour of Raptor
-                Strike and so spends focus faster. This is offset by Pack Leader&apos;s{' '}
-                <SpellLink spell={TALENTS.LETHAL_BARBS_TALENT} /> talent which generates 2 focus per
-                auto attack, but it is still not enough to completely avoid downtime. It is however
-                minimal with proper play: as low as a total of 3s in a 5 minute fight.
-              </>
-            }
-          >
-            (?)
-          </TooltipElement>
         </p>
         The chart below shows your <ResourceLink id={RESOURCE_TYPES.FOCUS.id} /> over the course of
         the encounter. You wasted{' '}

--- a/src/analysis/retail/hunter/survival/modules/talents/Takedown/Takedown.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/Takedown/Takedown.tsx
@@ -22,7 +22,6 @@ export interface TakedownCast {
   tipStacks: number;
   boomstickCooldownAtCast: number;
   hasBoomstickBeforeCast: boolean;
-  wildfireBombCastInWindow: boolean;
   wastedTipStacks: number;
   castsInWindow: CastEvent[];
   windowEnd: number;
@@ -74,10 +73,6 @@ export default class Takedown extends Analyzer.withDependencies({ spellUsable: S
     if (window && event.timestamp <= window.windowEnd) {
       window.castsInWindow.push(event);
 
-      if (event.ability.guid === TALENTS.WILDFIRE_BOMB_TALENT.id) {
-        window.wildfireBombCastInWindow = true;
-      }
-
       // Kill Command while TotS would overflow the cap = wasted stacks
       if (event.ability.guid === TALENTS.KILL_COMMAND_SURVIVAL_TALENT.id) {
         const tipStacks = this.selectedCombatant.getBuffStacks(SPELLS.TIP_OF_THE_SPEAR_CAST.id);
@@ -112,7 +107,6 @@ export default class Takedown extends Analyzer.withDependencies({ spellUsable: S
       tipStacks,
       boomstickCooldownAtCast,
       hasBoomstickBeforeCast,
-      wildfireBombCastInWindow: false,
       wastedTipStacks: 0,
       castsInWindow: [],
       windowEnd,
@@ -193,38 +187,7 @@ export default class Takedown extends Analyzer.withDependencies({ spellUsable: S
       });
     }
 
-    // 3. No Wildfire Bomb during the Takedown window (Pack Leader only)
-    if (this.isPackLeader) {
-      const wfbPerf = cast.wildfireBombCastInWindow
-        ? QualitativePerformance.Fail
-        : QualitativePerformance.Good;
-      downgrade(wfbPerf);
-      items.push({
-        label: (
-          <>
-            <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} />{' '}
-            <TooltipElement
-              content={
-                <>
-                  <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} /> to extend{' '}
-                  <SpellLink spell={SPELLS.WYVERNS_CRY} /> should be held until after{' '}
-                  <SpellLink spell={TALENTS.TAKEDOWN_TALENT} /> ends, or only used when out of focus
-                  and out of <SpellLink spell={TALENTS.KILL_COMMAND_SURVIVAL_TALENT} /> charges.
-                </>
-              }
-            >
-              (?)
-            </TooltipElement>
-          </>
-        ),
-        result: <PerformanceMark perf={wfbPerf} />,
-        details: cast.wildfireBombCastInWindow ? (
-          <TooltipElement content="cast during Takedown window">(?)</TooltipElement>
-        ) : null,
-      });
-    }
-
-    // 4. Wasted Tip of the Spear (KC cast while capped)
+    // 3. Wasted Tip of the Spear (KC cast while capped)
     const tipWastePerf =
       cast.wastedTipStacks === 0 ? QualitativePerformance.Good : QualitativePerformance.Fail;
     downgrade(tipWastePerf);

--- a/src/analysis/retail/hunter/survival/modules/talents/Takedown/TakedownSection.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/Takedown/TakedownSection.tsx
@@ -22,7 +22,6 @@ export default function TakedownSection(): JSX.Element | null {
     return null;
   }
 
-  const isPackLeader = takedown.isPackLeader;
   const hasTwinFangs = info.combatant.hasTalent(TALENTS.TWIN_FANGS_TALENT);
   const hasBoomstick = info.combatant.hasTalent(TALENTS.BOOMSTICK_TALENT);
 
@@ -32,12 +31,6 @@ export default function TakedownSection(): JSX.Element | null {
         <p>
           Always enter <SpellLink spell={TALENTS.TAKEDOWN_TALENT} /> with a{' '}
           <SpellLink spell={SPELLS.RAPTOR_SWIPE_BUFF} /> buff active.
-          {isPackLeader && (
-            <>
-              {' '}
-              Never cast <SpellLink spell={TALENTS.WILDFIRE_BOMB_TALENT} /> during the window.
-            </>
-          )}
         </p>
         {hasBoomstick && (
           <p>


### PR DESCRIPTION
### Description

Survival received a change to bombs, both shrapnel gives focus + main target takes more damage for PL so it's now used. Changes are to remove all the "dont use bomb except as last resort" checks.
Lunge doesn't reduce bomb CDR anymore.

- Test report URL: `/report/hW7BykJYcLCAZtdR/33-Mythic+Vorasius+-+Kill+(5:41)/10-Percival/standard`
