### PR TITLE
Better Frantic Frenzy Tracking and Sudden Ambush + Convoke bug fixes

### DIFF
--- a/src/analysis/retail/druid/feral/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/feral/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { change, date } from 'common/changelog';
 import {  Drowzen } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2026, 5,4), "Fixed Frantic Frenzy target tracking, SA + Convoke bug fixes, Updated default report", Drowzen),
   change(date(2026, 4, 12), "Fixed Sudden Ambush spell ID issues + tracking updates, updated tracking for DOTs", Drowzen),
   change(date(2026, 3, 15), "Added initial Chomp and Frantic Frenzy Support", Drowzen),
   change(date(2026, 3, 7,), "Initial Midnight update to activate Feral", Drowzen),

--- a/src/analysis/retail/druid/feral/CONFIG.tsx
+++ b/src/analysis/retail/druid/feral/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Drowzen],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.1',
+  patchCompatibility: '12.0.5',
   supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
@@ -49,7 +49,7 @@ const config: Config = {
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
-    '/report/7q4wXjc3V9GJbC1H/53-Mythic+One-Armed+Bandit+-+Kill+(7:09)/Elviiradruid/standard',
+    '/report/Ny8ngVxvfzaMbZ9m/5-Mythic+Chimaerus,+the+Undreamt+God+-+Kill+(6:11)/2-Nikeys/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/druid/feral/CombatLogParser.ts
+++ b/src/analysis/retail/druid/feral/CombatLogParser.ts
@@ -41,6 +41,7 @@ import SaberJaws from 'analysis/retail/druid/feral/modules/spells/SaberJaws';
 import SoulOfTheForestLinkNormalizer from 'analysis/retail/druid/feral/normalizers/SoulOfTheForestLinkNormalizer';
 import MercilessClaws from 'analysis/retail/druid/feral/modules/spells/MercilessClaws';
 import Chomp from 'analysis/retail/druid/feral/modules/spells/Chomp';
+import InfectedWounds from 'analysis/retail/druid/feral/modules/spells/InfectedWounds';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -99,6 +100,7 @@ class CombatLogParser extends CoreCombatLogParser {
     saberJaws: SaberJaws,
     mercilessClaws: MercilessClaws,
     chomp: Chomp,
+    infectedWounds: InfectedWounds,
     // TODO TWW - might actually want a Tiger's Tenacity module now
 
     // tier

--- a/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
@@ -3,7 +3,7 @@ import ComboPointTracker from 'analysis/retail/druid/feral/modules/core/combopoi
 import { TALENTS_DRUID } from 'common/TALENTS';
 import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import SPELLS from 'common/SPELLS';
-import Enemies from 'parser/shared/modules/Enemies';
+import Enemies, { encodeEventTargetString } from 'parser/shared/modules/Enemies';
 import { SpellLink } from 'interface';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { getLowestPerf, QualitativePerformance } from 'parser/ui/QualitativePerformance';
@@ -81,7 +81,7 @@ export default class FeralFrenzy extends Analyzer {
 
     const enemy = this.enemies.getEntity(event);
     const name = enemy?.name ?? 'Unknown';
-    const key = `${event.targetID}.${event.targetInstance ?? 0}`;
+    const key = encodeEventTargetString(event);
     const existing = currentCast.damageByEnemy.get(key);
     if (existing) {
       existing.damage += amount;
@@ -311,6 +311,6 @@ interface FeralFrenzyCast {
   isFrantic: boolean; // Feral Frenzy can be upgraded to Frantic Frenzy now
   /** Total damage (all hits + bleed ticks) attributed to this cast */
   damage: number;
-  /** Damage broken down per enemy, keyed by `${targetID}.${targetInstance}` */
+  /** Damage broken down per enemy, keyed by `encodeEventTargetString` */
   damageByEnemy: Map<string, { name: string; damage: number }>;
 }

--- a/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
@@ -1,7 +1,7 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import ComboPointTracker from 'analysis/retail/druid/feral/modules/core/combopoints/ComboPointTracker';
 import { TALENTS_DRUID } from 'common/TALENTS';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import SPELLS from 'common/SPELLS';
 import Enemies from 'parser/shared/modules/Enemies';
 import { SpellLink } from 'interface';
@@ -13,6 +13,12 @@ import CooldownExpandable, {
 import { PassFailCheckmark, PerformanceMark } from 'interface/guide';
 import EnergyTracker from 'analysis/retail/druid/feral/modules/core/energy/EnergyTracker';
 import { getDamageHits } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentDamageDone from 'parser/ui/ItemPercentDamageDone';
+import { formatNumber } from 'common/format';
 
 /**
  * **Feral Frenzy**
@@ -36,6 +42,8 @@ export default class FeralFrenzy extends Analyzer {
 
   /** Tracker for each Feral Frenzy cast */
   ffTrackers: FeralFrenzyCast[] = [];
+  /** Total damage dealt by Feral/Frantic Frenzy (all hits + bleed) */
+  totalDamage = 0;
 
   constructor(options: Options) {
     super(options);
@@ -43,6 +51,9 @@ export default class FeralFrenzy extends Analyzer {
     this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.FERAL_FRENZY_TALENT);
     this.isFrantic = this.selectedCombatant.hasTalent(TALENTS_DRUID.FRANTIC_FRENZY_TALENT);
     this.isFocused = this.selectedCombatant.hasTalent(TALENTS_DRUID.FOCUSED_FRENZY_TALENT);
+
+    const damageSpell = this.isFrantic ? SPELLS.FRANTIC_FRENZY_DEBUFF : SPELLS.FERAL_FRENZY_DEBUFF;
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(damageSpell), this.onFfDamage);
 
     if (!this.isFrantic) {
       this.addEventListener(
@@ -56,6 +67,28 @@ export default class FeralFrenzy extends Analyzer {
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS_DRUID.FRANTIC_FRENZY_TALENT),
       this.onCastFf,
     );
+  }
+
+  onFfDamage(event: DamageEvent) {
+    const amount = event.amount + (event.absorbed || 0);
+    this.totalDamage += amount;
+
+    const currentCast = this.ffTrackers[this.ffTrackers.length - 1];
+    if (!currentCast) {
+      // bleed tick from a cast that happened before fight start — not attributable
+      return;
+    }
+    currentCast.damage += amount;
+
+    const enemy = this.enemies.getEntity(event);
+    const name = enemy?.name ?? 'Unknown';
+    const key = `${event.targetID}.${event.targetInstance ?? 0}`;
+    const existing = currentCast.damageByEnemy.get(key);
+    if (existing) {
+      existing.damage += amount;
+    } else {
+      currentCast.damageByEnemy.set(key, { name, damage: amount });
+    }
   }
 
   onCastFf(event: CastEvent) {
@@ -72,6 +105,8 @@ export default class FeralFrenzy extends Analyzer {
       energyOnCast,
       isFrantic,
       hitCount,
+      damage: 0,
+      damageByEnemy: new Map(),
     });
   }
 
@@ -169,6 +204,74 @@ export default class FeralFrenzy extends Analyzer {
 
     return explanationAndDataSubsection(explanation, data);
   }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(1)}
+        size="flexible"
+        wide
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            Total damage dealt by <SpellLink spell={this.talent} /> (initial hits + bleed).
+          </>
+        }
+        dropdown={this.castBreakdownTable}
+      >
+        <BoringSpellValueText spell={this.talent}>
+          <ItemPercentDamageDone amount={this.totalDamage} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+
+  get castBreakdownTable() {
+    return (
+      <table className="table table-condensed">
+        <thead>
+          <tr>
+            <th>Cast #</th>
+            <th>Time</th>
+            <th>Damage</th>
+            <th>Enemies Hit</th>
+          </tr>
+        </thead>
+        <tbody>
+          {this.ffTrackers.map((cast, index) => (
+            <tr key={index}>
+              <th scope="row">{index + 1}</th>
+              <td>{this.owner.formatTimestamp(cast.timestamp)}</td>
+              <td>{formatNumber(cast.damage)}</td>
+              <td>
+                {Array.from(
+                  Array.from(cast.damageByEnemy.values())
+                    .reduce((acc, { name, damage }) => {
+                      const existing = acc.get(name);
+                      if (existing) {
+                        existing.count += 1;
+                        existing.damage += damage;
+                      } else {
+                        acc.set(name, { count: 1, damage });
+                      }
+                      return acc;
+                    }, new Map<string, { count: number; damage: number }>())
+                    .entries(),
+                )
+                  .sort(([, a], [, b]) => b.damage - a.damage)
+                  .map(([name, { count, damage }], i) => (
+                    <div key={i}>
+                      {name}
+                      {count > 1 && `(${count})`} — {formatNumber(damage)}
+                    </div>
+                  ))}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
 }
 
 interface FeralFrenzyCast {
@@ -178,4 +281,8 @@ interface FeralFrenzyCast {
   energyOnCast: number;
   isFrantic: boolean; // Feral Frenzy can be upgraded to Frantic Frenzy now
   hitCount: number; // The ability becomes AoE. This greatly changes the effeciency values.
+  /** Total damage (all hits + bleed ticks) attributed to this cast */
+  damage: number;
+  /** Damage broken down per enemy, keyed by `${targetID}.${targetInstance}` */
+  damageByEnemy: Map<string, { name: string; damage: number }>;
 }

--- a/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/FeralFrenzy.tsx
@@ -12,7 +12,6 @@ import CooldownExpandable, {
 } from 'interface/guide/components/CooldownExpandable';
 import { PassFailCheckmark, PerformanceMark } from 'interface/guide';
 import EnergyTracker from 'analysis/retail/druid/feral/modules/core/energy/EnergyTracker';
-import { getDamageHits } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -96,15 +95,12 @@ export default class FeralFrenzy extends Analyzer {
     const cpsOnCast = this.comboPointTracker.current;
     const energyOnCast = this.energyTracker.current;
     const isFrantic = this.isFrantic;
-    const damageEvents = getDamageHits(event);
-    const hitCount = new Set(damageEvents.map((e) => e.targetID)).size;
     this.ffTrackers.push({
       timestamp: event.timestamp,
       tfOnCast,
       cpsOnCast,
       energyOnCast,
       isFrantic,
-      hitCount,
       damage: 0,
       damageByEnemy: new Map(),
     });
@@ -185,7 +181,7 @@ export default class FeralFrenzy extends Analyzer {
             details: (
               <>
                 ({cast.cpsOnCast} CPs)
-                {this.isFrantic && <> ({cast.hitCount} Targets hit)</>}
+                {this.isFrantic && <> ({cast.damageByEnemy.size} Targets hit)</>}
               </>
             ),
           });
@@ -228,46 +224,79 @@ export default class FeralFrenzy extends Analyzer {
 
   get castBreakdownTable() {
     return (
-      <table className="table table-condensed">
+      <table className="table table-condensed" style={{ textAlign: 'left' }}>
         <thead>
           <tr>
-            <th>Cast #</th>
-            <th>Time</th>
-            <th>Damage</th>
-            <th>Enemies Hit</th>
+            <th style={{ textAlign: 'center' }}>Cast #</th>
+            <th style={{ textAlign: 'left' }}>Time</th>
+            <th style={{ textAlign: 'left' }}>Cast Damage</th>
+            <th style={{ textAlign: 'left' }}>Enemy</th>
+            <th style={{ textAlign: 'center' }}># Hit</th>
+            <th style={{ textAlign: 'left' }}>Damage</th>
           </tr>
         </thead>
         <tbody>
-          {this.ffTrackers.map((cast, index) => (
-            <tr key={index}>
-              <th scope="row">{index + 1}</th>
-              <td>{this.owner.formatTimestamp(cast.timestamp)}</td>
-              <td>{formatNumber(cast.damage)}</td>
-              <td>
-                {Array.from(
-                  Array.from(cast.damageByEnemy.values())
-                    .reduce((acc, { name, damage }) => {
-                      const existing = acc.get(name);
-                      if (existing) {
-                        existing.count += 1;
-                        existing.damage += damage;
-                      } else {
-                        acc.set(name, { count: 1, damage });
-                      }
-                      return acc;
-                    }, new Map<string, { count: number; damage: number }>())
-                    .entries(),
-                )
-                  .sort(([, a], [, b]) => b.damage - a.damage)
-                  .map(([name, { count, damage }], i) => (
-                    <div key={i}>
-                      {name}
-                      {count > 1 && `(${count})`} — {formatNumber(damage)}
-                    </div>
-                  ))}
-              </td>
-            </tr>
-          ))}
+          {this.ffTrackers.flatMap((cast, index) => {
+            const grouped = Array.from(
+              Array.from(cast.damageByEnemy.values())
+                .reduce((acc, { name, damage }) => {
+                  const existing = acc.get(name);
+                  if (existing) {
+                    existing.count += 1;
+                    existing.damage += damage;
+                  } else {
+                    acc.set(name, { count: 1, damage });
+                  }
+                  return acc;
+                }, new Map<string, { count: number; damage: number }>())
+                .entries(),
+            ).sort(([, a], [, b]) => b.damage - a.damage);
+
+            if (grouped.length === 0) {
+              return [
+                <tr key={index}>
+                  <th scope="row" style={{ textAlign: 'center' }}>
+                    {index + 1}
+                  </th>
+                  <td style={{ textAlign: 'left' }}>
+                    {this.owner.formatTimestamp(cast.timestamp)}
+                  </td>
+                  <td style={{ textAlign: 'left' }}>{formatNumber(cast.damage)}</td>
+                  <td colSpan={3} style={{ textAlign: 'left' }}>
+                    —
+                  </td>
+                </tr>,
+              ];
+            }
+
+            return grouped.map(([name, { count, damage }], i) => {
+              const subRowStyle = {
+                textAlign: 'left' as const,
+                ...(i > 0 ? { borderTopColor: 'transparent' } : {}),
+                ...(i < grouped.length - 1 ? { borderBottomColor: 'transparent' } : {}),
+              };
+              return (
+                <tr key={`${index}-${i}`}>
+                  {i === 0 && (
+                    <>
+                      <th scope="row" rowSpan={grouped.length} style={{ textAlign: 'center' }}>
+                        {index + 1}
+                      </th>
+                      <td rowSpan={grouped.length} style={{ textAlign: 'left' }}>
+                        {this.owner.formatTimestamp(cast.timestamp)}
+                      </td>
+                      <td rowSpan={grouped.length} style={{ textAlign: 'left' }}>
+                        {formatNumber(cast.damage)}
+                      </td>
+                    </>
+                  )}
+                  <td style={subRowStyle}>{name}</td>
+                  <td style={{ ...subRowStyle, textAlign: 'center' }}>{count}</td>
+                  <td style={subRowStyle}>{formatNumber(damage)}</td>
+                </tr>
+              );
+            });
+          })}
         </tbody>
       </table>
     );
@@ -280,7 +309,6 @@ interface FeralFrenzyCast {
   cpsOnCast: number;
   energyOnCast: number;
   isFrantic: boolean; // Feral Frenzy can be upgraded to Frantic Frenzy now
-  hitCount: number; // The ability becomes AoE. This greatly changes the effeciency values.
   /** Total damage (all hits + bleed ticks) attributed to this cast */
   damage: number;
   /** Damage broken down per enemy, keyed by `${targetID}.${targetInstance}` */

--- a/src/analysis/retail/druid/feral/modules/spells/InfectedWounds.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/InfectedWounds.tsx
@@ -1,0 +1,78 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import Events, { DamageEvent } from 'parser/core/Events';
+import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import SPELLS from 'common/SPELLS';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentDamageDone from 'parser/ui/ItemPercentDamageDone';
+
+const RAKE_DAMAGE_BONUS = 0.3;
+
+/**
+ * **Infected Wounds**
+ * Spec Talent
+ *
+ * Your Rake, Shred, and Thrash leave wounds that slow the target's movement by 50% for 12 sec.
+ * Rake damage is increased by 30%.
+ */
+export default class InfectedWounds extends Analyzer {
+  /** Damage added by the 30% Rake bonus */
+  rakeDirectDamage = 0;
+  rakeBleedDamage = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.INFECTED_WOUNDS_FERAL_TALENT);
+
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RAKE), this.onRakeDirect);
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.RAKE_BLEED),
+      this.onRakeBleed,
+    );
+  }
+
+  onRakeDirect(event: DamageEvent) {
+    this.rakeDirectDamage += calculateEffectiveDamage(event, RAKE_DAMAGE_BONUS);
+  }
+
+  onRakeBleed(event: DamageEvent) {
+    this.rakeBleedDamage += calculateEffectiveDamage(event, RAKE_DAMAGE_BONUS);
+  }
+
+  get totalDamage() {
+    return this.rakeDirectDamage + this.rakeBleedDamage;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(9)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            Damage attributable to the 30% <strong>Rake</strong> bonus from Infected Wounds.
+            <ul>
+              <li>
+                Direct hits:{' '}
+                <strong>{this.owner.formatItemDamageDone(this.rakeDirectDamage)}</strong>
+              </li>
+              <li>
+                Bleed ticks:{' '}
+                <strong>{this.owner.formatItemDamageDone(this.rakeBleedDamage)}</strong>
+              </li>
+            </ul>
+          </>
+        }
+      >
+        <BoringSpellValueText spell={TALENTS_DRUID.INFECTED_WOUNDS_FERAL_TALENT}>
+          <ItemPercentDamageDone amount={this.totalDamage} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
+++ b/src/analysis/retail/druid/feral/modules/spells/SuddenAmbush.tsx
@@ -26,6 +26,7 @@ import { BadColor } from 'interface/guide';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBreakdown';
 import { getDamageHits } from 'analysis/retail/druid/feral/normalizers/CastLinkNormalizer';
+import { isConvoking } from 'analysis/retail/druid/shared/spells/ConvokeSpirits';
 
 const SA_BUFF_BUFFER = 50;
 
@@ -95,6 +96,11 @@ class SuddenAmbush extends Analyzer {
   }
 
   onOverwriteSa(_event: RefreshBuffEvent) {
+    // Convoke can randomly proc SA while one is already up — not the player's choice,
+    // so don't count the gain or the overwrite.
+    if (isConvoking(this.selectedCombatant)) {
+      return;
+    }
     this.saGained += 1;
     this.saOverwritten += 1;
   }
@@ -105,19 +111,25 @@ class SuddenAmbush extends Analyzer {
     // Since onSaConsumerCast fires on cast events (which happen before removebuff),
     // if this removebuff wasn't preceded by a cast, it's an expiration.
     const totalAccountedFor = this.saUsed + this.saExpired + this.saOverwritten;
-    if (totalAccountedFor < this.saGained) {
-      // This removal wasn't from a cast - it expired
-      this.saExpired += 1;
-      this.useEntries.push({
-        value: QualitativePerformance.Fail,
-        tooltip: (
-          <>
-            <h5 style={{ color: BadColor }}>Bad because you let a proc expire</h5>@{' '}
-            <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
-          </>
-        ),
-      });
+    if (totalAccountedFor >= this.saGained) {
+      return;
     }
+    // Convoke fires Rake/Shred/Swipe without producing cast events, so a consume during
+    // a Convoke channel isn't the player's choice — count as used and don't penalize.
+    if (isConvoking(this.selectedCombatant)) {
+      this.saUsed += 1;
+      return;
+    }
+    this.saExpired += 1;
+    this.useEntries.push({
+      value: QualitativePerformance.Fail,
+      tooltip: (
+        <>
+          <h5 style={{ color: BadColor }}>Bad because you let a proc expire</h5>@{' '}
+          <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
+        </>
+      ),
+    });
   }
 
   onSaConsumerCast(event: CastEvent) {


### PR DESCRIPTION
### Description

Fixed SA bug with convoke consuming SA counting against the player despite having no control over it
Better Frantic Frenzy Tracking
Added a Frantic Frenzy statistic + table for the tracking

### Testing

Ran against reports where events occurred and verified proper counts directly against the logs 

- Test report URL: `/report/...`
https://www.warcraftlogs.com/reports/gvdKhMrFcDtRLC2m?fight=25&type=damage-done
https://www.warcraftlogs.com/reports/QkRNX6K7wzMtcmVZ?fight=4&type=damage-done
- Screenshot(s):

<img width="1851" height="286" alt="image" src="https://github.com/user-attachments/assets/136fad03-1947-4751-95ef-667544ed91f5" />

<img width="1863" height="260" alt="image" src="https://github.com/user-attachments/assets/6e13fb8c-bc8d-4856-aa1a-7a9af4bdc65e" />

<img width="1855" height="645" alt="image" src="https://github.com/user-attachments/assets/3f72ee87-ac75-409c-9b1a-6a360183c290" />
