### PR TITLE
[Unholy Death Knight] Add Festering Scythe module and guide section

### DIFF
--- a/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
@@ -5,7 +5,8 @@ import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/deathknight';
 
 export default [
-  change(date(2026, 5, 23), <>Added Virulent Plague and Dread Plague uptime and explanation to the guide.</>, Myrx),
+  change(date(2026, 5, 23), <>Added <SpellLink spell={TALENTS.FESTERING_SCYTHE_TALENT} /> analysis and added explanation and cast detail breakdown to guide.</>, Myrx),
+  change(date(2026, 5, 23), <>Added Virulent Plague and Dread Plague uptime and explanation to the guide.</>, Myrx),  
   change(date(2026, 5, 15), <>Added analysis for <SpellLink spell={TALENTS.PUTREFY_TALENT} /> usage.</>, Myrx),
   change(date(2026, 4, 10), <>Added Active Time section to the guide with ability uptime, melee uptime, and downtime tracking.</>, MarchingCube),
   change(date(2026, 4, 2), <>Add <SpellLink spell={TALENTS.UNHOLY_AURA_TALENT} /> haste tracking per active Magus of the Dead.</>, MarchingCube),

--- a/src/analysis/retail/deathknight/unholy/CombatLogParser.ts
+++ b/src/analysis/retail/deathknight/unholy/CombatLogParser.ts
@@ -13,6 +13,7 @@ import RuneTracker from './modules/core/RuneTracker';
 import SuddenDoom from './modules/talents/SuddenDoom';
 import ForbiddenKnowledge from './modules/talents/ForbiddenKnowledge';
 import Putrefy from './modules/talents/Putrefy';
+import FesteringScythe from './modules/talents/FesteringScythe';
 import RunicPowerDetails from './modules/core/RunicPowerDetails';
 import RunicPowerTracker from './modules/core/RunicPowerTracker';
 import PlagueEfficiency from './modules/features/PlagueEfficiency';
@@ -47,6 +48,7 @@ class CombatLogParser extends CoreCombatLogParser {
     forbiddenKnowledge: ForbiddenKnowledge,
     unholyAura: UnholyAura,
     putrefy: Putrefy,
+    festeringScythe: FesteringScythe,
     // RunicPower
     runicPowerTracker: RunicPowerTracker,
     runicPowerDetails: RunicPowerDetails,

--- a/src/analysis/retail/deathknight/unholy/modules/Guide.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/Guide.tsx
@@ -15,6 +15,8 @@ export default function Guide({ modules, info }: GuideProps<typeof CombatLogPars
 
       <Section title="Core Spells and Buffs">
         {modules.plagueEfficiency.guideSubsection}
+        {info.combatant.hasTalent(TALENTS.FESTERING_SCYTHE_TALENT) &&
+          modules.festeringScythe.guideSubsection}
         {info.combatant.hasTalent(TALENTS.PUTREFY_TALENT) && modules.putrefy.guideSubsection}
       </Section>
 

--- a/src/analysis/retail/deathknight/unholy/modules/talents/FesteringScythe.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/talents/FesteringScythe.tsx
@@ -1,0 +1,329 @@
+import { formatPercentage } from 'common/format';
+import DK_SPELLS from 'common/SPELLS/deathknight';
+import TALENTS from 'common/TALENTS/deathknight';
+import { SpellLink } from 'interface';
+import { PerformanceMark } from 'interface/guide';
+import CastDetail, { type PerCastData } from 'interface/guide/components/CastDetail';
+import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { TipBox } from 'interface/guide/components';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { ApplyBuffEvent, RefreshBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import type { JSX } from 'react';
+
+const FESTERING_SCYTHE_BUFF_DURATION = 25_000;
+const PERFECT_REFRESH_WINDOW = 3_000;
+const GOOD_REFRESH_WINDOW = 5_000;
+
+interface FesteringScytheRecord {
+  timestamp: number;
+  performance: QualitativePerformance;
+  remainingMs?: number;
+  missingMs?: number;
+  lesserGhoulStacks: number;
+  eventType: 'refresh' | 'drop';
+}
+
+class FesteringScythe extends Analyzer {
+  private lastBuffRemovedAt: number | null = null;
+
+  private refreshCount = 0;
+  private perfectRefreshes = 0;
+  private goodRefreshes = 0;
+  private droppedApplications = 0;
+
+  private readonly records: FesteringScytheRecord[] = [];
+  private castDetailsCache: PerCastData[] | null = null;
+
+  private get buffSpellId() {
+    return DK_SPELLS.FESTERING_SCYTHE_BUFF.id;
+  }
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS.FESTERING_SCYTHE_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(DK_SPELLS.FESTERING_SCYTHE_BUFF),
+      this.onApplyBuff,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(DK_SPELLS.FESTERING_SCYTHE_BUFF),
+      this.onRefreshBuff,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(DK_SPELLS.FESTERING_SCYTHE_BUFF),
+      this.onRemoveBuff,
+    );
+  }
+
+  private onApplyBuff(event: ApplyBuffEvent) {
+    if (this.lastBuffRemovedAt === null) {
+      return;
+    }
+
+    const missingMs = Math.max(event.timestamp - this.lastBuffRemovedAt, 0);
+    const lesserGhoulStacks = this.getLesserGhoulStacksBeforeScythe(event.timestamp);
+    this.droppedApplications += 1;
+    this.records.push({
+      timestamp: event.timestamp,
+      performance: QualitativePerformance.Fail,
+      missingMs,
+      lesserGhoulStacks,
+      eventType: 'drop',
+    });
+  }
+
+  private onRemoveBuff(event: RemoveBuffEvent) {
+    this.lastBuffRemovedAt = event.timestamp;
+  }
+
+  private onRefreshBuff(event: RefreshBuffEvent) {
+    const remainingMs = this.getRemainingTimeBeforeRefresh(event.timestamp);
+    const lesserGhoulStacks = this.getLesserGhoulStacksBeforeScythe(event.timestamp);
+    const value = this.getRefreshPerformance(remainingMs, lesserGhoulStacks);
+
+    this.refreshCount += 1;
+    this.records.push({
+      timestamp: event.timestamp,
+      performance: value,
+      remainingMs,
+      lesserGhoulStacks,
+      eventType: 'refresh',
+    });
+  }
+
+  private formatSeconds(durationMs: number) {
+    return (durationMs / 1000).toFixed(1);
+  }
+
+  private getRefreshPerformance(remainingMs: number, lesserGhoulStacks: number) {
+    if (remainingMs < PERFECT_REFRESH_WINDOW || lesserGhoulStacks <= 1) {
+      this.perfectRefreshes += 1;
+      return QualitativePerformance.Perfect;
+    }
+
+    if (remainingMs < GOOD_REFRESH_WINDOW) {
+      this.goodRefreshes += 1;
+      return QualitativePerformance.Good;
+    }
+
+    return QualitativePerformance.Ok;
+  }
+
+  private getLesserGhoulStacksBeforeScythe(timestamp: number): number {
+    return this.selectedCombatant.getBuffStacks(DK_SPELLS.LESSER_GHOUL_BUFF.id);
+  }
+
+  private getRemainingTimeBeforeRefresh(timestamp: number): number {
+    const currentBuff = this.selectedCombatant.getBuff(this.buffSpellId);
+
+    if (!currentBuff) {
+      return 0;
+    }
+
+    let previousApplicationTimestamp = currentBuff.start;
+    for (let i = currentBuff.refreshHistory.length - 1; i >= 0; i -= 1) {
+      const refreshTimestamp = currentBuff.refreshHistory[i];
+      if (refreshTimestamp < timestamp) {
+        previousApplicationTimestamp = refreshTimestamp;
+        break;
+      }
+    }
+
+    return Math.max(FESTERING_SCYTHE_BUFF_DURATION - (timestamp - previousApplicationTimestamp), 0);
+  }
+
+  private get goodOrPerfectRefreshRate() {
+    const trackedRefreshOutcomes = this.refreshCount + this.droppedApplications;
+    if (trackedRefreshOutcomes === 0) {
+      return 1;
+    }
+
+    return (this.perfectRefreshes + this.goodRefreshes) / trackedRefreshOutcomes;
+  }
+
+  private get uptime() {
+    return this.selectedCombatant.getBuffUptime(this.buffSpellId) / this.owner.fightDuration;
+  }
+
+  private buildCastDetails(): PerCastData[] {
+    if (this.castDetailsCache) {
+      return this.castDetailsCache;
+    }
+
+    this.castDetailsCache = this.records
+      .slice()
+      .sort((a, b) => a.timestamp - b.timestamp)
+      .map((record) => {
+        if (record.eventType === 'drop') {
+          return {
+            performance: record.performance,
+            timestamp: this.owner.formatTimestamp(record.timestamp),
+            stats: [
+              {
+                value: `${this.formatSeconds(record.missingMs ?? 0)}s`,
+                label: 'Missing time',
+              },
+              {
+                value: record.lesserGhoulStacks,
+                label: 'Lesser Ghoul stacks',
+              },
+            ],
+            details: (
+              <>
+                <SpellLink spell={DK_SPELLS.FESTERING_SCYTHE_BUFF} /> fell off before you reapplied
+                it. Avoid drops to keep disease haste active.
+              </>
+            ),
+          };
+        }
+
+        const remainingSeconds = this.formatSeconds(record.remainingMs ?? 0);
+        let details: JSX.Element;
+        if (record.performance === QualitativePerformance.Perfect) {
+          details = (
+            <>
+              You refreshed with {remainingSeconds}s left
+              {record.lesserGhoulStacks <= 1 ? (
+                <>
+                  {' '}
+                  while at ≤1 <SpellLink spell={DK_SPELLS.LESSER_GHOUL_BUFF} /> stack.
+                </>
+              ) : (
+                ' (under 3s).'
+              )}
+            </>
+          );
+        } else if (record.performance === QualitativePerformance.Good) {
+          details = <>Refreshed in the 3s to 5s window ({remainingSeconds}s remaining).</>;
+        } else {
+          details = (
+            <>
+              Refreshed too soon ({remainingSeconds}s remaining). Try to refresh later unless stack
+              conditions force it.
+            </>
+          );
+        }
+
+        return {
+          performance: record.performance,
+          timestamp: this.owner.formatTimestamp(record.timestamp),
+          stats: [
+            {
+              value: `${this.formatSeconds(record.remainingMs ?? 0)}s`,
+              label: 'Remaining duration',
+            },
+            {
+              value: record.lesserGhoulStacks,
+              label: 'Lesser Ghoul stacks',
+            },
+          ],
+          details,
+        };
+      });
+
+    return this.castDetailsCache;
+  }
+
+  get guideSubsection(): JSX.Element {
+    const legend = (
+      <TipBox hideIcon>
+        <div>
+          <PerformanceMark perf={QualitativePerformance.Perfect} /> Perfect - Refreshed with under 3
+          seconds remaining, or with 1 or fewer <SpellLink spell={DK_SPELLS.LESSER_GHOUL_BUFF} />{' '}
+          stacks
+        </div>
+        <div>
+          <PerformanceMark perf={QualitativePerformance.Good} /> Good - Refreshed in the 3 to 5
+          second window
+        </div>
+        <div>
+          <PerformanceMark perf={QualitativePerformance.Ok} /> Ok - Refreshed safely, but earlier
+          than the recommended window
+        </div>
+        <div>
+          <PerformanceMark perf={QualitativePerformance.Fail} /> Fail - The buff fell off before you
+          reapplied it
+        </div>
+      </TipBox>
+    );
+
+    const explanation = (
+      <>
+        <p>
+          <strong>
+            <SpellLink spell={DK_SPELLS.FESTERING_SCYTHE_BUFF} />
+          </strong>{' '}
+          is a high-value buff you want active for as much of the fight as possible. It hastens your
+          diseases, which increases <SpellLink spell={TALENTS.SUDDEN_DOOM_TALENT} /> proc
+          generation.
+        </p>
+        <p>
+          Aim to maximize uptime while still refreshing efficiently: late refreshes are better than
+          early ones, and the best refreshes are in the final seconds of the buff (or when your
+          <SpellLink spell={DK_SPELLS.LESSER_GHOUL_BUFF} /> stack condition is met).
+        </p>
+        {legend}
+      </>
+    );
+
+    const data = (
+      <div>
+        <div style={{ marginBottom: '6px' }}>
+          <strong>
+            <SpellLink spell={DK_SPELLS.FESTERING_SCYTHE} /> casts
+          </strong>
+        </div>
+        <div style={{ marginBottom: '8px' }}>
+          <div>
+            <strong>{formatPercentage(this.uptime, 1)}%</strong> <small>uptime</small>
+          </div>
+          <div>
+            <strong>{formatPercentage(this.goodOrPerfectRefreshRate, 0)}%</strong>{' '}
+            <small>good+perfect refreshes</small>
+          </div>
+          <div>
+            <strong>{this.droppedApplications}</strong> <small>buff drops</small>
+          </div>
+        </div>
+        <CastDetail title="Festering Scythe Timeline" casts={this.buildCastDetails()} />
+      </div>
+    );
+
+    return explanationAndDataSubsection(explanation, data, 40);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(14)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+      >
+        <BoringSpellValueText spell={DK_SPELLS.FESTERING_SCYTHE_BUFF}>
+          <div>
+            {formatPercentage(this.uptime, 1)}% <small>uptime</small>
+          </div>
+          <div>
+            {formatPercentage(this.goodOrPerfectRefreshRate, 0)}%{' '}
+            <small>good+perfect refreshes</small>
+          </div>
+          <div>
+            {this.droppedApplications} <small>buff drops</small>
+          </div>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default FesteringScythe;

--- a/src/common/SPELLS/deathknight.ts
+++ b/src/common/SPELLS/deathknight.ts
@@ -279,6 +279,13 @@ const spells = {
     runicPowerCost: -20,
   },
 
+  // Buff on the player while Festering Scythe is active
+  FESTERING_SCYTHE_BUFF: {
+    id: 1241077,
+    name: 'Festering Scythe',
+    icon: 'inv_polearm_2h_mawnecromancerboss_d_01_darkblue',
+  },
+
   DEATH_CHARGE: {
     id: 444347,
     name: 'Death Charge',


### PR DESCRIPTION
### Description

Works on: https://github.com/WoWAnalyzer/WoWAnalyzer/issues/7607

This PR adds analysis for the Festering Scythe buff.
- A simple statistics card
- Cast details table to analyze individual buff application windows
- Explanation in guide for Festering Scythe

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/YB49XHGgLTJxd23A/12-Heroic+Vaelgor+&+Ezzorak+-+Kill+(5:36)/16-Tinymyrx/standard/overview`
- Screenshot(s):

Statistics card:
<img width="294" height="204" alt="image" src="https://github.com/user-attachments/assets/e55503aa-3060-4ea6-8b0f-f53832ba7fd6" />

Guide update showing failed refresh:
<img width="1251" height="422" alt="image" src="https://github.com/user-attachments/assets/ebbc3c1a-1d88-4745-b576-1e14bf0f4343" />

Perfect refresh:
<img width="749" height="313" alt="image" src="https://github.com/user-attachments/assets/54a9144c-1a6e-4104-817b-69afe51d4079" />

Good refresh:
<img width="738" height="311" alt="image" src="https://github.com/user-attachments/assets/90b8e81f-a52a-4259-9d1b-adbae5395dfd" />

Okay refresh:
<img width="743" height="317" alt="image" src="https://github.com/user-attachments/assets/1c4a7d19-deac-46fb-acdb-2ad0553d15cd" />

