### PR TITLE
fix(probability): Fix slow loading by improving from O(n^3) to O(n^2)

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,7 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2026, 4, 25), 'Fix some extremely long loading times by improving probability calculations from o(n^3) to o(n^2).', Thias),
+  change(date(2026, 4, 25), 'Fix certain extremely long loading times by improving probability calculations from o(n^3) to o(n^2).', Thias),
   change(date(2026, 4, 22), 'Add Midnight raid boss abilities to uptime timelines.', emallson),
   change(date(2026, 4, 21), 'Improve glyph loading by pre-loading during initialization instead of lazy load', Thias),
   change(date(2026, 4, 20), "Regenerate talents for 12.0.5.", Vollmer),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 25), 'Fix some extremely long loading times by improving probability calculations from o(n^3) to o(n^2).', Thias),
   change(date(2026, 4, 22), 'Add Midnight raid boss abilities to uptime timelines.', emallson),
   change(date(2026, 4, 21), 'Improve glyph loading by pre-loading during initialization instead of lazy load', Thias),
   change(date(2026, 4, 20), "Regenerate talents for 12.0.5.", Vollmer),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,7 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2026, 4, 25), 'Fix certain extremely long loading times by improving probability calculations from o(n^3) to o(n^2).', Thias),
+  change(date(2026, 4, 25), 'Fix certain extremely long loading times by improving probability calculations from O(n^3) to O(n^2).', Thias),
   change(date(2026, 4, 22), 'Add Midnight raid boss abilities to uptime timelines.', emallson),
   change(date(2026, 4, 21), 'Improve glyph loading by pre-loading during initialization instead of lazy load', Thias),
   change(date(2026, 4, 20), "Regenerate talents for 12.0.5.", Vollmer),

--- a/src/analysis/retail/paladin/retribution/modules/talents/EmpyreanPower.tsx
+++ b/src/analysis/retail/paladin/retribution/modules/talents/EmpyreanPower.tsx
@@ -28,7 +28,6 @@ class EmpyreanPower extends Analyzer {
   buffRemovedTimestamp = 0;
 
   totalChances = 0;
-  procProbabilities: number[] = [];
 
   constructor(options: Options) {
     super(options);
@@ -60,7 +59,6 @@ class EmpyreanPower extends Analyzer {
 
   castCounter() {
     this.totalChances += 1;
-    this.procProbabilities.push(CRUSADING_STRIKE_EMPYREAN_POWER_CHANCE);
   }
 
   divineStormDamage(event: DamageEvent) {
@@ -107,8 +105,12 @@ class EmpyreanPower extends Analyzer {
         <BoringSpellValueText spell={SPELLS.EMPYREAN_POWER_TALENT_BUFF}>
           <ItemDamageDone amount={this.damageDone} />
         </BoringSpellValueText>
-        {this.procProbabilities.length > 0
-          ? plotOneVariableBinomChart(this.procsGained, this.totalChances, this.procProbabilities)
+        {this.totalChances > 0
+          ? plotOneVariableBinomChart(
+              this.procsGained,
+              this.totalChances,
+              CRUSADING_STRIKE_EMPYREAN_POWER_CHANCE,
+            )
           : null}
       </Statistic>
     );

--- a/src/parser/shared/modules/helpers/Probability.test.ts
+++ b/src/parser/shared/modules/helpers/Probability.test.ts
@@ -1,0 +1,59 @@
+import { computeProbabilityRange } from './Probability';
+
+describe('computeProbabilityRange', () => {
+  it('should throw when there are 0 proc attempts', () => {
+    expect(() => computeProbabilityRange(0, 0.1)).toThrowErrorMatchingInlineSnapshot(
+      `[Error: cannot compute probability range for proc with 0 attempts]`,
+    );
+  });
+
+  it('should throw when procProbabilities is an array whose length is not equal to `procAttempts`', () => {
+    expect(() => computeProbabilityRange(100, [0.1, 0.2])).toThrowErrorMatchingInlineSnapshot(
+      `[Error: You must supply a probability vector with the same length as the number of total tries into Poisson Binomial PMF]`,
+    );
+  });
+
+  it('should match precomputed values when using a non-array proc chance', () => {
+    const PROC_CHANCE = 0.1;
+    // fairly forgiving error margin. cba to set up python to get more precise numbers right now
+    const ABS_ERROR_MARGIN = 1e-12;
+    const CASES: { args: [number, number]; result: number }[] = [
+      { args: [0, 100], result: 0.000026561398887587544 },
+      { args: [10, 100], result: 0.13186534682448858 },
+      { args: [25, 100], result: 0.000008972933719565316 },
+    ];
+
+    for (const { args, result } of CASES) {
+      const range = computeProbabilityRange(args[1], PROC_CHANCE);
+      const actual = range.procProbabilities.find((point) => point.x === args[0])!;
+      expect(Math.abs(actual.y - result)).toBeLessThanOrEqual(ABS_ERROR_MARGIN);
+    }
+  });
+  const procChances = (count: number) => {
+    const result = [];
+    for (let i = 0; i < count; i++) {
+      result.push(i % 2 ? 0.25 : 0.1);
+    }
+
+    return result;
+  };
+
+  it('should match precomputed values when using an array proc chance', () => {
+    // fairly forgiving error margin
+    const ABS_ERROR_MARGIN = 1e-12;
+    // this test actually doesn't use precomputed external values. it is a consistency test for refactoring work.
+    // would be worth revalidating these numbers against scipy at some point
+
+    const CASES: { args: [number, number]; result: number }[] = [
+      { args: [0, 100], result: 2.918694512261613e-9 },
+      { args: [10, 100], result: 0.013211692412731131 },
+      { args: [25, 100], result: 0.014847417043472571 },
+    ];
+
+    for (const { args, result } of CASES) {
+      const range = computeProbabilityRange(args[1], procChances(args[1]));
+      const actual = range.procProbabilities.find((point) => point.x === args[0])!;
+      expect(Math.abs(actual.y - result)).toBeLessThanOrEqual(ABS_ERROR_MARGIN);
+    }
+  });
+});

--- a/src/parser/shared/modules/helpers/Probability.tsx
+++ b/src/parser/shared/modules/helpers/Probability.tsx
@@ -82,32 +82,35 @@ function binomialDistribution(n: number, k: number) {
   return result;
 }
 
-function resetProbabilityArray(
-  actualProcs: number,
-  procAttempts: number,
-  procChance: number | number[],
-) {
-  const procProbabilities: { x: number; y: number }[] = Array.from(
-    { length: procAttempts },
-    (_x, i: number) => {
-      if (typeof procChance === 'number') {
-        return { x: i, y: binomialPMF(i, procAttempts, procChance) };
-      } else {
-        return { x: i, y: poissonBinomialPMF(i, procAttempts, procChance) };
-      }
-    },
+function resetProbabilityArray(procAttempts: number, procChance: number | number[]) {
+  if (typeof procChance === 'number') {
+    return Array.from({ length: procAttempts }, (_x, i: number) => ({
+      x: i,
+      y: binomialPMF(i, procAttempts, procChance),
+    }));
+  }
+  if (procChance.length !== procAttempts) {
+    throw new Error(
+      'You must supply a probability vector with the same length as the number of total tries into Poisson Binomial PMF',
+    );
+  }
+  // Share one lookup table across all k values: each Ekj(k, j) cell is
+  // computed at most once.
+  const lookup: (number | null)[][] = [...Array(procAttempts + 1)].map(() =>
+    Array(procAttempts + 1).fill(null),
   );
-
-  return procProbabilities;
+  return Array.from({ length: procAttempts }, (_x, i: number) => ({
+    x: i,
+    y: Ekj(i, procAttempts, procChance, lookup),
+  }));
 }
 
 function setMinMaxProbabilities(
-  actualProcs: number,
   procAttempts: number,
   procChance: number | number[],
   threshold = 0.001,
 ) {
-  const procProbabilities = resetProbabilityArray(actualProcs, procAttempts, procChance);
+  const procProbabilities = resetProbabilityArray(procAttempts, procChance);
   const rangeMin = procProbabilities.findIndex(({ y }) => y >= threshold);
   const rangeMax = rangeMin + procProbabilities.slice(rangeMin).findIndex(({ y }) => y < threshold);
 
@@ -126,8 +129,7 @@ function setMinMaxProbabilities(
  * @param lookup {Array} Lookup table
  * @returns {Number} Probability
  */
-// oxlint-disable-next-line typescript-eslint/no-explicit-any -- Baseline suppression. Try to fix if you edit this code.
-function Ekj(k: number, j: number, p: number[], lookup: any[][]): number {
+function Ekj(k: number, j: number, p: number[], lookup: (number | null)[][]): number {
   if (k === -1) {
     return 0;
   }
@@ -137,8 +139,9 @@ function Ekj(k: number, j: number, p: number[], lookup: any[][]): number {
   if (k === 0 && j === 0) {
     return 1;
   }
-  if (lookup[k][j] !== null) {
-    return lookup[k][j];
+  const cached = lookup[k][j];
+  if (cached !== null) {
+    return cached;
   }
   // literature uses 1-based indices for probabilities, as we're using an array, we have to use 0 based
   const value: number =
@@ -157,8 +160,7 @@ function Ekj(k: number, j: number, p: number[], lookup: any[][]): number {
  * @param n {Number} Number of total tries
  * @param p {[Number]} Probability vector
  */
-// oxlint-disable-next-line typescript-eslint/no-explicit-any -- Baseline suppression. Try to fix if you edit this code.
-function poissonBinomialPMF(k: number, n: number, p: any[]) {
+function poissonBinomialPMF(k: number, n: number, p: number[]) {
   // denoted in the paper as ξk, I'll call it Ek for simplicity
   // using the recursive formula in chapter 2.5
   if (p.length !== n) {
@@ -169,7 +171,7 @@ function poissonBinomialPMF(k: number, n: number, p: any[]) {
   // Using a lookup table to simplify recursion a little bit
   // construct an (n+1) x (n+1) lookup table (because Ek,j uses indexes from 0 to n INCLUSIVE, with this we don't have to subtract indexes all the time)
   // intentionally set tu nulls so we know which values are computed or not
-  const lookup = [...Array(n + 1)].map((_) => Array(n + 1).fill(null));
+  const lookup: (number | null)[][] = [...Array(n + 1)].map(() => Array(n + 1).fill(null));
   return Ekj(k, n, p, lookup);
 }
 
@@ -202,7 +204,6 @@ export function plotOneVariableBinomChart(
     return null;
   }
   const { procProbabilities, rangeMin, rangeMax } = setMinMaxProbabilities(
-    actualProcs,
     procAttempts,
     procChance,
   );

--- a/src/parser/shared/modules/helpers/Probability.tsx
+++ b/src/parser/shared/modules/helpers/Probability.tsx
@@ -105,11 +105,18 @@ function resetProbabilityArray(procAttempts: number, procChance: number | number
   }));
 }
 
-function setMinMaxProbabilities(
+/**
+ * @internal
+ */
+export function computeProbabilityRange(
   procAttempts: number,
   procChance: number | number[],
   threshold = 0.001,
 ) {
+  if (procAttempts <= 0) {
+    throw new Error('cannot compute probability range for proc with 0 attempts');
+  }
+
   const procProbabilities = resetProbabilityArray(procAttempts, procChance);
   const rangeMin = procProbabilities.findIndex(({ y }) => y >= threshold);
   const rangeMax = rangeMin + procProbabilities.slice(rangeMin).findIndex(({ y }) => y < threshold);
@@ -175,6 +182,9 @@ function poissonBinomialPMF(k: number, n: number, p: number[]) {
   return Ekj(k, n, p, lookup);
 }
 
+/**
+ * @param procChance the chance of the proc occurring. use the array form ONLY if the proc chance can vary (such as if crits have a higher proc chance than non-crits). the array should contain the proc chance of each proc attempt. when the array form is used, this is significantly slower.
+ */
 export function plotOneVariableBinomChart(
   actualProcs: number,
   procAttempts: number,
@@ -203,7 +213,7 @@ export function plotOneVariableBinomChart(
   if (procAttempts < 1) {
     return null;
   }
-  const { procProbabilities, rangeMin, rangeMax } = setMinMaxProbabilities(
+  const { procProbabilities, rangeMin, rangeMax } = computeProbabilityRange(
     procAttempts,
     procChance,
   );


### PR DESCRIPTION
### Description

This PR intends to fix some logs loading incredibly slow due to O(n^3) probability calculations by only computing some variables once and becoming O(n^2)

Closes #7857 

### Testing

- Test report URL: `/report/dwB43Z87KtaH1JYG/6-Mythic++Maisara+Caverns+-+Kill+(40:40)/292-Isquared/standard/statistics`
- Screenshot(s):

**Old:**
<img width="387" height="164" alt="image" src="https://github.com/user-attachments/assets/56c47224-952b-48a0-8a20-43769c3fce46" />

**New:**
<img width="387" height="171" alt="image" src="https://github.com/user-attachments/assets/205d6f0a-f166-4604-8ddf-2f22f66aa0ae" />
