### PR TITLE
[Vengeance] Update Midnight talent guidance and support status

### DIFF
--- a/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import TALENTS from 'common/TALENTS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2026, 5, 7), <>Update <SpellLink spell={SPELLS.FRAILTY} /> guidance and <SpellLink spell={TALENTS.SOUL_CARVER_TALENT} /> analysis for Midnight, and mark Vengeance accurate for patch 12.0.5.</>, Guminator),
   change(date(2026, 4, 25), <>Update to 12.0.5<SpellLink spell={SPELLS.FRACTURE} /> and  <SpellLink spell={TALENTS.CELESTIAL_ECHOES_TALENT} /></>, Quaarkz),
   change(date(2026, 4, 19), <>Fix <SpellLink spell={SPELLS.FRAILTY} /> uptime analysis activation, <SpellLink spell={TALENTS.FIERY_DEMISE_TALENT} /> target checks, and <SpellLink spell={TALENTS.SOUL_BARRIER_TALENT} /> cooldown/statistic display for Midnight behavior.</>, Guminator),
   change(date(2026, 4, 18), <>Fix <SpellLink spell={SPELLS.DEMON_SPIKES} /> usage segmentation in the major defensive breakdown.</>, Guminator),

--- a/src/analysis/retail/demonhunter/vengeance/CONFIG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CONFIG.tsx
@@ -17,8 +17,8 @@ const config: Config = {
   contributors: [Topple, Quaarkz, Guminator],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.1',
-  supportLevel: SupportLevel.MaintainedPartial,
+  patchCompatibility: '12.0.5',
+  supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/analysis/retail/demonhunter/vengeance/CONFIG.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/CONFIG.tsx
@@ -18,7 +18,7 @@ const config: Config = {
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '12.0.5',
-  supportLevel: SupportLevel.MaintainedFull,
+  supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/analysis/retail/demonhunter/vengeance/modules/core/VulnerabilityExplanation.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/core/VulnerabilityExplanation.tsx
@@ -5,10 +5,9 @@ import { TALENTS_DEMON_HUNTER } from 'common/TALENTS/demonhunter';
 
 interface Props {
   lineBreak?: boolean;
-  numberOfFrailtyStacks: number;
 }
 
-const VulnerabilityExplanation = ({ lineBreak, numberOfFrailtyStacks }: Props) => {
+const VulnerabilityExplanation = ({ lineBreak }: Props) => {
   const info = useInfo();
   if (!info || !info.combatant.hasTalent(TALENTS_DEMON_HUNTER.VULNERABILITY_TALENT)) {
     return null;
@@ -17,9 +16,8 @@ const VulnerabilityExplanation = ({ lineBreak, numberOfFrailtyStacks }: Props) =
     <>
       {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
       {lineBreak ? <br /> : ' '}
-      Always use with at least {numberOfFrailtyStacks} stacks of{' '}
-      <SpellLink spell={SPELLS.FRAILTY} /> applied to the target in order to maximise the damage
-      dealt.
+      Always use with <SpellLink spell={SPELLS.FRAILTY} /> applied to the target in order to
+      maximise the damage dealt.
     </>
   );
 };

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/FelDevastation.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/FelDevastation.tsx
@@ -17,8 +17,6 @@ import MajorCooldown, {
 import { getDamageEvents } from 'analysis/retail/demonhunter/vengeance/normalizers/FelDevastationLinkNormalizer';
 import { isDefined } from 'common/typeGuards';
 
-const PERFECT_FRAILTY_STACKS = 1;
-
 interface FelDevastationDamage {
   targetStacksOfFrailty: number;
   hasFieryBrandDebuff: boolean;
@@ -55,7 +53,7 @@ export default class FelDevastation extends MajorCooldown<FelDevastationCooldown
           is a large burst of damage and healing.
         </section>
         <section>
-          <VulnerabilityExplanation lineBreak numberOfFrailtyStacks={PERFECT_FRAILTY_STACKS} />
+          <VulnerabilityExplanation lineBreak />
           <FieryDemiseExplanation includeDownInFlames lineBreak />
         </section>
       </>

--- a/src/analysis/retail/demonhunter/vengeance/modules/talents/SoulCarver.tsx
+++ b/src/analysis/retail/demonhunter/vengeance/modules/talents/SoulCarver.tsx
@@ -12,12 +12,8 @@ import { ChecklistUsageInfo, SpellUse, UsageInfo } from 'parser/core/SpellUsage/
 import MajorCooldown, { CooldownTrigger } from 'parser/core/MajorCooldowns/MajorCooldown';
 import { isDefined } from 'common/typeGuards';
 
-const PERFECT_FRAILTY_STACKS = 5;
-const GOOD_FRAILTY_STACKS = 3;
-const OK_FRAILTY_STACKS = 1;
-
 interface SoulCarverCooldownCast extends CooldownTrigger<CastEvent> {
-  primaryTargetStacksOfFrailty: number;
+  hasFrailtyDebuff: boolean;
   hasFieryBrandDebuff: boolean;
 }
 
@@ -44,7 +40,7 @@ export default class SoulCarver extends MajorCooldown<SoulCarverCooldownCast> {
           <SpellLink spell={TALENTS_DEMON_HUNTER.SOUL_CARVER_TALENT} />
         </strong>{' '}
         is a burst of damage that also generates a decent chunk of Soul Fragments.
-        <VulnerabilityExplanation numberOfFrailtyStacks={GOOD_FRAILTY_STACKS} />
+        <VulnerabilityExplanation />
         <FieryDemiseExplanation />
       </>
     );
@@ -97,20 +93,20 @@ export default class SoulCarver extends MajorCooldown<SoulCarverCooldownCast> {
   private onCast(event: CastEvent) {
     this.recordCooldown({
       event,
-      primaryTargetStacksOfFrailty: this.getTargetStacksOfFrailty(event),
+      hasFrailtyDebuff: this.doesTargetHaveFrailty(event),
       hasFieryBrandDebuff: this.doesTargetHaveFieryBrand(event),
     });
   }
 
-  private getTargetStacksOfFrailty(event: CastEvent | undefined) {
+  private doesTargetHaveFrailty(event: CastEvent | undefined) {
     if (!event) {
-      return 0;
+      return false;
     }
     const enemy = this.enemies.getEntity(event);
     if (!enemy) {
-      return 0;
+      return false;
     }
-    return enemy.getBuffStacks(SPELLS.FRAILTY.id, event.timestamp);
+    return enemy.hasBuff(SPELLS.FRAILTY.id, event.timestamp);
   }
 
   private doesTargetHaveFieryBrand(event: CastEvent | undefined) {
@@ -165,22 +161,7 @@ export default class SoulCarver extends MajorCooldown<SoulCarverCooldownCast> {
     if (!this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.VULNERABILITY_TALENT)) {
       return undefined;
     }
-    if (!this.selectedCombatant.hasTalent(TALENTS_DEMON_HUNTER.SOULCRUSH_TALENT)) {
-      if (cast.primaryTargetStacksOfFrailty > 0) {
-        return {
-          performance: QualitativePerformance.Perfect,
-          summary: (
-            <div>
-              <SpellLink spell={SPELLS.FRAILTY} /> applied to target
-            </div>
-          ),
-          details: (
-            <div>
-              <SpellLink spell={SPELLS.FRAILTY} /> applied to target.
-            </div>
-          ),
-        };
-      }
+    if (!cast.hasFrailtyDebuff) {
       return {
         performance: QualitativePerformance.Fail,
         summary: (
@@ -198,75 +179,16 @@ export default class SoulCarver extends MajorCooldown<SoulCarverCooldownCast> {
       };
     }
 
-    if (cast.primaryTargetStacksOfFrailty >= PERFECT_FRAILTY_STACKS) {
-      return {
-        performance: QualitativePerformance.Perfect,
-        summary: (
-          <div>
-            {cast.primaryTargetStacksOfFrailty} stack(s) of <SpellLink spell={SPELLS.FRAILTY} />{' '}
-            applied to target
-          </div>
-        ),
-        details: (
-          <div>
-            Had {cast.primaryTargetStacksOfFrailty} stack(s) of <SpellLink spell={SPELLS.FRAILTY} />{' '}
-            applied to target.
-          </div>
-        ),
-      };
-    }
-    if (cast.primaryTargetStacksOfFrailty >= GOOD_FRAILTY_STACKS) {
-      return {
-        performance: QualitativePerformance.Good,
-        summary: (
-          <div>
-            {cast.primaryTargetStacksOfFrailty} stack(s) of <SpellLink spell={SPELLS.FRAILTY} />{' '}
-            applied to target
-          </div>
-        ),
-        details: (
-          <div>
-            Only {cast.primaryTargetStacksOfFrailty} stack(s) of{' '}
-            <SpellLink spell={SPELLS.FRAILTY} /> applied to target. Try applying at least{' '}
-            {PERFECT_FRAILTY_STACKS} stack(s) of <SpellLink spell={SPELLS.FRAILTY} /> before casting{' '}
-            <SpellLink spell={TALENTS_DEMON_HUNTER.SOUL_CARVER_TALENT} />.
-          </div>
-        ),
-      };
-    }
-    if (cast.primaryTargetStacksOfFrailty >= OK_FRAILTY_STACKS) {
-      return {
-        performance: QualitativePerformance.Ok,
-        summary: (
-          <div>
-            {cast.primaryTargetStacksOfFrailty} stack(s) of <SpellLink spell={SPELLS.FRAILTY} />{' '}
-            applied to target
-          </div>
-        ),
-        details: (
-          <div>
-            Only {cast.primaryTargetStacksOfFrailty} stack(s) of{' '}
-            <SpellLink spell={SPELLS.FRAILTY} /> applied to target. Try applying at least{' '}
-            {PERFECT_FRAILTY_STACKS} stack(s) of <SpellLink spell={SPELLS.FRAILTY} /> before casting{' '}
-            <SpellLink spell={TALENTS_DEMON_HUNTER.SOUL_CARVER_TALENT} />.
-          </div>
-        ),
-      };
-    }
     return {
-      performance: QualitativePerformance.Fail,
+      performance: QualitativePerformance.Perfect,
       summary: (
         <div>
-          {cast.primaryTargetStacksOfFrailty} stack(s) of <SpellLink spell={SPELLS.FRAILTY} />{' '}
-          applied to target
+          <SpellLink spell={SPELLS.FRAILTY} /> applied to target
         </div>
       ),
       details: (
         <div>
-          Only {cast.primaryTargetStacksOfFrailty} stack(s) of <SpellLink spell={SPELLS.FRAILTY} />{' '}
-          applied to target. Try applying at least {PERFECT_FRAILTY_STACKS} stack(s) of{' '}
-          <SpellLink spell={SPELLS.FRAILTY} /> before casting{' '}
-          <SpellLink spell={TALENTS_DEMON_HUNTER.SOUL_CARVER_TALENT} />.
+          <SpellLink spell={SPELLS.FRAILTY} /> applied to target.
         </div>
       ),
     };


### PR DESCRIPTION
## Description

- Updated shared Vengeance Frailty guidance text for current Midnight behavior
- Removed outdated Frailty stack-based guidance from Soul Carver and Fel Devastation
- Updated Soul Carver Frailty evaluation to check for Frailty on the target instead of old stack thresholds
- Updated Vengeance support status to accurate for patch 12.0.5

## Testing

- `pnpm run typecheck`
- Verified locally that Soul Carver and Fel Devastation no longer reference outdated Frailty stack requirements
- Verified Soul Carver Frailty evaluation now matches current non-stack-based Midnight behavior
