### PR TITLE
add warning for Norushen + handle Classic fight splits

### DIFF
--- a/src/game/raids/index.ts
+++ b/src/game/raids/index.ts
@@ -9,6 +9,7 @@ import {
   toes as TerraceOfEndlessSpring,
 } from './mop_msv_hof_toes';
 import ThroneOfThunder from './throne_of_thunder';
+import SiegeOfOrgrimmar from './siege_of_orgrimmar';
 
 interface EncounterConfig {
   vantusRuneBuffId?: number;
@@ -78,6 +79,7 @@ const raids = {
   MogushanVaults,
   HeartOfFear,
   TerraceOfEndlessSpring,
+  SiegeOfOrgrimmar,
 };
 
 function findByDungeonBossId(id: number) {
@@ -100,4 +102,11 @@ export function findZoneByBossId(id: number): Raid | undefined {
   return Object.values(raids as Record<string, Raid>)
     .concat(Object.values(dungeons as Record<string, Raid>))
     .find((zone) => Object.values(zone.bosses).some((boss) => boss.id === id));
+}
+
+/**
+ * WCL adds 50,000 to repeated encounter IDs to distinguish them. This modifier is *not* present on `originalBoss`, though, and most assets are not copied to the duplicated IDs.
+ */
+export function normalizedEncounterId(id: number): number {
+  return id % 50_000;
 }

--- a/src/game/raids/siege_of_orgrimmar/Galakras.ts
+++ b/src/game/raids/siege_of_orgrimmar/Galakras.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1622,
+  id: 51622,
   name: 'Galakras',
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/GarroshHellscream.ts
+++ b/src/game/raids/siege_of_orgrimmar/GarroshHellscream.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1623,
+  id: 51623,
   name: 'Garrosh Hellscream',
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/GeneralNazgrim.ts
+++ b/src/game/raids/siege_of_orgrimmar/GeneralNazgrim.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1603,
+  id: 51603,
   name: 'General Nazgrim',
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/Immerseus.ts
+++ b/src/game/raids/siege_of_orgrimmar/Immerseus.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1602,
+  id: 51602,
   name: 'Immerseus',
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/IronJuggernaut.ts
+++ b/src/game/raids/siege_of_orgrimmar/IronJuggernaut.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1600,
+  id: 51600,
   name: 'Iron Juggernaut',
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/KorkronDarkShaman.ts
+++ b/src/game/raids/siege_of_orgrimmar/KorkronDarkShaman.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1606,
+  id: 51606,
   name: "Kor'kron Dark Shaman",
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/Malkorok.ts
+++ b/src/game/raids/siege_of_orgrimmar/Malkorok.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1595,
+  id: 51595,
   name: 'Malkorok',
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/Norushen.ts
+++ b/src/game/raids/siege_of_orgrimmar/Norushen.ts
@@ -1,9 +1,12 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1624,
+  id: 51624,
   name: 'Norushen',
-  fight: {},
+  fight: {
+    resultsWarning:
+      'Logging does not work reliably between the players doing the Tests and the rest of the raid. The ONLY way for analysis to be reliable on Norushen is to log yourself.',
+  },
 };
 
 export default boss;

--- a/src/game/raids/siege_of_orgrimmar/ParagonsOfTheKlaxxi.ts
+++ b/src/game/raids/siege_of_orgrimmar/ParagonsOfTheKlaxxi.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1593,
+  id: 51593,
   name: 'Paragons of the Klaxxi',
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/ShaOfPride.ts
+++ b/src/game/raids/siege_of_orgrimmar/ShaOfPride.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1604,
+  id: 51604,
   name: 'Sha of Pride',
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/SiegecrafterBlackfuse.ts
+++ b/src/game/raids/siege_of_orgrimmar/SiegecrafterBlackfuse.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1601,
+  id: 51601,
   name: 'Siegecrafter Blackfuse',
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/SpoilsOfPandaria.ts
+++ b/src/game/raids/siege_of_orgrimmar/SpoilsOfPandaria.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1594,
+  id: 51594,
   name: 'Spoils of Pandaria',
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/TheFallenProtectors.ts
+++ b/src/game/raids/siege_of_orgrimmar/TheFallenProtectors.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1598,
+  id: 51598,
   name: 'TheFallenProtectors',
   fight: {},
 };

--- a/src/game/raids/siege_of_orgrimmar/ThokTheBloodthirsty.ts
+++ b/src/game/raids/siege_of_orgrimmar/ThokTheBloodthirsty.ts
@@ -1,7 +1,7 @@
 import type { Boss } from '../index';
 
 const boss: Boss = {
-  id: 1599,
+  id: 51599,
   name: 'Thok the Bloodthirsty',
   fight: {},
 };

--- a/src/interface/report/Results/Header/index.tsx
+++ b/src/interface/report/Results/Header/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { i18n } from '@lingui/core';
 import { defineMessage } from '@lingui/core/macro';
-import { findZoneByBossId, type Boss } from 'game/raids';
+import { findZoneByBossId, normalizedEncounterId, type Boss } from 'game/raids';
 import {
   AboutIcon,
   ArmorIcon,
@@ -365,7 +365,7 @@ function CharacterMiniBox({
 }
 
 function BossMiniBox({ boss, fight }: Pick<HeaderProps, 'boss' | 'fight'>): JSX.Element | null {
-  const normalizedBossId = (boss?.id ?? fight.boss) % 50_000;
+  const normalizedBossId = normalizedEncounterId(boss?.id ?? fight.boss);
   let icon =
     boss?.icon ?? `https://assets.rpglogs.com/img/warcraft/bosses/${normalizedBossId}-icon.jpg`;
 

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -1,7 +1,7 @@
 import ErrorBoundary from 'interface/ErrorBoundary';
 import makeAnalyzerUrl from 'interface/makeAnalyzerUrl';
 import NavigationBar from 'interface/NavigationBar';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import BOSS_PHASES_STATE from './BOSS_PHASES_STATE';
 import { useConfig } from './ConfigContext';
@@ -30,7 +30,11 @@ import Report from 'parser/core/Report';
 import { Link, useNavigate } from 'react-router-dom';
 import { WCLFight } from 'parser/core/Fight';
 import handleApiError from './handleApiError';
-import { type CombatantInfoEvent } from 'parser/core/Events';
+import { EventType, type CombatantInfoEvent } from 'parser/core/Events';
+import { wclGameVersionToBranch } from 'game/VERSIONS';
+import GameBranch from 'game/GameBranch';
+import { fetchCombatants } from 'common/fetchWclApi';
+import { normalizedEncounterId } from 'game/raids';
 
 const UnsupportedSpecBouncer = ({ report, fight }: { report: Report; fight: WCLFight }) => (
   <main className="container offset">
@@ -164,14 +168,51 @@ const ResultsLoader = () => {
     events,
   });
 
-  const playerCombatantInfo = useMemo(
-    () =>
-      events?.find(
-        (event): event is CombatantInfoEvent =>
-          event.type === 'combatantinfo' && event.sourceID === player.id,
-      ),
-    [events, player.id],
-  );
+  const [playerCombatantInfo, setPlayerCombatantInfo] = useState<CombatantInfoEvent | undefined>();
+
+  useEffect(() => {
+    const existing = events?.find(
+      (event): event is CombatantInfoEvent =>
+        event.type === EventType.CombatantInfo && event.sourceID === player.id,
+    );
+
+    let cancelled = false;
+    if (existing) {
+      setPlayerCombatantInfo(existing);
+    } else if (wclGameVersionToBranch(report.gameVersion) === GameBranch.Classic) {
+      // in classic, RP handling may split the first part of a fight out into a separate "fight". check it for combatantinfo asynchronously
+      const prevFight = report.fights.find((other) => other.id === fight.id - 1);
+      if (
+        prevFight &&
+        prevFight.boss === 0 &&
+        prevFight.originalBoss === normalizedEncounterId(fight.boss)
+      ) {
+        fetchCombatants(report.code, prevFight.start_time, prevFight.end_time)
+          .then((combatantinfo) => {
+            if (cancelled) {
+              return;
+            }
+
+            const prevInfo = combatantinfo.find(
+              (event): event is CombatantInfoEvent =>
+                event.type === EventType.CombatantInfo && event.sourceID === player.id,
+            );
+            if (prevInfo) {
+              // the `current ?? prevInfo` prevents react dev mode from reprocessing data again
+              setPlayerCombatantInfo((current) => current ?? prevInfo);
+            }
+          })
+          .catch((error) => {
+            // don't fail in a visible way
+            console.error('failed to load previous combatantinfo', error);
+          });
+      }
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [events, player.id, report, fight]);
 
   // Original code only rendered EventParser if
   // > !this.state.isLoadingParser &&


### PR DESCRIPTION
### Description

Norushen does not log events across phases, so I added a warning for it. This led me down a rabbit-hole:

- Norushen has its RP split into a preceding fight. During player data refactoring, the handling for this was removed. I reintroduced it so that the fight can at least load.
- Siege bosses were not imported
- Siege bosses were using the original encounter IDs, but need the new ones to match the ones used by SoO Classic.

### Testing


- Test report URL: `/report/bYwJPNp7Mg6Rrjhv/5-Heroic+Norushen+-+Wipe+1+(6:47)/11-Joohoz/standard`
- Screenshot(s):
*Before*
<img width="1296" height="653" alt="image" src="https://github.com/user-attachments/assets/8e55ae4c-9ec0-4425-ad8c-a152f0a7b944" />

*After*
<img width="1296" height="653" alt="image" src="https://github.com/user-attachments/assets/4cba9ab7-1465-4f5f-89ee-ebaaae27eccd" />
