### PR TITLE
[SHAMAN][RESTORATION] Talent update and spellUsable (de-)bugfixing

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,10 +123,5 @@
       "pnpm run lint:fix"
     ]
   },
-  "packageManager": "pnpm@9.5.0",
-  "pnpm": {
-    "patchedDependencies": {
-      "vega-embed@6.20.2": "patches/vega-embed@6.20.2.patch"
-    }
-  }
+  "packageManager": "pnpm@9.5.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - 'packages/**'
   - 'scripts/background-images'
+
+patchedDependencies:
+  'vega-embed@6.20.2': 'patches/vega-embed@6.20.2.patch'

--- a/scripts/talents/README.md
+++ b/scripts/talents/README.md
@@ -14,6 +14,12 @@ To run it once
 $ npx tsx .\scripts\talents\generate-talents.ts
 ```
 
+On linux the \ have to be replaced with / to make the new command work. It otherwise tries to escape the command.
+
+```shell script
+pnpm exec tsx ./scripts/talents/generate-talents.ts
+```
+
 To watch the file continously:
 
 ```shell script

--- a/scripts/talents/generate-talents.ts
+++ b/scripts/talents/generate-talents.ts
@@ -28,7 +28,7 @@ import {
 import { DBCTable } from 'scripts/utils/dbc-types';
 import { RaidbotsStaticDataFile } from 'scripts/utils/raidbots-types';
 
-const LIVE_WOW_BUILD_NUMBER = '12.0.1.66220';
+const LIVE_WOW_BUILD_NUMBER = '12.0.5.67823';
 const LIVE_TALENT_DATA_URL = getRaidbotsStaticDataUrl(RaidbotsStaticDataFile.Talents);
 const LIVE_SPELLPOWER_DATA_URL = getDbcCsvUrl(DBCTable.SpellPower, LIVE_WOW_BUILD_NUMBER);
 const PTR_WOW_BUILD_NUMBER = '12.0.5.66741';

--- a/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
@@ -13,7 +13,6 @@ import HealingRainLocation from './modules/core/HealingRainLocation';
 import RestorationAbilityTracker from './modules/core/RestorationAbilityTracker';
 import AlwaysBeCasting from './modules/features/AlwaysBeCasting';
 import MasteryEffectiveness from './modules/features/MasteryEffectiveness';
-import SpellUsable from './modules/features/SpellUsable';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 // Talents
 import ChainHeal from './modules/spells/ChainHeal';
@@ -93,7 +92,6 @@ class CombatLogParser extends CoreCombatLogParser {
     // Features
     alwaysBeCasting: AlwaysBeCasting,
     masteryEffectiveness: MasteryEffectiveness,
-    spellUsable: SpellUsable,
     cooldownThroughputTracker: CooldownThroughputTracker,
     earthShieldBreakdown: EarthShieldBreakdown,
 

--- a/src/analysis/retail/shaman/restoration/modules/Abilities.ts
+++ b/src/analysis/retail/shaman/restoration/modules/Abilities.ts
@@ -1,38 +1,42 @@
 import { defineMessage } from '@lingui/core/macro';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/shaman';
-// import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
-import CoreAbilities from 'parser/core/modules/Abilities';
+import ClassAbilities from '../../shared/Abilities';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 import { i18n } from '@lingui/core';
 import { TIERS } from 'game/TIERS';
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from '../constants';
-import { TrackedRestoShamanAbility } from './core/RestorationAbilityTracker';
+// import { TrackedRestoShamanAbility } from './core/RestorationAbilityTracker';
+// import ISSUE_IMPORTANCE from 'parser/core/ISSUE_IMPORTANCE';
 
 const totemGCD = 1000;
 
-class Abilities extends CoreAbilities {
-  constructor(...args: ConstructorParameters<typeof CoreAbilities>) {
+class Abilities extends ClassAbilities {
+  constructor(...args: ConstructorParameters<typeof ClassAbilities>) {
     super(...args);
     this.abilitiesAffectedByHealingIncreases = ABILITIES_AFFECTED_BY_HEALING_INCREASES.map(
       (spell) => spell.id,
     );
   }
 
-  spellbook(): SpellbookAbility<TrackedRestoShamanAbility>[] {
+  spellbook(): SpellbookAbility[] {
     const combatant = this.selectedCombatant;
     const totemCDR = combatant.hasTalent(TALENTS.TOTEMIC_SURGE_TALENT) ? 5 : 0;
     return [
+      ...super.spellbook(),
       {
         spell: TALENTS.RIPTIDE_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         enabled: combatant.hasTalent(TALENTS.RIPTIDE_TALENT),
         charges:
           1 +
-          combatant.getTalentRank(TALENTS.ECHO_OF_THE_ELEMENTS_TALENT) +
-          combatant.getTalentRank(TALENTS.ELEMENTAL_REVERB_TALENT),
-        cooldown: 6 - combatant.getTalentRank(TALENTS.RIP_CURRENT_TALENT),
+          combatant.getMultipleTalentRanks(
+            //Adjusted to follow the pattern of HST
+            TALENTS.ECHO_OF_THE_ELEMENTS_TALENT,
+            TALENTS.ELEMENTAL_REVERB_TALENT,
+          ),
+        cooldown: 6 - (combatant.hasTalent(TALENTS.RIP_CURRENT_TALENT) ? 1 : 0),
         timelineSortIndex: 11,
         gcd: {
           base: 1500,
@@ -42,6 +46,15 @@ class Abilities extends CoreAbilities {
           // recommendedEfficiency: combatant.hasTalent(TALENTS.ECHO_OF_THE_ELEMENTS_TALENT)
           //   ? 0.75
           //   : 0.6,
+        },
+      },
+      {
+        spell: SPELLS.PURIFY_SPIRIT.id,
+        enabled: combatant.hasTalent(TALENTS.IMPROVED_PURIFY_SPIRIT_TALENT),
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 8,
+        gcd: {
+          base: 1500,
         },
       },
       {
@@ -81,7 +94,6 @@ class Abilities extends CoreAbilities {
       {
         spell: [SPELLS.STORMSTREAM_TOTEM.id],
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 50,
         timelineSortIndex: 10,
         enabled: combatant.hasTalent(TALENTS.STORMSTREAM_TOTEM_1_RESTORATION_TALENT),
         gcd: {
@@ -89,19 +101,6 @@ class Abilities extends CoreAbilities {
         },
         castEfficiency: {
           suggestion: false,
-        },
-      },
-      {
-        spell: TALENTS.ASTRAL_SHIFT_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.ASTRAL_SHIFT_TALENT),
-        buffSpellId: TALENTS.ASTRAL_SHIFT_TALENT.id,
-        category: SPELL_CATEGORY.DEFENSIVE,
-        timelineSortIndex: 82,
-        cooldown: 90,
-        castEfficiency: {
-          suggestion: false,
-          // recommendedEfficiency: 0.6,
-          // importance: ISSUE_IMPORTANCE.MINOR,
         },
       },
       {
@@ -160,7 +159,7 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS.ASCENDANCE_RESTORATION_TALENT),
         buffSpellId: TALENTS.ASCENDANCE_RESTORATION_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: combatant.hasTalent(TALENTS.FIRST_ASCENDANT_TALENT) ? 120 : 180,
+        cooldown: 180 - (combatant.hasTalent(TALENTS.FIRST_ASCENDANT_TALENT) ? 60 : 0),
         gcd: {
           base: 1500,
         },
@@ -177,7 +176,7 @@ class Abilities extends CoreAbilities {
         enabled: combatant.hasTalent(TALENTS.HEALING_TIDE_TOTEM_TALENT),
         buffSpellId: TALENTS.HEALING_TIDE_TOTEM_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: (combatant.hasTalent(TALENTS.CURRENT_CONTROL_TALENT) ? 135 : 180) - totemCDR,
+        cooldown: 180 - (combatant.hasTalent(TALENTS.FIRST_ASCENDANT_TALENT) ? 60 : 0) - totemCDR,
         gcd: {
           static: totemGCD,
         },
@@ -204,7 +203,6 @@ class Abilities extends CoreAbilities {
           // recommendedEfficiency: 0.6,
         },
       },
-
       {
         spell: SPELLS.HEALING_WAVE.id,
         timelineSortIndex: 13,
@@ -236,59 +234,11 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.HEALING_SURGE.id,
-        timelineSortIndex: 14,
-        gcd: {
-          base: 1500,
-        },
-        category: SPELL_CATEGORY.OTHERS,
-        castEfficiency: {
-          casts: (castCount) => castCount.casts - (castCount.healingTwHits || 0),
-        },
-      },
-      {
-        spell: SPELLS.HEALING_SURGE.id,
-        name: i18n._(
-          defineMessage({
-            id: 'shaman.restoration.abilities.buffedByTidalWave',
-            message: `Tidal Waved ${SPELLS.HEALING_SURGE.name}`,
-          }),
-        ),
-        timelineSortIndex: 14,
-        gcd: {
-          base: 1500,
-        },
-        category: SPELL_CATEGORY.OTHERS,
-        castEfficiency: {
-          casts: (castCount) => castCount.healingTwHits || 0,
-        },
-      },
-      {
         spell: TALENTS.CHAIN_HEAL_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.CHAIN_HEAL_TALENT),
         buffSpellId: SPELLS.HIGH_TIDE_BUFF.id,
         category: SPELL_CATEGORY.OTHERS,
         timelineSortIndex: 12,
-        gcd: {
-          base: 1500,
-        },
-      },
-
-      {
-        spell: SPELLS.PURIFY_SPIRIT.id,
-        category: SPELL_CATEGORY.UTILITY,
-        timelineSortIndex: 80,
-        cooldown: 8,
-        gcd: {
-          base: 1500,
-        },
-      },
-      {
-        spell: SPELLS.FLAME_SHOCK.id,
-        buffSpellId: SPELLS.FLAME_SHOCK.id,
-        category: SPELL_CATEGORY.HEALER_DAMAGING_SPELL,
-        timelineSortIndex: 60,
-        cooldown: 6,
         gcd: {
           base: 1500,
         },
@@ -304,153 +254,6 @@ class Abilities extends CoreAbilities {
         gcd: {
           base: 1500,
         },
-      },
-      {
-        spell: SPELLS.LIGHTNING_BOLT.id,
-        category: SPELL_CATEGORY.HEALER_DAMAGING_SPELL,
-        gcd: {
-          base: 1500,
-        },
-        timelineSortIndex: 60,
-      },
-      {
-        spell: TALENTS.CHAIN_LIGHTNING_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.CHAIN_LIGHTNING_TALENT),
-        category: SPELL_CATEGORY.HEALER_DAMAGING_SPELL,
-        gcd: {
-          base: 1500,
-        },
-        timelineSortIndex: 60,
-      },
-      {
-        spell: SPELLS.GHOST_WOLF.id,
-        buffSpellId: SPELLS.GHOST_WOLF.id,
-        category: SPELL_CATEGORY.UTILITY,
-        timelineSortIndex: 80,
-        gcd: {
-          base: 1500,
-        },
-      },
-      {
-        spell: TALENTS.SPIRITWALKERS_GRACE_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.SPIRITWALKERS_GRACE_TALENT),
-        buffSpellId: TALENTS.SPIRITWALKERS_GRACE_TALENT.id,
-        category: SPELL_CATEGORY.UTILITY,
-        cooldown: combatant.hasTalent(TALENTS.GRACEFUL_SPIRIT_TALENT) ? 90 : 120,
-        timelineSortIndex: 81,
-      },
-      {
-        spell: TALENTS.SPIRIT_WALK_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.SPIRIT_WALK_TALENT),
-        buffSpellId: TALENTS.SPIRIT_WALK_TALENT.id,
-        category: SPELL_CATEGORY.UTILITY,
-        cooldown: 60,
-        timelineSortIndex: 81,
-      },
-      {
-        spell: SPELLS.EARTHBIND_TOTEM.id,
-        category: SPELL_CATEGORY.UTILITY,
-        timelineSortIndex: 80,
-        gcd: {
-          base: totemGCD, // totem GCD but affected by Haste for some reason
-        },
-        cooldown: 30 - totemCDR,
-      },
-      {
-        spell: TALENTS.PURGE_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.PURGE_TALENT),
-        category: SPELL_CATEGORY.UTILITY,
-        timelineSortIndex: 80,
-        gcd: {
-          base: 1500,
-        },
-      },
-      {
-        spell: TALENTS.CAPACITOR_TOTEM_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.CAPACITOR_TOTEM_TALENT),
-        category: SPELL_CATEGORY.UTILITY,
-        timelineSortIndex: 80,
-        gcd: {
-          static: totemGCD,
-        },
-        cooldown: 60 - totemCDR,
-      },
-      {
-        spell: TALENTS.WIND_RUSH_TOTEM_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.WIND_RUSH_TOTEM_TALENT),
-        category: SPELL_CATEGORY.UTILITY,
-        timelineSortIndex: 80,
-        gcd: {
-          static: totemGCD,
-        },
-        cooldown: 120 - totemCDR,
-      },
-      {
-        spell: TALENTS.EARTHGRAB_TOTEM_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.EARTHGRAB_TOTEM_TALENT),
-        category: SPELL_CATEGORY.UTILITY,
-        timelineSortIndex: 80,
-        gcd: {
-          static: totemGCD,
-        },
-        cooldown: 30 - totemCDR,
-      },
-      {
-        spell: SPELLS.REINCARNATION.id,
-        category: SPELL_CATEGORY.UTILITY,
-        cooldown: 1800,
-      },
-      {
-        spell: TALENTS.WIND_SHEAR_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.WIND_SHEAR_TALENT),
-        category: SPELL_CATEGORY.UTILITY,
-        timelineSortIndex: 80,
-        cooldown: 12,
-        gcd: null,
-      },
-      {
-        // had to remove SPELLS.HEX_SKELETAL since the Blizzard API doesn't think it exists, causing issues. Please add it again if it's encountered in a log, and if so leave a comment with the log
-        spell: [
-          TALENTS.HEX_TALENT.id,
-          SPELLS.HEX_RAPTOR.id,
-          SPELLS.HEX_SNAKE.id,
-          SPELLS.HEX_SPIDER.id,
-          SPELLS.HEX_COCKROACH.id,
-        ],
-        buffSpellId: [
-          TALENTS.HEX_TALENT.id,
-          SPELLS.HEX_RAPTOR.id,
-          SPELLS.HEX_SNAKE.id,
-          SPELLS.HEX_SPIDER.id,
-          SPELLS.HEX_COCKROACH.id,
-        ],
-        enabled: combatant.hasTalent(TALENTS.HEX_TALENT),
-        category: SPELL_CATEGORY.UTILITY,
-        gcd: {
-          base: 1500,
-        },
-        timelineSortIndex: 80,
-        cooldown: 30,
-      },
-      {
-        spell: TALENTS.EARTH_SHIELD_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.EARTH_SHIELD_TALENT),
-        category: SPELL_CATEGORY.OTHERS,
-        gcd: {
-          base: 1500,
-        },
-        timelineSortIndex: 80,
-        healSpellIds: [SPELLS.EARTH_SHIELD_HEAL.id],
-      },
-      {
-        spell: TALENTS.TREMOR_TOTEM_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.TREMOR_TOTEM_TALENT),
-        category: SPELL_CATEGORY.UTILITY,
-        cooldown: 60 - totemCDR,
-        gcd: {
-          base: totemGCD, // totem GCD but affected by Haste for some reason
-        },
-        timelineSortIndex: 80,
       },
       {
         spell: SPELLS.DOWNPOUR_ABILITY.id,
@@ -469,70 +272,31 @@ class Abilities extends CoreAbilities {
         },
       },
       {
-        spell: SPELLS.BERSERKING.id,
-        buffSpellId: SPELLS.BERSERKING.id,
-        category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 180,
-        isUndetectable: true,
-        gcd: null,
-        castEfficiency: {
-          suggestion: true,
-          majorIssueEfficiency: 0.2,
-          averageIssueEfficiency: 0.5,
-          recommendedEfficiency: 0.7,
-        },
-      },
-      {
-        spell: TALENTS.EARTH_ELEMENTAL_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.EARTH_ELEMENTAL_TALENT),
-        category: SPELL_CATEGORY.UTILITY,
-        cooldown: 300,
-        gcd: {
-          base: 1500,
-        },
-        timelineSortIndex: 80,
-      },
-      {
         spell: TALENTS.NATURES_GUARDIAN_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.NATURES_GUARDIAN_TALENT),
         category: SPELL_CATEGORY.DEFENSIVE,
-        cooldown: 45,
+        cooldown: 45 - (combatant.hasTalent(TALENTS.NATURAL_HARMONY_TALENT) ? 15 : 0),
         healSpellIds: [SPELLS.NATURES_GUARDIAN_HEAL.id],
+      },
+      {
+        spell: TALENTS.SUPPORTIVE_IMBUEMENTS_TALENT.id, //SpellID: 457481
+        category: SPELL_CATEGORY.HIDDEN, //IDK what that means but I guess, hidden means not listed in Ability summary
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: TALENTS.EARTHLIVING_WEAPON_TALENT.id, //SpellID: 382021
+        category: SPELL_CATEGORY.HIDDEN, //IDK what that means but I guess, hidden means not listed in Ability summary
+        gcd: {
+          base: 1500,
+        },
       },
       {
         spell: SPELLS.WATER_SHIELD.id,
         category: SPELL_CATEGORY.UTILITY,
         gcd: {
           base: 1500,
-        },
-      },
-      {
-        spell: SPELLS.LIGHTNING_SHIELD.id,
-        category: SPELL_CATEGORY.UTILITY,
-        gcd: {
-          base: 1500,
-        },
-        isUndetectable: true, // its not but, why.
-      },
-      {
-        spell: TALENTS.FROST_SHOCK_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.FROST_SHOCK_TALENT),
-        category: SPELL_CATEGORY.HEALER_DAMAGING_SPELL,
-        gcd: {
-          base: 1500,
-        },
-      },
-      {
-        spell: TALENTS.NATURES_SWIFTNESS_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.NATURES_SWIFTNESS_TALENT),
-        category: SPELL_CATEGORY.UTILITY,
-        gcd: null,
-        cooldown: 60,
-        castEfficiency: {
-          suggestion: false,
-          majorIssueEfficiency: 0.7,
-          averageIssueEfficiency: 0.8,
-          recommendedEfficiency: 0.9,
         },
       },
       {
@@ -558,24 +322,6 @@ class Abilities extends CoreAbilities {
           base: 1000,
         },
         healSpellIds: [SPELLS.HEALING_RAIN_TOTEMIC.id],
-      },
-      {
-        spell: SPELLS.SKYFURY.id,
-        enabled: true,
-        category: SPELL_CATEGORY.OTHERS,
-        cooldown: 0,
-        gcd: {
-          base: 1500,
-        },
-      },
-      {
-        spell: TALENTS.TOTEMIC_PROJECTION_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.TOTEMIC_PROJECTION_TALENT),
-        category: SPELL_CATEGORY.UTILITY,
-        cooldown: 10,
-        gcd: {
-          base: 1500,
-        },
       },
     ];
   }

--- a/src/analysis/retail/shaman/restoration/modules/Buffs.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/Buffs.tsx
@@ -1,0 +1,76 @@
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/shaman';
+import { SpellbookAura } from 'parser/core/modules/Aura';
+import CoreAuras from '../../shared/Buffs';
+
+class Buffs extends CoreAuras {
+  auras(): SpellbookAura[] {
+    const combatant = this.selectedCombatant;
+
+    // This should include ALL buffs that can be applied by your spec.
+    // This data can be used by various kinds of modules to improve their results, and modules added in the future may rely on buffs that aren't used today.
+    const buffs = [
+      ...super.auras(),
+      {
+        spellId: [SPELLS.ASCENDANCE_RESTORATION_BUFF.id],
+        enabled:
+          combatant.getMultipleTalentRanks(
+            TALENTS.ASCENDANCE_RESTORATION_TALENT,
+            TALENTS.DEEPLY_ROOTED_ELEMENTS_TALENT,
+          ) > 0,
+        triggeredBySpellId: [TALENTS.ASCENDANCE_RESTORATION_TALENT.id],
+        timelineHighlight: true,
+      },
+      {
+        spellId: [SPELLS.ANCESTRAL_SWIFTNESS_CAST.id],
+        enabled: combatant.hasTalent(TALENTS.ANCESTRAL_SWIFTNESS_TALENT),
+        triggeredBySpellId: [SPELLS.ANCESTRAL_SWIFTNESS_CAST.id],
+      },
+      {
+        spellId: [SPELLS.CALL_OF_THE_ANCESTORS_BUFF.id],
+        enabled: combatant.hasTalent(TALENTS.CALL_OF_THE_ANCESTORS_TALENT),
+        triggeredBySpellId: [SPELLS.ANCESTRAL_SWIFTNESS_CAST.id],
+        timelineHighlight: false,
+      },
+      {
+        spellId: [TALENTS.SPIRITWALKERS_GRACE_TALENT.id],
+        enabled: combatant.hasTalent(TALENTS.SPIRITWALKERS_GRACE_TALENT),
+        triggeredBySpellId: [TALENTS.SPIRITWALKERS_GRACE_TALENT.id],
+        timelineHighlight: false,
+      },
+      {
+        spellId: [SPELLS.TIDECALLERS_GUARD.id],
+        enabled: combatant.hasTalent(TALENTS.SUPPORTIVE_IMBUEMENTS_TALENT),
+        triggeredBySpellId: [SPELLS.TIDECALLERS_GUARD.id],
+        timelineHighlight: false,
+      },
+      {
+        spellId: [SPELLS.LAVA_SURGE.id],
+        enabled: combatant.hasTalent(TALENTS.LAVA_BURST_TALENT),
+        timelineHighlight: false,
+      },
+      {
+        spellId: [SPELLS.EARTHLIVING_WEAPON_HEAL.id],
+        enabled: combatant.hasTalent(TALENTS.EARTHLIVING_WEAPON_TALENT),
+        timelineHighlight: false,
+      },
+      {
+        spellId: [SPELLS.STORMSTREAM_TOTEM_PROC.id],
+        enabled:
+          combatant.getMultipleTalentRanks(
+            TALENTS.STORMSTREAM_TOTEM_1_RESTORATION_TALENT,
+            TALENTS.STORMSTREAM_TOTEM_2_RESTORATION_TALENT,
+            TALENTS.STORMSTREAM_TOTEM_3_RESTORATION_TALENT,
+          ) > 0,
+        triggeredBySpellId: [SPELLS.NATURES_SWIFTNESS_BUFF.id, SPELLS.ANCESTRAL_SWIFTNESS_CAST.id],
+        timelineHighlight: false,
+      },
+    ];
+
+    //const swg = buffs.find((buff) => buff.spellId === TALENTS.SPIRITWALKERS_GRACE_TALENT.id);
+    //if (swg) swg.timelineHighlight = true;
+    return buffs;
+  }
+}
+
+export default Buffs;

--- a/src/analysis/retail/shaman/restoration/modules/spells/LavaSurge.ts
+++ b/src/analysis/retail/shaman/restoration/modules/spells/LavaSurge.ts
@@ -1,32 +1,64 @@
-import SPELLS from 'common/SPELLS';
+import SPELLS from 'common/SPELLS/shaman';
 import TALENTS from 'common/TALENTS/shaman';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events from 'parser/core/Events';
+import Events, { ApplyBuffEvent, EndChannelEvent, RefreshBuffEvent } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 
-import Abilities from '../Abilities';
-
-class LavaSurge extends Analyzer {
-  static dependencies = {
-    spellUsable: SpellUsable,
-    abilities: Abilities,
-  };
-
-  protected spellUsable!: SpellUsable;
-  protected abilities!: Abilities;
+class LavaSurge extends Analyzer.withDependencies({
+  spellUsable: SpellUsable,
+}) {
+  private lavaSurgeDuringLvB = false;
+  private isCastingLvB = false;
 
   constructor(options: Options) {
     super(options);
     this.addEventListener(
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.LAVA_SURGE),
-      this.onLavaSurgeProc,
+      this.applyBuff,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.LAVA_SURGE),
+      this.applyBuff,
+    );
+
+    this.addEventListener(
+      Events.begincast.by(SELECTED_PLAYER).spell(TALENTS.LAVA_BURST_TALENT),
+      () => (this.isCastingLvB = true),
+    );
+    this.addEventListener(
+      Events.EndChannel.by(SELECTED_PLAYER).spell(TALENTS.LAVA_BURST_TALENT),
+      this.onEndCast,
     );
   }
 
-  onLavaSurgeProc() {
-    if (this.spellUsable.isOnCooldown(TALENTS.LAVA_BURST_TALENT.id)) {
-      this.spellUsable.endCooldown(TALENTS.LAVA_BURST_TALENT.id, undefined, true);
+  applyBuff(event: ApplyBuffEvent | RefreshBuffEvent) {
+    if (this.isCastingLvB) {
+      this.lavaSurgeDuringLvB = true;
     }
+    if (this.deps.spellUsable.isOnCooldown(TALENTS.LAVA_BURST_TALENT.id)) {
+      this.deps.spellUsable.endCooldown(
+        TALENTS.LAVA_BURST_TALENT.id,
+        event.timestamp,
+        false,
+        false,
+      );
+    }
+  }
+
+  onEndCast(event: EndChannelEvent) {
+    this.isCastingLvB = false;
+    if (
+      this.lavaSurgeDuringLvB &&
+      this.deps.spellUsable.isOnCooldown(TALENTS.LAVA_BURST_TALENT.id)
+    ) {
+      this.deps.spellUsable.endCooldown(
+        TALENTS.LAVA_BURST_TALENT.id,
+        event.timestamp + 1,
+        false,
+        false,
+      );
+    }
+    this.lavaSurgeDuringLvB = false;
   }
 }
 

--- a/src/analysis/retail/shaman/restoration/modules/spells/PurifySpirit.ts
+++ b/src/analysis/retail/shaman/restoration/modules/spells/PurifySpirit.ts
@@ -1,0 +1,29 @@
+import SPELLS from 'common/SPELLS';
+import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { DispelEvent } from 'parser/core/Events';
+import CoreSpellUsable from 'parser/shared/modules/SpellUsable';
+
+//currently unused. May need rework. Caused errors without benefits in the current branch.
+class SpellUsable extends CoreSpellUsable {
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(
+      Events.dispel.by(SELECTED_PLAYER).spell(SPELLS.PURIFY_SPIRIT),
+      this.onDispel,
+    );
+  }
+  onDispel(event: DispelEvent) {
+    super.beginCooldown(event);
+  }
+
+  beginCooldown(cooldownTriggerEvent: DispelEvent, spellId: number) {
+    // Essentially having the purify spirit cast not be able to trigger the cooldown, the dispel event does it instead.
+    if (spellId === SPELLS.PURIFY_SPIRIT.id) {
+      return;
+    }
+
+    super.beginCooldown(cooldownTriggerEvent, spellId);
+  }
+}
+
+export default SpellUsable;

--- a/src/analysis/retail/shaman/shared/Abilities.tsx
+++ b/src/analysis/retail/shaman/shared/Abilities.tsx
@@ -138,7 +138,7 @@ class Abilities extends CoreAbilities {
         category: combatant.hasTalent(TALENTS.PRIMORDIAL_BOND_TALENT)
           ? SPELL_CATEGORY.DEFENSIVE
           : SPELL_CATEGORY.UTILITY,
-        cooldown: 300,
+        cooldown: 180,
         gcd: {
           base: 1500,
         },

--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -742,6 +742,11 @@ const spells = {
     name: 'Stormstream Totem',
     icon: 'inv12_apextalent_shaman_stormstreamtotem',
   },
+  STORMSTREAM_TOTEM_PROC: {
+    id: 1267089,
+    name: 'Stormstream Totem',
+    icon: 'inv12_apextalent_shaman_stormstreamtotem',
+  },
   STORMSWELL_HEAL: {
     id: 1268684,
     name: 'Stormstream Totem',
@@ -754,6 +759,11 @@ const spells = {
   },
   ASCENDANCE_ELEMENTAL_BUFF: {
     id: 1219480,
+    name: 'Ascendance',
+    icon: 'spell_fire_elementaldevastation',
+  },
+  ASCENDANCE_RESTORATION_BUFF: {
+    id: 114052,
     name: 'Ascendance',
     icon: 'spell_fire_elementaldevastation',
   },
@@ -968,46 +978,6 @@ const spells = {
     name: 'Downpour',
     icon: 'ability_mage_waterjet',
   },
-  HEALING_RAIN_TOTEMIC: {
-    id: 456366,
-    name: 'Healing Rain',
-    icon: 'spell_nature_giftofthewaterspirit',
-  },
-  SURGING_TOTEM: {
-    id: 444995,
-    name: 'Surging Totem',
-    icon: 'inv_ability_totemicshaman_surgingtotem',
-  },
-  SURGING_TOTEM_DAMAGE: {
-    id: 455622,
-    name: 'Surging Totem',
-    icon: 'spell_nature_earthquake',
-  },
-  WHIRLING_AIR: {
-    id: 453409,
-    name: 'Whirling Air',
-    icon: 'inv_10_elementalcombinedfoozles_air',
-  },
-  WHIRLING_EARTH: {
-    id: 453406,
-    name: 'Whirling Earth',
-    icon: 'inv_10_elementalcombinedfoozles_earth',
-  },
-  WHIRLING_WATER: {
-    id: 453407,
-    name: 'Whirling Water',
-    icon: 'inv_10_elementalcombinedfoozles_water',
-  },
-  WHIRLING_FIRE: {
-    id: 453405,
-    name: 'Whirling Fire',
-    icon: 'inv_10_elementalcombinedfoozles_fire',
-  },
-  PRIMAL_CATALYST_BUFF: {
-    id: 1260880,
-    name: 'Primal Catalyst',
-    icon: 'misc_legionfall_shaman',
-  },
   TIDEWATERS_HEAL: {
     id: 462425,
     name: 'Tidewaters',
@@ -1018,6 +988,7 @@ const spells = {
     name: 'Acid Rain',
     icon: 'spell_nature_acid_01',
   },
+
   /** HERO TALENTS **/
   // Stormbringer
   TEMPEST_CAST: {
@@ -1081,6 +1052,46 @@ const spells = {
     id: 467283,
     name: 'Sundering',
     icon: 'ability_rhyolith_lavapool',
+  },
+  TIDECALLERS_GUARD: {
+    id: 457481,
+    name: "Tidecaller's Guard",
+    icon: 'inv_shield_1h_artifactstormfist_d_04',
+  },
+  HEALING_RAIN_TOTEMIC: {
+    id: 456366,
+    name: 'Healing Rain',
+    icon: 'spell_nature_giftofthewaterspirit',
+  },
+  SURGING_TOTEM: {
+    id: 444995,
+    name: 'Surging Totem',
+    icon: 'inv_ability_totemicshaman_surgingtotem',
+  },
+  SURGING_TOTEM_DAMAGE: {
+    id: 455622,
+    name: 'Surging Totem',
+    icon: 'spell_nature_earthquake',
+  },
+  WHIRLING_AIR: {
+    id: 453409,
+    name: 'Whirling Air',
+    icon: 'inv_10_elementalcombinedfoozles_air',
+  },
+  WHIRLING_EARTH: {
+    id: 453406,
+    name: 'Whirling Earth',
+    icon: 'inv_10_elementalcombinedfoozles_earth',
+  },
+  WHIRLING_WATER: {
+    id: 453407,
+    name: 'Whirling Water',
+    icon: 'inv_10_elementalcombinedfoozles_water',
+  },
+  WHIRLING_FIRE: {
+    id: 453405,
+    name: 'Whirling Fire',
+    icon: 'inv_10_elementalcombinedfoozles_fire',
   },
 
   // Tier sets

--- a/src/common/TALENTS/shaman.ts
+++ b/src/common/TALENTS/shaman.ts
@@ -226,7 +226,7 @@ const talents = {
     maxRanks: 1,
     entryIds: [127861],
     definitionIds: [{ id: 132670, specId: 264 }],
-    manaCost: 11250,
+    manaCost: 10700,
   },
   CHAIN_LIGHTNING_TALENT: {
     id: 188443,
@@ -1348,7 +1348,7 @@ const talents = {
     maxRanks: 1,
     entryIds: [101905],
     definitionIds: [{ id: 106805, specId: 264 }],
-    manaCost: 4000,
+    manaCost: 3800,
   },
   RIP_CURRENT_TALENT: {
     id: 1254251,

--- a/src/parser/shared/modules/racials/draenei/GiftOfTheNaaru.ts
+++ b/src/parser/shared/modules/racials/draenei/GiftOfTheNaaru.ts
@@ -31,7 +31,7 @@ class GiftOfTheNaaru extends Analyzer {
         SPELLS.GIFT_OF_THE_NAARU_WARRIOR.id,
       ],
       category: SPELL_CATEGORY.DEFENSIVE,
-      cooldown: 180,
+      cooldown: 120,
       gcd: null,
     });
   }


### PR DESCRIPTION
### Description

- Adjusted pnpm-workspace.yaml & package.json to allow for talent regeneration of LIVE.
- Adjusted README.md to reflect the changes and add the new command line for regeneration.
- Updated shaman talents for LIVE build.
- Updated shaman spells (manual addition).
- Resolved issues with _Purify Spirit_ cooldown in the spell tracker.
- Resolved issues with _Stormstream Totem_ cooldown in the spell tracker.
- Corrected wrong cooldown duration of _Healing Tide Totem_ if the talent _First Ascendant_ was also taken.
- Corrected wrong cooldown duration of _Ascendance_ if the talent _First Ascendant_ was also taken.
- Corrected wrong cooldown duration of _Earth Elemental_.
- Corrected wrong cooldown duration of draenei racial ability _Gift of the Naaru_.
- Ported _Lava Surge_ cooldown reset module for _Lava Burst_ from elemental to restoration to fix the current implementation.
- Restoration shaman Spellbook now imports all BLOODLUST-Spells correctly according to the combatant's fraction.
- Added Buffs.tsx to allow better tracking of buffs in the future.
- Removed unused imports from CombatLogParser.tsx.
- Removed duplicates from restoration shaman Abilities.ts to touch only restoration shaman specific spells.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: 
 /report/KdTrR1nGC9YPfyzX/2-Mythic++Magisters'+Terrace+-+Kill+(29:56)/2-Naltarunir/standard/debug
 /report/j9KnH82bRwZYDxB3/8-Mythic+Fallen-King+Salhadaar+-+Kill+(4:38)/20-Naltarunir/standard/debug

- Screenshots:

Before: 
<img width="837" height="1153" alt="image" src="https://github.com/user-attachments/assets/167593bd-a2d3-49fb-b9d5-9e7467fd33a4" />

After: 
<img width="697" height="1053" alt="image" src="https://github.com/user-attachments/assets/379e9d6d-6d91-43cf-a81d-1c25dd379d77" />