### PR TITLE
[brewmaster] Track Elevated Stagger on Overview Stagger Pool chart

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -1,10 +1,12 @@
 import { change, date } from 'common/changelog';
-import { emallson, NotStirred } from 'CONTRIBUTORS';
+import { emallson, NotStirred, kate } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
+import spells from 'common/SPELLS';
 import SPELLS from './spell-list_Monk_Brewmaster.retail';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 26), <>Mark purify events in Overview Stagger Pool chart green if cast while <SpellLink spell={spells.ELEVATED_STAGGER_BUFF} /> is applied or <SpellLink spell={SPELLS.HIGH_IMPACT_TALENT} />isn't talented, otherwise red.</>, kate),
   change(date(2026, 4, 19), <>Fix <SpellLink spell={SPELLS.QUICK_SIP_TALENT} /> having too much <SpellLink spell={SPELLS.STAGGER_TALENT} /> clearing attributed to it, which resulted in <SpellLink spell={SPELLS.TRANQUIL_SPIRIT_TALENT} /> being undervalued (and sometimes crashing).</>, emallson),
   change(date(2026, 4, 19), <>Remove outdated <SpellLink spell={SPELLS.PRESS_THE_ADVANTAGE_TALENT} /> analysis.</>, emallson),
   change(date(2026, 4, 11), <>Add <SpellLink spell={SPELLS.NIUZAOS_RESOLVE_TALENT} /> statistic.</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/core/StaggerPool/StaggerPoolSection.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/StaggerPool/StaggerPoolSection.tsx
@@ -9,12 +9,14 @@ import {
   OTHER_SPECIAL_ID,
   spellName,
 } from 'interface/Table/ThroughputTable';
+import { Highlight } from 'interface/Highlight';
 import QuickSip from '../../talents/QuickSip';
 import StaggeringStrikes from '../../talents/StaggeringStrikes';
 import TranquilSpirit from '../../talents/TranquilSpirit';
 import PurifyingBrew from '../../talents/PurifyingBrew';
 import TouchOfDeathStagger from '../../spells/TouchOfDeathStagger';
-import SPELLS from '../../../spell-list_Monk_Brewmaster.retail';
+import SPELLS from 'common/SPELLS';
+import spells from '../../../spell-list_Monk_Brewmaster.retail';
 import styled from '@emotion/styled';
 import * as design from 'interface/design-system';
 import SpellLink from 'interface/SpellLink';
@@ -71,26 +73,26 @@ export default function StaggerPoolSection(): JSX.Element | null {
   return (
     <>
       <AlertInfo>
-        <SpellLink spell={SPELLS.STAGGER_TALENT} /> tracking has received a major overhaul in
+        <SpellLink spell={spells.STAGGER_TALENT} /> tracking has received a major overhaul in
         Midnight to handle all of the new talents that purify or prevent Stagger. If you see errors,
         please contact <code>@emallson</code> on Discord.
       </AlertInfo>
       {(tranquilSpirit?.missedClearsPerMinute ?? 0) >= 1 && (
         <AlertWarning>
-          <SpellLink spell={SPELLS.TRANQUIL_SPIRIT_TALENT} /> is missing a high number of{' '}
-          <SpellLink spell={SPELLS.STAGGER_TALENT} /> clearing events (
+          <SpellLink spell={spells.TRANQUIL_SPIRIT_TALENT} /> is missing a high number of{' '}
+          <SpellLink spell={spells.STAGGER_TALENT} /> clearing events (
           {tranquilSpirit!.missedClearsPerMinute.toFixed(1)} per minute). Please report this log to{' '}
           <code>@emallson</code> on Discord for investigation.
         </AlertWarning>
       )}
-      <SubSection title={<SpellLink spell={SPELLS.STAGGER_TALENT} />}>
+      <SubSection title={<SpellLink spell={spells.STAGGER_TALENT} />}>
         <SummaryDL>
           <dt>
-            Total Damage Absorbed by <SpellLink spell={SPELLS.STAGGER_TALENT} />
+            Total Damage Absorbed by <SpellLink spell={spells.STAGGER_TALENT} />
           </dt>
           <dd>{formatNumber(totalAbsorb)}</dd>
           <dt>
-            Total Damage Taken from <SpellLink spell={SPELLS.STAGGER_TALENT} /> (DoT)
+            Total Damage Taken from <SpellLink spell={spells.STAGGER_TALENT} /> (DoT)
           </dt>
           <dd>{formatNumber(stagger.totalTickDamageTaken)}</dd>
           <dt>
@@ -111,19 +113,30 @@ export default function StaggerPoolSection(): JSX.Element | null {
           <dd>{formatNumber(totalAbsorb - stagger.totalTickDamageTaken)} </dd>
         </SummaryDL>
         <Explanation>
-          This chart shows the amount of damage in the <SpellLink spell={SPELLS.STAGGER_TALENT} />{' '}
-          pool over time, with <SpellLink spell={SPELLS.PURIFYING_BREW_TALENT} /> casts highlighted.
+          This chart shows the amount of damage in the <SpellLink spell={spells.STAGGER_TALENT} />{' '}
+          pool over time, with <SpellLink spell={spells.PURIFYING_BREW_TALENT} /> casts highlighted
+          {graph?.deps.ht.active == true && (
+            <>
+              {' '}
+              in{' '}
+              <Highlight color="#00ff96" textColor="black">
+                green
+              </Highlight>{' '}
+              if cast while <SpellLink spell={SPELLS.ELEVATED_STAGGER_BUFF} /> is active
+            </>
+          )}
+          .
         </Explanation>
         <div>{graph?.plot}</div>
         <SideBySide>
           <div>
             <header>
               <strong>
-                Damage Added to <SpellLink spell={SPELLS.STAGGER_TALENT} />
+                Damage Added to <SpellLink spell={spells.STAGGER_TALENT} />
               </strong>
               <Explanation>
                 Part of damage taken from every hit is absorbed by{' '}
-                <SpellLink spell={SPELLS.STAGGER_TALENT} />. This table shows the amount added by
+                <SpellLink spell={spells.STAGGER_TALENT} />. This table shows the amount added by
                 incoming damage sources.
               </Explanation>
             </header>
@@ -132,11 +145,11 @@ export default function StaggerPoolSection(): JSX.Element | null {
           <div>
             <header>
               <strong>
-                Damage Removed from <SpellLink spell={SPELLS.STAGGER_TALENT} />
+                Damage Removed from <SpellLink spell={spells.STAGGER_TALENT} />
               </strong>
               <Explanation>
-                Damage can be removed from the <SpellLink spell={SPELLS.STAGGER_TALENT} />{' '}
-                <em>pool</em> before the <SpellLink spell={SPELLS.STAGGER_TALENT} /> DoT deals it as
+                Damage can be removed from the <SpellLink spell={spells.STAGGER_TALENT} />{' '}
+                <em>pool</em> before the <SpellLink spell={spells.STAGGER_TALENT} /> DoT deals it as
                 damage. This table shows the amount removed by different effects (including the
                 DoT).
               </Explanation>
@@ -151,7 +164,7 @@ export default function StaggerPoolSection(): JSX.Element | null {
 
 const commonTableColumns = {
   staggerSpellName: spellName.withLabels({
-    [SPELLS.STAGGER_TALENT.id]: <>Stagger (DoT)</>,
+    [spells.STAGGER_TALENT.id]: <>Stagger (DoT)</>,
   }),
   amountBar: amountBar('Damage'),
 };
@@ -256,7 +269,7 @@ function StaggerPurifiedTable(): JSX.Element | null {
     });
 
     rows.push({
-      spell: SPELLS.STAGGER_TALENT.id,
+      spell: spells.STAGGER_TALENT.id,
       type: 'Other',
       amount: totalDoT,
     });

--- a/src/analysis/retail/monk/brewmaster/modules/features/StaggerPoolGraph.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/features/StaggerPoolGraph.tsx
@@ -17,6 +17,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import StaggerPool from '../core/StaggerPool';
 import PurifyingBrew from '../talents/PurifyingBrew';
 import HighTolerance from '../spells/HighTolerance';
+import { OkColor } from 'interface/guide';
 
 interface StaggerEvent {
   timestamp: number;
@@ -153,6 +154,7 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
             filled: true,
             size: 60,
             opacity: 1,
+            strokeWidth: 1,
           },
           transform: [
             {
@@ -172,7 +174,14 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
                 test: 'datum["isElevated"] || datum["isElevated"] == null',
                 value: '#00ff96',
               },
-              value: '#c41f3b',
+              value: OkColor,
+            },
+            stroke: {
+              condition: {
+                test: 'datum["isElevated"] || datum["isElevated"] == null',
+                value: undefined,
+              },
+              value: 'black',
             },
             tooltip: [
               { field: 'amount', title: 'Amount Purified', format: '.3~s' },
@@ -222,12 +231,18 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
         };
       });
 
-      const purifyEvents = this.deps.pb.purifies.map((point) => ({
-        ...point,
-        isElevated: this.selectedCombatant.hasTalent(talents.HIGH_TOLERANCE_TALENT)
-          ? this.deps.ht.uptime.some((e) => e.start < point.timestamp && e.end > point.timestamp)
-          : null,
-      }));
+      const hasHT = this.selectedCombatant.hasTalent(talents.HIGH_TOLERANCE_TALENT);
+      const purifyEvents = !hasHT
+        ? this.deps.pb.purifies
+        : this.deps.pb.purifies.map((point) => {
+            // check if the buff was active when this cast occurred (strict before to deal with removals that occur exactly when you cast)
+            const previousBuffEvent = this.deps.ht.uptime.getBefore(point.timestamp, true);
+            const isElevated = previousBuffEvent?.type === EventType.ApplyBuff;
+            return {
+              ...point,
+              isElevated,
+            };
+          });
 
       return (
         <div

--- a/src/analysis/retail/monk/brewmaster/modules/features/StaggerPoolGraph.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/features/StaggerPoolGraph.tsx
@@ -16,6 +16,7 @@ import { VisualizationSpec } from 'react-vega';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import StaggerPool from '../core/StaggerPool';
 import PurifyingBrew from '../talents/PurifyingBrew';
+import HighTolerance from '../spells/HighTolerance';
 
 interface StaggerEvent {
   timestamp: number;
@@ -35,6 +36,7 @@ interface StaggerEvent {
 class StaggerPoolGraph extends Analyzer.withDependencies({
   stagger: StaggerPool,
   pb: PurifyingBrew,
+  ht: HighTolerance,
 }) {
   _hpEvents: HitpointsEvent<EventType>[] = [];
   _deathEvents: DeathEvent[] = [];
@@ -148,9 +150,9 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
           },
           mark: {
             type: 'point' as const,
-            color: '#00ff96',
             filled: true,
             size: 60,
+            opacity: 1,
           },
           transform: [
             {
@@ -164,6 +166,13 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
               field: 'oldPooledAmount',
               type: 'quantitative' as const,
               title: null,
+            },
+            color: {
+              condition: {
+                test: 'datum["isElevated"] || datum["isElevated"] == null',
+                value: '#00ff96',
+              },
+              value: '#c41f3b',
             },
             tooltip: [
               { field: 'amount', title: 'Amount Purified', format: '.3~s' },
@@ -213,6 +222,13 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
         };
       });
 
+      const purifyEvents = this.deps.pb.purifies.map((point) => ({
+        ...point,
+        isElevated: this.selectedCombatant.hasTalent(talents.HIGH_TOLERANCE_TALENT)
+          ? this.deps.ht.uptime.some((e) => e.start < point.timestamp && e.end > point.timestamp)
+          : null,
+      }));
+
       return (
         <div
           className="graph-container"
@@ -227,7 +243,7 @@ class StaggerPoolGraph extends Analyzer.withDependencies({
                 spec={spec}
                 data={{
                   combined: staggerEvents,
-                  purifies: this.deps.pb.purifies,
+                  purifies: purifyEvents,
                   deaths: this._deathEvents,
                   hp: hpEvents,
                 }}

--- a/src/analysis/retail/monk/brewmaster/modules/spells/HighTolerance.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/HighTolerance.tsx
@@ -2,14 +2,14 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import spells from '../../spell-list_Monk_Brewmaster.retail';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
-import Events, { CastEvent, ApplyBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
+import Events, { CastEvent, ApplyBuffEvent, RemoveBuffEvent, EventType } from 'parser/core/Events';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import BoringValue from 'parser/ui/BoringValueText';
-import { Uptime } from 'parser/ui/UptimeBar';
 import { formatDurationMinSec } from 'common/format';
 import SpellLink from 'interface/SpellLink';
+import StateHistory, { EventHistory } from 'parser/core/StateHistory';
 
 const CDR_PER_RANK = 3000;
 
@@ -19,7 +19,7 @@ class HighTolerance extends Analyzer.withDependencies({ spellUsable: SpellUsable
   protected cdrAmount = 0;
   protected wastedCdr = 0;
 
-  uptime: Uptime[] = [];
+  uptime: EventHistory<EventType.ApplyBuff | EventType.RemoveBuff> = new StateHistory([]);
 
   constructor(options: Options) {
     super(options);
@@ -39,7 +39,6 @@ class HighTolerance extends Analyzer.withDependencies({ spellUsable: SpellUsable
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.ELEVATED_STAGGER_BUFF),
       this.onRemoveBuff,
     );
-    this.addEventListener(Events.fightend, this.finalize);
   }
 
   private elevatedStaggerCdr(_event: CastEvent): void {
@@ -55,35 +54,11 @@ class HighTolerance extends Analyzer.withDependencies({ spellUsable: SpellUsable
   }
 
   private onApplyBuff(event: ApplyBuffEvent) {
-    const uptime: Uptime = {
-      start: event.timestamp,
-      end: event.timestamp,
-    };
-
-    this.uptime.push(uptime);
+    this.uptime.data.push(event);
   }
 
   private onRemoveBuff(event: RemoveBuffEvent) {
-    const last = this.uptime[this.uptime.length - 1];
-    if (last) {
-      last.end = event.timestamp;
-    } else {
-      const uptime: Uptime = {
-        start: this.owner.fight.start_time,
-        end: event.timestamp,
-      };
-
-      this.uptime.push(uptime);
-    }
-  }
-
-  private finalize() {
-    const last = this.uptime[this.uptime.length - 1];
-    if (!last || last.end !== last.start) {
-      return;
-    }
-
-    last.end = this.owner.fight.end_time;
+    this.uptime.data.push(event);
   }
 
   statistic() {

--- a/src/analysis/retail/monk/brewmaster/modules/spells/HighTolerance.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/HighTolerance.tsx
@@ -2,11 +2,12 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import spells from '../../spell-list_Monk_Brewmaster.retail';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, { CastEvent, ApplyBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import BoringValue from 'parser/ui/BoringValueText';
+import { Uptime } from 'parser/ui/UptimeBar';
 import { formatDurationMinSec } from 'common/format';
 import SpellLink from 'interface/SpellLink';
 
@@ -18,6 +19,8 @@ class HighTolerance extends Analyzer.withDependencies({ spellUsable: SpellUsable
   protected cdrAmount = 0;
   protected wastedCdr = 0;
 
+  uptime: Uptime[] = [];
+
   constructor(options: Options) {
     super(options);
     this.ranks = this.selectedCombatant.getTalentRank(spells.HIGH_TOLERANCE_TALENT);
@@ -27,6 +30,16 @@ class HighTolerance extends Analyzer.withDependencies({ spellUsable: SpellUsable
       Events.cast.spell(spells.PURIFYING_BREW_TALENT).by(SELECTED_PLAYER),
       this.elevatedStaggerCdr,
     );
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.ELEVATED_STAGGER_BUFF),
+      this.onApplyBuff,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.ELEVATED_STAGGER_BUFF),
+      this.onRemoveBuff,
+    );
+    this.addEventListener(Events.fightend, this.finalize);
   }
 
   private elevatedStaggerCdr(_event: CastEvent): void {
@@ -39,6 +52,38 @@ class HighTolerance extends Analyzer.withDependencies({ spellUsable: SpellUsable
       this.cdrAmount += actualCdr;
       this.wastedCdr += this.ranks * CDR_PER_RANK - actualCdr;
     }
+  }
+
+  private onApplyBuff(event: ApplyBuffEvent) {
+    const uptime: Uptime = {
+      start: event.timestamp,
+      end: event.timestamp,
+    };
+
+    this.uptime.push(uptime);
+  }
+
+  private onRemoveBuff(event: RemoveBuffEvent) {
+    const last = this.uptime[this.uptime.length - 1];
+    if (last) {
+      last.end = event.timestamp;
+    } else {
+      const uptime: Uptime = {
+        start: this.owner.fight.start_time,
+        end: event.timestamp,
+      };
+
+      this.uptime.push(uptime);
+    }
+  }
+
+  private finalize() {
+    const last = this.uptime[this.uptime.length - 1];
+    if (!last || last.end !== last.start) {
+      return;
+    }
+
+    last.end = this.owner.fight.end_time;
   }
 
   statistic() {


### PR DESCRIPTION
### Description

Mark purify events in Overview Stagger Pool chart green if cast while Elevated Stagger is applied or High Tolerance isn't talented, otherwise red.
Add text dynamically to describe Overview Stagger Pool chart marking behaviour.
Allow spell linking of Elevated Stagger buff in Stagger Pool Section text.

