### PR TITLE
fix(components): bug where if mitigation was >=1

### DIFF
--- a/src/interface/guide/components/MajorDefensives/MajorDefensiveAnalyzer.tsx
+++ b/src/interface/guide/components/MajorDefensives/MajorDefensiveAnalyzer.tsx
@@ -108,6 +108,9 @@ type InProgressMitigation<Apply extends EventType, Remove extends EventType> = P
  */
 export function absoluteMitigation(event: DamageEvent, mitPct: number): number {
   const actualAmount = event.amount + (event.absorbed ?? 0) + (event.overkill ?? 0);
+  if (mitPct >= 1) {
+    return actualAmount;
+  }
   const priorAmount = actualAmount * (1 / (1 - mitPct));
   return priorAmount - actualAmount;
 }


### PR DESCRIPTION
If mitPct was >=1 (like Aspect of the Turtle), it would calculate incorrectly and show there was 0 mitigation.
