### PR TITLE
[Mistweaver] 12.0.5 Cleanup

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 23), <>Fixed a bug with <SpellLink spell={TALENTS_MONK.SPIRITFONT_1_MISTWEAVER_TALENT} /> performance, fixed <SpellLink spell={TALENTS_MONK.SAVE_THEM_ALL_TALENT} /> showing as 0% for events without hitpoints data, removed <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> reference from <SpellLink spell={TALENTS_MONK.STRENGTH_OF_THE_BLACK_OX_TALENT} />, and created a "casting while moving" module baseline.</>, swirl),
   change(date(2026, 4, 15), <>Fixed a bug with <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT} /> statistic and guide subsection analysis when <SpellLink spell={TALENTS_MONK.SHEILUNS_GIFT_TALENT} /> is talented.</>, Vohrr),
   change(date(2026, 3, 29), <>Updated Celestial analysis, APL checks, and general healing cooldowns updates.</>, swirl),
   change(date(2026, 3, 24), <>Fixed <SpellLink spell={TALENTS_MONK.MISTY_COALESCENCE_TALENT} /> to correctly cap scaling at 20 players.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,7 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2026, 4, 23), <>Fixed a bug with <SpellLink spell={TALENTS_MONK.SPIRITFONT_1_MISTWEAVER_TALENT} /> performance, fixed <SpellLink spell={TALENTS_MONK.SAVE_THEM_ALL_TALENT} /> showing as 0% for events without hitpoints data, removed <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> reference from <SpellLink spell={TALENTS_MONK.STRENGTH_OF_THE_BLACK_OX_TALENT} />, and created a "casting while moving" module baseline.</>, swirl),
+  change(date(2026, 4, 23), <>Fixed a bug with <SpellLink spell={TALENTS_MONK.SPIRITFONT_1_MISTWEAVER_TALENT} /> performance, fixed <SpellLink spell={TALENTS_MONK.SAVE_THEM_ALL_TALENT} /> showing as 0% for events without hitpoints data, removed <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> reference from <SpellLink spell={TALENTS_MONK.STRENGTH_OF_THE_BLACK_OX_TALENT} />, and moved "casting while moving" module out of <SpellLink spell={TALENTS_MONK.WAY_OF_THE_SERPENT_TALENT}/>.</>, swirl),
   change(date(2026, 4, 15), <>Fixed a bug with <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT} /> statistic and guide subsection analysis when <SpellLink spell={TALENTS_MONK.SHEILUNS_GIFT_TALENT} /> is talented.</>, Vohrr),
   change(date(2026, 3, 29), <>Updated Celestial analysis, APL checks, and general healing cooldowns updates.</>, swirl),
   change(date(2026, 3, 24), <>Fixed <SpellLink spell={TALENTS_MONK.MISTY_COALESCENCE_TALENT} /> to correctly cap scaling at 20 players.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/CONFIG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CONFIG.tsx
@@ -9,7 +9,7 @@ const config: Config = {
   contributors: [Vohrr, swirl],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.0',
+  patchCompatibility: '12.0.5',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -91,6 +91,7 @@ import S1TierSet from './modules/tier/S1TierSet';
 import AmplifiedRush from './modules/spells/AmplifiedRush';
 import WayOfTheSerpent from './modules/spells/WayOfTheSerpent';
 import MovementTracker from './modules/features/MovementDuringBuffTracker';
+import CastingWhileMoving from './modules/features/CastingWhileMoving';
 import WayOfTheCrane from './modules/spells/WayOfTheCrane';
 import AncientTeachingsLinkNormalizer from './normalizers/AncientTeachingsLinkNormalizer';
 import SoothingMistLinkNormalizer from './normalizers/SoothingMistLinkNormalizer';
@@ -140,6 +141,7 @@ class CombatLogParser extends CoreCombatLogParser {
     talentHealingStatistic: TalentHealingStatistic,
     risingMistBreakdown: RisingMistBreakdown,
     movementTracker: MovementTracker,
+    castingWhileMoving: CastingWhileMoving,
 
     // Guide helpers
     sheilunsGiftCloudTracker: SheilunsGiftCloudTracker,

--- a/src/analysis/retail/monk/mistweaver/modules/features/CastingWhileMoving.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/CastingWhileMoving.tsx
@@ -1,0 +1,121 @@
+import SPELLS from 'common/SPELLS';
+import { TALENTS_MONK } from 'common/TALENTS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  BeginChannelEvent,
+  CastEvent,
+  RemoveBuffEvent,
+  GetRelatedEvents,
+} from 'parser/core/Events';
+import MovementDuringBuffTracker from '../features/MovementDuringBuffTracker';
+import { SOOTHING_MIST_CHANNEL_END } from '../../normalizers/EventLinks/EventLinkConstants';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { SpellLink } from 'interface';
+import { formatNumber, formatPercentage } from 'common/format';
+import DistanceMoved from 'parser/shared/modules/DistanceMoved';
+
+class CastingWhileMoving extends Analyzer {
+  static dependencies = {
+    movementTracker: MovementDuringBuffTracker,
+    distanceMoved: DistanceMoved,
+  };
+
+  protected movementTracker!: MovementDuringBuffTracker;
+  protected distanceMoved!: DistanceMoved;
+
+  soothingMistChannelEnds: Set<number> = new Set();
+
+  constructor(options: Options) {
+    super(options);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.SOOTHING_MIST_TALENT),
+      this.onSoothingMistCast,
+    );
+    this.addEventListener(
+      Events.removebuff
+        .by(SELECTED_PLAYER)
+        .spell(TALENTS_MONK.SOOTHING_MIST_TALENT)
+        .to(SELECTED_PLAYER),
+      this.onSoothingMistEnd,
+    );
+
+    this.addEventListener(
+      Events.BeginChannel.by(SELECTED_PLAYER).spell(SPELLS.CRACKLING_JADE_LIGHTNING),
+      this.onChannelStart,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.CRACKLING_JADE_LIGHTNING),
+      this.onChannelEnd,
+    );
+  }
+
+  onSoothingMistCast(event: CastEvent) {
+    this.movementTracker.startTracking(event.ability.guid, event.timestamp);
+
+    const channelEndEvents = GetRelatedEvents(event, SOOTHING_MIST_CHANNEL_END);
+    if (channelEndEvents.length > 0) {
+      const endEvent = channelEndEvents[0] as RemoveBuffEvent;
+      this.soothingMistChannelEnds.add(endEvent.timestamp);
+    }
+  }
+
+  onSoothingMistEnd(event: RemoveBuffEvent) {
+    if (this.soothingMistChannelEnds.has(event.timestamp)) {
+      this.movementTracker.stopTracking(TALENTS_MONK.SOOTHING_MIST_TALENT.id, event.timestamp);
+      this.soothingMistChannelEnds.delete(event.timestamp);
+    }
+  }
+
+  onChannelStart(event: CastEvent | BeginChannelEvent) {
+    this.movementTracker.startTracking(event.ability.guid, event.timestamp);
+  }
+
+  onChannelEnd(event: RemoveBuffEvent) {
+    this.movementTracker.stopTracking(event.ability.guid, event.timestamp);
+  }
+
+  statistic() {
+    const soomMovement = this.movementTracker.getTotalMovement(
+      TALENTS_MONK.SOOTHING_MIST_TALENT.id,
+    );
+    const cjlMovement = this.movementTracker.getTotalMovement(SPELLS.CRACKLING_JADE_LIGHTNING.id);
+    const totalMovement = soomMovement + cjlMovement;
+    const percentOfTotal =
+      this.distanceMoved.totalDistanceMoved > 0
+        ? totalMovement / this.distanceMoved.totalDistanceMoved
+        : 0;
+
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.UNIMPORTANT()}
+        size="flexible"
+        category={STATISTIC_CATEGORY.GENERAL}
+        tooltip={
+          <>
+            <div>
+              <SpellLink spell={TALENTS_MONK.SOOTHING_MIST_TALENT} />: {formatNumber(soomMovement)}{' '}
+              yards
+            </div>
+            <div>
+              <SpellLink spell={SPELLS.CRACKLING_JADE_LIGHTNING} />: {formatNumber(cjlMovement)}{' '}
+              yards
+            </div>
+          </>
+        }
+      >
+        <div className={`pad boring-text`}>
+          <label>Casting while moving</label>
+          <div className="value">
+            ≈ {formatNumber(totalMovement)} yards{' '}
+            <small>{formatPercentage(percentOfTotal)}% of total</small>
+          </div>
+        </div>
+      </Statistic>
+    );
+  }
+}
+
+export default CastingWhileMoving;

--- a/src/analysis/retail/monk/mistweaver/modules/heroTalents/StrengthOfTheBlackOx.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/heroTalents/StrengthOfTheBlackOx.tsx
@@ -72,7 +72,6 @@ class StrengthOfTheBlackOx extends Analyzer {
           </div>
           {isConsumed && (
             <div>
-              <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT} /> or{' '}
               <SpellLink spell={getCurrentCelestialTalent(this.selectedCombatant)} /> active:{' '}
               <strong>{hasBuff ? 'Yes' : 'No'}</strong>
             </div>
@@ -91,9 +90,8 @@ class StrengthOfTheBlackOx extends Analyzer {
         is a buff that makes your next <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT} />{' '}
         have a reduced cast time and apply a shield to 5 nearby allies. It is very important to
         never let this buff refresh or expire as it is a considerable amount of shielding. Try to
-        have <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT} /> or{' '}
-        <SpellLink spell={getCurrentCelestialTalent(this.selectedCombatant)} /> active when casting{' '}
-        <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT} /> as it is very expensive.
+        have <SpellLink spell={getCurrentCelestialTalent(this.selectedCombatant)} /> active when
+        casting <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT} /> as it is very expensive.
       </p>
     );
     const styleObj = {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeChiJi.tsx
@@ -316,7 +316,7 @@ class InvokeChiJi extends BaseCelestialAnalyzer {
         <BoringValueText
           label={
             <>
-              <SpellLink spell={TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT} /> and
+              <SpellLink spell={TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT} /> and{' '}
               <SpellLink spell={TALENTS_MONK.CELESTIAL_HARMONY_TALENT} />
             </>
           }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/InvokeYulon.tsx
@@ -283,7 +283,7 @@ class InvokeYulon extends BaseCelestialAnalyzer {
         <BoringValueText
           label={
             <>
-              <SpellLink spell={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} /> and
+              <SpellLink spell={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} /> and{' '}
               <SpellLink spell={TALENTS_MONK.CELESTIAL_HARMONY_TALENT} />
             </>
           }

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Spiritfont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Spiritfont.tsx
@@ -32,7 +32,10 @@ import {
   SPIRITFONT_PROC,
   SPIRITFONT_TFT,
 } from '../../normalizers/EventLinks/EventLinkConstants';
-import { isSpiritfontConsumed } from '../../normalizers/CastLinkNormalizer';
+import {
+  isSpiritfontConsumed,
+  isSpiritfontFalseRefresh,
+} from '../../normalizers/CastLinkNormalizer';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
@@ -122,6 +125,8 @@ class Spiritfont extends Analyzer {
   }
 
   private onRefreshBuff(event: RefreshBuffEvent) {
+    if (isSpiritfontFalseRefresh(event)) return;
+
     this.wastedBuffs += 1;
     this.entries.push({
       value: QualitativePerformance.Fail,

--- a/src/analysis/retail/monk/mistweaver/modules/spells/WayOfTheSerpent.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/WayOfTheSerpent.tsx
@@ -1,13 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, {
-  BeginChannelEvent,
-  CastEvent,
-  HealEvent,
-  RemoveBuffEvent,
-  GetRelatedEvents,
-} from 'parser/core/Events';
+import Events, { HealEvent } from 'parser/core/Events';
 import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
 import {
   WAY_OF_THE_SERPENT_VIV_SG_INCREASE,
@@ -21,22 +15,12 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 import { SpellLink } from 'interface/index';
 import { formatPercentage, formatNumber } from 'common/format';
-import MovementDuringBuffTracker from '../features/MovementDuringBuffTracker';
-import { SOOTHING_MIST_CHANNEL_END } from '../../normalizers/EventLinks/EventLinkConstants';
 
 class WayOfTheSerpent extends Analyzer {
-  static dependencies = {
-    movementTracker: MovementDuringBuffTracker,
-  };
-
-  protected movementTracker!: MovementDuringBuffTracker;
-
   activeVivifySpell = SPELLS.VIVIFY;
 
   vivifySheilunsHealing = 0;
   renewingMistHealing = 0;
-
-  soothingMistChannelEnds: Set<number> = new Set();
 
   constructor(options: Options) {
     super(options);
@@ -50,51 +34,6 @@ class WayOfTheSerpent extends Analyzer {
       Events.heal.by(SELECTED_PLAYER).spell([this.activeVivifySpell, SPELLS.RENEWING_MIST_HEAL]),
       this.onHeal,
     );
-
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.SOOTHING_MIST_TALENT),
-      this.onSoothingMistCast,
-    );
-    this.addEventListener(
-      Events.removebuff
-        .by(SELECTED_PLAYER)
-        .spell(TALENTS_MONK.SOOTHING_MIST_TALENT)
-        .to(SELECTED_PLAYER),
-      this.onSoothingMistEnd,
-    );
-    this.addEventListener(
-      Events.BeginChannel.by(SELECTED_PLAYER).spell(SPELLS.CRACKLING_JADE_LIGHTNING),
-      this.onChannelStart,
-    );
-    this.addEventListener(
-      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.CRACKLING_JADE_LIGHTNING),
-      this.onChannelEnd,
-    );
-  }
-
-  onSoothingMistCast(event: CastEvent) {
-    this.movementTracker.startTracking(event.ability.guid, event.timestamp);
-
-    const channelEndEvents = GetRelatedEvents(event, SOOTHING_MIST_CHANNEL_END);
-    if (channelEndEvents.length > 0) {
-      const endEvent = channelEndEvents[0] as RemoveBuffEvent;
-      this.soothingMistChannelEnds.add(endEvent.timestamp);
-    }
-  }
-
-  onSoothingMistEnd(event: RemoveBuffEvent) {
-    if (this.soothingMistChannelEnds.has(event.timestamp)) {
-      this.movementTracker.stopTracking(TALENTS_MONK.SOOTHING_MIST_TALENT.id, event.timestamp);
-      this.soothingMistChannelEnds.delete(event.timestamp);
-    }
-  }
-
-  onChannelStart(event: CastEvent | BeginChannelEvent) {
-    this.movementTracker.startTracking(event.ability.guid, event.timestamp);
-  }
-
-  onChannelEnd(event: RemoveBuffEvent) {
-    this.movementTracker.stopTracking(event.ability.guid, event.timestamp);
   }
 
   get totalHealing(): number {
@@ -124,11 +63,6 @@ class WayOfTheSerpent extends Analyzer {
   }
 
   statistic() {
-    const soomMovement = this.movementTracker.getTotalMovement(
-      TALENTS_MONK.SOOTHING_MIST_TALENT.id,
-    );
-    const cjlMovement = this.movementTracker.getTotalMovement(SPELLS.CRACKLING_JADE_LIGHTNING.id);
-
     return (
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL(1)}
@@ -144,28 +78,11 @@ class WayOfTheSerpent extends Analyzer {
               <SpellLink spell={SPELLS.RENEWING_MIST_HEAL} /> additional healing:{' '}
               {formatNumber(this.renewingMistHealing)}
             </div>
-            {soomMovement > 0 && (
-              <div>
-                Movement during <SpellLink spell={TALENTS_MONK.SOOTHING_MIST_TALENT} />:{' '}
-                {formatNumber(soomMovement)} yards
-              </div>
-            )}
-            {cjlMovement > 0 && (
-              <div>
-                Movement during <SpellLink spell={SPELLS.CRACKLING_JADE_LIGHTNING} />:{' '}
-                {formatNumber(cjlMovement)} yards
-              </div>
-            )}
           </>
         }
       >
         <TalentSpellText talent={TALENTS_MONK.WAY_OF_THE_SERPENT_TALENT}>
-          <div>
-            <ItemHealingDone amount={this.totalHealing} />
-          </div>
-          <div>
-            {formatNumber(soomMovement + cjlMovement)} <small>yards moved while channeling</small>
-          </div>
+          <ItemHealingDone amount={this.totalHealing} />
         </TalentSpellText>
       </Statistic>
     );

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -44,6 +44,7 @@ import {
   ZEN_PULSE_CAST,
   STRENGTH_OF_THE_BLACK_OX,
   SPIRITFONT_CONSUMED,
+  SPIRITFONT_FALSE_REFRESH,
   JADE_BOND_ENVM,
   INSURANCE_FROM_REM,
   INSURANCE,
@@ -303,8 +304,13 @@ export function HasStackChange(event: RefreshBuffEvent): boolean {
   return HasRelatedEvent(event, MT_STACK_CHANGE);
 }
 
+// apex talent (spiritfont)
 export function isSpiritfontConsumed(event: RemoveBuffEvent | RemoveBuffStackEvent): boolean {
   return HasRelatedEvent(event, SPIRITFONT_CONSUMED);
+}
+
+export function isSpiritfontFalseRefresh(event: RefreshBuffEvent): boolean {
+  return HasRelatedEvent(event, SPIRITFONT_FALSE_REFRESH);
 }
 
 // hero talents

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/ApexEventLinks.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/ApexEventLinks.ts
@@ -7,6 +7,7 @@ import {
   SPIRITFONT_PROC,
   SPIRITFONT_TFT,
   SPIRITFONT_CONSUMED,
+  SPIRITFONT_FALSE_REFRESH,
 } from './EventLinkConstants';
 
 export const APEX_EVENT_LINKS: EventLink[] = [
@@ -50,6 +51,19 @@ export const APEX_EVENT_LINKS: EventLink[] = [
     backwardBufferMs: CAST_BUFFER_MS,
     maximumLinks: 1,
     anyTarget: true,
+    isActive(c) {
+      return c.hasTalent(TALENTS_MONK.SPIRITFONT_1_MISTWEAVER_TALENT);
+    },
+  },
+  {
+    linkRelation: SPIRITFONT_FALSE_REFRESH,
+    linkingEventId: SPELLS.SPIRITFONT_BUFF.id,
+    linkingEventType: EventType.RefreshBuff,
+    referencedEventId: SPELLS.SPIRITFONT_BUFF.id,
+    referencedEventType: EventType.RemoveBuffStack,
+    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
     isActive(c) {
       return c.hasTalent(TALENTS_MONK.SPIRITFONT_1_MISTWEAVER_TALENT);
     },

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants.ts
@@ -76,6 +76,7 @@ export const RUSHING_WIND_KICK = 'RWK';
 export const SPIRITFONT_PROC = 'SpiritfontProc';
 export const SPIRITFONT_TFT = 'SpiritfontTFT';
 export const SPIRITFONT_CONSUMED = 'SpiritfontConsumed';
+export const SPIRITFONT_FALSE_REFRESH = 'SpiritfontFalseRefresh';
 
 // Soothing Mist Channel
 export const SOOTHING_MIST_CHANNEL_START = 'SoothingMistChannelStart';

--- a/src/analysis/retail/monk/shared/SaveThemAll.tsx
+++ b/src/analysis/retail/monk/shared/SaveThemAll.tsx
@@ -1,5 +1,5 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { HealEvent } from 'parser/core/Events';
+import Events, { HasHitpoints, HealEvent } from 'parser/core/Events';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
@@ -14,6 +14,7 @@ import { SAVE_THEM_ALL_MAX_INCREASE } from '../mistweaver/constants';
 
 class SaveThemAll extends Analyzer {
   totalHealed = 0;
+  excludedHealing = 0;
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.SAVE_THEM_ALL_TALENT);
@@ -22,7 +23,14 @@ class SaveThemAll extends Analyzer {
   }
 
   onHeal(event: HealEvent) {
-    const hpBeforeHeal = event.hitPoints - event.amount;
+    const healAmount = event.amount || 0;
+
+    if (!HasHitpoints(event)) {
+      this.excludedHealing += healAmount;
+      return;
+    }
+
+    const hpBeforeHeal = event.hitPoints - healAmount;
     const healingIncrease = (1 - hpBeforeHeal / event.maxHitPoints) * SAVE_THEM_ALL_MAX_INCREASE;
 
     this.totalHealed += calculateEffectiveHealing(event, healingIncrease);
@@ -45,7 +53,18 @@ class SaveThemAll extends Analyzer {
         position={STATISTIC_ORDER.CORE(12)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
-        tooltip={<>Total Healed: {formatNumber(this.totalHealed)}</>}
+        tooltip={
+          <>
+            <div>Total Healed: {formatNumber(this.totalHealed)}</div>
+            {this.excludedHealing > 0 && (
+              <div>
+                Excluded healing with incomplete data:{' '}
+                {formatPercentage(this.owner.getPercentageOfTotalHealingDone(this.excludedHealing))}
+                % of total
+              </div>
+            )}
+          </>
+        }
       >
         <TalentSpellText talent={TALENTS_MONK.SAVE_THEM_ALL_TALENT}>
           <ItemHealingDone amount={this.totalHealed} />


### PR DESCRIPTION
### Description

- Added false refresh event link for Spiritfont, where, if consuming the second stack of Spiritfont, a subsequent RefreshBuff event occurs and is not an actual wasted refresh event.
- Moved the "Casting while Moving" portion out of Way of the Serpent, and instead created a general statistic to track the yards of total moved with Soothing Mist and Crackling Jade Lightning.
- Cleaned up Invoke spacing with guaranteed space
- Fixed Save Them All displaying 0.00% as the total healing contributed was NaN due to the event not having hitpoints data. This is seemingly only visible from L'ura crystal healing, as those events did not send any hitpoint data alongside it. 
- Removed reference to Mana Tea for Strength of the Black Ox, as MT no longer has a "mana cost reduction" buff associated.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/w6fW4vnKxZ7c1rRA/36-Mythic+Vaelgor+&+Ezzorak+-+Kill+(7:39)/228-Br%C3%AE%C3%AEght/standard/overview`
- Screenshot(s):
#### Spiritfont:
New:
<img width="926" height="205" alt="image" src="https://github.com/user-attachments/assets/fae143b1-b397-4246-9997-79be542e3d68" />
Live: 
<img width="677" height="260" alt="image" src="https://github.com/user-attachments/assets/40656f13-bb96-4b2d-bfb3-d527cbfc3393" />
<img width="410" height="129" alt="image" src="https://github.com/user-attachments/assets/6f7c37cf-e006-464d-b09a-7b270dfe4243" />

#### Cast while moving:
New:
<img width="370" height="142" alt="image" src="https://github.com/user-attachments/assets/47fcb5a3-fd58-4f30-ae70-f9d9b5483b16" />
<img width="329" height="95" alt="image" src="https://github.com/user-attachments/assets/71f1e169-4fb2-49a5-ac17-89e3bc0b4736" />
Live:
<img width="267" height="298" alt="image" src="https://github.com/user-attachments/assets/d144c205-b3c7-4c1d-98f7-09e0caa5250f" />

#### Invoke Cleanup
New:
<img width="372" height="178" alt="image" src="https://github.com/user-attachments/assets/07824d2d-8f5a-4e49-ad6e-f77b3f590178" />
Live: 
<img width="334" height="232" alt="image" src="https://github.com/user-attachments/assets/2b48a1eb-2c1e-4804-acf2-a8d1f3917bcb" />

#### Save Them All
(most reports unaffected, except 100% of L'ura)
- Report URL: `/report/wfXRjWGt3aVJbAYQ/66-Mythic+Midnight+Falls+-+Wipe+23+(4:10)/155-Sweggles/standard`
New:
<img width="367" height="138" alt="image" src="https://github.com/user-attachments/assets/c731e470-90bf-4aa1-b085-da755b6d8c31" />
<img width="454" height="86" alt="image" src="https://github.com/user-attachments/assets/22030ad9-33bb-428c-912e-2e29447b567f" />
Live:
<img width="334" height="146" alt="image" src="https://github.com/user-attachments/assets/7a07e381-fb02-41bf-80f6-11f91f9ddb79" />

#### Mana Tea / SotbO
New:
<img width="637" height="186" alt="image" src="https://github.com/user-attachments/assets/cf50a48f-ba53-48b8-b5dc-439b300a905c" />
<img width="405" height="97" alt="image" src="https://github.com/user-attachments/assets/748b9e4d-3820-4e0d-87ef-3afa4bc5e28a" />
Live:
<img width="563" height="180" alt="image" src="https://github.com/user-attachments/assets/ac26c57f-30d5-426e-bb77-b348b9875172" />
<img width="523" height="88" alt="image" src="https://github.com/user-attachments/assets/e3ff196f-10dc-4eed-b2bc-4c6d7d1de020" />
