### PR TITLE
Fabricate an ApplyBuffStackEvent when normalizing buff events

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -32,13 +32,14 @@ import {
   Thias,
   Hezaerd,
   Dambroda,
-  Mahmud17,
+  Mahmud17, Ateis,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 5, 8), 'Fix number of stacks for Buffs at start of fight.', Ateis),
   change(date(2026, 5, 3), 'Use WCL-selected player damage DPS in the throughput stat and simplify the throughput boxes by removing hover details.', Mahmud17),
   change(date(2026, 4, 29), <>Added trinket support for <ItemLink id={ITEMS.VOLATILE_VOID_SUFFUSER.id} /> and <ItemLink id={ITEMS.LIGHT_OF_THE_COSMIC_CRESCENDO.id} />.</>, swirl),
   change(date(2026, 4, 25), "Fix `reduceCooldown` not correctly applying to multiple charges", Thias),

--- a/src/parser/shared/normalizers/ApplyBuff.ts
+++ b/src/parser/shared/normalizers/ApplyBuff.ts
@@ -199,7 +199,7 @@ class ApplyBuff extends EventsNormalizer {
       );
 
     const applyBuffStackEvent: ApplyBuffStackEvent = {
-      // These are all the properties a normal `applybuff` event would have.
+      // These are all the properties a normal `applybuffstack` event would have.
       timestamp: firstStartTimestamp + 1, // After the fabricated ApplyBuffEvent
       type: EventType.ApplyBuffStack,
       ability: event.ability,

--- a/src/parser/shared/normalizers/ApplyBuff.ts
+++ b/src/parser/shared/normalizers/ApplyBuff.ts
@@ -1,10 +1,11 @@
 import {
   AnyEvent,
   ApplyBuffEvent,
+  ApplyBuffStackEvent,
   EventType,
   HasAbility,
-  HasTarget,
   HasSource,
+  HasTarget,
 } from 'parser/core/Events';
 import EventsNormalizer from 'parser/core/EventsNormalizer';
 import { Options } from 'parser/core/Module';
@@ -12,7 +13,7 @@ import { maybeGetTalentOrSpell } from 'common/maybeGetTalentOrSpell';
 
 import { PlayerInfo } from '../../core/Player';
 
-const debug = false;
+const debug = true;
 
 /**
  * Some buffs like Bloodlust and Holy Avenger when they are applied pre-combat it doesn't show up as an `applybuff` event nor in the `combatantinfo` buffs array. It can still be detected by looking for a `removebuff` event, this uses that to detect it and then fabricates an `applybuff` event at the start of the log.
@@ -123,7 +124,7 @@ class ApplyBuff extends EventsNormalizer {
         }
 
         debug &&
-          this.warn(
+          console.warn(
             'Found a buff on',
             (playersById[targetId] && playersById[targetId].name) || '???',
             'that was applied before the pull:',
@@ -151,11 +152,68 @@ class ApplyBuff extends EventsNormalizer {
         events.splice(firstEventIndex, 0, applybuff);
         // It shouldn't happen twice, but better be safe than sorry.
         this._buffsAppliedByPlayerId[targetId].push(spellId);
+
+        if (sourceId !== undefined) {
+          this.normalizeMissingBuffStack(
+            event,
+            firstStartTimestamp,
+            sourceId,
+            targetId,
+            events,
+            firstEventIndex,
+            playersById[targetId],
+          );
+        }
       }
     }
     // endregion
 
     return events;
+  }
+
+  private normalizeMissingBuffStack(
+    event: AnyEvent,
+    firstStartTimestamp: number,
+    sourceId: number,
+    targetId: number,
+    events: AnyEvent[],
+    firstEventIndex: number,
+    playerInfo: PlayerInfo | undefined,
+  ) {
+    // Only these 2 events can give us a number of stacks
+    if (event.type !== EventType.ApplyBuffStack && event.type !== EventType.RemoveBuffStack) {
+      return;
+    }
+
+    const previousStackCount = event.stack + (event.type === EventType.ApplyBuffStack ? -1 : 1);
+    debug &&
+      console.warn(
+        'Found a buff on',
+        (playerInfo && playerInfo.name) || '???',
+        'that was applied before the pull:',
+        event.ability.name,
+        event.ability.guid,
+        '! Fabricating an `applybuffstack` event to ensure the stack count (',
+        previousStackCount,
+        ') is correct at start of fight.',
+      );
+
+    const applyBuffStackEvent: ApplyBuffStackEvent = {
+      // These are all the properties a normal `applybuff` event would have.
+      timestamp: firstStartTimestamp + 1, // After the fabricated ApplyBuffEvent
+      type: EventType.ApplyBuffStack,
+      ability: event.ability,
+      sourceID: sourceId,
+      sourceIsFriendly: event.sourceIsFriendly,
+      targetID: targetId,
+      targetIsFriendly: event.targetIsFriendly,
+      stack: previousStackCount,
+      // Custom properties:
+      prepull: true,
+      __fabricated: true,
+    };
+
+    events.splice(firstEventIndex + 1, 0, applyBuffStackEvent);
   }
 }
 

--- a/src/parser/shared/normalizers/ApplyBuff.ts
+++ b/src/parser/shared/normalizers/ApplyBuff.ts
@@ -60,7 +60,7 @@ class ApplyBuff extends EventsNormalizer {
             const spell = maybeGetTalentOrSpell(spellId);
 
             debug &&
-              console.warn(
+              this.warn(
                 'Found a buff on',
                 (playersById[targetId] && playersById[targetId].name) || '???',
                 'in the combatantinfo that was applied before the pull and never dropped:',
@@ -124,7 +124,7 @@ class ApplyBuff extends EventsNormalizer {
         }
 
         debug &&
-          console.warn(
+          this.warn(
             'Found a buff on',
             (playersById[targetId] && playersById[targetId].name) || '???',
             'that was applied before the pull:',
@@ -187,7 +187,7 @@ class ApplyBuff extends EventsNormalizer {
 
     const previousStackCount = event.stack + (event.type === EventType.ApplyBuffStack ? -1 : 1);
     debug &&
-      console.warn(
+      this.warn(
         'Found a buff on',
         (playerInfo && playerInfo.name) || '???',
         'that was applied before the pull:',
@@ -200,7 +200,7 @@ class ApplyBuff extends EventsNormalizer {
 
     const applyBuffStackEvent: ApplyBuffStackEvent = {
       // These are all the properties a normal `applybuffstack` event would have.
-      timestamp: firstStartTimestamp + 1, // After the fabricated ApplyBuffEvent
+      timestamp: firstStartTimestamp,
       type: EventType.ApplyBuffStack,
       ability: event.ability,
       sourceID: sourceId,

--- a/src/parser/shared/normalizers/ApplyBuff.ts
+++ b/src/parser/shared/normalizers/ApplyBuff.ts
@@ -13,7 +13,7 @@ import { maybeGetTalentOrSpell } from 'common/maybeGetTalentOrSpell';
 
 import { PlayerInfo } from '../../core/Player';
 
-const debug = true;
+const debug = false;
 
 /**
  * Some buffs like Bloodlust and Holy Avenger when they are applied pre-combat it doesn't show up as an `applybuff` event nor in the `combatantinfo` buffs array. It can still be detected by looking for a `removebuff` event, this uses that to detect it and then fabricates an `applybuff` event at the start of the log.


### PR DESCRIPTION
### Description

When we see a buff event (`RemoveBuff`, `ApplyBuffStack`, `RemoveBuffStack`, `RefreshBuff`, `FilterBuffInfo`) without having first seen an `ApplyBuff` event, we fabricate such event. It works great for buffs without stacks, but for buffs with stacks it is incomplete : we basically say that it was applied with 1 stack at the beginning of the fight.

The problem appears for example in the Resto druid analysis. We see 1 stack until the first `RemoveBuffStack` event and then we see 11 stacks. We should see 12 stacks since the beginning of the fight (as 1 stack has been removed at 00:49 and the new count is 11).
In the graph below, the purple line is the count of Abundance (buff) stacks :
<img width="1245" height="271" alt="image" src="https://github.com/user-attachments/assets/b1364720-069d-4403-8685-7692982ce95a" />

This PR creates a new `ApplyBuffStack` 1ms after the fabricated `ApplyBuff` event, with the number of stacks deduced from the first `ApplyBuffStack` or `RemoveBuffStack` event seen during the fight.
**⚠️ The logic is to add/remove 1 to the number of stacks in the first `ApplyBuffStack` or `RemoveBuffStack` event. I think it's a good approximation but it might not always be true. Please tell me if you see any issue with that !**

---

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/pB8fcN4aC9rRYyQL/22-Mythic+Lightblinded+Vanguard+-+Wipe+16+(6:15)/18-慌张的野猪/standard/overview`

**BEFORE**
<img width="1245" height="271" alt="image" src="https://github.com/user-attachments/assets/b18d042b-8fa4-4bed-8059-5fcbfd87c162" />
<img width="1287" height="300" alt="image" src="https://github.com/user-attachments/assets/ccbfd5bf-cab2-45d3-bfdf-4c4bbea2dcf2" />

**AFTER**
<img width="1212" height="266" alt="image" src="https://github.com/user-attachments/assets/92db36b4-e760-4c86-a5e4-ef10ecd751e0" />
<img width="1224" height="273" alt="image" src="https://github.com/user-attachments/assets/cc014e93-d97c-4d45-adac-a76814b58b50" />

