### PR TITLE
Midnight raid boss abilities

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 22), 'Add Midnight raid boss abilities to uptime timelines.', emallson),
   change(date(2026, 4, 21), 'Improve glyph loading by pre-loading during initialization instead of lazy load', Thias),
   change(date(2026, 4, 20), "Regenerate talents for 12.0.5.", Vollmer),
   change(date(2026, 4, 13), "Fix calculation for Effective Healing From Crit Increase when using a non standard crit heal multiplier.", squided),

--- a/src/game/raids/vs_dr_mqd/Beloren.ts
+++ b/src/game/raids/vs_dr_mqd/Beloren.ts
@@ -1,4 +1,29 @@
 import background from './backgrounds/Beloren.jpg';
 import { buildBoss } from 'game/raids/builders';
 
-export const Beloren = buildBoss({ background, id: 3182, name: "Belo'ren, Child of Al'ar" });
+export const Beloren = buildBoss({
+  background,
+  id: 3182,
+  name: "Belo'ren, Child of Al'ar",
+  timeline: {
+    abilities: [
+      // Voidlight Convergence (color change)
+      { id: 1242515, type: 'begincast' },
+      // Tank cones
+      { id: 1261217, type: 'cast' },
+      { id: 1261218, type: 'cast' },
+      { id: 1241678, type: 'cast' },
+      // dives
+      { id: 1241340, type: 'cast' },
+      { id: 1241291, type: 'cast' },
+    ],
+    debuffs: [
+      // quills
+      { id: 1241992 },
+      { id: 1242091 },
+      // dives
+      { id: 1241292 },
+      { id: 1241339 },
+    ],
+  },
+});

--- a/src/game/raids/vs_dr_mqd/Chimaerus.ts
+++ b/src/game/raids/vs_dr_mqd/Chimaerus.ts
@@ -1,4 +1,32 @@
 import background from './backgrounds/Chimaerus.jpg';
 import { buildBoss } from 'game/raids/builders';
 
-export const Chimaerus = buildBoss({ background, id: 3306, name: 'Chimaerus the Undreamt God' });
+export const Chimaerus = buildBoss({
+  background,
+  id: 3306,
+  name: 'Chimaerus the Undreamt God',
+  timeline: {
+    abilities: [
+      // Alndust Upheaval (group soak)
+      { id: 1262289, type: 'cast' },
+      // Rift Madness
+      { id: 1264756, type: 'cast' },
+      // Rift Emergence (summon adds)
+      { id: 1258610, type: 'cast' },
+      // Consume
+      { id: 1245396, type: 'begincast' },
+      // Ravenous Dive
+      { id: 1245406, type: 'cast' },
+    ],
+    debuffs: [
+      // Alndust Upheaval (group soak target)
+      { id: 1246149 },
+      // Consuming Miasma (dispel debuff)
+      { id: 1257087 },
+      // Rift Madness (target)
+      { id: 1264756 },
+      // Rift Madness (horrify)
+      { id: 1264757 },
+    ],
+  },
+});

--- a/src/game/raids/vs_dr_mqd/CrownOfTheCosmos.ts
+++ b/src/game/raids/vs_dr_mqd/CrownOfTheCosmos.ts
@@ -1,4 +1,34 @@
 import background from './backgrounds/CrownOfTheCosmos.jpg';
 import { buildBoss } from 'game/raids/builders';
 
-export const CrownOfTheCosmos = buildBoss({ background, id: 3181, name: 'Crown of the Cosmos' });
+export const CrownOfTheCosmos = buildBoss({
+  background,
+  id: 3181,
+  name: 'Crown of the Cosmos',
+  timeline: {
+    abilities: [
+      // interrupting tremor
+      { id: 1243743, type: 'cast' },
+      // ravenous abyss (vorelus circle)
+      { id: 1243753, type: 'cast' },
+      // Void Expulsion (area denial)
+      { id: 1233819, type: 'cast' },
+      // summon voidspawn
+      { id: 1237837, type: 'cast' },
+      // Aspect of the End
+      { id: 1239080, type: 'cast' },
+      // Devouring Cosmos
+      { id: 1238843, type: 'cast' },
+    ],
+    debuffs: [
+      // silverstrike arrow (p1)
+      { id: 1233602 },
+      // grasp of emptiness (obelisks)
+      { id: 1260027 },
+      // Ranger-Captain's Mark
+      { id: 1259861 },
+      // Aspect of the End (tether)
+      { id: 1239111 },
+    ],
+  },
+});

--- a/src/game/raids/vs_dr_mqd/ImperatorAverzian.ts
+++ b/src/game/raids/vs_dr_mqd/ImperatorAverzian.ts
@@ -1,4 +1,30 @@
 import background from './backgrounds/ImperatorAverzian.jpg';
 import { buildBoss } from 'game/raids/builders';
 
-export const ImperatorAverzian = buildBoss({ background, id: 3176, name: 'Imperator Averzian' });
+export const ImperatorAverzian = buildBoss({
+  background,
+  id: 3176,
+  name: 'Imperator Averzian',
+  timeline: {
+    abilities: [
+      // Shadow's Advance (Summon Tic-Tac-Toe adds) - 2 versions
+      { id: 1251361, type: 'cast' },
+      { id: 1262776, type: 'cast' },
+      // Umbral Collapse (group soak) - 2 versions
+      { id: 1249266, type: 'cast' },
+      { id: 1260206, type: 'cast' },
+      // Void Fall (non-enrage march) - 2 versions
+      { id: 1258880, type: 'cast' },
+      { id: 1266786, type: 'cast' },
+      // March of the Endless (enrage)
+      { id: 1251583, type: 'cast' },
+    ],
+    debuffs: [
+      // Void Marked (mythic dispel)
+      { id: 1280013, type: 'debuff' },
+      // Umbral Collapse (tank marked with group soak)
+      { id: 1260203, type: 'debuff' },
+      { id: 1249265, type: 'debuff' },
+    ],
+  },
+});

--- a/src/game/raids/vs_dr_mqd/LightblindedVanguard.ts
+++ b/src/game/raids/vs_dr_mqd/LightblindedVanguard.ts
@@ -5,4 +5,24 @@ export const LightblindedVanguard = buildBoss({
   background,
   id: 3180,
   name: 'Lightblinded Vanguard',
+  timeline: {
+    abilities: [
+      // Aura of Devotion
+      { id: 1246162, type: 'begincast' },
+      // elephant
+      { id: 1249130, type: 'cast' },
+      // Aura of Wrath
+      { id: 1248449, type: 'begincast' },
+      // Aura of Peace
+      { id: 1248451, type: 'begincast' },
+    ],
+    debuffs: [
+      // Judgment (Venel)
+      { id: 1246736 },
+      // Judgment (Bellamy)
+      { id: 1251857 },
+      // Execution Sentence (target)
+      { id: 1248994 },
+    ],
+  },
 });

--- a/src/game/raids/vs_dr_mqd/MidnightFalls.ts
+++ b/src/game/raids/vs_dr_mqd/MidnightFalls.ts
@@ -1,4 +1,47 @@
 import background from './backgrounds/MidnightFalls.jpg';
 import { buildBoss } from 'game/raids/builders';
 
-export const MidnightFalls = buildBoss({ background, id: 3183, name: 'Midnight Falls' });
+export const MidnightFalls = buildBoss({
+  background,
+  id: 3183,
+  name: 'Midnight Falls',
+  timeline: {
+    abilities: [
+      // glaive spawn
+      { id: 1253915, type: 'cast' },
+      // end of memory game (heroic)
+      { id: 1249620, type: 'begincast' },
+      // safeguard prism
+      { id: 1251386, type: 'cast' },
+      // into the darkwell (p2 start)
+      { id: 1282043, type: 'cast' },
+      // galvanize (p2 beams)
+      { id: 1284528, type: 'cast' },
+      // dark meltdown (p3 start)
+      { id: 1281123, type: 'cast' },
+      // severance (p3 mythic split)
+      { id: 1275539, type: 'cast' },
+      // Dark Archangel (p3 beam)
+      { id: 1251331, type: 'cast' },
+      // Termination Prism (mythic prisms)
+      { id: 1284931, type: 'cast' },
+      // end of memory game (mythic)
+      { id: 1285708, type: 'begincast' },
+      // Heaven & Hell (p4 beam)
+      { id: 1276525, type: 'begincast' },
+    ],
+    debuffs: [
+      // Dark Rune
+      { id: 1249609 },
+      // Galvanize (target)
+      { id: 1284527 },
+      // Glimmering
+      { id: 1253031 },
+      // Starsplinters (i1 blazes)
+      { id: 1285510 },
+      { id: 1279512 },
+      // Criticality (p2 spreads)
+      { id: 1281184 },
+    ],
+  },
+});

--- a/src/game/raids/vs_dr_mqd/Salhadaar.ts
+++ b/src/game/raids/vs_dr_mqd/Salhadaar.ts
@@ -1,3 +1,22 @@
 import { buildBoss } from 'game/raids/builders';
 
-export const Salhadaar = buildBoss({ id: 3179, name: 'Fallen King Salhadaar' });
+export const Salhadaar = buildBoss({
+  id: 3179,
+  name: 'Fallen King Salhadaar',
+  timeline: {
+    abilities: [
+      // Void Convergence (activate orbs)
+      { id: 1243453, type: 'cast' },
+      // summon kick adds
+      { id: 1254081, type: 'cast' },
+      // tank spikes
+      { id: 1253032, type: 'cast' },
+      // spinny
+      { id: 1246175, type: 'cast' },
+    ],
+    debuffs: [
+      // puddle drops
+      { id: 1248697 },
+    ],
+  },
+});

--- a/src/game/raids/vs_dr_mqd/VaelgorEzzorak.ts
+++ b/src/game/raids/vs_dr_mqd/VaelgorEzzorak.ts
@@ -1,4 +1,32 @@
 import background from './backgrounds/VaelgorEzzorak.jpg';
 import { buildBoss } from 'game/raids/builders';
 
-export const VaelgorEzzorak = buildBoss({ background, id: 3178, name: 'Vaelgor & Ezzorak' });
+export const VaelgorEzzorak = buildBoss({
+  background,
+  id: 3178,
+  name: 'Vaelgor & Ezzorak',
+  timeline: {
+    abilities: [
+      // Dread Breath
+      { id: 1244221, type: 'cast' },
+      // Gloom
+      { id: 1245391, type: 'cast' },
+      // Void Howl (orb spawns)
+      { id: 1244917, type: 'cast' },
+      // Nullbeam
+      { id: 1262623, type: 'cast' },
+      // Midnight Flames
+      { id: 1249748, type: 'begincast' },
+    ],
+    debuffs: [
+      // Dread Breath (target)
+      { id: 1255612, type: 'debuff' },
+      // Dread Breath (fear)
+      { id: 1255979 },
+      // Nullzone (tether)
+      { id: 1244672 },
+      // Shadowmark
+      { id: 1270497 },
+    ],
+  },
+});

--- a/src/game/raids/vs_dr_mqd/Vorasius.ts
+++ b/src/game/raids/vs_dr_mqd/Vorasius.ts
@@ -1,4 +1,22 @@
 import background from './backgrounds/Vorasius.jpg';
 import { buildBoss } from 'game/raids/builders';
 
-export const Vorasius = buildBoss({ background, id: 3177, name: 'Vorasius' });
+export const Vorasius = buildBoss({
+  background,
+  id: 3177,
+  name: 'Vorasius',
+  timeline: {
+    abilities: [
+      // Primordial Roar
+      { id: 1260052, type: 'cast' },
+      // Parasite Expulsion
+      { id: 1254199, type: 'cast' },
+      // Void Breath
+      { id: 1256855, type: 'cast' },
+    ],
+    debuffs: [
+      // Fixate
+      { id: 1254113, type: 'debuff' },
+    ],
+  },
+});

--- a/src/interface/selectors/url/report/getPlayerName.ts
+++ b/src/interface/selectors/url/report/getPlayerName.ts
@@ -7,9 +7,10 @@ export const getPlayerNameFromParam = (param: string | null | undefined) => {
     const hasSeparator = index !== -1;
     const hasAnonSeparator = player.includes('+');
     if (hasSeparator) {
-      return player.substr(index + 1);
+      return decodeURIComponent(player.substring(index + 1));
     }
     if (hasAnonSeparator) {
+      // anonymous names don't need uri component decoding, since they're anonymous
       return player.replace('+', ' ');
     }
     if (!Number.isInteger(player)) {


### PR DESCRIPTION
### Description

this (finally) adds abilities to the timelines for midnight s1 bosses. it also fixes the header showing uri-encoded character names.

<img width="1276" height="411" alt="image" src="https://github.com/user-attachments/assets/ee6ea1d0-1cec-474f-9f2e-87bad0d18ddd" />
<img width="678" height="224" alt="image" src="https://github.com/user-attachments/assets/0133cb5a-d08f-4798-9eb6-89baa225e13f" />
<img width="1304" height="574" alt="image" src="https://github.com/user-attachments/assets/69eecdc0-5f7c-489f-b76b-87d37526a092" />