### PR TITLE
[Warlock] [Destruction] [Affliction] Spec compatibility update for 12.0.5

### DIFF
--- a/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 
 export default [
+  change(date(2026, 4, 21), "Spec compatibility updated for 12.0.5", Katorri),
   change(date(2026, 3, 22), <>Created an analyzer for the cooldown reduction on <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> based on <SpellLink spell={TALENTS.CULL_THE_WEAK_TALENT} />.</>, Katorri),
   change(date(2026, 3, 20), "Add Demonic Healthstone Tracker.", Katorri),
   change(date(2026, 3, 9), <>Created new analyzers for <SpellLink spell={SPELLS.CORRUPTION_DEBUFF} /> / <SpellLink spell={TALENTS.WITHER_TALENT} />, <SpellLink spell={SPELLS.AGONY} />, and <SpellLink spell={TALENTS.HAUNT_TALENT} />. </>, Katorri),

--- a/src/analysis/retail/warlock/affliction/CONFIG.tsx
+++ b/src/analysis/retail/warlock/affliction/CONFIG.tsx
@@ -11,7 +11,7 @@ const CONFIG: Config = {
   contributors: [Gazh, Katorri],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.1',
+  patchCompatibility: '12.0.5',
   supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import {Katorri} from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 21), "Spec compatibility updated for 12.0.5", Katorri),
   change(date(2026, 3, 28), "Add Backdraft analyzer and guide. Updated from Partial to Full support", Katorri),
   change(date(2026, 3, 20), "Add Demonic Healthstone Tracker, update guide structure.", Katorri),
   change(date(2026, 3, 8), "Created Guide, ImmolateUptime tracker, Havoc Analyzer, and new CooldownUsage section.", Katorri),

--- a/src/analysis/retail/warlock/destruction/CONFIG.tsx
+++ b/src/analysis/retail/warlock/destruction/CONFIG.tsx
@@ -10,7 +10,7 @@ export default {
   contributors: [Gazh, Katorri],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.1',
+  patchCompatibility: '12.0.5',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.


### PR DESCRIPTION
Nothing really changed for Destruction or Affliction, so updating them for 12.0.5