### PR TITLE
[Mistweaver] Adjust TFT Performance Metrics

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 5, 27), <>Tightened <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> performance criteria.</>, swirl),
   change(date(2026, 5, 18), <>Fixed <SpellLink spell={TALENTS_MONK.VEIL_OF_PRIDE_TALENT} /> correctly evaluating 0-cloud casts.</>, swirl),
   change(date(2026, 5, 16), <>Refreshed UI elements of the performance modules in the Overview tab.</>, swirl),
   change(date(2026, 5, 14), <>Fixed a bug with <SpellLink spell={SPELLS.ANCIENT_TEACHINGS} /> events doubling on filters.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -47,8 +47,6 @@ class ThunderFocusTea extends Analyzer {
   private castsBySpell = new Map<number, number>();
 
   private castsTft = 0;
-  private correctCasts = 0;
-
   private ftActive = false;
   private currentRskTalent: Talent;
   private currentCelestial: Talent;
@@ -167,45 +165,13 @@ class ThunderFocusTea extends Analyzer {
     firstSpellId: number,
     secondSpellId: number | null,
   ): { performance: QualitativePerformance; summary: JSX.Element } {
-    let performance: QualitativePerformance;
-
-    const isYulon = this.currentCelestial === TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT;
-
-    if (isYulon && this.ftActive && secondSpellId !== null) {
-      // just scoring first charge on yu'on as an automatic fail - losing
-      // SI's haste buff is too big of a loss to justify giving any other result.
-      if (firstSpellId !== SPELLS.RENEWING_MIST_CAST.id) {
-        performance = QualitativePerformance.Fail;
-      } else if (secondSpellId === SPELLS.RENEWING_MIST_CAST.id) {
-        performance = QualitativePerformance.Perfect;
-      } else if (secondSpellId === this.currentRskTalent.id) {
-        performance = QualitativePerformance.Good;
-      } else if (secondSpellId === TALENTS_MONK.ENVELOPING_MIST_TALENT.id) {
-        performance = QualitativePerformance.Ok;
-      } else {
-        performance = QualitativePerformance.Fail;
-      }
-    } else {
-      // 2x weight to first empower due to secret infusion only buffing the first
-      const score =
-        secondSpellId !== null
-          ? Math.round((2 * this.spellScore(firstSpellId) + this.spellScore(secondSpellId)) / 3)
-          : this.spellScore(firstSpellId);
-      performance = numberToQualitativePerformance(score);
-    }
-    const label = performance as string;
-    if (
-      performance === QualitativePerformance.Perfect ||
-      performance === QualitativePerformance.Good
-    ) {
-      this.correctCasts += 1;
-    }
+    const performance = this.computePerformance(firstSpellId, secondSpellId);
 
     return {
       performance,
       summary: (
         <>
-          {label}: <SpellLink spell={firstSpellId} />
+          {performance as string}: <SpellLink spell={firstSpellId} />
           {secondSpellId !== null && (
             <>
               {' '}
@@ -215,6 +181,38 @@ class ThunderFocusTea extends Analyzer {
         </>
       ),
     };
+  }
+
+  private computePerformance(
+    firstSpellId: number,
+    secondSpellId: number | null,
+  ): QualitativePerformance {
+    const isYulon = this.currentCelestial === TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT;
+
+    if (!isYulon || !this.ftActive || secondSpellId === null) {
+      // 2x weight to first empower due to secret infusion only buffing the first
+      const score =
+        secondSpellId !== null
+          ? Math.round((2 * this.spellScore(firstSpellId) + this.spellScore(secondSpellId)) / 3)
+          : this.spellScore(firstSpellId);
+      return numberToQualitativePerformance(score);
+    }
+
+    // just scoring yu'lon focused thunder as rem first only -
+    // losing SI's haste buff on the first empower is too costly
+    if (firstSpellId !== SPELLS.RENEWING_MIST_CAST.id) {
+      return QualitativePerformance.Fail;
+    }
+    if (secondSpellId === SPELLS.RENEWING_MIST_CAST.id) {
+      return QualitativePerformance.Perfect;
+    }
+    if (secondSpellId === this.currentRskTalent.id) {
+      return QualitativePerformance.Good;
+    }
+    if (secondSpellId === TALENTS_MONK.ENVELOPING_MIST_TALENT.id) {
+      return QualitativePerformance.Ok;
+    }
+    return QualitativePerformance.Fail;
   }
 
   private buffedCast(event: CastEvent) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ThunderFocusTea.tsx
@@ -167,13 +167,32 @@ class ThunderFocusTea extends Analyzer {
     firstSpellId: number,
     secondSpellId: number | null,
   ): { performance: QualitativePerformance; summary: JSX.Element } {
-    // 2x weight to first empower due to secret infusion only buffing the first
-    const score =
-      secondSpellId !== null
-        ? Math.round((2 * this.spellScore(firstSpellId) + this.spellScore(secondSpellId)) / 3)
-        : this.spellScore(firstSpellId);
+    let performance: QualitativePerformance;
 
-    const performance = numberToQualitativePerformance(score);
+    const isYulon = this.currentCelestial === TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT;
+
+    if (isYulon && this.ftActive && secondSpellId !== null) {
+      // just scoring first charge on yu'on as an automatic fail - losing
+      // SI's haste buff is too big of a loss to justify giving any other result.
+      if (firstSpellId !== SPELLS.RENEWING_MIST_CAST.id) {
+        performance = QualitativePerformance.Fail;
+      } else if (secondSpellId === SPELLS.RENEWING_MIST_CAST.id) {
+        performance = QualitativePerformance.Perfect;
+      } else if (secondSpellId === this.currentRskTalent.id) {
+        performance = QualitativePerformance.Good;
+      } else if (secondSpellId === TALENTS_MONK.ENVELOPING_MIST_TALENT.id) {
+        performance = QualitativePerformance.Ok;
+      } else {
+        performance = QualitativePerformance.Fail;
+      }
+    } else {
+      // 2x weight to first empower due to secret infusion only buffing the first
+      const score =
+        secondSpellId !== null
+          ? Math.round((2 * this.spellScore(firstSpellId) + this.spellScore(secondSpellId)) / 3)
+          : this.spellScore(firstSpellId);
+      performance = numberToQualitativePerformance(score);
+    }
     const label = performance as string;
     if (
       performance === QualitativePerformance.Perfect ||


### PR DESCRIPTION
### Description

Tightened up MW's perf metrics for Thunder Focus Tea on Yu'lon - ReM first always, othewise fail. Then continue down prio

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/H7jY9mDWfnT8CdcB/36-Mythic+Lightblinded+Vanguard+-+Kill+(7:20)/32-Swirl/standard`
- Screenshot(s):

<img width="941" height="572" alt="image" src="https://github.com/user-attachments/assets/60a26e93-1248-4941-ad5d-767d3e31c91b" />
