### PR TITLE
[Warrior][Fury][Arms] 12.0.5 APL updates and bugfixes

### DIFF
--- a/src/analysis/retail/warrior/arms/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/arms/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { Nevdok } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2026, 4, 25), 'Fix Heroic Strike tracking, update APL', Nevdok),
   change(date(2026, 4, 3), 'Fix apex talent CS cdr', Nevdok),
   change(date(2026, 3, 14), 'Midnight season 1 APL updates', Nevdok),
   change(date(2026, 1, 19), 'Midnight cleanup before prepatch', Nevdok),

--- a/src/analysis/retail/warrior/arms/modules/Abilities.ts
+++ b/src/analysis/retail/warrior/arms/modules/Abilities.ts
@@ -43,6 +43,13 @@ class Abilities extends CoreAbilities {
         },
       },
       {
+        spell: SPELLS.HEROIC_STRIKE.id,
+        category: SPELL_CATEGORY.ROTATIONAL,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
         spell: TALENTS.REND_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: {

--- a/src/analysis/retail/warrior/arms/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/warrior/arms/modules/core/AplCheck.tsx
@@ -64,12 +64,16 @@ export const buildSlayerApl = (
     {
       spell: SPELLS.MORTAL_STRIKE,
       condition: cnd.and(
-        cnd.debuffStacks(SPELLS.EXECUTIONERS_PRECISION_DEBUFF, { atLeast: 2 }),
+        cnd.or(
+          cnd.debuffStacks(SPELLS.EXECUTIONERS_PRECISION_DEBUFF, { atLeast: 2 }),
+          cnd.debuffPresent(SPELLS.COLOSSUS_SMASH_DEBUFF),
+        ),
         cnd.inExecute(executeThreshold),
       ),
       description: (
         <>
-          Cast <SpellLink spell={SPELLS.MORTAL_STRIKE} /> while in execute range with 2 stacks of{' '}
+          Cast <SpellLink spell={SPELLS.MORTAL_STRIKE} /> while in execute range during{' '}
+          <SpellLink spell={SPELLS.COLOSSUS_SMASH_DEBUFF} /> or with 2 stacks of{' '}
           <SpellLink spell={SPELLS.EXECUTIONERS_PRECISION_DEBUFF} />
         </>
       ),
@@ -78,10 +82,10 @@ export const buildSlayerApl = (
     // OP inside execute with low rage
     {
       spell: SPELLS.OVERPOWER,
-      condition: cnd.and(cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 900 }), executeUsable),
+      condition: cnd.and(cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 800 }), executeUsable),
       description: (
         <>
-          Cast <SpellLink spell={SPELLS.OVERPOWER} /> while in execute range with below 90 rage
+          Cast <SpellLink spell={SPELLS.OVERPOWER} /> while in execute range with below 80 rage
         </>
       ),
     },
@@ -97,7 +101,29 @@ export const buildSlayerApl = (
       ),
     },
 
+    // OP inside execute
+    {
+      spell: SPELLS.OVERPOWER,
+      condition: cnd.inExecute(executeThreshold),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.OVERPOWER} /> while in execute range
+        </>
+      ),
+    },
+
     // outside of execute prio
+
+    // HS
+    {
+      spell: SPELLS.HEROIC_STRIKE,
+      condition: cnd.buffPresent(SPELLS.MASTER_OF_WARFARE),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.HEROIC_STRIKE} />
+        </>
+      ),
+    },
 
     // MS outside execute
     {
@@ -117,17 +143,6 @@ export const buildSlayerApl = (
       description: (
         <>
           Cast <SpellLink spell={executeSpell} />
-        </>
-      ),
-    },
-
-    // HS
-    {
-      spell: SPELLS.HEROIC_STRIKE,
-      condition: cnd.buffPresent(SPELLS.MASTER_OF_WARFARE),
-      description: (
-        <>
-          Cast <SpellLink spell={SPELLS.HEROIC_STRIKE} />
         </>
       ),
     },
@@ -164,6 +179,38 @@ export const buildColossusApl = (
   return build([
     // execute prio
 
+    // HS inside execute
+    {
+      spell: SPELLS.HEROIC_STRIKE,
+      condition: cnd.and(
+        cnd.inExecute(executeThreshold),
+        cnd.buffPresent(SPELLS.MASTER_OF_WARFARE),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.HEROIC_STRIKE} /> while in execute range
+        </>
+      ),
+    },
+
+    // MS in exe
+    {
+      spell: SPELLS.MORTAL_STRIKE,
+      condition: cnd.and(
+        cnd.inExecute(executeThreshold),
+        cnd.or(
+          cnd.debuffStacks(SPELLS.EXECUTIONERS_PRECISION_DEBUFF, { atLeast: 2 }),
+          cnd.not(cnd.hasTalent(TALENTS.EXECUTIONERS_PRECISION_TALENT)),
+        ),
+      ),
+      description: (
+        <>
+          Cast <SpellLink spell={SPELLS.MORTAL_STRIKE} /> in execute range, with 2 stacks of{' '}
+          <SpellLink spell={SPELLS.EXECUTIONERS_PRECISION_DEBUFF} /> if it is talented
+        </>
+      ),
+    },
+
     // Exe with SD
     {
       spell: executeSpell,
@@ -179,45 +226,18 @@ export const buildColossusApl = (
       ),
     },
 
-    // HS inside execute
+    // Exe with DW and high rage
     {
-      spell: SPELLS.HEROIC_STRIKE,
+      spell: executeSpell,
       condition: cnd.and(
         cnd.inExecute(executeThreshold),
-        cnd.buffPresent(SPELLS.MASTER_OF_WARFARE),
+        cnd.hasTalent(TALENTS.DEEP_WOUNDS_TALENT),
+        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 750 }),
       ),
       description: (
         <>
-          Cast <SpellLink spell={SPELLS.HEROIC_STRIKE} /> while in execute range
-        </>
-      ),
-    },
-
-    // OP in exe
-    {
-      spell: SPELLS.OVERPOWER,
-      condition: cnd.and(
-        cnd.inExecute(executeThreshold),
-        cnd.or(
-          cnd.hasResource(RESOURCE_TYPES.RAGE, { atMost: 400 }),
-          cnd.spellCharges(SPELLS.OVERPOWER, { atLeast: 2 }),
-        ),
-      ),
-      description: (
-        <>
-          Cast <SpellLink spell={SPELLS.OVERPOWER} /> in execute range when you have two charges, or
-          are below 40 rage
-        </>
-      ),
-    },
-
-    // MS in exe
-    {
-      spell: SPELLS.MORTAL_STRIKE,
-      condition: cnd.and(cnd.inExecute(executeThreshold)),
-      description: (
-        <>
-          Cast <SpellLink spell={SPELLS.MORTAL_STRIKE} /> in execute range
+          Cast <SpellLink spell={executeSpell} /> with above 75 rage if{' '}
+          <SpellLink spell={TALENTS.DEEP_WOUNDS_TALENT} /> is talented
         </>
       ),
     },
@@ -236,10 +256,14 @@ export const buildColossusApl = (
     // exe in exe
     {
       spell: executeSpell,
-      condition: cnd.and(executeUsable, cnd.inExecute(executeThreshold)),
+      condition: cnd.and(
+        executeUsable,
+        cnd.inExecute(executeThreshold),
+        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 750 }),
+      ),
       description: (
         <>
-          Cast <SpellLink spell={executeSpell} /> in execute range
+          Cast <SpellLink spell={executeSpell} /> in execute range while above 75 rage
         </>
       ),
     },
@@ -279,18 +303,6 @@ export const buildColossusApl = (
       ),
     },
 
-    // Exe with SD
-    {
-      spell: executeSpell,
-      condition: cnd.buffPresent(SPELLS.SUDDEN_DEATH_TALENT_BUFF),
-      description: (
-        <>
-          Cast <SpellLink spell={executeSpell} /> with{' '}
-          <SpellLink spell={SPELLS.SUDDEN_DEATH_TALENT_BUFF} />
-        </>
-      ),
-    },
-
     // OP no exe
     {
       spell: SPELLS.OVERPOWER,
@@ -298,6 +310,17 @@ export const buildColossusApl = (
       description: (
         <>
           Cast <SpellLink spell={SPELLS.OVERPOWER} />
+        </>
+      ),
+    },
+
+    // Exe with SD
+    {
+      spell: executeSpell,
+      condition: executeUsable,
+      description: (
+        <>
+          Cast <SpellLink spell={executeSpell} />
         </>
       ),
     },

--- a/src/analysis/retail/warrior/arms/modules/talents/AngerManagement.tsx
+++ b/src/analysis/retail/warrior/arms/modules/talents/AngerManagement.tsx
@@ -10,7 +10,7 @@ import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 import { Fragment } from 'react';
 
 /**
- * Every 20 Rage you spend reduces the remaining cooldown on Colossus Smash and Bladestorm by 1 sec.
+ * Every 20 Rage you spend reduces the remaining cooldown on Colossus Smash and Avatar by 1 sec.
  */
 
 const RAGE_NEEDED_FOR_A_PROC = 20;

--- a/src/analysis/retail/warrior/arms/modules/talents/Demolish.tsx
+++ b/src/analysis/retail/warrior/arms/modules/talents/Demolish.tsx
@@ -14,7 +14,7 @@ import { DEMOLISH_DAMAGE_CAST } from '../../normalizers/DemolishNormalizer';
 import { DEFAULT_EXECUTE_THRESHOLD, MASSACRE_EXECUTE_THRESHOLD } from '../core/AplCheck';
 
 const COLOSSAL_MIGHT_MAX_STACKS = 10;
-const COLOSSAL_MIGHT_CD_REDUCTION = 2000; // ms
+const COLOSSAL_MIGHT_CD_REDUCTION = 5000; // ms
 
 class Demolish extends Analyzer {
   static dependencies = {

--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { Gambyt, Nevdok } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2026, 4, 25), 'Minor APL updates', Nevdok),
   change(date(2026, 4, 9), 'Fix max casts for Thunder Blast', Gambyt),
   change(date(2026, 4, 3), 'More midnight season 1 APL updates', Nevdok),
   change(date(2026, 4, 2), 'Remove old talents. Fix Anger Management Statistics', Gambyt),

--- a/src/analysis/retail/warrior/fury/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/warrior/fury/modules/core/AplCheck.tsx
@@ -19,6 +19,14 @@ export const MASSACRE_EXECUTE_THRESHOLD = 0.35;
 export const DEFAULT_EXECUTE_THRESHOLD = 0.2;
 
 export const apl = (info: PlayerInfo): Apl => {
+  const rampageRageThreshold = 1000;
+  // threshold below which builders are still better than spending (100 rage)
+  // in the future this will probably be based on talents
+
+  const apexRampageRageReduction =
+    info.combatant.getTalentRank(TALENTS.RAMPAGING_BERSERKER_2_FURY_TALENT) * 150;
+  // fury apex reduces rampage rage cost by 15 rage per rank
+
   const executeThreshold = info.combatant.hasTalent(TALENTS.MASSACRE_FURY_TALENT)
     ? MASSACRE_EXECUTE_THRESHOLD
     : DEFAULT_EXECUTE_THRESHOLD;
@@ -29,25 +37,24 @@ export const apl = (info: PlayerInfo): Apl => {
   const executeSpell = info.combatant.hasTalent(TALENTS.MASSACRE_FURY_TALENT)
     ? SPELLS.EXECUTE_FURY_MASSACRE
     : SPELLS.EXECUTE_FURY;
-
-  const rampageRageThreshold = 1000;
-  // threshold below which builders are still better than spending (115 rage)
-  // in the future this will probably be based on talents
-
-  const apexRampageRageReduction =
-    info.combatant.getTalentRank(TALENTS.RAMPAGING_BERSERKER_2_FURY_TALENT) * 150;
-  // fury apex reduces rampage rage cost by 15 rage per rank
+  const rampageUsable = cnd.or(
+    cnd.and(
+      cnd.buffPresent(SPELLS.RECKLESSNESS),
+      cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 - apexRampageRageReduction }),
+    ),
+    cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 }),
+  );
 
   return info.combatant.hasTalent(TALENTS.SLAYERS_DOMINANCE_TALENT)
     ? buildSlayerApl(
-        executeThreshold,
+        rampageUsable,
         executeUsable,
         executeSpell,
         rampageRageThreshold,
         apexRampageRageReduction,
       )
     : buildThaneApl(
-        executeThreshold,
+        rampageUsable,
         executeUsable,
         executeSpell,
         rampageRageThreshold,
@@ -56,18 +63,18 @@ export const apl = (info: PlayerInfo): Apl => {
 };
 
 export const buildSlayerApl = (
-  executeThreshold: number,
+  rampageUsable: Condition<boolean>,
   executeUsable: Condition<boolean>,
   executeSpell: Spell,
   rampageRageThreshold: number,
   apexRampageRageReduction: number,
 ): Apl => {
   return build([
-    // Enrage
+    // Enrage or high rage ramp
     {
       spell: SPELLS.RAMPAGE,
       condition: cnd.and(
-        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 }),
+        rampageUsable,
         cnd.or(
           cnd.buffMissing(SPELLS.ENRAGE),
           cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
@@ -98,10 +105,7 @@ export const buildSlayerApl = (
     // rampage during reck
     {
       spell: SPELLS.RAMPAGE,
-      condition: cnd.and(
-        cnd.buffPresent(SPELLS.RECKLESSNESS),
-        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 - apexRampageRageReduction }),
-      ),
+      condition: cnd.and(cnd.buffPresent(SPELLS.RECKLESSNESS), rampageUsable),
       description: (
         <>
           Cast <SpellLink spell={SPELLS.RAMPAGE} /> during <SpellLink spell={SPELLS.RECKLESSNESS} />
@@ -149,7 +153,7 @@ export const buildSlayerApl = (
     // fallback rampage
     {
       spell: SPELLS.RAMPAGE,
-      condition: cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 }),
+      condition: rampageUsable,
       description: (
         <>
           Cast <SpellLink spell={SPELLS.RAMPAGE} />
@@ -171,24 +175,27 @@ export const buildSlayerApl = (
 };
 
 export const buildThaneApl = (
-  executeThreshold: number,
+  rampageUsable: Condition<boolean>,
   executeUsable: Condition<boolean>,
   executeSpell: Spell,
   rampageRageThreshold: number,
   apexRampageRageReduction: number,
 ): Apl => {
   return build([
-    // Enrage
+    // Enrage or high rage ramp
     {
       spell: SPELLS.RAMPAGE,
       condition: cnd.and(
-        cnd.buffMissing(SPELLS.ENRAGE),
-        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 }),
+        rampageUsable,
+        cnd.or(
+          cnd.buffMissing(SPELLS.ENRAGE),
+          cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
+        ),
       ),
       description: (
         <>
-          Cast <SpellLink spell={SPELLS.RAMPAGE} /> to apply <SpellLink spell={SPELLS.ENRAGE} /> if
-          it is missing
+          Cast <SpellLink spell={SPELLS.RAMPAGE} /> above {rampageRageThreshold / 10} rage, or to
+          apply <SpellLink spell={SPELLS.ENRAGE} /> if it is missing
         </>
       ),
     },
@@ -203,18 +210,6 @@ export const buildThaneApl = (
       description: (
         <>
           Cast <SpellLink spell={SPELLS.THUNDER_BLAST} /> with 2 stacks
-        </>
-      ),
-    },
-
-    // high rage rampage
-    {
-      spell: SPELLS.RAMPAGE,
-      condition: cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
-      description: (
-        <>
-          Cast <SpellLink spell={SPELLS.RAMPAGE} /> above {rampageRageThreshold / 10} rage to avoid
-          overcapping
         </>
       ),
     },
@@ -236,10 +231,7 @@ export const buildThaneApl = (
     // rampage during reck
     {
       spell: SPELLS.RAMPAGE,
-      condition: cnd.and(
-        cnd.buffPresent(SPELLS.RECKLESSNESS),
-        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 - apexRampageRageReduction }),
-      ),
+      condition: cnd.and(cnd.buffPresent(SPELLS.RECKLESSNESS), rampageUsable),
       description: (
         <>
           Cast <SpellLink spell={SPELLS.RAMPAGE} /> during <SpellLink spell={SPELLS.RECKLESSNESS} />
@@ -278,10 +270,10 @@ export const buildThaneApl = (
     // Exe conditions
     {
       spell: executeSpell,
-      condition: cnd.and(executeUsable, cnd.hasTalent(TALENTS.DEEP_WOUNDS_TALENT)),
+      condition: executeUsable,
       description: (
         <>
-          Cast <SpellLink spell={executeSpell} /> if specced into its respective talents
+          Cast <SpellLink spell={executeSpell} />
         </>
       ),
     },
@@ -317,7 +309,7 @@ export const buildThaneApl = (
     // fallback rampage
     {
       spell: SPELLS.RAMPAGE,
-      condition: cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 }),
+      condition: rampageUsable,
       description: (
         <>
           Cast <SpellLink spell={SPELLS.RAMPAGE} />

--- a/src/analysis/retail/warrior/shared/modules/talents/Executioner.tsx
+++ b/src/analysis/retail/warrior/shared/modules/talents/Executioner.tsx
@@ -39,8 +39,14 @@ class Executioner extends Analyzer.withDependencies({
 
   onExecute(event: CastEvent) {
     const executionerStacks = this.selectedCombatant.getBuffStacks(SPELLS.EXECUTIONER_TALENT_BUFF);
+    const hadSuddenDeath = this.selectedCombatant.hasBuff(SPELLS.SUDDEN_DEATH_TALENT_BUFF);
 
-    this.deps.spellUsable.reduceCooldown(SPELLS.BLADESTORM.id, executionerStacks * 5000);
+    // only reduce cd if was SD exe
+    // 5 seconds per executioner stack
+    // SD buff looks like it's removed very shortly after exe cast so should be safe to check
+    if (hadSuddenDeath) {
+      this.deps.spellUsable.reduceCooldown(SPELLS.BLADESTORM.id, executionerStacks * 5000);
+    }
   }
 
   onBladestorm(event: CastEvent) {

--- a/src/common/SPELLS/warrior.ts
+++ b/src/common/SPELLS/warrior.ts
@@ -440,7 +440,7 @@ const spells = {
     icon: 'warrior_talent_icon_skirmisher',
   },
   MASTER_OF_WARFARE: {
-    id: 1269394,
+    id: 1269391,
     name: 'Master of Warfare',
     icon: 'inv12_apextalent_warrior_masterofwarfare',
   },


### PR DESCRIPTION
### Description

Update both Arms and Fury AplCheck modules for 12.0.5 updates. Additionally, update spell interactions which changed during 12.0.5, and fix a bug that was causing Heroic Strike to get tracked incorrectly because it was checking the wrong spell ID.

### Testing

- Test report URL: `/report/6XL1ZWkc2DTdCbRB/41/472`, `/report/hTjpYMFR9a71QXtx/19-Mythic+Fallen-King+Salhadaar+-+Kill+(5:02)/16-Bigbowwl/standard/overview`
- Screenshot(s):
<img width="1253" height="634" alt="image" src="https://github.com/user-attachments/assets/fcdd1783-a38c-48c4-8118-d46dcc6a7d1b" />
<img width="1292" height="641" alt="image" src="https://github.com/user-attachments/assets/ffb631a4-8e79-4644-83b9-f164ff99a0c0" />

