### PR TITLE
[Havoc] Fix inertia analysis to account for Abyssal Gaze

### DIFF
--- a/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
+++ b/src/analysis/retail/demonhunter/havoc/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import SPELLS from 'common/SPELLS/demonhunter';
 
 // prettier-ignore
 export default [
+  change(date(2026, 5, 21), <>Fixing <SpellLink spell={TALENTS.INERTIA_TALENT} /> analysis to work with <SpellLink spell={SPELLS.ABYSSAL_GAZE} />.</>, Zogmaw),
   change(date(2026, 5, 12), <>Add <SpellLink spell={SPELLS.BLUR} /> charges and clean up old havoc spells.</>, Zogmaw),
   change(date(2026, 4, 10), <>Add <SpellLink spell={SPELLS.BLUR} /> analysis to Havoc analysis.</>, Hezaerd),
   change(date(2026, 4, 2), <>Add initial Havoc analysis for <SpellLink spell={TALENTS.INERTIA_TALENT} /> and clean up outdated guide talent references.</>, Hezaerd),

--- a/src/analysis/retail/demonhunter/havoc/modules/talents/Inertia.tsx
+++ b/src/analysis/retail/demonhunter/havoc/modules/talents/Inertia.tsx
@@ -235,16 +235,6 @@ export default class Inertia extends Analyzer {
     const quickBurstStart =
       firstBurstCast !== undefined && firstBurstCast.timestamp - start <= QUICK_BURST_START_MS;
 
-    if (abyssalGazeCast) {
-      console.log('AG Info');
-      console.log(abyssalGazeCast);
-      console.log(abyssalGazeCast.channel?.timestamp);
-      console.log(end);
-    }
-    if (eyeBeamCast) {
-      console.log('EB Info');
-      console.log(eyeBeamCast);
-    }
     return {
       event,
       start,
@@ -393,9 +383,6 @@ export default class Inertia extends Analyzer {
         ),
       };
     }
-    // if (window.startedAbyssalGazeDuringWindow) {
-    //   console.log('AG Info');
-    // }
 
     if (window.startedEyeBeamDuringWindow || window.startedAbyssalGazeDuringWindow) {
       return {

--- a/src/analysis/retail/demonhunter/havoc/modules/talents/Inertia.tsx
+++ b/src/analysis/retail/demonhunter/havoc/modules/talents/Inertia.tsx
@@ -58,6 +58,8 @@ interface InertiaWindow {
   burstGlobalCount: number;
   startedEyeBeamDuringWindow: boolean;
   fullyChanneledEyeBeamDuringWindow: boolean;
+  startedAbyssalGazeDuringWindow: boolean;
+  fullyChanneledAbyssalGazeDuringWindow: boolean;
   triggeredFuriousGaze: boolean;
   quickBurstStart: boolean;
 }
@@ -216,6 +218,7 @@ export default class Inertia extends Analyzer {
     const eyeBeamCast = casts.find(
       (cast) => cast.ability.guid === TALENTS_DEMON_HUNTER.EYE_BEAM_TALENT.id,
     );
+    const abyssalGazeCast = casts.find((cast) => cast.ability.guid === SPELLS.ABYSSAL_GAZE.id);
     const deathSweepCasts = casts.filter((cast) => cast.ability.guid === SPELLS.DEATH_SWEEP.id);
     const annihilationCasts = casts.filter((cast) => cast.ability.guid === SPELLS.ANNIHILATION.id);
     const fillerCasts = casts.filter((cast) => !BURST_WINDOW_SPELLS.has(cast.ability.guid));
@@ -231,6 +234,17 @@ export default class Inertia extends Analyzer {
     );
     const quickBurstStart =
       firstBurstCast !== undefined && firstBurstCast.timestamp - start <= QUICK_BURST_START_MS;
+
+    if (abyssalGazeCast) {
+      console.log('AG Info');
+      console.log(abyssalGazeCast);
+      console.log(abyssalGazeCast.channel?.timestamp);
+      console.log(end);
+    }
+    if (eyeBeamCast) {
+      console.log('EB Info');
+      console.log(eyeBeamCast);
+    }
     return {
       event,
       start,
@@ -244,6 +258,12 @@ export default class Inertia extends Analyzer {
       startedEyeBeamDuringWindow: Boolean(eyeBeamCast),
       fullyChanneledEyeBeamDuringWindow: Boolean(
         eyeBeamCast && eyeBeamCast.channel?.timestamp && eyeBeamCast.channel.timestamp <= end,
+      ),
+      startedAbyssalGazeDuringWindow: Boolean(abyssalGazeCast),
+      fullyChanneledAbyssalGazeDuringWindow: Boolean(
+        abyssalGazeCast &&
+        abyssalGazeCast.channel?.timestamp &&
+        abyssalGazeCast.channel.timestamp <= end,
       ),
       triggeredFuriousGaze: eyeBeamCast
         ? getFuriousGazeBuffApplication(eyeBeamCast) !== undefined
@@ -353,7 +373,7 @@ export default class Inertia extends Analyzer {
   }
 
   private eyeBeamPerformance(window: InertiaWindow): UsageInfo {
-    if (window.fullyChanneledEyeBeamDuringWindow) {
+    if (window.fullyChanneledEyeBeamDuringWindow || window.fullyChanneledAbyssalGazeDuringWindow) {
       return {
         performance: QualitativePerformance.Perfect,
         summary: <div>Fully channeled Eye Beam during Inertia</div>,
@@ -373,8 +393,11 @@ export default class Inertia extends Analyzer {
         ),
       };
     }
+    // if (window.startedAbyssalGazeDuringWindow) {
+    //   console.log('AG Info');
+    // }
 
-    if (window.startedEyeBeamDuringWindow) {
+    if (window.startedEyeBeamDuringWindow || window.startedAbyssalGazeDuringWindow) {
       return {
         performance: QualitativePerformance.Ok,
         summary: <div>Started Eye Beam during Inertia</div>,

--- a/src/parser/shared/normalizers/Channeling.ts
+++ b/src/parser/shared/normalizers/Channeling.ts
@@ -102,6 +102,7 @@ class Channeling extends EventsNormalizer {
     // Demon Hunter
     buffChannelSpec(TALENTS_DEMON_HUNTER.EYE_BEAM_TALENT.id), // TODO special handling because of the two buffs?
     buffChannelSpec(TALENTS_DEMON_HUNTER.VOID_RAY_TALENT.id),
+    buffChannelSpec(SPELLS.ABYSSAL_GAZE.id),
     // Shaman
     // Hunter
     buffChannelSpec(TALENTS_HUNTER.RAPID_FIRE_TALENT.id),


### PR DESCRIPTION
### Description

Previously, the inertia analyzer only looked for Eye Beam casts to determine if the buff was used well.  With the Demonic Intensity hero talent, after using Meta Eye Beam becomes Abyssal Gaze, so inertia windows where AG was used were incorrectly being categorized as bad usage.

### Testing

Tested using this log, looking at Inertia rotation section https://www.warcraftlogs.com/reports/AB4yrGankTVjDXpm/?fight=9&source=2


