### PR TITLE
[Survival] Boomstick & Tip Analysis fixes

### DIFF
--- a/src/analysis/retail/hunter/survival/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/survival/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import { Kivlov,
  } from 'CONTRIBUTORS';
 
 export default [
+  change(date(2026,5,31), 'Boomstick fix and Tip of the Spear Analysis adjustment', Kivlov),
   change(date(2026,5,24), 'Swipe ready for Takedown no longer suggested', Kivlov),
   change(date(2026,5,10), 'APL Checker temporarily disabled', Kivlov),
   change(date(2026,4,28), 'Takedown Analyser adjustment. Swipe counting fix', Kivlov),

--- a/src/analysis/retail/hunter/survival/modules/guide/sections/resources/TipOfTheSpearSection.tsx
+++ b/src/analysis/retail/hunter/survival/modules/guide/sections/resources/TipOfTheSpearSection.tsx
@@ -10,7 +10,9 @@ export default function TipOfTheSpearSection(modules: ModulesOf<typeof CombatLog
         <SpellLink spell={TALENTS.KILL_COMMAND_SURVIVAL_TALENT} /> <strong>builds</strong>{' '}
         <SpellLink spell={TALENTS.TIP_OF_THE_SPEAR_TALENT} /> stacks. These stacks are consumed one
         per cast of your direct-damage abilities. Avoid wasting stacks by timing your Kill Commands
-        carefully, and always cast tippable abilities with at least one stack active.
+        carefully, and always cast tippable abilities with at least one stack active. The aim for
+        survival is to spend before you generate which means even though you have the room for focus
+        and tip at 1 stack, you should still spend it prior to generating more.
       </p>
       <p>
         You wasted <strong>{modules.tipOfTheSpear.wastedStacks}</strong> stack

--- a/src/analysis/retail/hunter/survival/modules/talents/Boomstick.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/Boomstick.tsx
@@ -51,11 +51,12 @@ class Boomstick extends Analyzer.withDependencies({ haste: Haste }) {
   private totalTicks = 0;
   private useEntries: BoxRowEntry[] = [];
   private clippedCasts = 0;
+  private hasteAtCast: Map<number, number> = new Map();
 
   private static readonly BUCKET_WINDOW_MS = 100;
   private static readonly EXPECTED_TICKS = 4;
-  private static readonly BASE_TICK_INTERVAL_MS = 800;
-  private static readonly TICK_MATCH_TOLERANCE_MS = 400; // Haste issue with live, return to 200 and tick interval to 1000 on midnight release
+  private static readonly BASE_TICK_INTERVAL_MS = 1000;
+  private static readonly TICK_MATCH_TOLERANCE_MS = 200;
 
   constructor(options: Options) {
     super(options);
@@ -65,10 +66,20 @@ class Boomstick extends Analyzer.withDependencies({ haste: Haste }) {
     }
 
     this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.BOOMSTICK_TALENT),
+      this.onCast,
+    );
+
+    this.addEventListener(
       Events.EndChannel.by(SELECTED_PLAYER).spell(TALENTS.BOOMSTICK_TALENT),
       this.onEndChannel,
     );
   }
+
+  // Capture haste at the start of the channel
+  private onCast = (event: CastEvent) => {
+    this.hasteAtCast.set(event.timestamp, this.deps.haste.current);
+  };
 
   private onEndChannel = (event: EndChannelEvent) => {
     const cast = GetRelatedEvent<CastEvent>(event, BOOMSTICK_CAST_END);
@@ -139,8 +150,8 @@ class Boomstick extends Analyzer.withDependencies({ haste: Haste }) {
       return acc;
     }, []);
 
-    // Calculate expected tick times based on haste
-    const hasteAtCast = this.deps.haste.current;
+    // Use haste captured at cast start to adjust tick interval
+    const hasteAtCast = this.hasteAtCast.get(cast.timestamp) ?? this.deps.haste.current;
     const tickInterval = Boomstick.BASE_TICK_INTERVAL_MS / (1 + hasteAtCast);
 
     // Match each expected tick slot to actual damage buckets

--- a/src/analysis/retail/hunter/survival/modules/talents/TipOfTheSpear.tsx
+++ b/src/analysis/retail/hunter/survival/modules/talents/TipOfTheSpear.tsx
@@ -2,8 +2,14 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/hunter';
 import { SpellLink } from 'interface';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { CastEvent } from 'parser/core/Events';
-import { KCFocusLink } from '../../normalizers/KillCommandNormalizer';
+import Events, {
+  CastEvent,
+  BeginCastEvent,
+  ResourceChangeEvent,
+  GetRelatedEvent,
+  HasAbility,
+} from 'parser/core/Events';
+import { KC_FOCUS_LINK, KC_NEXT_CAST } from '../../normalizers/KillCommandNormalizer';
 import BuffStackTracker from 'parser/shared/modules/BuffStackTracker';
 import BoringValueText from 'parser/ui/BoringValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -14,7 +20,7 @@ import CastSummaryAndBreakdown from 'interface/guide/components/CastSummaryAndBr
 import { PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { BoxRowEntry } from 'interface/guide/components/PerformanceBoxRow';
-import { BadColor, GoodColor, OkColor } from 'interface/guide';
+import { BadColor, GoodColor } from 'interface/guide';
 import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 const MAX_STACKS = 3;
@@ -82,6 +88,16 @@ class TipOfTheSpear extends BuffStackTracker {
     return event.classResources?.find((r) => r.type === RESOURCE_TYPES.FOCUS.id)?.amount ?? 0;
   }
 
+  // Check if the next ability cast after this Kill Command is Takedown
+  private isNextCastTakedown(event: CastEvent): boolean {
+    const nextCast = GetRelatedEvent<CastEvent | BeginCastEvent>(event, KC_NEXT_CAST);
+    return (
+      nextCast !== undefined &&
+      HasAbility(nextCast) &&
+      nextCast.ability.guid === TALENTS.TAKEDOWN_TALENT.id
+    );
+  }
+
   private onTippableCast = (event: CastEvent) => {
     const wasTipped = this.selectedCombatant.hasBuff(
       SPELLS.TIP_OF_THE_SPEAR_CAST.id,
@@ -143,7 +159,7 @@ class TipOfTheSpear extends BuffStackTracker {
       this.wastedStacks += potentialStacks - MAX_STACKS;
     }
 
-    const focusEvent = KCFocusLink.first(event);
+    const focusEvent = GetRelatedEvent<ResourceChangeEvent>(event, KC_FOCUS_LINK);
     // amount is post-generation; subtract effective focus gained to recover pre-cast focus.
     const preCastFocus = focusEvent
       ? this.getFocus(event) - (focusEvent.resourceChange - focusEvent.waste)
@@ -175,10 +191,17 @@ class TipOfTheSpear extends BuffStackTracker {
         value = QualitativePerformance.Good;
         header = 'Good: generated at 0 stacks.';
         color = GoodColor;
-      } else if (!hasHowlBuff && currentStacks <= 2) {
-        value = QualitativePerformance.Ok;
-        header = `Ok: generated at ${currentStacks} stack${currentStacks !== 1 ? 's' : ''}.`;
-        color = OkColor;
+      } else if (!hasHowlBuff && currentStacks === 1) {
+        // 1 stack is acceptable if the next cast is Takedown (reactive ability)
+        if (this.isNextCastTakedown(event)) {
+          value = QualitativePerformance.Good;
+          header = 'Good: generated at 1 stack into Takedown.';
+          color = GoodColor;
+        } else {
+          value = QualitativePerformance.Fail;
+          header = `Bad: generated at ${currentStacks} stack${currentStacks !== 1 ? 's' : ''}.`;
+          color = BadColor;
+        }
       } else {
         value = QualitativePerformance.Fail;
         const wastedAmount = potentialStacks - MAX_STACKS;
@@ -186,15 +209,22 @@ class TipOfTheSpear extends BuffStackTracker {
         color = BadColor;
       }
     } else {
-      // Sentinel rules: 0 stacks = Good, 1 stack = Ok, 2+ = Bad (wastage).
+      // Sentinel rules: 0 stacks = Good, 1 stack = Bad, 2+ = Bad (wastage).
       if (currentStacks === 0) {
         value = QualitativePerformance.Good;
         header = 'Good: generated at 0 stacks.';
         color = GoodColor;
       } else if (currentStacks === 1) {
-        value = QualitativePerformance.Ok;
-        header = 'Ok: generated at 1 stack.';
-        color = OkColor;
+        // 1 stack is acceptable if the next cast is Takedown (reactive ability)
+        if (this.isNextCastTakedown(event)) {
+          value = QualitativePerformance.Good;
+          header = 'Good: generated at 1 stack into Takedown.';
+          color = GoodColor;
+        } else {
+          value = QualitativePerformance.Fail;
+          header = 'Bad: generated at 1 stack.';
+          color = BadColor;
+        }
       } else {
         value = QualitativePerformance.Fail;
         const wastedAmount = potentialStacks - MAX_STACKS;

--- a/src/analysis/retail/hunter/survival/normalizers/BoomstickNormalizer.ts
+++ b/src/analysis/retail/hunter/survival/normalizers/BoomstickNormalizer.ts
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS/hunter';
 import TALENTS from 'common/TALENTS/hunter';
 import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
-import { EventType } from 'parser/core/Events';
+import { EventType, HasAbility } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
 import Channeling from 'parser/shared/normalizers/Channeling';
 
@@ -34,7 +34,7 @@ const EVENT_LINKS: EventLink[] = [
     anyTarget: true,
     maximumLinks: 1,
   },
-  // Link the EndChannel event to potential clipped ability
+  // Link the EndChannel event to potential clipped ability (exclude melee explicitly to avoid any false positive display in case a melee sneaks out with the cast that interrupted it).
   {
     linkRelation: BOOMSTICK_NEXT_CAST,
     linkingEventId: TALENTS.BOOMSTICK_TALENT.id,
@@ -44,6 +44,8 @@ const EVENT_LINKS: EventLink[] = [
     forwardBufferMs: 100,
     anyTarget: true,
     maximumLinks: 1,
+    additionalCondition: (_linkingEvent, referencedEvent) =>
+      !HasAbility(referencedEvent) || referencedEvent.ability.guid !== 1,
   },
 ];
 

--- a/src/analysis/retail/hunter/survival/normalizers/KillCommandNormalizer.ts
+++ b/src/analysis/retail/hunter/survival/normalizers/KillCommandNormalizer.ts
@@ -1,22 +1,49 @@
 import TALENTS from 'common/TALENTS/hunter';
-import EventLinkNormalizer from 'parser/core/EventLinkNormalizer';
-import { EventType } from 'parser/core/Events';
+import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer';
+import { EventType, HasAbility } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
 
-/**
- * Links a Kill Command cast event to its corresponding focus resourcechange event
- * at the same timestamp, allowing analyzers to read the actual focus gained
- * (including waste from overcapping) directly from the cast event.
- */
-const { normalizer: KillCommandNormalizer, linkHelper: KCFocusLink } = EventLinkNormalizer.build({
-  linkRelation: 'kill-command-cast-focus',
-  linkingEventId: TALENTS.KILL_COMMAND_SURVIVAL_TALENT.id,
-  linkingEventType: EventType.Cast,
-  referencedEventId: TALENTS.KILL_COMMAND_SURVIVAL_TALENT.id,
-  referencedEventType: EventType.ResourceChange,
-  forwardBufferMs: 0,
-  anyTarget: true,
-  maximumLinks: 1,
-} as const);
+export const KC_FOCUS_LINK = 'kill-command-cast-focus';
+export const KC_NEXT_CAST = 'kill-command-next-cast';
 
-export { KCFocusLink };
+const EVENT_LINKS: EventLink[] = [
+  // Link Kill Command cast to its focus resourcechange event
+  {
+    linkRelation: KC_FOCUS_LINK,
+    linkingEventId: TALENTS.KILL_COMMAND_SURVIVAL_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: TALENTS.KILL_COMMAND_SURVIVAL_TALENT.id,
+    referencedEventType: EventType.ResourceChange,
+    forwardBufferMs: 50,
+    backwardBufferMs: 50,
+    anyTarget: true,
+    maximumLinks: 1,
+  },
+  // Link Kill Command cast to the next player cast (used to check if Takedown follows)
+  {
+    linkRelation: KC_NEXT_CAST,
+    linkingEventId: TALENTS.KILL_COMMAND_SURVIVAL_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: null,
+    referencedEventType: [EventType.Cast, EventType.BeginCast],
+    forwardBufferMs: 3000,
+    anyTarget: true,
+    maximumLinks: 1,
+    // Exclude melee and exclude Kill Command itself
+    additionalCondition: (linkingEvent, referencedEvent) => {
+      if (!HasAbility(referencedEvent)) {
+        return false;
+      }
+      const guid = referencedEvent.ability.guid;
+      return guid !== 1 && guid !== TALENTS.KILL_COMMAND_SURVIVAL_TALENT.id;
+    },
+  },
+];
+
+class KillCommandNormalizer extends EventLinkNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_LINKS);
+  }
+}
+
 export default KillCommandNormalizer;


### PR DESCRIPTION
### Description

I had left the boomstick tick interval at 800ms w/ larger buffer but it needs to go back to 1000. 3s channel, 4 ticks, 1 on cast and hasted so now it's correctly determining when the ticks should be and matching without having odd haste values causing it to miss. I have also adjusted it to look for the haste on cast instead of end channel. I don't suspect it will make a difference with the buffer but it is more correct anyways.

I have also explicitly removed melee from the event linking just in case if you do clip something, and your character melees at the same instant that it doesn't grab the melee as what interrupted it as melees cannot stop the channel.

Second, Kill Command management/Tip of the Spear Section. I had these flagged as "ok" to cast Kill Command at 1 tip stack since it wasn't wasting resources but it should match what the APL calls for, which is to spend before generate which means to go to 0 stacks before generating unless there is a specific reason to Kill Command early: Beast spawn or pre-takedown. I have also added a check to see if the following event after Kill Command is Takedown to avoid it flagging the 1 stack tip as bad.

### Testing

The following report shows an example of both "missed ticks" and "cancelled" ticks (which also show as cancelled by melee which is impossible). I have checked all 3 failures in the log and all 3 had all 4 ticks present. The 1000ms now properly flags them.

- Test report URL: `/report/vdbxDq8BQJZwVznC/1-Mythic++Maisara+Caverns+-+Kill+(18:55)/1-Ryoujïn/standard`

