### PR TITLE
[Devastation] Fixed Dragonrage Remove-Apply Event Jank

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import ItemSetLink from 'interface/ItemSetLink';
 import { EVOKER_MID1_ID } from 'common/ITEMS';
 
 export default [
+  change(date(2026, 5, 24), <>Corrected logging issues for <SpellLink spell={TALENTS.DRAGONRAGE_TALENT} /></>, Baumritter),
   change(date(2026, 5, 10), <>Added breakdown chart for <SpellLink spell={TALENTS.CONSUME_FLAME_TALENT} /> triggers</>, KYZ),
   change(date(2026, 4, 20), <>Fixed <SpellLink spell={SPELLS.HOVER} /> not counting as castable while casting</>, Baumritter),
   change(date(2026, 3, 30),  <>Update <SpellLink spell={TALENTS.WINGLEADER_TALENT} /> CDR modifier.</>, Vollmer),

--- a/src/analysis/retail/evoker/devastation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/devastation/CombatLogParser.ts
@@ -78,6 +78,7 @@ import {
 import MID1Devastation2P from './modules/midnight/MID1Devastation2P';
 import MID1Devastation4P from './modules/midnight/MID1Devastation4P';
 import RisingFury from './modules/talents/RisingFury';
+import DragonrageNormalizer from './modules/normalizers/DragonrageNormalizer';
 
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
@@ -119,6 +120,7 @@ class CombatLogParser extends MainCombatLogParser {
     eternitySurgeNormalizer: EternitySurgeNormalizer,
     disintegrateChainCastLinks: DisintegrateChainCastLinks,
     strafingRunNormalizer: StrafingRunNormalizer,
+    dragonrageNormalizer: DragonrageNormalizer,
 
     // features
     //apls: AplCheck,

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
@@ -68,9 +68,6 @@ const DISINTEGRATE_TICK_BUFFER = 4_000; // Haste dependant
 const DEEP_BREATH_FLIGHT_TIME_MS = 4_000; // 3s + some leeway
 const TWIN_FLAME_TRAVEL_TIME_MS = 1_000;
 
-export const INVALID_DRAGONRAGE_REMOVE = 'InvalidDragonrageRemove';
-const INVALID_DRAGONRAGE_REMOVE_BUFFER_MS = 50; // Biggest observed diff was 1ms but no harm in making it a bit larger
-
 const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: BURNOUT_CONSUME,
@@ -375,18 +372,6 @@ const EVENT_LINKS: EventLink[] = [
     additionalCondition(_linkingEvent, referencedEvent) {
       return !HasRelatedEvent(referencedEvent, CONSUME_FLAME_DAMAGE_LINK);
     },
-  },
-  {
-    linkRelation: INVALID_DRAGONRAGE_REMOVE,
-    reverseLinkRelation: INVALID_DRAGONRAGE_REMOVE,
-    linkingEventId: TALENTS.DRAGONRAGE_TALENT.id,
-    linkingEventType: EventType.ApplyBuff,
-    referencedEventId: TALENTS.DRAGONRAGE_TALENT.id,
-    referencedEventType: EventType.RemoveBuff,
-    forwardBufferMs: INVALID_DRAGONRAGE_REMOVE_BUFFER_MS,
-    backwardBufferMs: INVALID_DRAGONRAGE_REMOVE_BUFFER_MS,
-    maximumLinks: 1,
-    isActive: (c) => c.hasTalent(TALENTS.DRAGONRAGE_TALENT),
   },
 ];
 

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/CastLinkNormalizer.ts
@@ -68,6 +68,9 @@ const DISINTEGRATE_TICK_BUFFER = 4_000; // Haste dependant
 const DEEP_BREATH_FLIGHT_TIME_MS = 4_000; // 3s + some leeway
 const TWIN_FLAME_TRAVEL_TIME_MS = 1_000;
 
+export const INVALID_DRAGONRAGE_REMOVE = 'InvalidDragonrageRemove';
+const INVALID_DRAGONRAGE_REMOVE_BUFFER_MS = 50; // Biggest observed diff was 1ms but no harm in making it a bit larger
+
 const EVENT_LINKS: EventLink[] = [
   {
     linkRelation: BURNOUT_CONSUME,
@@ -372,6 +375,18 @@ const EVENT_LINKS: EventLink[] = [
     additionalCondition(_linkingEvent, referencedEvent) {
       return !HasRelatedEvent(referencedEvent, CONSUME_FLAME_DAMAGE_LINK);
     },
+  },
+  {
+    linkRelation: INVALID_DRAGONRAGE_REMOVE,
+    reverseLinkRelation: INVALID_DRAGONRAGE_REMOVE,
+    linkingEventId: TALENTS.DRAGONRAGE_TALENT.id,
+    linkingEventType: EventType.ApplyBuff,
+    referencedEventId: TALENTS.DRAGONRAGE_TALENT.id,
+    referencedEventType: EventType.RemoveBuff,
+    forwardBufferMs: INVALID_DRAGONRAGE_REMOVE_BUFFER_MS,
+    backwardBufferMs: INVALID_DRAGONRAGE_REMOVE_BUFFER_MS,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS.DRAGONRAGE_TALENT),
   },
 ];
 

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/DragonrageNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/DragonrageNormalizer.ts
@@ -1,0 +1,31 @@
+import TALENTS from 'common/TALENTS/evoker';
+import { AnyEvent, EventType, HasRelatedEvent } from 'parser/core/Events';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+import CastLinkNormalizer, { INVALID_DRAGONRAGE_REMOVE } from './CastLinkNormalizer';
+
+/** This Normalizer fixes an issue that happens very sporadically, where Dragonrage gets removed and reapplied on the same tick.
+ * This is has no effect on actual gameplay and will just mess up the analyzers (Likely some hallucination by the log).
+ * As a remedy we just remove both events.
+ * */
+
+class DragonrageNormalizer extends EventsNormalizer {
+  static dependencies = {
+    ...EventsNormalizer.dependencies,
+    castLinkNormalizer: CastLinkNormalizer,
+  };
+  normalize(events: AnyEvent[]): AnyEvent[] {
+    const fixedEvents: AnyEvent[] = [];
+    events.forEach((event: AnyEvent) => {
+      if (
+        (event.type !== EventType.RemoveBuff && event.type !== EventType.ApplyBuff) ||
+        event.ability.guid !== TALENTS.DRAGONRAGE_TALENT.id ||
+        !HasRelatedEvent(event, INVALID_DRAGONRAGE_REMOVE)
+      ) {
+        fixedEvents.push(event);
+      }
+    });
+    return fixedEvents;
+  }
+}
+
+export default DragonrageNormalizer;

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/DragonrageNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/DragonrageNormalizer.ts
@@ -11,11 +11,10 @@ const EVENT_LINKS: EventLink[] = [
     linkRelation: INVALID_DRAGONRAGE_REMOVE,
     reverseLinkRelation: INVALID_DRAGONRAGE_REMOVE,
     linkingEventId: TALENTS.DRAGONRAGE_TALENT.id,
-    linkingEventType: EventType.ApplyBuff,
+    linkingEventType: EventType.RemoveBuff,
     referencedEventId: TALENTS.DRAGONRAGE_TALENT.id,
-    referencedEventType: EventType.RemoveBuff,
+    referencedEventType: EventType.ApplyBuff,
     forwardBufferMs: INVALID_DRAGONRAGE_REMOVE_BUFFER_MS,
-    backwardBufferMs: INVALID_DRAGONRAGE_REMOVE_BUFFER_MS,
     maximumLinks: 1,
     isActive: (c) => c.hasTalent(TALENTS.DRAGONRAGE_TALENT),
   },
@@ -24,6 +23,8 @@ const EVENT_LINKS: EventLink[] = [
 /** This Normalizer fixes an issue that happens very sporadically, where Dragonrage gets removed and reapplied on the same tick.
  * This is has no effect on actual gameplay and will just mess up the analyzers (Likely some hallucination by the log).
  * As a remedy we just remove both events.
+ * Issue is visible in the following log (also applies to the other fight in the log):
+ * https://www.warcraftlogs.com/reports/bmZzt7RXcAq9KMW6?fight=1&type=auras&source=4&ability=375087&view=events
  * */
 class DragonrageNormalizer extends EventLinkNormalizer {
   constructor(options: Options) {

--- a/src/analysis/retail/evoker/devastation/modules/normalizers/DragonrageNormalizer.ts
+++ b/src/analysis/retail/evoker/devastation/modules/normalizers/DragonrageNormalizer.ts
@@ -1,19 +1,37 @@
 import TALENTS from 'common/TALENTS/evoker';
 import { AnyEvent, EventType, HasRelatedEvent } from 'parser/core/Events';
-import EventsNormalizer from 'parser/core/EventsNormalizer';
-import CastLinkNormalizer, { INVALID_DRAGONRAGE_REMOVE } from './CastLinkNormalizer';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { Options } from 'parser/core/Module';
+
+const INVALID_DRAGONRAGE_REMOVE = 'InvalidDragonrageRemove';
+const INVALID_DRAGONRAGE_REMOVE_BUFFER_MS = 50; // Biggest observed diff was 1ms but no harm in making it a bit larger
+
+const EVENT_LINKS: EventLink[] = [
+  {
+    linkRelation: INVALID_DRAGONRAGE_REMOVE,
+    reverseLinkRelation: INVALID_DRAGONRAGE_REMOVE,
+    linkingEventId: TALENTS.DRAGONRAGE_TALENT.id,
+    linkingEventType: EventType.ApplyBuff,
+    referencedEventId: TALENTS.DRAGONRAGE_TALENT.id,
+    referencedEventType: EventType.RemoveBuff,
+    forwardBufferMs: INVALID_DRAGONRAGE_REMOVE_BUFFER_MS,
+    backwardBufferMs: INVALID_DRAGONRAGE_REMOVE_BUFFER_MS,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS.DRAGONRAGE_TALENT),
+  },
+];
 
 /** This Normalizer fixes an issue that happens very sporadically, where Dragonrage gets removed and reapplied on the same tick.
  * This is has no effect on actual gameplay and will just mess up the analyzers (Likely some hallucination by the log).
  * As a remedy we just remove both events.
  * */
+class DragonrageNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
 
-class DragonrageNormalizer extends EventsNormalizer {
-  static dependencies = {
-    ...EventsNormalizer.dependencies,
-    castLinkNormalizer: CastLinkNormalizer,
-  };
-  normalize(events: AnyEvent[]): AnyEvent[] {
+  normalize(rawEvents: AnyEvent[]): AnyEvent[] {
+    const events = super.normalize(rawEvents);
     const fixedEvents: AnyEvent[] = [];
     events.forEach((event: AnyEvent) => {
       if (


### PR DESCRIPTION
### Description
Sometime recently (no clear date known) the logs started producing numerous events for Dragonrage's Buff removing it and applying it with ~2ms (See SS 1). This is not something that has any effect on gameplay and is likely some hallucination by the log.

The adverse effect of this is that the Dragonrage module will see these small interruptions as full Dragonrage windows which is both wrong and extremely goofy (See SS2 for actual count and SS3 for current module display)

Since these events have no actual purpose, reason or effect I just remove them with a normalizer.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/bmZzt7RXcAq9KMW6/1-Mythic++Magisters'+Terrace+-+Kill+(30:15)/4-Dydymus/standard/overview`
- Test log URL: `https://www.warcraftlogs.com/reports/bmZzt7RXcAq9KMW6?fight=1&type=auras&source=4&ability=375087&view=events`
- Screenshot(s):

Events:
<img width="311" height="255" alt="image" src="https://github.com/user-attachments/assets/512d93ea-3f70-4052-87bc-314c18eff02b" />
Actual Count:
<img width="353" height="88" alt="image" src="https://github.com/user-attachments/assets/d6f41296-5b10-4020-be22-526616e4e304" />
Current Display:
<img width="593" height="228" alt="image" src="https://github.com/user-attachments/assets/0ee6f7a8-b0b0-4a80-ba4f-0957c590ef1f" />
Postfix Display:
<img width="1271" height="240" alt="image" src="https://github.com/user-attachments/assets/81023ed5-799f-442a-a1b1-d3a6ea01b8af" />


