### PR TITLE
Update Evoker Abilities.tsx

### DIFF
--- a/src/analysis/retail/evoker/shared/modules/Abilities.tsx
+++ b/src/analysis/retail/evoker/shared/modules/Abilities.tsx
@@ -80,13 +80,17 @@ class Abilities extends CoreAbilities {
         charges: combatant.hasTalent(TALENTS.LEGACY_OF_THE_LIFEBINDER_TALENT) ? 2 : 1,
       },
       {
-        spell: SPELLS.LIVING_FLAME_CAST.id,
+        spell: combatant.hasTalent(TALENTS.CHRONO_FLAME_TALENT)
+          ? SPELLS.CHRONO_FLAME_CAST.id
+          : SPELLS.LIVING_FLAME_CAST.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: {
           base: 1500,
         },
         range: BASE_EVOKER_RANGE,
-        damageSpellIds: [SPELLS.LIVING_FLAME_DAMAGE.id],
+        damageSpellIds: combatant.hasTalent(TALENTS.CHRONO_FLAME_TALENT)
+          ? [SPELLS.LIVING_FLAME_DAMAGE.id, SPELLS.CHRONO_FLAME_DAMAGE.id]
+          : [SPELLS.LIVING_FLAME_DAMAGE.id],
       },
       {
         spell: SPELLS.AZURE_STRIKE.id,
@@ -206,8 +210,13 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS.OPPRESSING_ROAR_TALENT.id,
         category: SPELL_CATEGORY.UTILITY,
-        cooldown: 120 * interwovenThreadsMultiplier,
+        cooldown: combatant.hasTalent(TALENTS.OVERAWE_TALENT)
+          ? 90 * interwovenThreadsMultiplier
+          : 120 * interwovenThreadsMultiplier,
         enabled: combatant.hasTalent(TALENTS.OPPRESSING_ROAR_TALENT),
+        gcd: {
+          base: 1500,
+        },
       },
       {
         spell: TALENTS.RESCUE_TALENT.id,
@@ -239,7 +248,9 @@ class Abilities extends CoreAbilities {
       {
         spell: SPELLS.HOVER.id,
         category: SPELL_CATEGORY.UTILITY,
-        cooldown: 30 * interwovenThreadsMultiplier,
+        cooldown: combatant.hasTalent(TALENTS.WARP_TALENT)
+          ? 25 * interwovenThreadsMultiplier
+          : 30 * interwovenThreadsMultiplier,
         charges: combatant.hasTalent(TALENTS.AERIAL_MASTERY_TALENT) ? 2 : 1,
         gcd: null,
         enabled: true,
@@ -297,6 +308,11 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
         enabled: combatant.hasTalent(TALENTS.SOURCE_OF_MAGIC_TALENT),
+      },
+      {
+        spell: SPELLS.VISAGE.id,
+        category: SPELL_CATEGORY.OTHERS,
+        gcd: null,
       },
       //endregion
     ];


### PR DESCRIPTION
Small PR fixing issue that caused Chrono Flames not to be counted as a cast (e.g. for always be casting module), Oppressing Roar not to have the correct cooldown or global cooldown, and Visage showing an issue in debug view due to not being listed.

(No changelog so as not to spam the Aug and Pres modules with multiple changelogs in a single day.)