### PR TITLE
Update Mighty Inferno

### DIFF
--- a/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
@@ -84,7 +84,7 @@ class MightyInferno extends Analyzer {
   }
 
   onFightEnd(event: FightEndEvent) {
-    this.infernoApps.forEach((app) => this.onInfernosRemove(app.playerID, event.timestamp, true));
+    this.infernoApps.forEach((app) => this.onInfernosRemove(app.playerID, event.timestamp));
   }
 
   onInfernosApply(targetID: number, timestamp: number) {
@@ -98,11 +98,7 @@ class MightyInferno extends Analyzer {
     });
   }
 
-  onInfernosRemove(targetID: number, timestamp: number, fightEnd = false) {
-    if (fightEnd && !this.owner.players[targetID]) {
-      // Pets often fail to log a remove buff event, ignore them
-      return;
-    }
+  onInfernosRemove(targetID: number, timestamp: number) {
     const index = this.infernoApps.findIndex((app) => app.playerID === targetID);
     if (index === -1) {
       return;


### PR DESCRIPTION
Minor edit to remove a fix for Mighty Inferno in the case that Inferno's Blessing was applied to pets. As Inferno's Blessing was fixed to no longer apply to pets in 12.0.5, therefore this check was never needed.