### PR TITLE
[Core] Volatile Void Suffuser + Cosmic Crescendo Trinkets

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,6 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 4, 29), <>Added trinket support for <ItemLink id={ITEMS.VOLATILE_VOID_SUFFUSER.id} />.</>, swirl),
   change(date(2026, 4, 25), "Fix `reduceCooldown` not correctly applying to multiple charges", Thias),
   change(date(2026, 4, 25), 'Fix certain extremely long loading times by improving probability calculations from O(n^3) to O(n^2).', Thias),
   change(date(2026, 4, 22), 'Add Midnight raid boss abilities to uptime timelines.', emallson),

--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -38,7 +38,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2026, 4, 29), <>Added trinket support for <ItemLink id={ITEMS.VOLATILE_VOID_SUFFUSER.id} />.</>, swirl),
+  change(date(2026, 4, 29), <>Added trinket support for <ItemLink id={ITEMS.VOLATILE_VOID_SUFFUSER.id} /> and <ItemLink id={ITEMS.LIGHT_OF_THE_COSMIC_CRESCENDO.id} />.</>, swirl),
   change(date(2026, 4, 25), "Fix `reduceCooldown` not correctly applying to multiple charges", Thias),
   change(date(2026, 4, 25), 'Fix certain extremely long loading times by improving probability calculations from O(n^3) to O(n^2).', Thias),
   change(date(2026, 4, 22), 'Add Midnight raid boss abilities to uptime timelines.', emallson),

--- a/src/common/ITEMS/midnight/trinkets.ts
+++ b/src/common/ITEMS/midnight/trinkets.ts
@@ -6,6 +6,11 @@ const trinkets = {
     name: 'Volatile Void Suffuser',
     icon: 'inv_12_trinket_raid_voidspire_healer1_volatilevoidsuffuser',
   },
+  LIGHT_OF_THE_COSMIC_CRESCENDO: {
+    id: 249811,
+    name: 'Light of the Cosmic Crescendo',
+    icon: 'inv_12_trinket_raid_darkwelle_healer3_cosmiccrescendo',
+  },
 } satisfies Record<string, Item>;
 
 export default trinkets;

--- a/src/common/ITEMS/midnight/trinkets.ts
+++ b/src/common/ITEMS/midnight/trinkets.ts
@@ -1,5 +1,11 @@
 import Item from '../Item';
 
-const trinkets = {} satisfies Record<string, Item>;
+const trinkets = {
+  VOLATILE_VOID_SUFFUSER: {
+    id: 249341,
+    name: 'Volatile Void Suffuser',
+    icon: 'inv_12_trinket_raid_voidspire_healer1_volatilevoidsuffuser',
+  },
+} satisfies Record<string, Item>;
 
 export default trinkets;

--- a/src/common/SPELLS/midnight/trinkets.ts
+++ b/src/common/SPELLS/midnight/trinkets.ts
@@ -11,6 +11,16 @@ const spells = {
     name: 'Void Suffusion',
     icon: 'inv_12_trinket_raid_voidspire_healer1_volatilevoidsuffuser',
   },
+  COSMIC_CRESCENDO: {
+    id: 1264948,
+    name: 'Cosmic Crescendo',
+    icon: 'inv_12_trinket_raid_darkwelle_healer3_cosmiccrescendo',
+  },
+  COSMIC_HYMN: {
+    id: 1265019,
+    name: 'Cosmic Hymn',
+    icon: 'inv_12_trinket_raid_darkwelle_healer3_cosmiccrescendo',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/common/SPELLS/midnight/trinkets.ts
+++ b/src/common/SPELLS/midnight/trinkets.ts
@@ -6,6 +6,11 @@ const spells = {
     name: 'Eye of the Drowning Void',
     icon: 'inv_archaeology_70_tauren_moosebonefishhook.jpg',
   },
+  VOID_SUFFUSION: {
+    id: 1258534,
+    name: 'Void Suffusion',
+    icon: 'inv_12_trinket_raid_voidspire_healer1_volatilevoidsuffuser',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -109,6 +109,7 @@ import { MeleeUptimeAnalyzer } from 'interface/guide/foundation/analyzers/MeleeU
 import DowntimeDebuffAnalyzer from 'interface/guide/foundation/analyzers/DowntimeDebuffAnalyzer';
 import { ServerMetrics } from 'common/server-metrics';
 import IncorporealEssenceGorger from 'parser/retail/modules/items/thewarwithin/trinkets/IncorporealEssenceGorger';
+import VolatileVoidSuffuser from 'parser/retail/modules/items/midnight/trinkets/VolatileVoidSuffuser';
 // This prints to console anything that the DI has to do
 const debugDependencyInjection = false;
 const MAX_DI_ITERATIONS = 100;
@@ -218,6 +219,7 @@ class CombatLogParser {
     mereldarsToll: MereldarsToll,
     cirralConcoctory: CirralConcoctory,
     incorporealEssenceGorger: IncorporealEssenceGorger,
+    volatileVoidSuffuser: VolatileVoidSuffuser,
 
     // Embellishments
     darkmoonSigilAscension: DarkmoonSigilAscension,

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -110,6 +110,7 @@ import DowntimeDebuffAnalyzer from 'interface/guide/foundation/analyzers/Downtim
 import { ServerMetrics } from 'common/server-metrics';
 import IncorporealEssenceGorger from 'parser/retail/modules/items/thewarwithin/trinkets/IncorporealEssenceGorger';
 import VolatileVoidSuffuser from 'parser/retail/modules/items/midnight/trinkets/VolatileVoidSuffuser';
+import LightOfTheCosmicCrescendo from 'parser/retail/modules/items/midnight/trinkets/LightOfTheCosmicCrescendo';
 // This prints to console anything that the DI has to do
 const debugDependencyInjection = false;
 const MAX_DI_ITERATIONS = 100;
@@ -220,6 +221,7 @@ class CombatLogParser {
     cirralConcoctory: CirralConcoctory,
     incorporealEssenceGorger: IncorporealEssenceGorger,
     volatileVoidSuffuser: VolatileVoidSuffuser,
+    lightOfTheCosmicCrescendo: LightOfTheCosmicCrescendo,
 
     // Embellishments
     darkmoonSigilAscension: DarkmoonSigilAscension,

--- a/src/parser/retail/modules/items/midnight/trinkets/LightOfTheCosmicCrescendo.tsx
+++ b/src/parser/retail/modules/items/midnight/trinkets/LightOfTheCosmicCrescendo.tsx
@@ -1,0 +1,154 @@
+import ITEMS from 'common/ITEMS/midnight/trinkets';
+import SPELLS from 'common/SPELLS/midnight/trinkets';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { DamageEvent, HealEvent } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringItemValueText from 'parser/ui/BoringItemValueText';
+import { formatDuration, formatNumber, formatPercentage } from 'common/format';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import { ItemLink, SpellIcon } from 'interface';
+
+const BASE_HEALING_INCREASE = 0.3;
+const MAX_HEALING_INCREASE = 1.5;
+
+interface HealProc {
+  timestamp: number;
+  targetCount: number;
+  totalHealing: number;
+}
+
+export default class LightOfTheCosmicCrescendo extends Analyzer {
+  protected damage = 0;
+  protected healing = 0;
+  protected healProcs: HealProc[] = [];
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.LIGHT_OF_THE_COSMIC_CRESCENDO.id);
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.COSMIC_CRESCENDO),
+      this.onDamage,
+    );
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER).spell(SPELLS.COSMIC_HYMN), this.onHeal);
+  }
+
+  private currentProc: HealProc | null = null;
+
+  private onDamage(event: DamageEvent) {
+    this.damage += event.amount + (event.absorbed || 0);
+  }
+
+  private onHeal(event: HealEvent) {
+    const healing = event.amount + (event.absorbed || 0);
+    this.healing += healing;
+
+    // most procs are on the same timestamp but a few are delayed by a millisecond
+    if (!this.currentProc || event.timestamp - this.currentProc.timestamp > 100) {
+      if (this.currentProc) {
+        this.healProcs.push(this.currentProc);
+      }
+      this.currentProc = {
+        timestamp: event.timestamp,
+        targetCount: 1,
+        totalHealing: healing,
+      };
+    } else {
+      this.currentProc.targetCount += 1;
+      this.currentProc.totalHealing += healing;
+    }
+  }
+
+  onFightEnd() {
+    if (this.currentProc) {
+      this.healProcs.push(this.currentProc);
+    }
+  }
+
+  get totalProcs() {
+    return this.healProcs.length;
+  }
+
+  get averageTargets() {
+    if (this.healProcs.length === 0) return 0;
+
+    const totalTargets = this.healProcs.reduce((sum, proc) => sum + proc.targetCount, 0);
+    return totalTargets / this.healProcs.length;
+  }
+
+  get averageHealingPerProc() {
+    if (this.healProcs.length === 0) return 0;
+
+    return this.healing / this.healProcs.length;
+  }
+
+  get averageHealingIncrease() {
+    if (this.healProcs.length === 0) return 0;
+
+    // max is -probably- not needed? the trinket only heals 5 players for each proc but keeping for failsafe
+    const totalIncrease = this.healProcs.reduce(
+      (sum, proc) => sum + Math.min(proc.targetCount * BASE_HEALING_INCREASE, MAX_HEALING_INCREASE),
+      0,
+    );
+    return totalIncrease / this.healProcs.length;
+  }
+
+  statistic() {
+    const procRows = this.healProcs.map((proc, index) => {
+      const castTime = proc.timestamp - this.owner.fight.start_time;
+      return (
+        <tr key={index}>
+          <td>{formatDuration(castTime)}</td>
+          <td>{proc.targetCount}</td>
+          <td>{formatNumber(proc.totalHealing)}</td>
+        </tr>
+      );
+    });
+
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.ITEMS}
+        size="flexible"
+        tooltip={
+          <>
+            <ItemLink id={ITEMS.LIGHT_OF_THE_COSMIC_CRESCENDO.id} /> healed <b>{this.totalProcs}</b>{' '}
+            times ({this.owner.getPerMinute(this.totalProcs).toFixed(2)} procs per minute).
+          </>
+        }
+        dropdown={
+          <>
+            <table className="table table-condensed">
+              <thead>
+                <tr>
+                  <th>Time</th>
+                  <th>Targets</th>
+                  <th>Healing</th>
+                </tr>
+              </thead>
+              <tbody>{procRows}</tbody>
+            </table>
+          </>
+        }
+      >
+        <BoringItemValueText item={ITEMS.LIGHT_OF_THE_COSMIC_CRESCENDO}>
+          <div>
+            {formatPercentage(this.averageHealingIncrease)}% <small>average increase</small>
+          </div>
+          <div>
+            <SpellIcon spell={SPELLS.COSMIC_HYMN} /> {formatNumber(this.averageHealingPerProc)}{' '}
+            <small>average healing per proc</small>
+          </div>
+          <div>
+            <ItemHealingDone amount={this.healing} />
+          </div>
+          <div>
+            <ItemDamageDone amount={this.damage} />
+          </div>
+        </BoringItemValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/parser/retail/modules/items/midnight/trinkets/VolatileVoidSuffuser.tsx
+++ b/src/parser/retail/modules/items/midnight/trinkets/VolatileVoidSuffuser.tsx
@@ -15,6 +15,7 @@ import { formatDuration, formatNumber, formatPercentage } from 'common/format';
 import { HealthIcon, IntellectIcon } from 'interface/icons';
 import SpellLink from 'interface/SpellLink';
 import { calculatePrimaryStat } from 'parser/core/stats';
+import StatTracker from 'parser/shared/modules/StatTracker';
 
 // base taken from wowhead
 // https://www.wowhead.com/item=249341/volatile-void-suffuser
@@ -29,7 +30,9 @@ interface ProcData {
   ability: Ability;
 }
 
-export default class VolatileVoidSuffuser extends Analyzer {
+export default class VolatileVoidSuffuser extends Analyzer.withDependencies({
+  statTracker: StatTracker,
+}) {
   protected procs: ProcData[] = [];
 
   intellectProc = BASE_INTELLECT;
@@ -80,6 +83,8 @@ export default class VolatileVoidSuffuser extends Analyzer {
     // int proc + ((1% of int proc) per 1% missing hp)
     const intellectGained =
       this.intellectProc + (this.intellectProc / 100) * (missingHealthPercent * 100);
+
+    this.deps.statTracker.add(SPELLS.VOID_SUFFUSION.id, { intellect: intellectGained });
 
     this.procs.push({
       timestamp,

--- a/src/parser/retail/modules/items/midnight/trinkets/VolatileVoidSuffuser.tsx
+++ b/src/parser/retail/modules/items/midnight/trinkets/VolatileVoidSuffuser.tsx
@@ -1,0 +1,189 @@
+import ITEMS from 'common/ITEMS/midnight/trinkets';
+import SPELLS from 'common/SPELLS/midnight/trinkets';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, {
+  HealEvent,
+  ApplyBuffEvent,
+  ApplyBuffStackEvent,
+  Ability,
+} from 'parser/core/Events';
+import { HasHitpoints } from 'parser/core/Events';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringItemValueText from 'parser/ui/BoringItemValueText';
+import { formatDuration, formatNumber, formatPercentage } from 'common/format';
+import { HealthIcon, IntellectIcon } from 'interface/icons';
+import SpellLink from 'interface/SpellLink';
+import { calculatePrimaryStat } from 'parser/core/stats';
+
+// base taken from wowhead
+// https://www.wowhead.com/item=249341/volatile-void-suffuser
+const BASE_ILVL = 45;
+const BASE_INTELLECT = 15;
+
+interface ProcData {
+  timestamp: number;
+  targetHealthPercent: number;
+  missingHealthPercent: number;
+  intellectGained: number;
+  ability: Ability;
+}
+
+export default class VolatileVoidSuffuser extends Analyzer {
+  protected procs: ProcData[] = [];
+
+  intellectProc = BASE_INTELLECT;
+
+  constructor(options: Options) {
+    super(options);
+
+    const suffuser = this.selectedCombatant.getTrinket(ITEMS.VOLATILE_VOID_SUFFUSER.id);
+    if (!suffuser) {
+      this.active = false;
+      return;
+    }
+
+    this.intellectProc = calculatePrimaryStat(BASE_ILVL, BASE_INTELLECT, suffuser.itemLevel);
+
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
+    this.addEventListener(
+      Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.VOID_SUFFUSION),
+      this.onBuffGain,
+    );
+    this.addEventListener(
+      Events.applybuffstack.to(SELECTED_PLAYER).spell(SPELLS.VOID_SUFFUSION),
+      this.onBuffGain,
+    );
+  }
+
+  private onHeal(event: HealEvent) {
+    if (!HasHitpoints(event)) return;
+
+    this.lastHealEvent = event;
+  }
+
+  private lastHealEvent: HealEvent | null = null;
+
+  private onBuffGain(event: ApplyBuffEvent | ApplyBuffStackEvent) {
+    this.recordProc(event.timestamp);
+  }
+
+  private recordProc(timestamp: number) {
+    if (!this.lastHealEvent || !HasHitpoints(this.lastHealEvent)) return;
+
+    const healEvent = this.lastHealEvent;
+
+    const healthBeforeHeal = healEvent.hitPoints - healEvent.amount;
+    const targetHealthPercent = healthBeforeHeal / healEvent.maxHitPoints;
+    const missingHealthPercent = 1 - targetHealthPercent;
+
+    // int proc + ((1% of int proc) per 1% missing hp)
+    const intellectGained =
+      this.intellectProc + (this.intellectProc / 100) * (missingHealthPercent * 100);
+
+    this.procs.push({
+      timestamp,
+      targetHealthPercent,
+      missingHealthPercent,
+      intellectGained,
+      ability: healEvent.ability,
+    });
+  }
+
+  get totalProcs() {
+    return this.procs.length;
+  }
+
+  private average<K extends keyof ProcData>(key: K): number {
+    if (this.procs.length === 0) return 0;
+
+    return this.procs.reduce((acc, proc) => acc + (proc[key] as number), 0) / this.procs.length;
+  }
+
+  statistic() {
+    const uptime = this.selectedCombatant.getBuffUptime(SPELLS.VOID_SUFFUSION.id);
+    const uptimePercent = uptime / this.owner.fightDuration;
+    const stackUptimes = this.selectedCombatant.getStackBuffUptimes(SPELLS.VOID_SUFFUSION.id);
+
+    const procRows = this.procs.map((proc, index) => {
+      const castTime = proc.timestamp - this.owner.fight.start_time;
+      return (
+        <tr key={index}>
+          <td>{formatDuration(castTime)}</td>
+          <td>
+            <SpellLink spell={proc.ability.guid} />
+          </td>
+          <td>{formatPercentage(proc.targetHealthPercent, 1)}%</td>
+        </tr>
+      );
+    });
+
+    const stackRows = Object.entries(stackUptimes)
+      .filter(([stacks]) => Number(stacks) > 0)
+      .sort(([a], [b]) => Number(a) - Number(b))
+      .map(([stacks, uptime]) => {
+        const stackUptimePercent = uptime / this.owner.fightDuration;
+        return (
+          <tr key={stacks}>
+            <td>{stacks}</td>
+            <td>{formatDuration(uptime)}</td>
+            <td>{formatPercentage(stackUptimePercent, 1)}%</td>
+          </tr>
+        );
+      });
+
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.ITEMS}
+        size="flexible"
+        tooltip={
+          <>
+            <div>
+              <b>
+                <SpellLink spell={ITEMS.VOLATILE_VOID_SUFFUSER} />
+              </b>{' '}
+              triggered <b>{this.totalProcs}</b> times,{' '}
+              {this.owner.getPerMinute(this.totalProcs).toFixed(2)} procs per minute with{' '}
+              {formatPercentage(uptimePercent, 1)}% total uptime.
+            </div>
+            <div>
+              <table className="table table-condensed">
+                <thead>
+                  <tr>
+                    <th>Stacks</th>
+                    <th>Uptime</th>
+                    <th>% of Fight</th>
+                  </tr>
+                </thead>
+                <tbody>{stackRows}</tbody>
+              </table>
+            </div>
+          </>
+        }
+        dropdown={
+          <table className="table table-condensed">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Ability</th>
+                <th>Target HP %</th>
+              </tr>
+            </thead>
+            <tbody>{procRows}</tbody>
+          </table>
+        }
+      >
+        <BoringItemValueText item={ITEMS.VOLATILE_VOID_SUFFUSER}>
+          <div>
+            <HealthIcon /> {formatPercentage(this.average('targetHealthPercent'), 1)}%{' '}
+            <small>average target health</small>
+          </div>
+          <div>
+            <IntellectIcon /> {formatNumber(this.average('intellectGained'))}{' '}
+            <small>average Intellect per proc</small>
+          </div>
+        </BoringItemValueText>
+      </Statistic>
+    );
+  }
+}


### PR DESCRIPTION
### Description

Added two new trinket modules: [Volatile Void Suffuser](https://www.wowhead.com/item=249341/volatile-void-suffuser) and [Light of the Cosmic Crescendo](https://www.wowhead.com/item=249811/light-of-the-cosmic-crescendo).

**Void Suffuser** gets better the lower avg HP% your raid sits at - useful to do analysis on QELive for effectiveness of the proc but unfortunately, the avg raid HP% is still pretty high for when it procs.
**Cosmic Crescendo** is a simple - every 2s the trinket procs healing on up to 5 players if someone is below 60% hp.

Both have dropdowns to show data on when they've procced - will admit the dropdowns on crescendo especially are a _bit_ rough considering their length and especially in dungeons. Feedback on whether to keep or remove would be great here.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

#### Suffuser
- Test report URL: `report/6ZxLRhNYMT9Xn8fw/14-Mythic+Lightblinded+Vanguard+-+Kill+(7:24)/54-%E9%9B%BE%E9%87%8C%E4%B8%A8%E7%9C%8B%E8%8A%B1/standard/statistics`
- Screenshot(s):
<img width="374" height="239" alt="image" src="https://github.com/user-attachments/assets/f05ff04b-d344-4346-90e2-7b42c05dee22" />
<img width="750" height="234" alt="image" src="https://github.com/user-attachments/assets/f113f9dc-0621-45f2-a47a-69cbcc8cce50" />
<img width="381" height="1061" alt="image" src="https://github.com/user-attachments/assets/7c74cc35-4d21-40f8-904c-eb2a4429b915" />


#### Crescendo
- Test report URL: `report/4ZAhLH6732BfRKWx/18-Mythic++Algeth'ar+Academy+-+Kill+(28:58)/318-%E6%82%A0%E6%87%92%E7%91%B6%E7%91%B6/standard/statistics`
- Screenshot(s):
<img width="373" height="338" alt="image" src="https://github.com/user-attachments/assets/7018d75b-e676-42b1-88ac-a74883853822" />
<img width="613" height="67" alt="image" src="https://github.com/user-attachments/assets/9eaadc8e-232b-4fb4-974f-fbbdc71a9663" />
<img width="379" height="357" alt="image" src="https://github.com/user-attachments/assets/4bd0dec8-2d51-4dcb-b315-3442544785d8" />
<img width="379" height="598" alt="image" src="https://github.com/user-attachments/assets/01db0bd2-a066-4af0-ad7f-6f372502cfc3" />
