### PR TITLE
[Survival] remove 'prime swipe' evaluation

### DIFF
--- a/src/analysis/retail/hunter/survival/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/survival/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import { Kivlov,
  } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2026,5,24), 'Swipe ready for Takedown no longer suggested', Kivlov),
   change(date(2026,5,10), 'APL Checker temporarily disabled', Kivlov),
   change(date(2026,4,28), 'Takedown Analyser adjustment. Swipe counting fix', Kivlov),
   change(date(2026,4,20), 'Update for 12.0.5', Kivlov),

--- a/src/analysis/retail/hunter/survival/modules/talents/Takedown/Takedown.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/Takedown/Takedown.tsx
@@ -15,7 +15,6 @@ const MAX_TIP_STACKS = 3;
 export interface TakedownCast {
   castEvent: CastEvent;
   isFirstTakedown: boolean;
-  hasRaptorSwipeBuff: boolean;
   tipStacks: number;
   wastedTipStacks: number;
   castsInWindow: CastEvent[];
@@ -73,9 +72,6 @@ export default class Takedown extends Analyzer {
 
   private onTakedown(event: CastEvent) {
     const isFirstTakedown = this.takedownCasts.length === 0;
-    const hasRaptorSwipeBuff =
-      this.selectedCombatant.hasBuff(SPELLS.RAPTOR_SWIPE_BUFF.id) ||
-      this.selectedCombatant.hasBuff(SPELLS.RAPTOR_SWIPE_BUFF_2.id);
     const tipStacks = this.selectedCombatant.getBuffStacks(SPELLS.TIP_OF_THE_SPEAR_CAST.id);
 
     const windowEnd = event.timestamp + TAKEDOWN_WINDOW_MS + WINDOW_EXTENSION_MS;
@@ -83,7 +79,6 @@ export default class Takedown extends Analyzer {
     this.takedownCasts.push({
       castEvent: event,
       isFirstTakedown,
-      hasRaptorSwipeBuff,
       tipStacks,
       wastedTipStacks: 0,
       castsInWindow: [],
@@ -104,35 +99,7 @@ export default class Takedown extends Analyzer {
       }
     };
 
-    // 1. Raptor Swipe buffed before cast
-    const swipeBuffPerf = cast.hasRaptorSwipeBuff
-      ? QualitativePerformance.Good
-      : QualitativePerformance.Fail;
-    downgrade(swipeBuffPerf);
-    items.push({
-      label: (
-        <>
-          <SpellLink spell={SPELLS.RAPTOR_SWIPE_BUFF} />{' '}
-          <TooltipElement
-            content={
-              <>
-                <SpellLink spell={SPELLS.RAPTOR_SWIPE_BUFF} /> can be primed to maximise the number
-                of <SpellLink spell={TALENTS.STRIKE_AS_ONE_TALENT} /> procs from our Apex Talent
-                during <SpellLink spell={TALENTS.TAKEDOWN_TALENT} />.
-              </>
-            }
-          >
-            (?)
-          </TooltipElement>
-        </>
-      ),
-      result: <PerformanceMark perf={swipeBuffPerf} />,
-      details: !cast.hasRaptorSwipeBuff ? (
-        <TooltipElement content="not primed before cast">(?) </TooltipElement>
-      ) : null,
-    });
-
-    // 2. Tip of the Spear stacks at cast
+    // 1. Tip of the Spear stacks at cast
     if (this.hasTwinFangs) {
       // Twin Fangs generates TotS during Takedown, so ideally enter with 0 stacks
       const tipPerf =
@@ -203,14 +170,15 @@ export default class Takedown extends Analyzer {
       });
     }
 
-    // 3. Wasted Tip of the Spear (KC cast while capped)
+    // 2. Wasted Tip of the Spear (KC cast while capped)
     const tipWastePerf =
       cast.wastedTipStacks === 0 ? QualitativePerformance.Good : QualitativePerformance.Fail;
     downgrade(tipWastePerf);
     items.push({
       label: (
         <>
-          <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} />{' '}
+          <SpellLink spell={SPELLS.TIP_OF_THE_SPEAR_CAST} />
+          {'  waste '}
           <TooltipElement
             content={
               <>

--- a/src/analysis/retail/hunter/survival/modules/talents/Takedown/TakedownSection.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/Takedown/TakedownSection.tsx
@@ -27,11 +27,6 @@ export default function TakedownSection(): JSX.Element | null {
   return (
     <SubSection title={<SpellLink spell={TALENTS.TAKEDOWN_TALENT} />}>
       <Explanation>
-        <p>
-          Always enter <SpellLink spell={TALENTS.TAKEDOWN_TALENT} /> with a{' '}
-          <SpellLink spell={SPELLS.RAPTOR_SWIPE_BUFF} /> buff active.
-        </p>
-
         {hasTwinFangs ? (
           <p>
             With <SpellLink spell={TALENTS.TWIN_FANGS_TALENT} />, Takedown generates{' '}
@@ -46,12 +41,6 @@ export default function TakedownSection(): JSX.Element | null {
             stacks during Takedown.
           </p>
         )}
-        <p>
-          The analysis below is done as if you are in a situation in which you can follow the APL.
-          Some fights may dictate that you do not prime Swipe, or that you immediately Kill Command
-          to spawn a beast such as the tight timings on Mythic Averzian. In these cases, the
-          suggestions below may not be applicable.
-        </p>
       </Explanation>
       <CooldownGrid
         label={<SpellLink spell={TALENTS.TAKEDOWN_TALENT} />}


### PR DESCRIPTION
### Description

Swipe priming no longer suggested by the guide

### Testing
Not much to test. Just removing code


- Test report URL: `/report/HtjZ1n7hMbGKrcqk/34-Mythic+Lightblinded+Vanguard+-+Kill+(6:46)/5-Imnotanorc/standard`
- Screenshot(s):
