### PR TITLE
Add Consume Flame chart

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -1,5 +1,5 @@
 import { change, date } from 'common/changelog';
-import { Vollmer, Baumritter } from 'CONTRIBUTORS';
+import { Vollmer, Baumritter, KYZ } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
@@ -7,6 +7,7 @@ import ItemSetLink from 'interface/ItemSetLink';
 import { EVOKER_MID1_ID } from 'common/ITEMS';
 
 export default [
+  change(date(2026, 5, 10), <>Added breakdown chart for <SpellLink spell={TALENTS.CONSUME_FLAME_TALENT} /> triggers</>, KYZ),
   change(date(2026, 4, 20), <>Fixed <SpellLink spell={SPELLS.HOVER} /> not counting as castable while casting</>, Baumritter),
   change(date(2026, 3, 30),  <>Update <SpellLink spell={TALENTS.WINGLEADER_TALENT} /> CDR modifier.</>, Vollmer),
   change(date(2026, 3, 23), "Update guide section for midnight and introduce new No Wasted Buffs section.", Vollmer),

--- a/src/analysis/retail/evoker/devastation/CONFIG.tsx
+++ b/src/analysis/retail/evoker/devastation/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Vollmer],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.0',
+  patchCompatibility: '12.0.5',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/evoker/devastation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/devastation/CombatLogParser.ts
@@ -37,6 +37,7 @@ import StrafingRunNormalizer from './modules/normalizers/StrafingRun';
 import AzureSweep from './modules/talents/AzureSweep';
 import ShatteringStars from './modules/talents/ShatteringStars';
 import StarSalvo from './modules/talents/StarSalvo';
+import ConsumeFlame from './modules/talents/ConsumeFlame';
 
 // Shared
 import {
@@ -160,6 +161,7 @@ class CombatLogParser extends MainCombatLogParser {
     slipstream: Slipstream,
     refinedEssence: RefinedEssence,
     commandSquadron: CommandSquadron,
+    consumeFlame: ConsumeFlame,
 
     // core abilities
     disintegrate: Disintegrate,

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
@@ -52,6 +52,7 @@ const SHATTERING_STAR_DAMAGE = 'ShatteringStarDamage';
 const ETERNITY_SURGE_SHATTER_STAR_LINK = 'EternitySurgeShatterStarLink';
 
 const CONSUME_FLAME_TICK = 'ConsumeFlameTick';
+const CONSUME_FLAME_DAMAGE_LINK = 'ConsumeFlameDamageLink';
 const FIRE_BREATH_REMOVE_DEBUFF = 'FireBreathRemoveDebuff';
 const FIRE_BREATH_REMOVE_CONSUME_FLAME_BUFFER_MS = 250;
 
@@ -358,6 +359,20 @@ const EVENT_LINKS: EventLink[] = [
     maximumLinks: 1,
     isActive: (c) => c.hasTalent(TALENTS.CONSUME_FLAME_TALENT),
   },
+  {
+    linkRelation: CONSUME_FLAME_DAMAGE_LINK,
+    reverseLinkRelation: CONSUME_FLAME_DAMAGE_LINK,
+    linkingEventId: [SPELLS.DISINTEGRATE.id, SPELLS.PYRE.id],
+    linkingEventType: EventType.Damage,
+    referencedEventId: SPELLS.CONSUME_FLAME_DAMAGE.id,
+    referencedEventType: EventType.Damage,
+    forwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS.CONSUME_FLAME_TALENT),
+    additionalCondition(_linkingEvent, referencedEvent) {
+      return !HasRelatedEvent(referencedEvent, CONSUME_FLAME_DAMAGE_LINK);
+    },
+  },
 ];
 
 class CastLinkNormalizer extends EventLinkNormalizer {
@@ -638,6 +653,10 @@ export function getFireBreathDebuffEvents(
 
 export function getConsumeFlameTickEvent(event: RemoveDebuffEvent) {
   return GetRelatedEvent<DamageEvent>(event, CONSUME_FLAME_TICK);
+}
+
+export function getConsumeFlameDamageLinkEvent(event: DamageEvent) {
+  return GetRelatedEvent<DamageEvent>(event, CONSUME_FLAME_DAMAGE_LINK);
 }
 
 export default CastLinkNormalizer;

--- a/src/analysis/retail/evoker/devastation/modules/talents/ConsumeFlame.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/talents/ConsumeFlame.tsx
@@ -1,0 +1,81 @@
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/evoker';
+import { formatNumber } from 'common/format';
+
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import Events, { DamageEvent } from 'parser/core/Events';
+
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+import { getConsumeFlameDamageLinkEvent } from '../normalizers/CastLinkNormalizer';
+import DonutChart from 'parser/ui/DonutChart';
+
+class ConsumeFlame extends Analyzer {
+  totalDamage = 0;
+  disintegrateDamage = 0;
+  pyreDamage = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.CONSUME_FLAME_TALENT);
+
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.CONSUME_FLAME_DAMAGE),
+      this.onHit,
+    );
+  }
+
+  onHit(event: DamageEvent) {
+    this.totalDamage += event.amount + (event.absorbed || 0);
+    const consumeFlameDamageEvent = getConsumeFlameDamageLinkEvent(event);
+    if (!consumeFlameDamageEvent) {
+      return;
+    }
+    if (consumeFlameDamageEvent.ability.guid == SPELLS.DISINTEGRATE.id) {
+      this.disintegrateDamage += event.amount + (event.absorbed || 0);
+    } else {
+      this.pyreDamage += event.amount + (event.absorbed || 0);
+    }
+  }
+
+  statistic() {
+    const damageItems = [
+      {
+        color: 'rgb(183,65,14)',
+        label: 'Pyre',
+        spellId: SPELLS.PYRE.id,
+        valueTooltip: formatNumber(this.pyreDamage),
+        value: this.pyreDamage,
+      },
+      {
+        color: 'rgb(41,134,204)',
+        label: 'Disintegrate',
+        spellId: SPELLS.DISINTEGRATE.id,
+        valueTooltip: formatNumber(this.disintegrateDamage),
+        value: this.disintegrateDamage,
+      },
+    ];
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.HERO_TALENTS}
+        tooltip={<li>Damage: {formatNumber(this.totalDamage)}</li>}
+      >
+        <TalentSpellText talent={TALENTS.CONSUME_FLAME_TALENT}>
+          <ItemDamageDone amount={this.totalDamage} />
+        </TalentSpellText>
+
+        <div className="pad">
+          <label>Damage sources</label>
+          <DonutChart items={damageItems} />
+        </div>
+      </Statistic>
+    );
+  }
+}
+
+export default ConsumeFlame;


### PR DESCRIPTION
Adds a breakdown chart for Devastation Evoker indicating how much of Consume Flame's damage came from each ability.

Example: `/report/fyKD1rAHC7Bt6PMX/19-Mythic++Pit+of+Saron+-+Kill+(29:34)/4-湮灭龙/standard/statistics`
<img width="344" height="273" alt="Untitled" src="https://github.com/user-attachments/assets/2aff341c-66a4-4633-b153-b457bb43acc3" />
