### PR TITLE
[Evoker][Devastation] Updated Dragonrage Window with performance indicators for clearer readability

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import ItemSetLink from 'interface/ItemSetLink';
 import { EVOKER_MID1_ID } from 'common/ITEMS';
 
 export default [
+  change(date(2026, 6, 1), <>Updated display of <SpellLink spell={TALENTS.DRAGONRAGE_TALENT} /> module</>, Baumritter),
   change(date(2026, 5, 24), <>Corrected logging issues for <SpellLink spell={TALENTS.DRAGONRAGE_TALENT} /></>, Baumritter),
   change(date(2026, 5, 10), <>Added breakdown chart for <SpellLink spell={TALENTS.CONSUME_FLAME_TALENT} /> triggers</>, KYZ),
   change(date(2026, 4, 20), <>Fixed <SpellLink spell={SPELLS.HOVER} /> not counting as castable while casting</>, Baumritter),

--- a/src/analysis/retail/evoker/devastation/modules/abilities/DragonRage.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/abilities/DragonRage.tsx
@@ -5,9 +5,11 @@ import Events, {
   ApplyBuffEvent,
   CastEvent,
   EmpowerEndEvent,
+  EventType,
   FightEndEvent,
   RemoveBuffEvent,
 } from 'parser/core/Events';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
 const {
   DISINTEGRATE,
@@ -20,10 +22,23 @@ const {
 
 const { DRAGONRAGE_TALENT, PYRE_TALENT } = TALENTS_EVOKER;
 
+const EXTENSION_PERFORMANCE_THRESHHOLDS = {
+  PERFECT: 6,
+  GOOD: 4,
+};
+
+const EMPOWER_PERFORMANCE_THRESHHOLDS = {
+  PERFECT: 3,
+  GOOD: 2,
+};
+
 export interface RageWindowCounter {
   start: number;
   fireBreaths: number;
   eternitySurges: number;
+  extensionPerf: QualitativePerformance;
+  fireBreathPerf: QualitativePerformance;
+  eternitySurgePerf: QualitativePerformance;
   essenceBursts: number;
   pyres: number;
   disintegrateTicks: number;
@@ -50,12 +65,12 @@ class DragonRage extends Analyzer {
     this.addEventListener(
       Events.removebuff.by(SELECTED_PLAYER).spell(DRAGONRAGE_TALENT),
       (event) => {
-        this.onRemoveDragonrage(event);
+        this.onDragonrageEnd(event);
       },
     );
 
     this.addEventListener(Events.fightend, (event) => {
-      this.endOfFightCheck(event);
+      this.onDragonrageEnd(event);
     });
 
     this.addEventListener(
@@ -107,15 +122,54 @@ class DragonRage extends Analyzer {
       pyres: 0,
       end: 0,
       fightEndDuringDR: false,
+      extensionPerf: QualitativePerformance.Fail,
+      eternitySurgePerf: QualitativePerformance.Fail,
+      fireBreathPerf: QualitativePerformance.Fail,
     };
   }
 
-  onRemoveDragonrage(event: RemoveBuffEvent) {
-    this.inDragonRageWindow = false;
-    if (this.rageWindowCounters[this.totalCasts] === undefined) {
-      return;
+  onDragonrageEnd(event: RemoveBuffEvent | FightEndEvent) {
+    if (this.inDragonRageWindow) {
+      this.inDragonRageWindow = false;
+      if (this.rageWindowCounters[this.totalCasts] === undefined) {
+        return;
+      }
+      if (event.type === EventType.FightEnd)
+        this.rageWindowCounters[this.totalCasts].fightEndDuringDR = true;
+
+      this.rageWindowCounters[this.totalCasts].end = event.timestamp;
+
+      this.rageWindowCounters[this.totalCasts].fireBreathPerf = this.evaluateEmpowerPerformance(
+        this.rageWindowCounters[this.totalCasts].fireBreaths,
+      );
+
+      this.rageWindowCounters[this.totalCasts].eternitySurgePerf = this.evaluateEmpowerPerformance(
+        this.rageWindowCounters[this.totalCasts].eternitySurges,
+      );
+
+      const extensions =
+        this.rageWindowCounters[this.totalCasts].fireBreaths +
+        this.rageWindowCounters[this.totalCasts].eternitySurges;
+
+      this.rageWindowCounters[this.totalCasts].extensionPerf =
+        extensions >= EXTENSION_PERFORMANCE_THRESHHOLDS.PERFECT
+          ? QualitativePerformance.Perfect
+          : extensions >= EXTENSION_PERFORMANCE_THRESHHOLDS.GOOD
+            ? QualitativePerformance.Good
+            : this.rageWindowCounters[this.totalCasts].fightEndDuringDR
+              ? QualitativePerformance.Ok
+              : QualitativePerformance.Fail;
     }
-    this.rageWindowCounters[this.totalCasts].end = event.timestamp;
+  }
+
+  private evaluateEmpowerPerformance(castCount: number) {
+    return castCount >= EMPOWER_PERFORMANCE_THRESHHOLDS.PERFECT
+      ? QualitativePerformance.Perfect
+      : castCount >= EMPOWER_PERFORMANCE_THRESHHOLDS.GOOD
+        ? QualitativePerformance.Good
+        : this.rageWindowCounters[this.totalCasts].fightEndDuringDR
+          ? QualitativePerformance.Ok
+          : QualitativePerformance.Fail;
   }
 
   onEmpowerCast(event: CastEvent | EmpowerEndEvent) {
@@ -130,15 +184,6 @@ class DragonRage extends Analyzer {
       case ETERNITY_SURGE.name:
         this.currentRageWindow.eternitySurges += 1;
         break;
-    }
-  }
-
-  // Fix edgecase where DR window was registered but wasn't ended due to fight ending during the window
-  endOfFightCheck(event: FightEndEvent) {
-    if (this.inDragonRageWindow) {
-      this.inDragonRageWindow = false;
-      this.rageWindowCounters[this.totalCasts].fightEndDuringDR = true;
-      this.rageWindowCounters[this.totalCasts].end = event.timestamp;
     }
   }
 

--- a/src/analysis/retail/evoker/devastation/modules/guide/DragonRageSection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DragonRageSection.tsx
@@ -1,4 +1,4 @@
-import { SpellLink } from 'interface';
+import { SpellLink, TooltipElement } from 'interface';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 import SPELLS from 'common/SPELLS/evoker';
 import { GuideProps, Section } from 'interface/guide';
@@ -24,10 +24,18 @@ export function DragonRageSection({ modules, events, info }: GuideProps<typeof C
         <SpellLink spell={TALENTS_EVOKER.TYRANNY_TALENT} /> and guaranteed{' '}
         <SpellLink spell={SPELLS.ESSENCE_BURST_DEV_BUFF} /> procs, we need to utilize the talent{' '}
         <SpellLink spell={TALENTS_EVOKER.ANIMOSITY_TALENT} /> to extend the buff duration as long as
-        possible. We do this by getting in <strong>at least</strong> 2 rounds of{' '}
-        <SpellLink spell={TALENTS_EVOKER.ETERNITY_SURGE_TALENT} /> and{' '}
-        <SpellLink spell={SPELLS.FIRE_BREATH} /> by making the most of the talents:{' '}
-        <SpellLink spell={TALENTS_EVOKER.CAUSALITY_TALENT} /> and{' '}
+        possible. We do this by getting casting <strong>at least</strong> 4{' '}
+        <TooltipElement
+          content={
+            <>
+              <SpellLink spell={TALENTS_EVOKER.ETERNITY_SURGE_TALENT} /> and{' '}
+              <SpellLink spell={SPELLS.FIRE_BREATH} />
+            </>
+          }
+        >
+          Empowers
+        </TooltipElement>{' '}
+        by making the most of the talents: <SpellLink spell={TALENTS_EVOKER.CAUSALITY_TALENT} /> and{' '}
         <SpellLink spell={TALENTS_EVOKER.TIP_THE_SCALES_TALENT} />.
       </p>
       <p>

--- a/src/analysis/retail/evoker/devastation/modules/guide/DragonRageSection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DragonRageSection.tsx
@@ -24,7 +24,7 @@ export function DragonRageSection({ modules, events, info }: GuideProps<typeof C
         <SpellLink spell={TALENTS_EVOKER.TYRANNY_TALENT} /> and guaranteed{' '}
         <SpellLink spell={SPELLS.ESSENCE_BURST_DEV_BUFF} /> procs, we need to utilize the talent{' '}
         <SpellLink spell={TALENTS_EVOKER.ANIMOSITY_TALENT} /> to extend the buff duration as long as
-        possible. We do this by getting casting <strong>at least</strong> 4{' '}
+        possible. We do this by casting <strong>at least</strong> 4{' '}
         <TooltipElement
           content={
             <>

--- a/src/analysis/retail/evoker/devastation/modules/guide/DragonRageSection.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DragonRageSection.tsx
@@ -34,9 +34,9 @@ export function DragonRageSection({ modules, events, info }: GuideProps<typeof C
           }
         >
           Empowers
-        </TooltipElement>{' '}
-        by making the most of the talents: <SpellLink spell={TALENTS_EVOKER.CAUSALITY_TALENT} /> and{' '}
-        <SpellLink spell={TALENTS_EVOKER.TIP_THE_SCALES_TALENT} />.
+        </TooltipElement>
+        , by making the most of the talents: <SpellLink spell={TALENTS_EVOKER.CAUSALITY_TALENT} />{' '}
+        and <SpellLink spell={TALENTS_EVOKER.TIP_THE_SCALES_TALENT} />.
       </p>
       <p>
         To generate <SpellLink spell={SPELLS.ESSENCE_BURST_DEV_BUFF} /> procs inside of{' '}

--- a/src/analysis/retail/evoker/devastation/modules/guide/DragonRageWindows.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DragonRageWindows.tsx
@@ -116,13 +116,13 @@ function Statistics({ window }: { window: RageWindowCounter }) {
           </PerformanceStrong>
         </li>
         <li>
-          <SpellLink spell={SPELLS.FIRE_BREATH} /> -
+          <SpellLink spell={SPELLS.FIRE_BREATH} /> -{' '}
           <PerformanceStrong performance={window.fireBreathPerf}>
             {window.fireBreaths} casts
           </PerformanceStrong>
         </li>
         <li>
-          <SpellLink spell={SPELLS.ETERNITY_SURGE} /> -
+          <SpellLink spell={SPELLS.ETERNITY_SURGE} /> -{' '}
           <PerformanceStrong performance={window.eternitySurgePerf}>
             {window.eternitySurges} casts
           </PerformanceStrong>

--- a/src/analysis/retail/evoker/devastation/modules/guide/DragonRageWindows.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/guide/DragonRageWindows.tsx
@@ -13,6 +13,7 @@ import SpellLink from 'interface/SpellLink';
 import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 import './styling.scss';
+import PerformanceStrong from 'interface/PerformanceStrong';
 
 export function DragonRageWindowSection({
   rageWindows,
@@ -105,22 +106,40 @@ export function DragonRageWindowSection({
 // Need something prettier lol
 function Statistics({ window }: { window: RageWindowCounter }) {
   return (
-    <ul>
-      <li>
-        <SpellLink spell={SPELLS.FIRE_BREATH} /> - {window.fireBreaths}/2 casts
-      </li>
-      <li>
-        <SpellLink spell={SPELLS.ETERNITY_SURGE} /> - {window.eternitySurges}/2 casts
-      </li>
-      <li>
-        <SpellLink spell={SPELLS.ESSENCE_BURST_DEV_BUFF} /> - {window.essenceBursts} casts
-      </li>
-      <li>
-        <SpellLink spell={SPELLS.DISINTEGRATE} /> - {window.disintegrateTicks} ticks
-      </li>
-      <li>
-        <SpellLink spell={TALENTS.PYRE_TALENT} /> - {window.pyres} casts
-      </li>
-    </ul>
+    <>
+      <strong>Extenders</strong>
+      <ul>
+        <li>
+          <SpellLink spell={TALENTS.ANIMOSITY_TALENT} /> -{' '}
+          <PerformanceStrong performance={window.extensionPerf}>
+            {window.fireBreaths + window.eternitySurges} extensions
+          </PerformanceStrong>
+        </li>
+        <li>
+          <SpellLink spell={SPELLS.FIRE_BREATH} /> -
+          <PerformanceStrong performance={window.fireBreathPerf}>
+            {window.fireBreaths} casts
+          </PerformanceStrong>
+        </li>
+        <li>
+          <SpellLink spell={SPELLS.ETERNITY_SURGE} /> -
+          <PerformanceStrong performance={window.eternitySurgePerf}>
+            {window.eternitySurges} casts
+          </PerformanceStrong>
+        </li>
+      </ul>
+      <strong>Spenders</strong>
+      <ul>
+        <li>
+          <SpellLink spell={SPELLS.ESSENCE_BURST_DEV_BUFF} /> - {window.essenceBursts} uses
+        </li>
+        <li>
+          <SpellLink spell={SPELLS.DISINTEGRATE} /> - {window.disintegrateTicks} ticks
+        </li>
+        <li>
+          <SpellLink spell={TALENTS.PYRE_TALENT} /> - {window.pyres} casts
+        </li>
+      </ul>
+    </>
   );
 }


### PR DESCRIPTION
### Description
The current version of the module is a bit vague and confusing for newer players so I updated it with performance indicators to more closely indicate what is valid play.
I also updated the description of the guide to be more concise (4 empowers total instead of 2 of each because of Flameshaper and Event Horizon).

### Test report(s):
-  `/report/cPrH2k7KYRf4GvQ1/18-Mythic+Fallen-King+Salhadaar+-+Kill+(3:38)/224-Gilgvoker/standard`
-  `/report/bmZzt7RXcAq9KMW6/1-Mythic++Magisters'+Terrace+-+Kill+(30:15)/4-Dydymus/standard/overview`

### Screenshot(s):
Old:
<img width="488" height="223" alt="image" src="https://github.com/user-attachments/assets/9cd87f54-c60f-43a3-82b4-10dbc6c9df0f" />
New:
<img width="579" height="299" alt="image" src="https://github.com/user-attachments/assets/00c9d914-5212-4c25-9204-05fcfbff40fc" />

