### PR TITLE
update Anvil and Stave implementation, update HT CDR post-nerf

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,8 @@ import SPELLS from './spell-list_Monk_Brewmaster.retail';
 
 // prettier-ignore
 export default [
+  change(date(2026, 5, 6), <>Update <SpellLink spell={SPELLS.HIGH_TOLERANCE_TALENT} /> CDR to reflect the recent nerfs.</>, emallson),
+  change(date(2026, 5, 6), <>Update support of <SpellLink spell={SPELLS.ANVIL_AND_STAVE_TALENT} />.</>, emallson),
   change(date(2026, 5, 2), <>Add an Elevated Purifying Brew comparison box to Stagger Management with cast efficiency, total casts, elevated casts, max casts, and elevated cooldown reduction for <SpellLink spell={SPELLS.PURIFYING_BREW_TALENT} /> while <SpellLink spell={spells.ELEVATED_STAGGER_BUFF} /> is active (CDR shown as mm:ss).</>, Mahmud17),
   change(date(2026, 4, 26), <>Mark purify events in Overview Stagger Pool chart green if cast while <SpellLink spell={spells.ELEVATED_STAGGER_BUFF} /> is applied or <SpellLink spell={SPELLS.HIGH_IMPACT_TALENT} />isn't talented, otherwise red.</>, kate),
   change(date(2026, 4, 19), <>Fix <SpellLink spell={SPELLS.QUICK_SIP_TALENT} /> having too much <SpellLink spell={SPELLS.STAGGER_TALENT} /> clearing attributed to it, which resulted in <SpellLink spell={SPELLS.TRANQUIL_SPIRIT_TALENT} /> being undervalued (and sometimes crashing).</>, emallson),

--- a/src/analysis/retail/monk/brewmaster/modules/spells/HighTolerance.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/HighTolerance.tsx
@@ -11,7 +11,7 @@ import { formatDurationMinSec } from 'common/format';
 import SpellLink from 'interface/SpellLink';
 import StateHistory, { EventHistory } from 'parser/core/StateHistory';
 
-const CDR_PER_RANK = 3000;
+const CDR_PER_RANK = 2000;
 
 class HighTolerance extends Analyzer.withDependencies({ spellUsable: SpellUsable }) {
   protected ranks = 0;

--- a/src/analysis/retail/monk/brewmaster/modules/talents/AnvilStave.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/talents/AnvilStave.tsx
@@ -1,4 +1,4 @@
-import { formatDuration, formatDurationMinSec, formatPercentage } from 'common/format';
+import { formatDurationMinSec } from 'common/format';
 import HIT_TYPES from 'game/HIT_TYPES';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
@@ -6,18 +6,48 @@ import Events, { DamageEvent } from 'parser/core/Events';
 import BoringValue from 'parser/ui/BoringValueText';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+
 import { ReactNode } from 'react';
 import SharedBrews from '../core/SharedBrews';
 import spells from '../../spell-list_Monk_Brewmaster.retail';
+import { encodeEventSourceString } from 'parser/shared/modules/Enemies';
 
 // 500ms per rank
 const CDR_RATE = 500;
-const RECHARGE_DURATION = 3000;
+const RECENT_DURATION = 5000;
+const MAX_ATTACKERS = 5;
+
+/**
+ * The rate of CDR applied based on the number of recent attackers. This is multiplied by the
+ * CDR from the talent itself.
+ */
+const CDR_FACTOR: number[] = [];
+for (let i = 0; i < MAX_ATTACKERS; i++) {
+  // formula for `n` attackers is (\sum_{i = 0}^{n-1} 2^{-i}) / n
+  // a very literal translation of the tooltip, surprisingly
+  CDR_FACTOR[i] =
+    Array.from({ length: i + 1 })
+      .map((_, i) => Math.pow(2, -i))
+      .reduce((a, b) => a + b, 0) /
+    (i + 1);
+}
+
+const DEBUG = false;
 
 /**
  * Anvil & Stave reduces Brew CDs by 0.5/1.0s every time you dodge / an enemy misses, with some extra steps.
  *
- * Prior to TWW, this operated on a 3s ICD. Now, we don't really know how it works but the lowest CDR model I've found that still works is treating it kind of like you have a "CDR pool" that regenerates over time, maxing out at 0.5/1.0s after 3s of no dodging.
+ * In Midnight, the tooltip states "reduced by 50% for every recent attacker, up to 5." Testing indicates that:
+ *
+ * - "recent attacker" means "attacker that triggered A&S within the past 5s"
+ * - CDR is static for each attacker: if you are being hit by 2 enemies that have triggered A&S recently, both enemies give the same amount of CDR on each trigger.
+ *
+ * The upshot of this is that this scales *very well* with added targets. The theoretical model with no cap on attackers would reach 2x
+ * the single-target rate with infinitely many targets and never go beyond it.
+ *
+ * With the way the cap is implemented, you reach the same value as theoretical at 5 targets (~1.9x). But then at 6 targets you're over 2x and at 8 targets you're over 3x.
+ *
+ * Message @emallson if you want the data from testing.
  */
 export default class AnvilStave extends Analyzer {
   static dependencies = {
@@ -28,8 +58,9 @@ export default class AnvilStave extends Analyzer {
 
   private rank: number;
   private totalCdr = 0;
-  private lastTriggerTimestamp?: number;
   private triggerCount = 0;
+
+  private recentTriggers: DamageEvent[] = [];
 
   get cdr() {
     return this.totalCdr;
@@ -48,42 +79,43 @@ export default class AnvilStave extends Analyzer {
     this.addEventListener(Events.damage.to(SELECTED_PLAYER), this.onDamage);
   }
 
+  private recentAttackerCount(event: DamageEvent): number {
+    this.recentTriggers.push(event);
+    this.recentTriggers = this.recentTriggers.filter(
+      (prev) => prev.timestamp >= event.timestamp - RECENT_DURATION,
+    );
+
+    return new Set(this.recentTriggers.map((event) => encodeEventSourceString(event))).size;
+  }
+
   private onDamage(event: DamageEvent) {
     if (event.hitType !== HIT_TYPES.MISS && event.hitType !== HIT_TYPES.DODGE) {
       return;
     }
 
-    const chargeRatio = this.lastTriggerTimestamp
-      ? Math.min(1.0, (event.timestamp - this.lastTriggerTimestamp) / RECHARGE_DURATION)
-      : 1.0;
+    const attackerCount = this.recentAttackerCount(event);
+    const cdrAmount = this.rank * CDR_RATE * CDR_FACTOR[Math.min(MAX_ATTACKERS, attackerCount) - 1];
 
-    const cdrAmount = chargeRatio * this.rank * CDR_RATE;
     this.triggerCount += 1;
     const actualCdr = this.sharedBrews.reduceCooldown(cdrAmount);
     this.totalCdr += actualCdr;
-    this.addDebugAnnotation(event, {
-      color: 'lightgrey',
-      summary: `A&S reduced cooldown (raw: ${cdrAmount.toFixed(1)}, actual: ${cdrAmount.toFixed(1)})`,
-      details: (
-        <dl>
-          <dt>Last Trigger:</dt>
-          <dd>
-            {this.lastTriggerTimestamp
-              ? `${formatDuration(this.lastTriggerTimestamp - this.owner.fight.start_time)} (${formatDurationMinSec((event.timestamp - this.lastTriggerTimestamp) / 1000)} ago)`
-              : 'never'}
-          </dd>
-          <dt>Charge %:</dt>
-          <dd>{formatPercentage(chargeRatio)}%</dd>
-          <dt>Max CDR (ms)</dt>
-          <dd>{this.rank * CDR_RATE}</dd>
-          <dt>Raw CDR (ms)</dt>
-          <dd>{cdrAmount.toFixed(2)}</dd>
-          <dt>Actual CDR (ms)</dt>
-          <dd>{actualCdr.toFixed(2)}</dd>
-        </dl>
-      ),
-    });
-    this.lastTriggerTimestamp = event.timestamp;
+    DEBUG &&
+      this.addDebugAnnotation(event, {
+        color: 'lightgrey',
+        summary: `A&S reduced cooldown (raw: ${cdrAmount.toFixed(1)}, actual: ${cdrAmount.toFixed(1)})`,
+        details: (
+          <dl>
+            <dt>Recent Attacker Count</dt>
+            <dd>{attackerCount}</dd>
+            <dt>Max CDR (ms)</dt>
+            <dd>{this.rank * CDR_RATE}</dd>
+            <dt>Raw CDR (ms)</dt>
+            <dd>{cdrAmount.toFixed(2)}</dd>
+            <dt>Actual CDR (ms)</dt>
+            <dd>{actualCdr.toFixed(2)}</dd>
+          </dl>
+        ),
+      });
   }
 
   statistic(): ReactNode {

--- a/src/parser/core/Entity.ts
+++ b/src/parser/core/Entity.ts
@@ -61,6 +61,8 @@ abstract class Entity {
   }
 
   /**
+   * Check if this entity has a buff. There is a fast-path that is **MUCH** faster if only `spell` or `spell` + `sourceID` are specified.
+   *
    * @param {number | Spell} spell buff (ID) to check for
    * @param {number} forTimestamp Timestamp (in ms) to be considered, or the current timestamp if null. Won't work right for timestamps after the currentTimestamp.
    * @param {number} bufferTime Time (in ms) after buff's expiration where it will still be included. There's a bug in the combat log where if a spell consumes a buff that buff may disappear a short time before the heal or damage event it's buffing is logged. This can sometimes go up to hundreds of milliseconds.

--- a/src/parser/shared/modules/racials/dwarf/Stoneform.jsx
+++ b/src/parser/shared/modules/racials/dwarf/Stoneform.jsx
@@ -48,11 +48,7 @@ class Stoneform extends Analyzer {
     }
 
     const damageTaken = event.amount + (event.absorbed || 0);
-    const isStoneformActive = this.selectedCombatant.hasBuff(
-      SPELLS.STONEFORM_BUFF.id,
-      event.timestamp,
-      this.owner.playerId,
-    );
+    const isStoneformActive = this.selectedCombatant.hasBuff(SPELLS.STONEFORM_BUFF.id);
 
     if (isStoneformActive) {
       this.physicalDamageTaken += damageTaken;


### PR DESCRIPTION
### Description

HT change is an update to reflect [this nerf.](https://www.wowhead.com/blue-tracker/news/us/hotfixes-may-5-2026-world-of-warcraft-blizzard-news-24276957)

Anvil & Stave has always been only *approximately* correct. The talent defied precise modeling for the entirety of TWW. Going into Midnight, it got a tooltip update. It is unclear if the talent itself changed in functionality, or if this is just a clarification.

Anyway, after some pretty extensive testing this week we now know how it works with a fairly high degree of confidence, and the implementation has been updated to reflect that

### Testing

`/report/C2qtLmjavDbQA4nd/1-Mythic++Magisters'+Terrace+-+Kill+(32:32)/1-Coldflames/standard/statistics`

<img width="1261" height="374" alt="image" src="https://github.com/user-attachments/assets/0f1159d3-e9f4-4b88-834c-f519658bc4b3" />



