### PR TITLE
remove react-select-search dependency, use normal select for NameSearch

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "react-masonry-component": "^6.3.0",
     "react-redux": "9.2.0",
     "react-router-dom": "^6.30.3",
-    "react-select-search": "^4.1.9",
     "react-textfit": "^1.1.1",
     "react-transition-group": "^4.4.5",
     "react-vega": "^7.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,9 +67,6 @@ importers:
       react-router-dom:
         specifier: ^6.30.3
         version: 6.30.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react-select-search:
-        specifier: ^4.1.9
-        version: 4.1.9(prop-types@15.8.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-textfit:
         specifier: ^1.1.1
         version: 1.1.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3916,13 +3913,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
-
-  react-select-search@4.1.9:
-    resolution: {integrity: sha512-ubP+J4v8ODCfdR2AMds5l9st6M2F5cJnDfYjtHQPNma22gAlSK/FDBYac4ZmH29cQwsSOpUrmnyBsGWI5hP30w==}
-    peerDependencies:
-      prop-types: ^15.8.1
-      react: ^19.0.0 || ^18.0.1 || ^17.0.1
-      react-dom: ^19.0.0 || ^18.0.1 || ^17.0.1
 
   react-test-renderer@19.2.0:
     resolution: {integrity: sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==}
@@ -8096,12 +8086,6 @@ snapshots:
     dependencies:
       '@remix-run/router': 1.23.2
       react: 19.2.6
-
-  react-select-search@4.1.9(prop-types@15.8.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-    dependencies:
-      prop-types: 15.8.1
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
 
   react-test-renderer@19.2.0(react@19.2.6):
     dependencies:

--- a/src/interface/NameSearch.tsx
+++ b/src/interface/NameSearch.tsx
@@ -6,7 +6,6 @@ import makeGuildPageUrl from 'common/makeGuildPageUrl';
 import { REALM_LIST, CLASSIC_REALM_LIST } from 'game/RealmList';
 import { FormEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import SelectSearch from 'react-select-search';
 import { useLingui } from '@lingui/react';
 import { RETAIL_EXPANSION_NAME, CLASSIC_EXPANSION_NAME } from 'game/Expansion';
 
@@ -185,33 +184,35 @@ const NameSearch = ({ type }: Props) => {
           </option>
         ))}
       </select>
-      <SelectSearch
+      <select
         key={currentRegion}
-        className="realm"
-        search
-        options={currentRealms[currentRegion].map((elem) => ({
-          value: elem.name,
-          name: elem.name,
-        }))}
+        className="form-control realm"
         value={currentRealm}
-        onChange={(value) => {
-          if (typeof value === 'string') {
-            setCurrentRealm(value);
+        onChange={(event) => {
+          if (event.target.value) {
+            setCurrentRealm(event.target.value);
           }
         }}
-        placeholder={i18n._(
-          defineMessage({
-            id: 'interface.nameSearch.realm',
-            message: `Realm`,
-          }),
-        )}
-        onBlur={() => {
-          // do nothing
-        }}
-        onFocus={() => {
-          // do nothing
-        }}
-      />
+      >
+        <option value="" disabled>
+          {i18n._(
+            defineMessage({
+              id: 'interface.nameSearch.realm',
+              message: `Realm`,
+            }),
+          )}
+        </option>
+        {currentRealms[currentRegion]
+          .map((elem) => ({
+            value: elem.name,
+            name: elem.name,
+          }))
+          .map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.name}
+            </option>
+          ))}
+      </select>
       <input
         type="text"
         name="code"


### PR DESCRIPTION
### Description

`react-select-search` has received only minimal updates since at least 2022. it appears incompatible with vite 8, and we're now hitting [this issue](https://github.com/tbleckert/react-select-search/issues/274).

rather than hack around it, this PR switches to using a standard HTML `<select>`

### Testing

<img width="795" height="460" alt="image" src="https://github.com/user-attachments/assets/ff772858-36fa-4031-8f65-9df1d9e88816" />
<img width="795" height="460" alt="image" src="https://github.com/user-attachments/assets/7bc6f224-3335-4cd7-b4be-74994506b502" />
<img width="795" height="460" alt="image" src="https://github.com/user-attachments/assets/1bbf2812-7059-4224-8cfd-fda32f232617" />

