### PR TITLE
[Fire Mage] Fix FlameStrike Hot Streaks in Combustion

### DIFF
--- a/src/analysis/retail/mage/fire/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/fire/CHANGELOG.tsx
@@ -19,6 +19,7 @@ const scorch = <SpellLink spell={SPELLS.SCORCH} />
 
 // prettier-ignore
 export default [
+  change(date(2026, 5, 24), <>Fixed an issue causing {combustion} to not properly count all iterations of {flamestrike} as a {hotStreak} cast.</>, Sharrq),
   change(date(2026, 4, 26), <>Fixed an issue causing {heatShimmer} to not properly account for buff refreshes.</>, Sharrq),
   change(date(2026, 4, 21), <>Updated Spec Compatability to 12.0.5.</>, Sharrq),
   change(date(2026, 4, 17), <>Temporarily fix crash of {heatShimmer} by extending the buffer</>, Thias),

--- a/src/analysis/retail/mage/fire/core/Abilities.tsx
+++ b/src/analysis/retail/mage/fire/core/Abilities.tsx
@@ -30,7 +30,11 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.FLAMESTRIKE.id,
+        spell: [
+          SPELLS.FLAMESTRIKE.id,
+          TALENTS.FLAMESTRIKE_1_FIRE_TALENT.id,
+          TALENTS.FLAMESTRIKE_2_FIRE_TALENT.id,
+        ],
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
         gcd: {
           base: 1500,

--- a/src/analysis/retail/mage/fire/guide/Combustion.tsx
+++ b/src/analysis/retail/mage/fire/guide/Combustion.tsx
@@ -13,6 +13,13 @@ import { EventType, GetRelatedEvent, CastEvent } from 'parser/core/Events';
 
 import CombustionCasts, { CombustionCast } from '../core/Combustion';
 
+const HOT_STREAK_CASTS = [
+  TALENTS.PYROBLAST_TALENT.id,
+  SPELLS.FLAMESTRIKE.id,
+  TALENTS.FLAMESTRIKE_1_FIRE_TALENT.id,
+  TALENTS.FLAMESTRIKE_2_FIRE_TALENT.id,
+];
+
 class CombustionGuide extends Analyzer {
   static dependencies = {
     combustion: CombustionCasts,
@@ -171,10 +178,7 @@ class CombustionGuide extends Analyzer {
       const activeTimePerf = this.combustion.activeTimePerformance(cb.activeTime, combustDuration);
       const delayPerf = this.combustion.combustionCastDelayPerformance(cb.castDelay);
       const hotStreakCasts = cb.spellCasts.filter((sc) => {
-        return (
-          sc.ability.guid === TALENTS.PYROBLAST_TALENT.id ||
-          sc.ability.guid === SPELLS.FLAMESTRIKE.id
-        );
+        return HOT_STREAK_CASTS.includes(sc.ability.guid);
       });
       const sequenceEntry = combustSequences[index];
 


### PR DESCRIPTION
The Combustion module was not properly accounting for both of the flamestrike versions in the talent tree, both of which have their own Spell ID. Additionally, the Fire Spellbook did not have the flamestrike talent IDs which was causing it to not register the GCD for Flamestrike.

Before
<img width="877" height="272" alt="image" src="https://github.com/user-attachments/assets/0010e717-7dfb-4e1d-9a46-a2d015235452" />
<img width="744" height="465" alt="image" src="https://github.com/user-attachments/assets/dca7cb87-36d6-44b1-b396-e90a860dc44d" />

After
<img width="825" height="232" alt="image" src="https://github.com/user-attachments/assets/88e016de-28a6-4793-badb-cfdf2dba7f9c" />
<img width="728" height="469" alt="image" src="https://github.com/user-attachments/assets/da911640-d904-49fa-a39f-78d125a33ed1" />
