### PR TITLE
[Unholy Death Knight] Fix soul reaper dt remaining

### DIFF
--- a/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/deathknight';
 
 export default [
+  change(date(2026, 5, 28), <>Fixed an issue with remaining DT cooldown calulation in Soul Reaper module.</>, Myrx),
   change(date(2026, 5, 27), <>Improved Plague efficiency analysis.</>, Myrx),
   change(date(2026, 5, 23), <>Added analysis for <SpellLink spell={TALENTS.SCOURGE_STRIKE_TALENT} /> usage.</>, Myrx),
   change(date(2026, 5, 23), <>Added <SpellLink spell={TALENTS.SOUL_REAPER_TALENT} /> analysis and better cooldown tracking.</>, Myrx),

--- a/src/analysis/retail/deathknight/unholy/CONFIG.tsx
+++ b/src/analysis/retail/deathknight/unholy/CONFIG.tsx
@@ -9,7 +9,7 @@ const config: Config = {
   contributors: [Brandrewsss, Myrx],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.0',
+  patchCompatibility: '12.0.5',
   supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/deathknight/unholy/modules/talents/SoulReaper.tsx
+++ b/src/analysis/retail/deathknight/unholy/modules/talents/SoulReaper.tsx
@@ -242,6 +242,30 @@ class SoulReaper extends ExecuteHelper.withDependencies({
     };
   }
 
+  private formatSeconds(durationMs: number): string {
+    return (durationMs / 1000).toFixed(1);
+  }
+
+  private getDarkTransformationCooldownRemaining(
+    castTimestamp: number,
+    nextDarkTransformationTimestamp: number | null,
+  ): string {
+    const darkTransformationCooldownState = this.deps.spellUsable
+      .history(TALENTS.DARK_TRANSFORMATION_TALENT.id)
+      .getBefore(castTimestamp, true);
+
+    const remainingMs = darkTransformationCooldownState?.isOnCooldown
+      ? darkTransformationCooldownState.expectedRechargeTimestamp - castTimestamp
+      : nextDarkTransformationTimestamp === null
+        ? 0
+        : Math.min(
+            SOUL_REAPER_COOLDOWN_MS,
+            Math.max(0, nextDarkTransformationTimestamp - castTimestamp),
+          );
+
+    return `${this.formatSeconds(Math.max(0, remainingMs))}s`;
+  }
+
   private getDarkTransformationAssessment(
     darkTransformationWindowId: number,
     firstCastInDarkTransformationWindows: Set<number>,
@@ -385,14 +409,12 @@ class SoulReaper extends ExecuteHelper.withDependencies({
         darkTransformationContext.nextDarkTransformationTimestamp,
       );
       const inDarkTransformation = cast.darkTransformationWindowId !== null;
-      let darkTransformationCooldownRemaining: string;
-      if (inDarkTransformation) {
-        darkTransformationCooldownRemaining = 'Active';
-      } else if (darkTransformationContext.nextDarkTransformationTimestamp === null) {
-        darkTransformationCooldownRemaining = 'N/A';
-      } else {
-        darkTransformationCooldownRemaining = `${((darkTransformationContext.nextDarkTransformationTimestamp - cast.timestamp) / 1000).toFixed(1)}s`;
-      }
+      const darkTransformationCooldownRemaining = inDarkTransformation
+        ? 'Active'
+        : this.getDarkTransformationCooldownRemaining(
+            cast.timestamp,
+            darkTransformationContext.nextDarkTransformationTimestamp,
+          );
 
       details.push({
         timestamp: cast.timestamp,


### PR DESCRIPTION
### Description

**Note: Mering this PR will officially mark Unholy DK as supported in 12.0.5**

Fixed an issue with the Dark Transformation remaining cooldown time for the cases where Soul Reaper fails. It was erroneously using the next USAGE of DT as the basis rather than the next time is COULD BE USED. I swapped the logic to use `spellUsable`.

### Testing

Bugged calculation:
<img width="818" height="366" alt="image" src="https://github.com/user-attachments/assets/b75b8c7a-775a-4c14-af8c-f15f4bb1bcf6" />

Fixed calculation:
<img width="746" height="357" alt="image" src="https://github.com/user-attachments/assets/1f781040-ae49-4fa7-a75d-018969e3dbbb" />


<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/A1w7qYzXygQLhjBc/3-Mythic++Pit+of+Saron+-+Kill+(27:04)/5-Notblouses/standard`
- Screenshot(s):
