### PR TITLE
[Mage] Update Arcane Mage & Fire Mage to 12.0.5 Support

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -14,6 +14,7 @@ const presenceOfMind = <SpellLink spell={TALENTS.PRESENCE_OF_MIND_TALENT} />
 const clearcasting = <SpellLink spell={SPELLS.CLEARCASTING_ARCANE} />
 
 export default [
+  change(date(2026, 4, 21), <>Updated Spec Compatability to 12.0.5.</>, Sharrq),
   change(date(2026, 4, 4), <>Updated Spec Compatability to 12.0.1.</>, Sharrq),
   change(date(2026, 4, 4), <>Removed {clearcasting} expiration and overcap checks.</>, Sharrq),
   change(date(2026, 4, 4), <>Updated {arcaneBarrage}, {arcaneOrb}, {arcaneMissiles}, {touchOfTheMagi}, {arcaneSurge}, and {presenceOfMind} to support the Spellslinger Missiles, Spellslinger Orbs, and Sunfury builds and rotations.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CONFIG.tsx
+++ b/src/analysis/retail/mage/arcane/CONFIG.tsx
@@ -11,7 +11,7 @@ const config: Config = {
   contributors: [Sharrq],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.1',
+  patchCompatibility: '12.0.5',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
@@ -59,7 +59,7 @@ const config: Config = {
     overview: {
       notes: (
         <AlertWarning>
-          This spec has been fully updated for Midnight (As of April 4). If anything is missing or
+          This spec has been fully updated for Midnight (As of April 21). If anything is missing or
           incorrect, please ping <code>@Sharrq</code> in the Altered Time Discord.
         </AlertWarning>
       ),

--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { Thias, Sharrq } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 21), <>Updated Spec Compatability to 12.0.5.</>, Sharrq),
   change(date(2026, 4, 17), <>Temporarily fix crash of <SpellLink spell={SPELLS.HEAT_SHIMMER_BUFF} /> by extending the buffer</>, Thias),
   change(date(2026, 3, 20), <>Fixed an issue that prevented <SpellLink spell={TALENTS.FLAMESTRIKE_2_FIRE_TALENT} /> from being detected as a <SpellLink spell={SPELLS.HOT_STREAK} /> spender if the player chose the talent to cast <SpellLink spell={TALENTS.FLAMESTRIKE_2_FIRE_TALENT} /> at your target instead of your cursor.</>, Sharrq),
   change(date(2026, 3, 20), <>Fixed an issue that caused some <SpellLink spell={SPELLS.FIRE_BLAST.id} /> casts to not detect that <SpellLink spell={TALENTS.COMBUSTION_TALENT} /> was active.</>, Sharrq),

--- a/src/analysis/retail/mage/fire/CONFIG.tsx
+++ b/src/analysis/retail/mage/fire/CONFIG.tsx
@@ -11,7 +11,7 @@ const config: Config = {
   contributors: [Sharrq],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.1',
+  patchCompatibility: '12.0.5',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
@@ -40,7 +40,7 @@ const config: Config = {
     overview: {
       notes: (
         <AlertWarning>
-          This spec has been fully updated for Midnight (As of March 6). If anything is missing or
+          This spec has been fully updated for Midnight (As of April 21). If anything is missing or
           incorrect, please ping <code>@Sharrq</code> in the Altered Time Discord.
         </AlertWarning>
       ),


### PR DESCRIPTION
Nothing really changes for Arcane Mage and Fire Mage, so updating spec support to 12.0.5