### PR TITLE
[Mistweaver] Fix Veil of Pride 0-stack evaluation

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 5, 18), <>Fixed <SpellLink spell={TALENTS_MONK.VEIL_OF_PRIDE_TALENT} /> correctly evaluating 0-cloud casts.</>, swirl),
   change(date(2026, 5, 16), <>Refreshed UI elements of the performance modules in the Overview tab.</>, swirl),
   change(date(2026, 5, 14), <>Fixed a bug with <SpellLink spell={SPELLS.ANCIENT_TEACHINGS} /> events doubling on filters.</>, swirl),
   change(date(2026, 5, 13), <>Added <SpellLink spell={TALENTS_MONK.HEART_OF_THE_JADE_SERPENT_TALENT}/> CDR analysis.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/BaseCelestialAnalyzer.tsx
@@ -240,7 +240,6 @@ class BaseCelestialAnalyzer extends Analyzer {
 
   onHotjsApply(event: ApplyBuffEvent) {
     this.hotjsCurrentHaste = this.haste.current;
-    console.log(this.hotjsCurrentHaste);
     this.hotjsApplyTimestamp = event.timestamp;
     if (!this.celestialActive) {
       return;

--- a/src/analysis/retail/monk/mistweaver/modules/spells/JadefireTeachings.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/JadefireTeachings.tsx
@@ -53,7 +53,6 @@ class JadefireTeachings extends Analyzer {
   }
 
   lastDamageEvent(event: DamageEvent) {
-    if (event.ability.guid === SPELLS.JADEFIRE_STOMP_DAMAGE.id) console.log('JFS Damage: ', event);
     this.lastDamageSpellID = event.ability.guid;
 
     if (!this.damageSpellToHealing.has(this.lastDamageSpellID)) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/VeilOfPride.tsx
@@ -42,6 +42,10 @@ class VeilOfPride extends Analyzer {
   onHeal(event: HealEvent) {
     const total = this.sheilunsGift.curClouds + this.sheilunsGift.cloudsLostSinceLastCast;
     const baseStacks = Math.min(10, Math.floor(total / 2));
+    if (baseStacks === 0) {
+      // sheiluns gift can be cast at 0 stacks
+      return;
+    }
     const extraStacks = this.sheilunsGift.curClouds - baseStacks;
     // double clouds = 100% increase -> 2x / x - 1 = 1
     const increase = this.sheilunsGift.curClouds / baseStacks - 1;


### PR DESCRIPTION
### Description

Users reported Veil of Pride sitting at 0.00% total healing - caused by casting their first Sheilun's Gift without any stacks which brought a NaN into the accumulator.
As Veil wasn't updated with Midnight's changes to SG castable at 0 stacks, added a guard to remove any 0 stack casts, anyways, as these don't do anything for Veil of Pride's effective gain.

Cleaned up extra logging being done in two modules.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/36q2bKcLX4nRFvxP/1-Mythic++Pit+of+Saron+-+Kill+(27:15)/2-Kholer/standard/statistics`
- Screenshot(s):

<img width="368" height="54" alt="image" src="https://github.com/user-attachments/assets/76cce943-f586-4f27-b3e9-8083f11f0646" />


<img width="361" height="41" alt="image" src="https://github.com/user-attachments/assets/a91a1049-40c9-4d31-89dd-22712d85979e" />
