### PR TITLE
Removed Log Statement from new module

### DIFF
--- a/src/analysis/retail/evoker/shared/modules/core/EmpowerAnalyzer.tsx
+++ b/src/analysis/retail/evoker/shared/modules/core/EmpowerAnalyzer.tsx
@@ -70,7 +70,6 @@ class EmpowerAnalyzer extends Analyzer {
 
   onEmpowerEnd(event: EmpowerEndEvent) {
     const castEvent = GetRelatedEvent(event, EMPOWER_CAST, (e) => e.type === EventType.Cast);
-    console.log(castEvent);
     if (
       castEvent !== undefined &&
       castEvent.type === EventType.Cast &&


### PR DESCRIPTION
### Description
The EmpowerAnalyzer module that was merged earlier accidentally had a `console.log` statement that wasn't supposed to be merged.