### PR TITLE
[BrM] High Tolerance applies CDR before consuming a charge

### DIFF
--- a/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/brewmaster/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SPELLS from './spell-list_Monk_Brewmaster.retail';
 
 // prettier-ignore
 export default [
+  change(date(2026, 5, 6), <>Adjust <SpellLink spell={SPELLS.HIGH_TOLERANCE_TALENT} /> logic to apply CDR before consuming a charge (replicating the in-game bug).</>, emallson),
   change(date(2026, 5, 6), <>Update <SpellLink spell={SPELLS.HIGH_TOLERANCE_TALENT} /> CDR to reflect the recent nerfs.</>, emallson),
   change(date(2026, 5, 6), <>Update support of <SpellLink spell={SPELLS.ANVIL_AND_STAVE_TALENT} />.</>, emallson),
   change(date(2026, 5, 2), <>Add an Elevated Purifying Brew comparison box to Stagger Management with cast efficiency, total casts, elevated casts, max casts, and elevated cooldown reduction for <SpellLink spell={SPELLS.PURIFYING_BREW_TALENT} /> while <SpellLink spell={spells.ELEVATED_STAGGER_BUFF} /> is active (CDR shown as mm:ss).</>, Mahmud17),

--- a/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
+++ b/src/analysis/retail/monk/brewmaster/CombatLogParser.ts
@@ -57,12 +57,14 @@ import {
   KegSmashPrimaryTargetNormalizer,
   SpinningCraneKickTickNormalizer,
 } from './normalizers/PrimaryTargetLinks';
+import SpellUsable from './modules/core/SpellUsable';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
     // Core
     healingDone: HealingDone,
     damageTaken: DamageTaken,
+    spellUsable: SpellUsable,
     brewCdr: BrewCDR,
     brews: SharedBrews,
     channeling: Channeling,

--- a/src/analysis/retail/monk/brewmaster/modules/core/SpellUsable.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/core/SpellUsable.tsx
@@ -1,0 +1,26 @@
+import { CastEvent, EventType, FilterCooldownInfoEvent } from 'parser/core/Events';
+import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
+import SPELLS from '../../spell-list_Monk_Brewmaster.retail';
+import HighTolerance from '../spells/HighTolerance';
+import SPELLS_COMMON from 'common/SPELLS';
+
+export default class SpellUsable extends CoreSpellUsable {
+  static dependencies = {
+    ...CoreSpellUsable.dependencies,
+    highTolerance: HighTolerance,
+  };
+
+  private highTolerance!: HighTolerance;
+
+  protected onCast(event: CastEvent | FilterCooldownInfoEvent): void {
+    if (
+      event.type === EventType.Cast &&
+      event.ability.guid === SPELLS.PURIFYING_BREW_TALENT.id &&
+      this.selectedCombatant.hasBuff(SPELLS_COMMON.ELEVATED_STAGGER_BUFF.id)
+    ) {
+      this.highTolerance.reducePurifyCooldown(event, this);
+    }
+
+    super.onCast(event);
+  }
+}

--- a/src/analysis/retail/monk/brewmaster/modules/spells/HighTolerance.tsx
+++ b/src/analysis/retail/monk/brewmaster/modules/spells/HighTolerance.tsx
@@ -1,8 +1,7 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS';
 import spells from '../../spell-list_Monk_Brewmaster.retail';
-import SpellUsable from 'parser/shared/modules/SpellUsable';
-import Events, { CastEvent, ApplyBuffEvent, RemoveBuffEvent, EventType } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, RemoveBuffEvent, EventType, CastEvent } from 'parser/core/Events';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -10,10 +9,12 @@ import BoringValue from 'parser/ui/BoringValueText';
 import { formatDurationMinSec } from 'common/format';
 import SpellLink from 'interface/SpellLink';
 import StateHistory, { EventHistory } from 'parser/core/StateHistory';
+import type SpellUsable from 'parser/shared/modules/SpellUsable';
 
 const CDR_PER_RANK = 2000;
 
-class HighTolerance extends Analyzer.withDependencies({ spellUsable: SpellUsable }) {
+// CDR for HT is handled in SpellUsable in order to deal with the bug where CDR is applied *before* a charge is consumed.
+class HighTolerance extends Analyzer {
   protected ranks = 0;
 
   protected elevatedPurifyCount = 0;
@@ -28,17 +29,27 @@ class HighTolerance extends Analyzer.withDependencies({ spellUsable: SpellUsable
     return this.cdrAmount;
   }
 
+  /**
+   * Externally-callable method to apply HT CDR. this is used by Brew's SpellUsable to apply CDR *before* the cast, matching in-game behavior.
+   */
+  public reducePurifyCooldown(event: CastEvent, spellUsable: SpellUsable): void {
+    if (!this.active) {
+      return;
+    }
+
+    const cdr = this.ranks * CDR_PER_RANK;
+    const actualAmount = spellUsable.reduceCooldown(spells.PURIFYING_BREW_TALENT.id, cdr);
+    this.cdrAmount += actualAmount;
+    this.wastedCdr += cdr - actualAmount;
+    this.elevatedPurifyCount += 1;
+  }
+
   uptime: EventHistory<EventType.ApplyBuff | EventType.RemoveBuff> = new StateHistory([]);
 
   constructor(options: Options) {
     super(options);
     this.ranks = this.selectedCombatant.getTalentRank(spells.HIGH_TOLERANCE_TALENT);
     this.active = this.ranks > 0;
-
-    this.addEventListener(
-      Events.cast.spell(spells.PURIFYING_BREW_TALENT).by(SELECTED_PLAYER),
-      this.elevatedStaggerCdr,
-    );
 
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.ELEVATED_STAGGER_BUFF),
@@ -48,19 +59,6 @@ class HighTolerance extends Analyzer.withDependencies({ spellUsable: SpellUsable
       Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.ELEVATED_STAGGER_BUFF),
       this.onRemoveBuff,
     );
-  }
-
-  private elevatedStaggerCdr(_event: CastEvent): void {
-    if (this.selectedCombatant.hasBuff(SPELLS.ELEVATED_STAGGER_BUFF)) {
-      this.elevatedPurifyCount += 1;
-      // note: this is NOT shared brew CDR! it is only Purifying Brew!
-      const actualCdr = this.deps.spellUsable.reduceCooldown(
-        spells.PURIFYING_BREW_TALENT.id,
-        this.ranks * CDR_PER_RANK,
-      );
-      this.cdrAmount += actualCdr;
-      this.wastedCdr += this.ranks * CDR_PER_RANK - actualCdr;
-    }
   }
 
   private onApplyBuff(event: ApplyBuffEvent) {
@@ -77,6 +75,13 @@ class HighTolerance extends Analyzer.withDependencies({ spellUsable: SpellUsable
         position={STATISTIC_ORDER.OPTIONAL()}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            {formatDurationMinSec(this.wastedCdr / 1000)} CDR wasted. Note that{' '}
+            <strong>High Tolerance has a bug</strong> causing cooldown reduction to be applied
+            before consuming a charge.
+          </>
+        }
       >
         <BoringValue
           label={


### PR DESCRIPTION
there is a bug in-game where the CDR is applied first, then the charge is consumed. this causes the CDR to be wasted sometimes, which would not otherwise be possible.

supporting this in WoWA required some reorg in the brew modules, moving the handling of the cast into `SpellUsable` so that the CDR can be (literally) applied before the spell is put on cooldown.