### PR TITLE
[Survival] APL Check Disabled Temporarily.

### DIFF
--- a/src/analysis/retail/hunter/survival/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/survival/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import { Kivlov,
  } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2026,5,10), 'APL Checker temporarily disabled', Kivlov),
   change(date(2026,4,28), 'Takedown Analyser adjustment. Swipe counting fix', Kivlov),
   change(date(2026,4,20), 'Update for 12.0.5', Kivlov),
   change(date(2026,3,31), 'Better Tip of the Spear Analysis', Kivlov),

--- a/src/analysis/retail/hunter/survival/modules/guide/Guide.tsx
+++ b/src/analysis/retail/hunter/survival/modules/guide/Guide.tsx
@@ -8,7 +8,7 @@ import ActiveTime from './sections/rotation/ActiveTime';
 import Cooldown from './sections/rotation/Cooldown';
 import MajorDefensives from '../../../shared/guide/defensives/DamageTaken';
 import { IntroSection } from './sections/intro/IntroSection';
-import { AplSection } from '../apl/AplCheck';
+// import { AplSection } from '../apl/AplCheck';
 import HeroSection from './sections/rotation/HeroTalents';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
@@ -21,7 +21,7 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
       <Cooldown modules={modules} events={events} info={info} />
       <RotationSection modules={modules} events={events} info={info} />
       <HeroSection modules={modules} events={events} info={info} />
-      <AplSection />
+      {/* <AplSection /> */}
       <MajorDefensives />
       {modules.exhilarationTiming.guideSubsection}
       <PreparationSection />


### PR DESCRIPTION
### Description

APL Check is out of date and causing questions. I need to make some changes that are much larger in scope than just the APL being wrong to get it to report properly. (stuff like KC reading it's current focus after generation and so reporting the wrong thing) or strike/swipe being always available but gated by a buff so the Priority list looks very gross with all the conditions not masked.

I'm half way through getting everything to work cleanly but it keeps coming up so I'd rather we just disable it until I get it properly re-enabled.