### PR TITLE
Add Chrono Flame to Pupil of Alexstrasza and Leaping Flames

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,9 +5,10 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 
 export default [
-  change(date(2026, 4, 23), <>Fix module showing as not updated for 12.0.5</>, KYZ),
+  change(date(2026, 4, 27), <>Update <SpellLink spell={TALENTS.PUPIL_OF_ALEXSTRASZA_TALENT} /> and <SpellLink spell={TALENTS.LEAPING_FLAMES_TALENT} /> modules to include <SpellLink spell={SPELLS.CHRONO_FLAME_CAST} /> damage.</>, KYZ),
+  change(date(2026, 4, 23), <>Fix module showing as not updated for 12.0.5.</>, KYZ),
   change(date(2026, 4, 21), <>Updated for 12.0.5.</>, KYZ),
-  change(date(2026, 4, 20), <>Fixed <SpellLink spell={SPELLS.HOVER} /> not counting as castable while casting</>, Baumritter),
+  change(date(2026, 4, 20), <>Fixed <SpellLink spell={SPELLS.HOVER} /> not counting as castable while casting.</>, Baumritter),
   change(date(2026, 4, 8), <>Significant updates to guide section.</>, KYZ),
   change(date(2026, 3, 17), <>Updated with further class tuning hotfixes.</>, KYZ),
   change(date(2026, 3, 15), <>Updated with class tuning hotfixes.</>, KYZ),

--- a/src/analysis/retail/evoker/augmentation/modules/talents/PupilOfAlexstrasza.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/PupilOfAlexstrasza.tsx
@@ -6,6 +6,7 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Events, { CastEvent } from 'parser/core/Events';
 import { getPupilDamageEvent } from '../normalizers/CastLinkNormalizer';
+import { getChronoFlameDamageLink } from 'analysis/retail/evoker/shared/modules/normalizers/ChronowardenCastLinkNormalizer';
 
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -22,19 +23,38 @@ class PupilOfAlexstrasza extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.PUPIL_OF_ALEXSTRASZA_TALENT);
 
-    this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell([SPELLS.LIVING_FLAME_CAST, SPELLS.CHRONO_FLAME_CAST]),
-      this.onCast,
-    );
+    if (this.selectedCombatant.hasTalent(TALENTS.CHRONO_FLAME_TALENT)) {
+      this.addEventListener(
+        Events.cast.by(SELECTED_PLAYER).spell(SPELLS.CHRONO_FLAME_CAST),
+        this.onChronoFlameCast,
+      );
+    } else {
+      this.addEventListener(
+        Events.cast.by(SELECTED_PLAYER).spell(SPELLS.LIVING_FLAME_CAST),
+        this.onLivingFlameCast,
+      );
+    }
   }
 
-  onCast(event: CastEvent) {
+  onLivingFlameCast(event: CastEvent) {
     const damageEvent = getPupilDamageEvent(event);
     if (!damageEvent) {
       return;
     }
-
     this.PupilOfAlexstraszaDamage += damageEvent.amount + (damageEvent.absorbed ?? 0);
+  }
+
+  onChronoFlameCast(event: CastEvent) {
+    const damageEvent = getPupilDamageEvent(event);
+    if (!damageEvent) {
+      return;
+    }
+    this.PupilOfAlexstraszaDamage += damageEvent.amount + (damageEvent.absorbed ?? 0);
+    const chronoDamageEvent = getChronoFlameDamageLink(damageEvent);
+    if (!chronoDamageEvent) {
+      return;
+    }
+    this.PupilOfAlexstraszaDamage += chronoDamageEvent.amount + (chronoDamageEvent.absorbed ?? 0);
   }
 
   statistic() {

--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -1,11 +1,12 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_EVOKER } from 'common/TALENTS';
-import { Harrek } from 'CONTRIBUTORS';
+import { Harrek, KYZ } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 27), <>Update <SpellLink spell={TALENTS_EVOKER.LEAPING_FLAMES_TALENT} /> modules to include <SpellLink spell={SPELLS.CHRONO_FLAME_CAST} /> damage and healing.</>, KYZ),
   change(date(2026, 4, 23), <>Update <SpellLink spell={TALENTS_EVOKER.FIELD_OF_DREAMS_TALENT} /> module, implement <SpellLink spell={TALENTS_EVOKER.FLUTTERING_SEEDLINGS_TALENT} /> analysis.</>, Harrek),
   change(date(2026, 4, 3), <>Update <SpellLink spell={SPELLS.MERITHRAS_BLESSING_CAST} /> analysis.</>, Harrek),
   change(date(2026, 3, 20), <>Initial Midnight support</>, Harrek),

--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -6,7 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2026, 4, 27), <>Update <SpellLink spell={TALENTS_EVOKER.LEAPING_FLAMES_TALENT} /> modules to include <SpellLink spell={SPELLS.CHRONO_FLAME_CAST} /> damage and healing.</>, KYZ),
+  change(date(2026, 4, 27), <>Update <SpellLink spell={TALENTS_EVOKER.LEAPING_FLAMES_TALENT} /> module to include <SpellLink spell={SPELLS.CHRONO_FLAME_CAST} /> damage and healing.</>, KYZ),
   change(date(2026, 4, 23), <>Update <SpellLink spell={TALENTS_EVOKER.FIELD_OF_DREAMS_TALENT} /> module, implement <SpellLink spell={TALENTS_EVOKER.FLUTTERING_SEEDLINGS_TALENT} /> analysis.</>, Harrek),
   change(date(2026, 4, 3), <>Update <SpellLink spell={SPELLS.MERITHRAS_BLESSING_CAST} /> analysis.</>, Harrek),
   change(date(2026, 3, 20), <>Initial Midnight support</>, Harrek),

--- a/src/analysis/retail/evoker/preservation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/preservation/CombatLogParser.ts
@@ -68,6 +68,7 @@ import {
   MotesOfAcceleration,
   TimeSpiral,
   MobilityCastLinkNormalizer,
+  ChronowardenCastLinkNormalizer,
 } from '../shared';
 import ConsumeFlame from './modules/talents/ConsumeFlame';
 
@@ -84,6 +85,7 @@ class CombatLogParser extends CoreCombatLogParser {
     castLinkNormalizer: CastLinkNormalizer,
     hotApplicationNormalizer: HotApplicationNormalizer,
     hotRemovalNormalizer: HotRemovalNormalizer,
+    chronowardenCastLinkNormalizer: ChronowardenCastLinkNormalizer,
 
     // Generic healer things
     manaLevelChart: ManaLevelChart,

--- a/src/analysis/retail/evoker/shared/modules/normalizers/ChronowardenCastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/shared/modules/normalizers/ChronowardenCastLinkNormalizer.ts
@@ -6,13 +6,20 @@ import SPELLS from 'common/SPELLS/evoker';
 import TALENTS from 'common/TALENTS/evoker';
 import { Options } from 'parser/core/Analyzer';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
-import { DamageEvent, EventType, GetRelatedEvent, HasRelatedEvent } from 'parser/core/Events';
+import {
+  DamageEvent,
+  EventType,
+  GetRelatedEvent,
+  HasRelatedEvent,
+  HealEvent,
+} from 'parser/core/Events';
 import { isFromLeapingFlames, LIVING_FLAME_CAST_HIT } from './LeapingFlamesNormalizer';
 import { AFTERIMAGE_MAX_HITS } from '../../constants';
 
 const AFTERIMAGE_CAST_LINK = 'AfterimageCastLink';
 const AFTERIMAGE_DAMAGE_LINK = 'AfterimageDamageLink';
 const CHRONO_FLAME_DAMAGE_LINK = 'ChronoFlameDamageLink';
+const CHRONO_FLAME_HEAL_LINK = 'ChronoFlameHealLink';
 // Afterimage has a travel time, buffer needs to be relatively large.
 // The cast link also needs an additional delay, as the cast event comes earlier.
 const AFTERIMAGE_CAST_BUFFER = 1250;
@@ -93,6 +100,18 @@ const EVENT_LINKS: EventLink[] = [
     maximumLinks: 1,
     isActive: (c) => c.hasTalent(TALENTS.CHRONO_FLAME_TALENT),
   },
+  {
+    linkRelation: CHRONO_FLAME_HEAL_LINK,
+    reverseLinkRelation: CHRONO_FLAME_HEAL_LINK,
+    linkingEventId: SPELLS.LIVING_FLAME_HEAL.id,
+    linkingEventType: EventType.Heal,
+    referencedEventId: SPELLS.CHRONO_FLAME_HEAL.id,
+    referencedEventType: EventType.Heal,
+    anyTarget: false,
+    forwardBufferMs: CHRONO_FLAME_BUFFER,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS.CHRONO_FLAME_TALENT),
+  },
 ];
 
 class AfterimageCastLinkNormalizer extends EventLinkNormalizer {
@@ -109,6 +128,10 @@ export function isFromAfterimageDamage(event: DamageEvent): boolean {
 
 export function getChronoFlameDamageLink(event: DamageEvent): DamageEvent | undefined {
   return GetRelatedEvent<DamageEvent>(event, CHRONO_FLAME_DAMAGE_LINK);
+}
+
+export function getChronoFlameHealLink(event: HealEvent): HealEvent | undefined {
+  return GetRelatedEvent<HealEvent>(event, CHRONO_FLAME_HEAL_LINK);
 }
 
 function isNotFromOtherLFSources(event: DamageEvent): boolean {

--- a/src/analysis/retail/evoker/shared/modules/talents/LeapingFlames.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/LeapingFlames.tsx
@@ -10,6 +10,10 @@ import {
   getLivingFlameCastHit,
   getLeapingCast,
 } from '../normalizers/LeapingFlamesNormalizer';
+import {
+  getChronoFlameDamageLink,
+  getChronoFlameHealLink,
+} from 'analysis/retail/evoker/shared/modules/normalizers/ChronowardenCastLinkNormalizer';
 
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -117,6 +121,7 @@ class LeapingFlames extends Analyzer {
         if (event.type === EventType.Damage) {
           acc.damageHits += 1;
           this.leapingFlamesDamage += event.amount + (event.absorbed ?? 0);
+          this.leapingFlamesDamage += getChronoFlameDamageLink(event)?.amount ?? 0;
         } else {
           const absHealAmount = event.amount + (event.absorbed ?? 0);
 
@@ -126,6 +131,8 @@ class LeapingFlames extends Analyzer {
           if (absHealAmount > 0) {
             acc.healHits += 1;
           }
+          this.leapingFlamesHealing += getChronoFlameHealLink(event)?.amount ?? 0;
+          this.leapingFlamesOverHealing += getChronoFlameHealLink(event)?.overheal ?? 0;
         }
         return acc;
       },

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -605,17 +605,17 @@ const spells = {
   },
   CHRONO_FLAME_CAST: {
     id: 431443,
-    name: 'Chronoflame',
+    name: 'Chrono Flames',
     icon: 'inv_ability_chronowardenevoker_chronoflame',
   },
   CHRONO_FLAME_HEAL: {
     id: 431483,
-    name: 'Chronoflame',
+    name: 'Chrono Flame',
     icon: 'inv_ability_chronowardenevoker_chronoflame',
   },
   CHRONO_FLAME_DAMAGE: {
     id: 431583,
-    name: 'Chronoflame',
+    name: 'Chrono Flame',
     icon: 'inv_ability_chronowardenevoker_chronoflame',
   },
   MERITHRAS_BLESSING_BUFF: {


### PR DESCRIPTION
Adds Chrono Flame damage to the Pupil of Alexstrasza module, and adds Chrono Flame damage and healing to the Leaping Flames module.

`/report/Kwtz6QZHfX8V9xPr/1-Mythic++The+Seat+of+the+Triumvirate+-+Kill+(20:43)/7-Iyaiya/standard/statistics`

Before:
<img width="315" height="403" alt="Before" src="https://github.com/user-attachments/assets/6eee0b78-5c8b-4064-8d9c-83906e158419" />

After:
<img width="303" height="381" alt="After" src="https://github.com/user-attachments/assets/9e453432-fdc9-4f83-8a11-9647eb1ca185" />
