### PR TITLE
Add Umbilicus Eternus to timeline for Blood Death Knight

### DIFF
--- a/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 24), <>Added <SpellLink spell={talents.UMBILICUS_ETERNUS_TALENT}/> to timeline .</>, Badkad),
   change(date(2026, 4, 10), <>Enabled Changelog.</>, Badkad),
   change(date(2026, 4, 5), <>Updated cooldown of <SpellLink spell={talents.DANCING_RUNE_WEAPON_TALENT} />.</>, Badkad),
   change(date(2026, 4, 1), "Added basic support for Midnight", Badkad),

--- a/src/analysis/retail/deathknight/blood/modules/Abilities.ts
+++ b/src/analysis/retail/deathknight/blood/modules/Abilities.ts
@@ -27,6 +27,12 @@ class Abilities extends CoreAbilities {
         timelineSortIndex: 10,
       },
       {
+        spell: TALENTS.UMBILICUS_ETERNUS_TALENT.id,
+        buffSpellId: SPELLS.UMBILICUS_ETERNUS_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS.UMBILICUS_ETERNUS_TALENT),
+        category: SPELL_CATEGORY.HIDDEN,
+      },
+      {
         spell: SPELLS.ANTI_MAGIC_SHELL.id,
         buffSpellId: SPELLS.ANTI_MAGIC_SHELL.id,
         category: SPELL_CATEGORY.DEFENSIVE,

--- a/src/common/SPELLS/deathknight.ts
+++ b/src/common/SPELLS/deathknight.ts
@@ -137,7 +137,7 @@ const spells = {
     icon: 'spell_deathknight_deathstrike',
   },
   UMBILICUS_ETERNUS_BUFF: {
-    id: 391519,
+    id: 391527,
     name: 'Umbilicus Eternus',
     icon: 'artifactability_blooddeathknight_umbilicuseternus',
   },

--- a/src/common/SPELLS/deathknight.ts
+++ b/src/common/SPELLS/deathknight.ts
@@ -136,6 +136,11 @@ const spells = {
     name: 'Heartbreaker',
     icon: 'spell_deathknight_deathstrike',
   },
+  UMBILICUS_ETERNUS_BUFF: {
+    id: 391519,
+    name: 'Umbilicus Eternus',
+    icon: 'artifactability_blooddeathknight_umbilicuseternus',
+  },
 
   // region Frost Specialization
 


### PR DESCRIPTION
### Description

Add Umblicius Eternus to abiltities.ts and deathknight.ts

### Testing

Load blood death knight log with umblicius eternus talanted. Check for it one the timeline

- Test report URL: `/report/PpRQdLz3Y9NG8ht4?fight=1`
- Screenshot(s):
<img width="2244" height="572" alt="image" src="https://github.com/user-attachments/assets/24b4228c-9185-4533-abfc-3919eac25c0f" />
