### PR TITLE
[Unholy Death Knight] Add disease uptime component and guide subsection

### DIFF
--- a/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/deathknight';
 
 export default [
+  change(date(2026, 5, 23), <>Added Virulent Plague and Dread Plague uptime and explanation to the guide.</>, Myrx),
   change(date(2026, 5, 15), <>Added analysis for <SpellLink spell={TALENTS.PUTREFY_TALENT} /> usage.</>, Myrx),
   change(date(2026, 4, 10), <>Added Active Time section to the guide with ability uptime, melee uptime, and downtime tracking.</>, MarchingCube),
   change(date(2026, 4, 2), <>Add <SpellLink spell={TALENTS.UNHOLY_AURA_TALENT} /> haste tracking per active Magus of the Dead.</>, MarchingCube),

--- a/src/analysis/retail/deathknight/unholy/CONFIG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CONFIG.tsx
@@ -2,11 +2,11 @@ import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
 import CHANGELOG from './CHANGELOG';
-import { Brandrewsss } from 'CONTRIBUTORS';
+import { Brandrewsss, Myrx } from 'CONTRIBUTORS';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Brandrewsss],
+  contributors: [Brandrewsss, Myrx],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
   patchCompatibility: '12.0.0',

--- a/src/analysis/retail/deathknight/unholy/modules/Guide.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/Guide.tsx
@@ -14,6 +14,7 @@ export default function Guide({ modules, info }: GuideProps<typeof CombatLogPars
       <IntroSection />
 
       <Section title="Core Spells and Buffs">
+        {modules.plagueEfficiency.guideSubsection}
         {info.combatant.hasTalent(TALENTS.PUTREFY_TALENT) && modules.putrefy.guideSubsection}
       </Section>
 

--- a/src/analysis/retail/deathknight/unholy/modules/features/PlagueEfficiency.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/features/PlagueEfficiency.tsx
@@ -1,11 +1,23 @@
 import { formatPercentage } from 'common/format';
 import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/deathknight';
+import { SpellLink } from 'interface';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import UptimeIcon from 'interface/icons/Uptime';
 import Analyzer from 'parser/core/Analyzer';
 import Enemies from 'parser/shared/modules/Enemies';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import uptimeBarSubStatistic from 'parser/ui/UptimeBarSubStatistic';
+import type { JSX } from 'react';
+
+const PERFECT_DISEASE_UPTIME_THRESHOLD = 0.99;
+const GOOD_DISEASE_UPTIME_THRESHOLD = 0.97;
+const OK_DISEASE_UPTIME_THRESHOLD = 0.95;
+const TARGET_DISEASE_UPTIME_PERCENT = Math.round(PERFECT_DISEASE_UPTIME_THRESHOLD * 100);
+const TRACKED_DISEASES = [SPELLS.VIRULENT_PLAGUE, SPELLS.DREAD_PLAGUE] as const;
 
 class PlagueEfficiency extends Analyzer {
   static dependencies = {
@@ -13,29 +25,102 @@ class PlagueEfficiency extends Analyzer {
   };
 
   protected enemies!: Enemies;
+  private diseaseMetricsCache?: Array<{
+    spell: (typeof TRACKED_DISEASES)[number];
+    uptime: number;
+    history: ReturnType<Enemies['getDebuffHistory']>;
+    performance: QualitativePerformance;
+  }>;
 
-  get virulentPlagueUptime() {
-    return this.enemies.getBuffUptime(SPELLS.VIRULENT_PLAGUE.id) / this.owner.fightDuration;
+  private getDiseaseUptime(spellId: number) {
+    return this.enemies.getBuffUptime(spellId) / this.owner.fightDuration;
   }
 
-  get dreadPlagueUptime() {
-    return this.enemies.getBuffUptime(SPELLS.DREAD_PLAGUE.id) / this.owner.fightDuration;
+  private getDiseasePerformance(uptime: number): QualitativePerformance {
+    if (uptime >= PERFECT_DISEASE_UPTIME_THRESHOLD) {
+      return QualitativePerformance.Perfect;
+    }
+    if (uptime >= GOOD_DISEASE_UPTIME_THRESHOLD) {
+      return QualitativePerformance.Good;
+    }
+    if (uptime >= OK_DISEASE_UPTIME_THRESHOLD) {
+      return QualitativePerformance.Ok;
+    }
+    return QualitativePerformance.Fail;
+  }
+
+  private getDiseaseMetrics(disease: (typeof TRACKED_DISEASES)[number]) {
+    const uptime = this.getDiseaseUptime(disease.id);
+    return {
+      spell: disease,
+      uptime,
+      history: this.enemies.getDebuffHistory(disease.id),
+      performance: this.getDiseasePerformance(uptime),
+    };
+  }
+
+  private get diseaseMetrics() {
+    if (!this.diseaseMetricsCache) {
+      this.diseaseMetricsCache = TRACKED_DISEASES.map((disease) => this.getDiseaseMetrics(disease));
+    }
+
+    return this.diseaseMetricsCache;
+  }
+
+  get guideSubsection(): JSX.Element {
+    const diseaseMetrics = this.diseaseMetrics;
+
+    const explanation = (
+      <>
+        <p>
+          Keep <SpellLink spell={SPELLS.VIRULENT_PLAGUE} /> and{' '}
+          <SpellLink spell={SPELLS.DREAD_PLAGUE} /> active for as much of the fight as possible.
+          Strong disease uptime is core to Unholy pressure and feeds several talent interactions.
+        </p>
+        <p>
+          With <SpellLink spell={TALENTS.FORBIDDEN_KNOWLEDGE_3_UNHOLY_TALENT} />,{' '}
+          <SpellLink spell={SPELLS.DREAD_PLAGUE} /> can rouse additional{' '}
+          <SpellLink spell={SPELLS.LESSER_GHOUL} />s to <SpellLink spell={TALENTS.PUTREFY_TALENT} />
+          . With <SpellLink spell={TALENTS.SUDDEN_DOOM_TALENT} />, keeping{' '}
+          <SpellLink spell={SPELLS.DREAD_PLAGUE} /> active also sustains that proc engine.
+        </p>
+      </>
+    );
+
+    const data = (
+      <div>
+        <div style={{ marginBottom: '6px' }}>
+          <strong>Disease timeline</strong>
+        </div>
+        <p>
+          Keep both diseases rolling with minimal gaps. {TARGET_DISEASE_UPTIME_PERCENT}%+ uptime is
+          the goal.
+        </p>
+        {diseaseMetrics.map((disease) => (
+          <div key={disease.spell.id}>
+            {uptimeBarSubStatistic(this.owner.fight, {
+              spells: [disease.spell],
+              uptimes: disease.history,
+              perf: disease.performance,
+            })}
+          </div>
+        ))}
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data, 40);
   }
 
   statistic() {
+    const diseaseMetrics = this.diseaseMetrics;
+
     return (
       <Statistic position={STATISTIC_ORDER.CORE(7)} size="flexible">
-        <BoringSpellValueText spell={SPELLS.VIRULENT_PLAGUE.id}>
-          <>
-            <UptimeIcon /> {formatPercentage(this.virulentPlagueUptime)}%{' '}
-            <small>Disease Uptime</small>
-          </>
-        </BoringSpellValueText>
-        <BoringSpellValueText spell={SPELLS.DREAD_PLAGUE.id}>
-          <>
-            <UptimeIcon /> {formatPercentage(this.dreadPlagueUptime)}% <small>Disease Uptime</small>
-          </>
-        </BoringSpellValueText>
+        {diseaseMetrics.map((disease) => (
+          <BoringSpellValueText key={disease.spell.id} spell={disease.spell.id}>
+            <UptimeIcon /> {formatPercentage(disease.uptime)}% <small>Disease Uptime</small>
+          </BoringSpellValueText>
+        ))}
       </Statistic>
     );
   }


### PR DESCRIPTION
### Description

Works on: https://github.com/WoWAnalyzer/WoWAnalyzer/issues/7607

This PR adds the existing `PlagueEfficiency` component to the guide with uptime bars and an explanation.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/YB49XHGgLTJxd23A/12-Heroic+Vaelgor+&+Ezzorak+-+Kill+(5:36)/16-Tinymyrx/standard`
- Screenshot(s):

New guide section:
<img width="1250" height="179" alt="image" src="https://github.com/user-attachments/assets/fa5d6be9-5e26-4a3d-90b8-d16a5a983bf5" />

Existing statistic card still correct after performance refactor:
<img width="298" height="207" alt="image" src="https://github.com/user-attachments/assets/da2ccd1f-2666-4057-8614-ba7c4902f182" />


