### PR TITLE
[Mistweaver] Add CastDetail module to Thunder Focus Tea overview

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 5, 12), <>Added cast analysis to <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT}/> cast efficiency overview.</>, swirl),
   change(date(2026, 4, 23), <>Fixed a bug with <SpellLink spell={TALENTS_MONK.SPIRITFONT_1_MISTWEAVER_TALENT} /> performance, fixed <SpellLink spell={TALENTS_MONK.SAVE_THEM_ALL_TALENT} /> showing as 0% for events without hitpoints data, removed <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> reference from <SpellLink spell={TALENTS_MONK.STRENGTH_OF_THE_BLACK_OX_TALENT} />, and moved "casting while moving" module out of <SpellLink spell={TALENTS_MONK.WAY_OF_THE_SERPENT_TALENT}/>.</>, swirl),
   change(date(2026, 4, 15), <>Fixed a bug with <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT} /> statistic and guide subsection analysis when <SpellLink spell={TALENTS_MONK.SHEILUNS_GIFT_TALENT} /> is talented.</>, Vohrr),
   change(date(2026, 3, 29), <>Updated Celestial analysis, APL checks, and general healing cooldowns updates.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,7 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
-  change(date(2026, 5, 12), <>Added cast analysis to <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT}/> cast efficiency overview.</>, swirl),
+  change(date(2026, 5, 12), <>Improved cast analysis of <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT}/> cast efficiency.</>, swirl),
   change(date(2026, 4, 23), <>Fixed a bug with <SpellLink spell={TALENTS_MONK.SPIRITFONT_1_MISTWEAVER_TALENT} /> performance, fixed <SpellLink spell={TALENTS_MONK.SAVE_THEM_ALL_TALENT} /> showing as 0% for events without hitpoints data, removed <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> reference from <SpellLink spell={TALENTS_MONK.STRENGTH_OF_THE_BLACK_OX_TALENT} />, and moved "casting while moving" module out of <SpellLink spell={TALENTS_MONK.WAY_OF_THE_SERPENT_TALENT}/>.</>, swirl),
   change(date(2026, 4, 15), <>Fixed a bug with <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT} /> statistic and guide subsection analysis when <SpellLink spell={TALENTS_MONK.SHEILUNS_GIFT_TALENT} /> is talented.</>, Vohrr),
   change(date(2026, 3, 29), <>Updated Celestial analysis, APL checks, and general healing cooldowns updates.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -3,31 +3,39 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, CastEvent, RemoveBuffEvent } from 'parser/core/Events';
 import DonutChart from 'parser/ui/DonutChart';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticsListBox';
 import Haste from 'parser/shared/modules/Haste';
 import {
+  getCurrentCelestialTalent,
   getCurrentRSKTalent,
   SECRET_INFUSION_INCREASE_PER_RANK,
   SPELL_COLORS,
   THUNDER_FOCUS_TEA_SPELLS,
 } from '../../constants';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { qualitativePerformanceToColor } from 'interface/guide';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
-import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
-import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import { Arrow } from 'interface/icons';
+import { numberToQualitativePerformance } from 'common/combineQualitativePerformances';
 import { Talent } from 'common/TALENTS/types';
+import type Spell from 'common/SPELLS/Spell';
+import CastDetail, { type PerCastData } from 'interface/guide/components/CastDetail';
+import { SpellSequence, type CastInSequence } from 'interface/guide/components/CastSequence';
 
-const debug = false;
+interface TftWindow {
+  timestamp: number;
+  performance: QualitativePerformance;
+  summary: JSX.Element;
+  sequence: CastInSequence[];
+}
 
-//TODO clean up and make easier to add triggers
 class ThunderFocusTea extends Analyzer {
   static dependencies = {
     haste: Haste,
@@ -35,151 +43,248 @@ class ThunderFocusTea extends Analyzer {
 
   protected haste!: Haste;
 
-  castEntries: BoxRowEntry[] = [];
-  castsTftRsk = 0;
-  castsTftEnm = 0;
-  castsTftRem = 0;
+  private tftWindows: TftWindow[] = [];
+  private castsBySpell = new Map<number, number>();
 
-  castsTft = 0;
-  castsUnderTft = 0;
+  private castsTft = 0;
+  private correctCasts = 0;
 
-  correctCasts = 0;
+  private ftActive = false;
+  private currentRskTalent: Talent;
+  private currentCelestial: Talent;
+  private spellPriorities!: [Spell, number][];
 
-  castBufferTimestamp = 0;
-  ftActive = false;
-  correctCapstoneSpells: number[] = [];
-  okCapstoneSpells: number[] = [];
-  currentRskTalent: Talent;
+  private ftFirstCharge: { spellId: number; timestamp: number } | null = null;
+
+  private currentWindowStart = 0;
+  private openWindowSequence: CastInSequence[] = [];
+  private windowOpen = false;
 
   constructor(options: Options) {
     super(options);
     this.haste = options.haste as Haste;
     this.active = this.selectedCombatant.hasTalent(TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT);
+
     const secretInfusionRank = this.selectedCombatant.getTalentRank(
       TALENTS_MONK.SECRET_INFUSION_TALENT,
     );
-
     this.haste.addHasteBuff(
       SPELLS.SECRET_INFUSION_HASTE_BUFF.id,
       SECRET_INFUSION_INCREASE_PER_RANK * secretInfusionRank,
     );
 
     this.ftActive = this.selectedCombatant.hasTalent(TALENTS_MONK.FOCUSED_THUNDER_TALENT);
+    this.currentCelestial = getCurrentCelestialTalent(this.selectedCombatant);
     this.currentRskTalent = getCurrentRSKTalent(this.selectedCombatant);
+
+    this.spellPriorities =
+      this.currentCelestial === TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT
+        ? [
+            [this.currentRskTalent, 3],
+            [TALENTS_MONK.ENVELOPING_MIST_TALENT, 1],
+            [SPELLS.RENEWING_MIST_CAST, 0],
+          ]
+        : [
+            [SPELLS.RENEWING_MIST_CAST, 3],
+            [this.currentRskTalent, 2],
+            [TALENTS_MONK.ENVELOPING_MIST_TALENT, 0],
+          ];
+
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT),
       this.tftCast,
     );
     this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT),
+      this.onTftApply,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT),
+      this.onTftRemove,
+    );
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onAnyCast);
+    this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(THUNDER_FOCUS_TEA_SPELLS),
       this.buffedCast,
     );
-    if (this.selectedCombatant.hasTalent(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT)) {
-      this.correctCapstoneSpells = [getCurrentRSKTalent(this.selectedCombatant).id];
-      this.okCapstoneSpells = [TALENTS_MONK.ENVELOPING_MIST_TALENT.id];
-    } else {
-      this.correctCapstoneSpells = [SPELLS.RENEWING_MIST_CAST.id];
-      this.okCapstoneSpells = [
-        getCurrentRSKTalent(this.selectedCombatant).id,
-        TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
-      ];
-    }
   }
 
-  get incorrectTftCasts() {
-    return this.castsUnderTft - this.correctCasts;
-  }
-
-  isCorrect(event: CastEvent, isOk: boolean): boolean {
-    const spellId: number = event.ability.guid;
-    const spellMap = isOk ? this.okCapstoneSpells : this.correctCapstoneSpells;
-    return spellMap.includes(spellId);
-  }
-
-  tftCast(event: CastEvent) {
+  private tftCast(event: CastEvent) {
     this.castsTft += this.ftActive ? 2 : 1;
+    this.currentWindowStart = event.timestamp;
   }
 
-  buffedCast(event: CastEvent) {
-    const spellId: number = event.ability.guid;
+  private onTftApply(_event: ApplyBuffEvent) {
+    this.windowOpen = true;
+    this.openWindowSequence = [];
+  }
 
-    // Implemented as a way to remove non-buffed REM casts that occur at the same timestamp as the buffed Viv cast.
-    // Need to think of cleaner solution
+  private onTftRemove(_event: RemoveBuffEvent) {
+    this.windowOpen = false;
+    this.openWindowSequence = [];
+    this.ftFirstCharge = null;
+  }
+
+  private onAnyCast(event: CastEvent) {
+    if (!this.windowOpen || event.ability.guid <= 1) return;
+
+    const cast = this.toCastInSequence(event);
+    if (event.ability.guid === TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id) {
+      cast.ghosted = false;
+    }
+    this.openWindowSequence.push(cast);
+  }
+
+  private markConsumer(timestamp: number, spellId: number, color: string) {
+    const seqEntry = this.openWindowSequence.find(
+      (c) => c.timestamp === timestamp && c.spellId === spellId,
+    );
+    if (seqEntry) {
+      seqEntry.outlineColor = color;
+      seqEntry.ghosted = false;
+    }
+  }
+
+  private trackSpellCount(spellId: number) {
+    this.castsBySpell.set(spellId, (this.castsBySpell.get(spellId) ?? 0) + 1);
+  }
+
+  private toCastInSequence(event: CastEvent): CastInSequence {
+    return {
+      timestamp: event.timestamp,
+      spellId: event.ability.guid,
+      spellName: event.ability.name,
+      icon: event.ability.abilityIcon.replace('.jpg', ''),
+      ghosted: true,
+    };
+  }
+
+  private spellScore(spellId: number): number {
+    return this.spellPriorities.find(([spell]) => spell.id === spellId)?.[1] ?? 0;
+  }
+
+  private scoreWindow(
+    firstSpellId: number,
+    secondSpellId: number | null,
+  ): { performance: QualitativePerformance; summary: JSX.Element } {
+    // 2x weight to first empower due to secret infusion only buffing the first
+    const score =
+      secondSpellId !== null
+        ? Math.round((2 * this.spellScore(firstSpellId) + this.spellScore(secondSpellId)) / 3)
+        : this.spellScore(firstSpellId);
+
+    const performance = numberToQualitativePerformance(score);
+    const label = performance as string;
     if (
-      event.timestamp - this.castBufferTimestamp < 25 ||
-      !this.selectedCombatant.hasBuff(TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id)
+      performance === QualitativePerformance.Perfect ||
+      performance === QualitativePerformance.Good
     ) {
+      this.correctCasts += 1;
+    }
+
+    return {
+      performance,
+      summary: (
+        <>
+          {label}: <SpellLink spell={firstSpellId} />
+          {secondSpellId !== null && (
+            <>
+              {' '}
+              / <SpellLink spell={secondSpellId} />
+            </>
+          )}
+        </>
+      ),
+    };
+  }
+
+  private buffedCast(event: CastEvent) {
+    if (!this.selectedCombatant.hasBuff(TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id)) return;
+
+    const spellId = event.ability.guid;
+
+    this.trackSpellCount(spellId);
+
+    if (this.ftActive) {
+      if (this.ftFirstCharge === null) {
+        this.ftFirstCharge = { spellId, timestamp: event.timestamp };
+        return;
+      }
+      const { spellId: firstSpellId, timestamp: firstTimestamp } = this.ftFirstCharge;
+      this.ftFirstCharge = null;
+      this.commitWindow(firstSpellId, spellId, firstTimestamp, event.timestamp);
       return;
     }
 
-    if (this.currentRskTalent.id === spellId) {
-      this.castsUnderTft += 1;
-      this.castsTftRsk += 1;
-      debug && console.log('RSK TFT Check ', event.timestamp);
-    } else if (TALENTS_MONK.ENVELOPING_MIST_TALENT.id === spellId) {
-      this.castsUnderTft += 1;
-      this.castsTftEnm += 1;
-      debug && console.log('Enm TFT Check ', event.timestamp);
-    } else if (SPELLS.RENEWING_MIST_CAST.id === spellId) {
-      this.castsUnderTft += 1;
-      this.castsTftRem += 1;
-      debug && console.log('REM TFT Check ', event.timestamp);
-    } else {
-      return;
+    this.commitWindow(spellId, null, null, event.timestamp);
+  }
+
+  private commitWindow(
+    firstSpellId: number,
+    secondSpellId: number | null,
+    firstTimestamp: number | null,
+    secondTimestamp: number,
+  ) {
+    const { performance, summary } = this.scoreWindow(firstSpellId, secondSpellId);
+    const color = qualitativePerformanceToColor(performance);
+    if (firstTimestamp !== null) {
+      this.markConsumer(firstTimestamp, firstSpellId, color);
     }
-    let tooltip = null;
-    let value = null;
-    if (this.isCorrect(event, false /* isOk */)) {
-      value = QualitativePerformance.Good;
-      tooltip = (
-        <>
-          Correct cast: buffed <SpellLink spell={spellId} />
-        </>
-      );
-      this.correctCasts += 1;
-    } else if (this.isCorrect(event, true /* isOk */)) {
-      value = QualitativePerformance.Ok;
-      tooltip = (
-        <>
-          Ok cast: buffed <SpellLink spell={spellId} />
-        </>
-      );
-    } else {
-      value = QualitativePerformance.Fail;
-      tooltip = (
-        <>
-          Incorrect cast: buffed <SpellLink spell={spellId} />
-        </>
-      );
-    }
-    this.castEntries.push({ value, tooltip });
+    this.markConsumer(secondTimestamp, secondSpellId ?? firstSpellId, color);
+    this.tftWindows.push({
+      timestamp: this.currentWindowStart,
+      performance,
+      summary,
+      sequence: [...this.openWindowSequence],
+    });
+  }
+
+  private buildCastDetails(): PerCastData[] {
+    return this.tftWindows.map((window) => ({
+      performance: window.performance,
+      timestamp: this.owner.formatTimestamp(window.timestamp),
+      stats: [],
+      tooltip: window.summary,
+      additionalContent: {
+        content: <SpellSequence casts={window.sequence} iconSize={34} />,
+      },
+      details: window.summary,
+    }));
   }
 
   renderCastRatioChart() {
+    const count = (id: number) => this.castsBySpell.get(id) ?? 0;
     const items = [
       {
         color: SPELL_COLORS.RENEWING_MIST,
-        label: 'Renewing Mist',
+        label: SPELLS.RENEWING_MIST_CAST.name,
         spellId: SPELLS.RENEWING_MIST_CAST.id,
-        value: this.castsTftRem,
+        value: count(SPELLS.RENEWING_MIST_CAST.id),
       },
       {
         color: SPELL_COLORS.ENVELOPING_MIST,
-        label: 'Enveloping Mists',
+        label: TALENTS_MONK.ENVELOPING_MIST_TALENT.name,
         spellId: TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
-        value: this.castsTftEnm,
+        value: count(TALENTS_MONK.ENVELOPING_MIST_TALENT.id),
       },
       {
         color: SPELL_COLORS.RISING_SUN_KICK,
-        label: 'Rising Sun Kick',
+        label: this.currentRskTalent.name,
         spellId: this.currentRskTalent.id,
-        value: this.castsTftRsk,
+        value: count(this.currentRskTalent.id),
       },
     ];
     return <DonutChart items={items} />;
   }
 
-  /** Guide subsection describing the proper usage of TFT */
+  private perfBadge(perf: QualitativePerformance): JSX.Element {
+    return (
+      <span>
+        (<span style={{ color: qualitativePerformanceToColor(perf) }}>{perf}</span>)
+      </span>
+    );
+  }
+
   get guideSubsection(): JSX.Element {
     const explanation = (
       <>
@@ -188,50 +293,36 @@ class ThunderFocusTea extends Analyzer {
             <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} />
           </b>{' '}
           is an important spell used to empower other abilities. It should be used on cooldown at
-          all times and the spell that you use it on depends on your talent selection, in general
-          try to adhere to the following priority list
+          all times and the spell that you use it on depends on your talent selection. Try to adhere
+          to the following priority list with <SpellLink spell={this.currentCelestial} />:
         </p>
-        <ol>
-          <li>
-            <SpellLink spell={TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT} /> talented <Arrow />{' '}
-            use on <SpellLink spell={getCurrentRSKTalent(this.selectedCombatant)} /> (
-            <span style={{ color: 'green' }}>best</span>) or{' '}
-            <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT} /> (
-            <span style={{ color: 'yellow' }}>ok</span>)
-          </li>
-          <li>
-            {' '}
-            <SpellLink spell={TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT} /> talented{' '}
-            <Arrow /> use on <SpellLink spell={SPELLS.RENEWING_MIST_CAST} /> (
-            <span style={{ color: 'green' }}>best</span>) or{' '}
-            <SpellLink spell={getCurrentRSKTalent(this.selectedCombatant)} /> (
-            <span style={{ color: 'yellow' }}>ok</span>) or{' '}
-            <SpellLink spell={TALENTS_MONK.ENVELOPING_MIST_TALENT} /> (
-            <span style={{ color: 'yellow' }}>ok</span>)
-          </li>
-        </ol>
+        <ul style={{ marginBottom: '1em' }}>
+          {this.spellPriorities.map(([spell, score], i) => (
+            <li key={i}>
+              <SpellLink spell={spell} /> {this.perfBadge(numberToQualitativePerformance(score))}
+            </li>
+          ))}
+        </ul>
+        {this.ftActive && (
+          <p>
+            With <SpellLink spell={TALENTS_MONK.FOCUSED_THUNDER_TALENT} />, the second empower
+            carries slightly less weight as{' '}
+            <SpellLink spell={TALENTS_MONK.SECRET_INFUSION_TALENT} /> only changes the secondary
+            stat buff gain on the first empower.
+          </p>
+        )}
       </>
     );
     const data = (
-      <div>
-        <RoundedPanel>
-          <strong>
-            <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> cast efficiency
-          </strong>
-          <div>
-            {this.subStatistic()}
-            <p>
-              <strong>Casts </strong>
-              <small>
-                - Green indicates a correct{' '}
-                <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> cast, while red
-                indicates an incorrect cast.
-              </small>
-            </p>
-            <PerformanceBoxRow values={this.castEntries} />
-          </div>
-        </RoundedPanel>
-      </div>
+      <RoundedPanel>
+        <strong>
+          <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> cast efficiency
+        </strong>
+        {this.subStatistic()}
+        <div style={{ minWidth: 0, overflow: 'hidden' }}>
+          <CastDetail title="Empowered Spells" casts={this.buildCastDetails()} />
+        </div>
+      </RoundedPanel>
     );
 
     return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);


### PR DESCRIPTION
### Description

- Improved cast analysis of Thunder Focus Tea's empowered spells with CastDetail chart, and weighting Focused Thunder's empowered spells together under 1 cast with an average of their scoring,
- Set Enveloping Mist to a 'fail' state now post 12.0.5 after Spiritfont changes made it 50% cast speed already for Yu'lon
- For focused thunder, the weighing on the first charge is at double the rate due to secret infusion only caring about the first charge's empower and not the second.
- Also improved the wording on the explanation section slightly.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

#### Yu'lon
- Test report URL: `report/kzQdwjP4aZnBLphT/30-Mythic+Imperator+Averzian+-+Kill+(4:42)/17-Teirim/standard`
- Screenshot(s):
<img width="1570" height="571" alt="image" src="https://github.com/user-attachments/assets/d2e8319a-891c-4e86-b2f6-569529de1b5b" />

#### Chi-Ji
- Test report URL: `/report/rYBjpzq9ghK3LM7c/8-Mythic++Windrunner+Spire+-+Kill+(31:33)/282-Swirl/standard`
- Screenshot(s):
<img width="925" height="635" alt="image" src="https://github.com/user-attachments/assets/579f8560-1a4a-4de1-8e96-f811704263ba" />
<img width="639" height="334" alt="image" src="https://github.com/user-attachments/assets/60ee7a9f-8a78-47fe-8fd3-1cdfde07290b" />


#### No Focused Thunder
- Test report URL: `report/3LCzhQWVJtpkxMKj/20-Mythic+Lightblinded+Vanguard+-+Kill+(7:23)/8-Ptayter/standard`
- Screenshot(s)
<img width="935" height="585" alt="image" src="https://github.com/user-attachments/assets/e8b316d7-d82f-452c-b036-0369839b28c7" />
<img width="630" height="368" alt="image" src="https://github.com/user-attachments/assets/c4ede63f-c055-4cfc-a923-cf95226f0a15" />
