### PR TITLE
Add augmented/normalized DPS tracking for Evoker augmentation buffs

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -32,12 +32,14 @@ import {
   Thias,
   Hezaerd,
   Dambroda,
+  Mahmud17,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 5, 2), "Add augmented/normalized DPS tracking for Evoker augmentation buffs with tooltip explaining the boost.", Mahmud17),
   change(date(2026, 4, 29), <>Added trinket support for <ItemLink id={ITEMS.VOLATILE_VOID_SUFFUSER.id} /> and <ItemLink id={ITEMS.LIGHT_OF_THE_COSMIC_CRESCENDO.id} />.</>, swirl),
   change(date(2026, 4, 25), "Fix `reduceCooldown` not correctly applying to multiple charges", Thias),
   change(date(2026, 4, 25), 'Fix certain extremely long loading times by improving probability calculations from O(n^3) to O(n^2).', Thias),

--- a/src/parser/shared/modules/throughput/DamageDone.tsx
+++ b/src/parser/shared/modules/throughput/DamageDone.tsx
@@ -11,6 +11,14 @@ import ThroughputPerformance, { UNAVAILABLE } from 'parser/ui/ThroughputPerforma
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import DamageValue from '../DamageValue';
+import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
+import SPELLS from 'common/SPELLS/evoker';
+import {
+  EBON_MIGHT_PERSONAL_DAMAGE_AMP,
+  BREATH_OF_EONS_MULTIPLIER,
+  GOLDEN_OPPORTUNITY_PRESCIENCE_MULTIPLIER,
+  SHIFTING_SANDS_MASTERY_COEFFICIENT,
+} from 'analysis/retail/evoker/augmentation/constants';
 import { i18n } from '@lingui/core';
 import Enemies from '../Enemies';
 
@@ -24,6 +32,10 @@ class DamageDone extends Analyzer.withDependencies({ enemies: Enemies }) {
 
   _total = DamageValue.empty();
   private _totalBoss = DamageValue.empty();
+  _augmentedExtra = 0;
+
+  _augmentationDamageTotal = 0;
+  _augmentationBreakdown: Record<number, number> = {};
 
   get total() {
     return this._total;
@@ -60,6 +72,34 @@ class DamageDone extends Analyzer.withDependencies({ enemies: Enemies }) {
         this.bySecond[secondsIntoFight] = DamageValue.empty();
       }
       this.bySecond[secondsIntoFight] = this.bySecond[secondsIntoFight].addEvent(event);
+
+      // Track damage done while any augmentation buff is active, and attribute extra damage
+      try {
+        const augmentationBuffs: Array<{ id: number | undefined; multiplier?: number }> = [
+          { id: SPELLS.EBON_MIGHT_BUFF_EXTERNAL?.id, multiplier: EBON_MIGHT_PERSONAL_DAMAGE_AMP },
+          { id: SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF?.id, multiplier: BREATH_OF_EONS_MULTIPLIER },
+          { id: SPELLS.PRESCIENCE_BUFF?.id, multiplier: GOLDEN_OPPORTUNITY_PRESCIENCE_MULTIPLIER },
+          { id: SPELLS.SHIFTING_SANDS_BUFF?.id, multiplier: SHIFTING_SANDS_MASTERY_COEFFICIENT },
+        ];
+
+        let anyAug = false;
+        augmentationBuffs.forEach((b) => {
+          if (!b.id) return;
+          if (this.selectedCombatant.hasBuff(b.id, event.timestamp)) {
+            anyAug = true;
+            this._augmentationBreakdown[b.id] =
+              (this._augmentationBreakdown[b.id] || 0) + event.amount + (event.absorbed || 0);
+            if (b.multiplier) {
+              this._augmentedExtra += calculateEffectiveDamage(event, b.multiplier as number);
+            }
+          }
+        });
+        if (anyAug) {
+          this._augmentationDamageTotal += event.amount + (event.absorbed || 0);
+        }
+      } catch (error) {
+        console.warn('Failed to track augmentation buffs:', error);
+      }
     }
   }
   onByPlayerPetDamage(event: DamageEvent) {
@@ -73,6 +113,34 @@ class DamageDone extends Analyzer.withDependencies({ enemies: Enemies }) {
       const petId = event.sourceID;
       if (petId) {
         this._byPet[petId] = this.byPet(petId).addEvent(event);
+      }
+
+      // Track augmentation damage for pets similarly
+      try {
+        const augmentationBuffs: Array<{ id: number | undefined; multiplier?: number }> = [
+          { id: SPELLS.EBON_MIGHT_BUFF_EXTERNAL?.id, multiplier: EBON_MIGHT_PERSONAL_DAMAGE_AMP },
+          { id: SPELLS.ESSENCE_BURST_AUGMENTATION_BUFF?.id, multiplier: BREATH_OF_EONS_MULTIPLIER },
+          { id: SPELLS.PRESCIENCE_BUFF?.id, multiplier: GOLDEN_OPPORTUNITY_PRESCIENCE_MULTIPLIER },
+          { id: SPELLS.SHIFTING_SANDS_BUFF?.id, multiplier: SHIFTING_SANDS_MASTERY_COEFFICIENT },
+        ];
+
+        let anyAug = false;
+        augmentationBuffs.forEach((b) => {
+          if (!b.id) return;
+          if (this.selectedCombatant.hasBuff(b.id, event.timestamp)) {
+            anyAug = true;
+            this._augmentationBreakdown[b.id] =
+              (this._augmentationBreakdown[b.id] || 0) + event.amount + (event.absorbed || 0);
+            if (b.multiplier) {
+              this._augmentedExtra += calculateEffectiveDamage(event, b.multiplier as number);
+            }
+          }
+        });
+        if (anyAug) {
+          this._augmentationDamageTotal += event.amount + (event.absorbed || 0);
+        }
+      } catch (error) {
+        console.warn('Failed to track augmentation buffs:', error);
       }
     }
   }
@@ -90,6 +158,10 @@ class DamageDone extends Analyzer.withDependencies({ enemies: Enemies }) {
     }));
 
     const perSecond = (this.total.effective / this.owner.fightDuration) * 1000;
+    // Normalized DPS attempts to remove damage attributable to augmentation buffs so we can compare
+    // a player's baseline performance without augmentation. We currently attribute Ebon Might as a 20% buff.
+    const normalizedDamage = Math.max(0, this.total.effective - this._augmentedExtra);
+    const normalizedPerSecond = (normalizedDamage / this.owner.fightDuration) * 1000;
     const wclUrl = makeWclUrl(this.owner.report.code, {
       fight: this.owner.fightId,
       source: this.owner.playerId,
@@ -116,7 +188,49 @@ class DamageDone extends Analyzer.withDependencies({ enemies: Enemies }) {
             }
           >
             <div className="flex-sub value" style={{ width: 190 }}>
-              {formatThousands(perSecond)} DPS
+              {this._augmentedExtra > 0 ? (
+                <div>
+                  <div style={{ fontWeight: 600 }}>{formatThousands(perSecond)} DPS</div>
+                  <div style={{ fontSize: 12, color: '#999', marginTop: 6 }}>
+                    <Tooltip
+                      content={
+                        <>
+                          Due to Evoker augmentation buffs you were boosted by{' '}
+                          <strong>
+                            {formatPercentage(
+                              // boost relative to baseline
+                              this.total.effective - this._augmentedExtra > 0
+                                ? this._augmentedExtra /
+                                    (this.total.effective - this._augmentedExtra)
+                                : 0,
+                              1,
+                            )}
+                          </strong>
+                          . This amounts to roughly{' '}
+                          <strong>
+                            {formatThousands(
+                              (this._augmentedExtra / this.owner.fightDuration) * 1000,
+                            )}
+                          </strong>{' '}
+                          DPS added. Without augmentation your DPS would be{' '}
+                          <strong>{formatThousands(normalizedPerSecond)}</strong>.
+                        </>
+                      }
+                    >
+                      <span style={{ textDecoration: 'underline', cursor: 'help' }}>
+                        Augmented DPS
+                      </span>
+                    </Tooltip>
+                    : <strong>{formatThousands(perSecond)}</strong>
+                  </div>
+                  <div style={{ fontSize: 12, color: '#999', marginTop: 3 }}>
+                    <span>Normalized DPS: </span>
+                    <strong>{formatThousands(normalizedPerSecond)}</strong>
+                  </div>
+                </div>
+              ) : (
+                <div style={{ fontWeight: 600 }}>{formatThousands(perSecond)} DPS</div>
+              )}
             </div>
           </Tooltip>
           <div


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->
Add augmented/normalized DPS tracking for Evoker augmentation buffs with tooltip explaining the boost.
Based off the issue: https://github.com/WoWAnalyzer/WoWAnalyzer/issues/7817

- Track damage from multiple augmentation buffs (Ebon Might, Essence Burst, Prescience, Shifting Sands)
- Display both Augmented DPS and Normalized DPS in the statistic tab:
<img width="573" height="403" alt="{3DFA3D66-7903-4A7D-8A4D-A0A635576238}" src="https://github.com/user-attachments/assets/803d70bd-27ba-44d4-8f57-3639e653d12d" />

- Include tooltip explaining the boost percentage and baseline DPS

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->
You can test it by entering the same log as in the issue:

https://wowanalyzer.com/report/RDt7PrcYz9Qnywq2/3-Mythic++Skyreach+-+Kill+(26:37)/113-Biggerbits/standard/statistics
https://www.warcraftlogs.com/reports/RDt7PrcYz9Qnywq2?fight=last&type=damage-done&options=65536

- Test report URL: `/report/...`
- Screenshot(s):
<img width="561" height="138" alt="{37EB1808-88AF-46AF-8D04-3D476F979D07}" src="https://github.com/user-attachments/assets/dcac994d-18ca-42af-b87c-f7565526f3d6" />
