### PR TITLE
Update Mighty Inferno

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2026, 5, 14), <>Update <SpellLink spell={TALENTS.MIGHTY_INFERNO_TALENT} /> module to include DPS from extension.</>, KYZ),
   change(date(2026, 5, 6), <>Implement <SpellLink spell={TALENTS.TEMPORAL_BURST_TALENT} /> CDR.</>, KYZ),
   change(date(2026, 4, 27), <>Update <SpellLink spell={TALENTS.PUPIL_OF_ALEXSTRASZA_TALENT} /> and <SpellLink spell={TALENTS.LEAPING_FLAMES_TALENT} /> modules to include <SpellLink spell={SPELLS.CHRONO_FLAME_CAST} /> damage.</>, KYZ),
   change(date(2026, 4, 23), <>Fix module showing as not updated for 12.0.5.</>, KYZ),

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
@@ -67,7 +67,8 @@ class MightyInferno extends Analyzer {
   }
 
   onDamage(event: DamageEvent) {
-    this.damage += calculateEffectiveDamage(event, MIGHTY_INFERNO_DAMAGE_MULTIPLIER);
+    const ampedDamage = calculateEffectiveDamage(event, MIGHTY_INFERNO_DAMAGE_MULTIPLIER);
+    this.damage += ampedDamage;
   }
 
   onApplyBuff(event: ApplyBuffEvent) {
@@ -92,9 +93,8 @@ class MightyInferno extends Analyzer {
       playerID: targetID,
       timestamp,
       baseInfernosDuration:
-        (INFERNOS_BLESSING_BASE_DURATION_MS *
-          (1 + TIMEWALKER_BASE_EXTENSION + this.stats.currentMasteryPercentage)) /
-        1000,
+        INFERNOS_BLESSING_BASE_DURATION_MS *
+        (1 + TIMEWALKER_BASE_EXTENSION + this.stats.currentMasteryPercentage),
     });
   }
 
@@ -103,7 +103,7 @@ class MightyInferno extends Analyzer {
     if (index === -1) {
       return;
     }
-    const infernosDuration = (timestamp - this.infernoApps[index].timestamp) / 1000;
+    const infernosDuration = timestamp - this.infernoApps[index].timestamp;
     // While refreshing Inferno's Blessing with Fire Breath will appear to set the duration to 10 or 11 sec,
     // this is actually 8 sec and then immediately being extended by 2 or 3 sec.
     const extensionValue = infernosDuration - this.infernoApps[index].baseInfernosDuration;
@@ -125,7 +125,7 @@ class MightyInferno extends Analyzer {
             <ItemDamageDone amount={this.damage} />
           </div>
           <div>
-            <InformationIcon /> {formatNumber(this.totalInfernosExtension)} sec
+            <InformationIcon /> {formatNumber(this.totalInfernosExtension / 1000)} sec
             <small> extra duration granted</small>
           </div>
         </TalentSpellText>

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
@@ -70,13 +70,14 @@ class MightyInferno extends Analyzer {
     const ampDamage = calculateEffectiveDamage(event, MIGHTY_INFERNO_DAMAGE_MULTIPLIER);
     this.ampedDamage += ampDamage;
     const playerId = event.supportID ? event.supportID : event.sourceID;
+    console.log(playerId);
     const index = this.infernoApps.findIndex((app) => app.playerID === playerId);
     if (index === -1) {
       return;
     }
-    //if (((event.timestamp - this.infernoApps[index].timestamp) - this.infernoApps[index].baseInfernosDuration) > 0) {
-
-    //}
+    if (event.timestamp - this.infernoApps[index].baseEndTimestamp) {
+      this.extensionDamage += event.amount - ampDamage;
+    }
   }
 
   onApplyBuff(event: ApplyBuffEvent) {
@@ -126,10 +127,16 @@ class MightyInferno extends Analyzer {
         position={STATISTIC_ORDER.OPTIONAL(13)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            <li>Damage from amp: {formatNumber(this.ampedDamage)}</li>
+            <li>Damage from extension: {formatNumber(this.extensionDamage)}</li>
+          </>
+        }
       >
         <TalentSpellText talent={TALENTS.MIGHTY_INFERNO_TALENT}>
           <div>
-            <ItemDamageDone amount={this.ampedDamage} />
+            <ItemDamageDone amount={this.ampedDamage + this.extensionDamage} />
           </div>
           <div>
             <InformationIcon /> {formatNumber(this.totalInfernosExtension / 1000)} sec

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
@@ -70,7 +70,6 @@ class MightyInferno extends Analyzer {
     const ampDamage = calculateEffectiveDamage(event, MIGHTY_INFERNO_DAMAGE_MULTIPLIER);
     this.ampedDamage += ampDamage;
     const playerId = event.supportID ? event.supportID : event.sourceID;
-    console.log(playerId);
     const index = this.infernoApps.findIndex((app) => app.playerID === playerId);
     if (index === -1) {
       return;

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
@@ -22,6 +22,7 @@ import { formatNumber } from 'common/format';
 import TALENTS from 'common/TALENTS/evoker';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import { InformationIcon } from 'interface/icons';
+import { SpellLink } from 'interface/index';
 
 interface infernoApplication {
   playerID: number;
@@ -30,7 +31,6 @@ interface infernoApplication {
 
 /**
  * Inferno's Blessing deals 40% increased damage.
- * Sands of Time also extends Inferno's Blessing. [NYI]
  */
 class MightyInferno extends Analyzer {
   static dependencies = {
@@ -41,6 +41,8 @@ class MightyInferno extends Analyzer {
   extensionDamage = 0;
   infernoApps: infernoApplication[] = [];
   totalInfernosExtension = 0;
+  // This can mess with the results.
+  hasReceivedExternalInfernos = false;
 
   constructor(options: Options) {
     super(options);
@@ -64,12 +66,25 @@ class MightyInferno extends Analyzer {
       this.onRemoveBuff,
     );
     this.addEventListener(Events.fightend, this.onFightEnd);
+
+    this.addEventListener(
+      Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.INFERNOS_BLESSING_BUFF),
+      this.onReceiveBuff,
+    );
   }
 
   onDamage(event: DamageEvent) {
+    const playerId = event.supportID ? event.supportID : event.sourceID;
+    if (
+      this.hasReceivedExternalInfernos &&
+      playerId === this.selectedCombatant.id &&
+      !this.selectedCombatant.hasOwnBuff(SPELLS.INFERNOS_BLESSING_BUFF.id)
+    ) {
+      // This damage belongs to another Aug
+      return;
+    }
     const ampDamage = calculateEffectiveDamage(event, MIGHTY_INFERNO_DAMAGE_MULTIPLIER);
     this.ampedDamage += ampDamage;
-    const playerId = event.supportID ? event.supportID : event.sourceID;
     const index = this.infernoApps.findIndex((app) => app.playerID === playerId);
     if (index === -1) {
       return;
@@ -106,6 +121,12 @@ class MightyInferno extends Analyzer {
     });
   }
 
+  onReceiveBuff(event: ApplyBuffEvent) {
+    if (event.sourceID != this.owner.selectedCombatant.id) {
+      this.hasReceivedExternalInfernos = true;
+    }
+  }
+
   onInfernosRemove(targetID: number, timestamp: number) {
     const index = this.infernoApps.findIndex((app) => app.playerID === targetID);
     if (index === -1) {
@@ -130,6 +151,12 @@ class MightyInferno extends Analyzer {
           <>
             <li>Damage from amp: {formatNumber(this.ampedDamage)}</li>
             <li>Damage from extension: {formatNumber(this.extensionDamage)}</li>
+            {this.hasReceivedExternalInfernos && (
+              <li>
+                You received {<SpellLink spell={TALENTS.INFERNOS_BLESSING_TALENT} />} from another
+                Evoker, which can cause these damage numbers to be too large.
+              </li>
+            )}
           </>
         }
       >

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
@@ -26,7 +26,7 @@ import { InformationIcon } from 'interface/icons';
 interface infernoApplication {
   playerID: number;
   timestamp: number;
-  baseInfernosDuration: number;
+  baseEndTimestamp: number;
 }
 
 /**
@@ -38,7 +38,8 @@ class MightyInferno extends Analyzer {
     stats: StatTracker,
   };
   protected stats!: StatTracker;
-  damage = 0;
+  ampedDamage = 0;
+  extensionDamage = 0;
   infernoApps: infernoApplication[] = [];
   totalInfernosExtension = 0;
 
@@ -67,8 +68,16 @@ class MightyInferno extends Analyzer {
   }
 
   onDamage(event: DamageEvent) {
-    const ampedDamage = calculateEffectiveDamage(event, MIGHTY_INFERNO_DAMAGE_MULTIPLIER);
-    this.damage += ampedDamage;
+    const ampDamage = calculateEffectiveDamage(event, MIGHTY_INFERNO_DAMAGE_MULTIPLIER);
+    this.ampedDamage += ampDamage;
+    const playerId = event.supportID ? event.supportID : event.sourceID;
+    const index = this.infernoApps.findIndex((app) => app.playerID === playerId);
+    if (index === -1) {
+      return;
+    }
+    //if (((event.timestamp - this.infernoApps[index].timestamp) - this.infernoApps[index].baseInfernosDuration) > 0) {
+
+    //}
   }
 
   onApplyBuff(event: ApplyBuffEvent) {
@@ -92,9 +101,10 @@ class MightyInferno extends Analyzer {
     this.infernoApps.push({
       playerID: targetID,
       timestamp,
-      baseInfernosDuration:
+      baseEndTimestamp:
+        timestamp +
         INFERNOS_BLESSING_BASE_DURATION_MS *
-        (1 + TIMEWALKER_BASE_EXTENSION + this.stats.currentMasteryPercentage),
+          (1 + TIMEWALKER_BASE_EXTENSION + this.stats.currentMasteryPercentage),
     });
   }
 
@@ -103,10 +113,9 @@ class MightyInferno extends Analyzer {
     if (index === -1) {
       return;
     }
-    const infernosDuration = timestamp - this.infernoApps[index].timestamp;
     // While refreshing Inferno's Blessing with Fire Breath will appear to set the duration to 10 or 11 sec,
     // this is actually 8 sec and then immediately being extended by 2 or 3 sec.
-    const extensionValue = infernosDuration - this.infernoApps[index].baseInfernosDuration;
+    const extensionValue = timestamp - this.infernoApps[index].baseEndTimestamp;
     if (extensionValue > 0) {
       this.totalInfernosExtension += extensionValue;
     }
@@ -122,7 +131,7 @@ class MightyInferno extends Analyzer {
       >
         <TalentSpellText talent={TALENTS.MIGHTY_INFERNO_TALENT}>
           <div>
-            <ItemDamageDone amount={this.damage} />
+            <ItemDamageDone amount={this.ampedDamage} />
           </div>
           <div>
             <InformationIcon /> {formatNumber(this.totalInfernosExtension / 1000)} sec

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
@@ -25,7 +25,6 @@ import { InformationIcon } from 'interface/icons';
 
 interface infernoApplication {
   playerID: number;
-  timestamp: number;
   baseEndTimestamp: number;
 }
 
@@ -100,7 +99,6 @@ class MightyInferno extends Analyzer {
   onInfernosApply(targetID: number, timestamp: number) {
     this.infernoApps.push({
       playerID: targetID,
-      timestamp,
       baseEndTimestamp:
         timestamp +
         INFERNOS_BLESSING_BASE_DURATION_MS *


### PR DESCRIPTION
Updates the Mighty Inferno module:

- Calculates several extension-related stats on buff apply rather than on buff remove, so that these can be used elsewhere
- DPS number also includes damage from the extension (i.e. damage dealt more than 8 sec after the buff was applied)
- Added a tooltip breaking down how much damage respectively came from the 40% amp and extending the buff
- Attempted to filter out damage from other Aug's Inferno's Blessings
- Added a warning if other Augs have applied Inferno's to the player, as without pulling more events, these often cannot be filtered out