### PR TITLE
Update Classic (MoP) enchant checker and wire to Preparation tab

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -33,14 +33,16 @@ import {
   Hezaerd,
   Dambroda,
   Baumritter,
-  Mahmud17, 
+  Mahmud17,
   Ateis,
+  Xinito,
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 6, 6), 'Update the Classic (Mists of Pandaria) enchant checker: drop the Head slot (MoP has no head enchant), recognise current MoP enchants, and grade top-tier enchants as Perfect in the Preparation tab.', Xinito),
   change(date(2026, 5, 21), "Fix events tab crashing after build tooling updates", Putro),
   change(date(2026, 5, 19), 'Add Siege of Orgrimmar Raid / Bosses for MoP Classic', jazminite),
   change(date(2026, 5, 19), 'Update build tooling.', Topple),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -3004,3 +3004,16 @@ export const Zogmaw: Contributor = {
     Youtube: 'https://www.youtube.com/@Zogmaw',
   },
 };
+
+export const Xinito: Contributor = {
+  nickname: 'Xinito',
+  github: '1337Xinito',
+  discord: 'Xinito',
+  mains: [
+    {
+      name: 'Skullbonka',
+      spec: SPECS.FURY_WARRIOR,
+      link: 'https://classic.warcraftlogs.com/character/eu/garalon/skullbonka',
+    },
+  ],
+};

--- a/src/common/ITEMS/classic/enchants.ts
+++ b/src/common/ITEMS/classic/enchants.ts
@@ -1,0 +1,85 @@
+import { Enchant } from 'common/ITEMS/Item';
+
+// Curated best-in-slot melee/strength-DPS Mists of Pandaria enchants — one recommended pick per
+// slot (Strength inscriptions/armor kits, Dancing Steel, etc.). This is intentionally NOT a
+// complete MoP enchant list: it only backs the "recommended enchant" tooltips in the Preparation
+// tab. The comprehensive set of enchants accepted when *grading* a slot lives in the classic
+// EnchantChecker's MAX_ENCHANT_IDS (parser/classic/modules/items/EnchantChecker).
+//
+// `id` is the enchanting scroll/armor-kit item id and `effectId` is the `permanentEnchant`
+// (SpellItemEnchantment) effect id, both sourced from wowsims/mop (assets/database/db.json).
+const enchants = {
+  // #region Shoulder
+  GREATER_TIGER_FANG_INSCRIPTION: {
+    id: 83006,
+    name: 'Greater Tiger Fang Inscription',
+    icon: 'inv_inscription_runescrolloffortitude_yellow',
+    effectId: 4803,
+  },
+  // #endregion
+
+  // #region Cloak
+  ENCHANT_CLOAK_SUPERIOR_CRITICAL_STRIKE: {
+    id: 74713,
+    name: 'Enchant Cloak - Superior Critical Strike',
+    icon: 'inv_misc_enchantedscroll',
+    effectId: 4424,
+  },
+  // #endregion
+
+  // #region Chest
+  ENCHANT_CHEST_GLORIOUS_STATS: {
+    id: 74708,
+    name: 'Enchant Chest - Glorious Stats',
+    icon: 'inv_misc_enchantedscroll',
+    effectId: 4419,
+  },
+  // #endregion
+
+  // #region Bracers
+  ENCHANT_BRACER_EXCEPTIONAL_STRENGTH: {
+    id: 74704,
+    name: 'Enchant Bracer - Exceptional Strength',
+    icon: 'inv_misc_enchantedscroll',
+    effectId: 4415,
+  },
+  // #endregion
+
+  // #region Gloves
+  ENCHANT_GLOVES_SUPER_STRENGTH: {
+    id: 74721,
+    name: 'Enchant Gloves - Super Strength',
+    icon: 'inv_misc_enchantedscroll',
+    effectId: 4432,
+  },
+  // #endregion
+
+  // #region Legs
+  ANGERHIDE_LEG_ARMOR: {
+    id: 83765,
+    name: 'Angerhide Leg Armor',
+    icon: 'inv_misc_armorkit_mop_04',
+    effectId: 4823,
+  },
+  // #endregion
+
+  // #region Boots
+  ENCHANT_BOOTS_PANDARENS_STEP: {
+    id: 74718,
+    name: "Enchant Boots - Pandaren's Step",
+    icon: 'inv_misc_enchantedscroll',
+    effectId: 4429,
+  },
+  // #endregion
+
+  // #region Weapon
+  ENCHANT_WEAPON_DANCING_STEEL: {
+    id: 74726,
+    name: 'Enchant Weapon - Dancing Steel',
+    icon: 'inv_misc_enchantedscroll',
+    effectId: 4444,
+  },
+  // #endregion
+} satisfies Record<string, Enchant>;
+
+export default enchants;

--- a/src/common/ITEMS/classic/index.ts
+++ b/src/common/ITEMS/classic/index.ts
@@ -1,12 +1,14 @@
 import Item from 'common/ITEMS/Item';
 import safeMerge from '../../safeMerge';
 import Cooking from './cooking';
+import Enchants from './enchants';
 import OTHERS from './others';
 import Potions from './potions';
 import Trinkets from './trinkets';
 
 const items = {
   ...safeMerge(Cooking),
+  ...safeMerge(Enchants),
   ...safeMerge(OTHERS),
   ...safeMerge(Potions),
   ...safeMerge(Trinkets),

--- a/src/parser/classic/modules/items/EnchantChecker.tsx
+++ b/src/parser/classic/modules/items/EnchantChecker.tsx
@@ -2,9 +2,15 @@ import type { JSX } from 'react';
 import GEAR_SLOTS, { GEAR_SLOT_NAMES } from 'game/GEAR_SLOTS';
 import BaseEnchantChecker from 'parser/shared/modules/items/EnchantChecker';
 import { GearSlotName } from 'parser/core/Combatant';
+import { Item } from 'parser/core/Events';
+import { Enchant as EnchantItem } from 'common/ITEMS/Item';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 
+// Mists of Pandaria enchant data. Enchant ids are the `permanentEnchant` (SpellItemEnchantment)
+// effect ids, sourced from wowsims/mop (assets/database/db.json).
+// NOTE: In MoP the Head slot can no longer be enchanted (Cataclysm head Arcanums were removed) —
+// the head only takes a Meta Gem now, so it is intentionally absent from the enchantable slots.
 const ENCHANTABLE_SLOT_NAMES = [
-  'HEAD',
   'SHOULDER',
   'CHEST',
   'LEGS',
@@ -20,108 +26,85 @@ const ENCHANTABLE_SLOTS: Partial<Record<GearSlotName, JSX.Element>> = Object.fro
   ENCHANTABLE_SLOT_NAMES.map((slot) => [slot, GEAR_SLOT_NAMES[GEAR_SLOTS[slot]]]),
 );
 
+// Lower-rank / budget MoP enchants. Currently informational only — the base EnchantChecker grades
+// any present enchant as at least "OK"; only MaxEnchantIds promotes an enchant to "Good".
 const MIN_ENCHANT_IDS = [
-  // Head
-  4245, // https://www.wowhead.com/cata/spell=96245/arcanum-of-vicious-intellect
-  4246, // https://www.wowhead.com/cata/spell=96246/arcanum-of-vicious-agility
-  4247, // https://www.wowhead.com/cata/spell=96247/arcanum-of-vicious-strength
-  // Shoulder
-  4197, // https://www.wowhead.com/cata/spell=86847/inscription-of-unbreakable-quartz
-  4199, // https://www.wowhead.com/cata/spell=86898/inscription-of-charged-lodestone
-  4201, // https://www.wowhead.com/cata/spell=86900/inscription-of-jagged-stone
-  4205, // https://www.wowhead.com/cata/spell=86909/inscription-of-shattered-crystal
-  // Chest
-  4063, // https://www.wowhead.com/cata/spell=74191/enchant-chest-mighty-stats
-  4070, // https://www.wowhead.com/cata/spell=74200/enchant-chest-stamina
-  // Legs
-  3873, // https://www.wowhead.com/cata/spell=56034/masters-spellthread
-  4109, // https://www.wowhead.com/cata/spell=75149/ghostly-spellthread
-  4111, // https://www.wowhead.com/cata/spell=75151/enchanted-spellthread
-  4122, // https://www.wowhead.com/cata/spell=78169/scorched-leg-armor
-  4124, // https://www.wowhead.com/cata/spell=78170/twilight-leg-armor
-  // Boots
-  // Bracers
-  4065, // https://www.wowhead.com/cata/spell=74193/enchant-bracer-speed
-  4071, // https://www.wowhead.com/cata/spell=74201/enchant-bracer-critical-strike
-  // Gloves
-  4061, // https://www.wowhead.com/cata/spell=74132/enchant-gloves-mastery
-  4075, // https://www.wowhead.com/cata/spell=74212/enchant-gloves-exceptional-strength
-  // Ring
-  // Cloak
-  4072, // https://www.wowhead.com/cata/spell=74202/enchant-cloak-intellect
-  4087, // https://www.wowhead.com/cata/spell=74230/enchant-cloak-critical-strike
-  // Weapon
-  4066, // https://www.wowhead.com/cata/spell=74195/enchant-weapon-mending
-  // Offhand
-  // Other
-  4120, // https://www.wowhead.com/cata/spell=78165/savage-armor-kit
-  4121, // https://www.wowhead.com/cata/spell=78166/heavy-savage-armor-kit
+  // Shoulder (Inscription, non-greater)
+  4907, // Tiger Fang Inscription (Strength)
+  4908, // Tiger Claw Inscription (Agility)
+  4909, // Crane Wing Inscription (Intellect)
+  4910, // Ox Horn Inscription (Stamina)
+  // Legs (lesser leg armors / spellthreads)
+  4870, // Toughened Leg Armor (Stamina)
+  4871, // Sha-Touched Leg Armor (Agility)
+  4872, // Brutal Leg Armor (Strength)
+  5003, // Cerulean Spellthread (Intellect)
+  5004, // Pearlescent Spellthread (Spirit)
 ];
 
 const MAX_ENCHANT_IDS = [
-  // Head
-  4206, // https://www.wowhead.com/cata/spell=86931/arcanum-of-the-earthern-ring
-  4207, // https://www.wowhead.com/cata/spell=86932/arcanum-of-hyjal
-  4208, // https://www.wowhead.com/cata/spell=86933/arcanum-of-the-highlands
-  4209, // https://www.wowhead.com/cata/spell=86934/arcanum-of-ramkahen
-  // Shoulder
-  4198, // https://www.wowhead.com/cata/spell=86854/greater-inscription-of-unbreakable-quartz
-  4200, // https://www.wowhead.com/cata/spell=86899/greater-inscription-of-charged-lodestone
-  4202, // https://www.wowhead.com/cata/spell=86901/greater-inscription-of-jagged-stone
-  4204, // https://www.wowhead.com/cata/spell=86907/greater-inscription-of-shattered-crystal
-  // Chest
-  4102, // https://www.wowhead.com/cata/spell=74250/enchant-chest-peerless-stats
-  // Belt
-  4188, // https://www.wowhead.com/cata/spell=84427/grounded-plasma-shield
-  4223, // https://www.wowhead.com/cata/spell=55016/nitro-boosts
-  // Legs
-  4110, // https://www.wowhead.com/cata/spell=75150/powerful-ghostly-spellthread
-  4112, // https://www.wowhead.com/cata/spell=75152/powerful-enchanted-spellthread
-  4113, // https://www.wowhead.com/cata/spell=75154/masters-spellthread-rank-2
-  4126, // https://www.wowhead.com/cata/spell=78171/dragonscale-leg-armor
-  4127, // https://www.wowhead.com/cata/spell=78172/charscale-leg-armor
-  4270, // https://www.wowhead.com/cata/spell=101598/drakehide-leg-armor
-  // Boots
-  4062, // https://www.wowhead.com/cata/spell=74189/enchant-boots-earthen-vitality
-  4069, // https://www.wowhead.com/cata/spell=74199/enchant-boots-haste
-  4076, // https://www.wowhead.com/cata/spell=74213/enchant-boots-major-agility
-  4094, // https://www.wowhead.com/cata/spell=74238/enchant-boots-mastery
-  4104, // https://www.wowhead.com/cata/spell=74253/enchant-boots-lavawalker
-  4105, // https://www.wowhead.com/cata/spell=74252/enchant-boots-assassins-step
-  // Bracers
-  4101, // https://www.wowhead.com/cata/spell=74248/enchant-bracer-greater-critical-strike
-  4108, // https://www.wowhead.com/cata/spell=74256/enchant-bracer-greater-speed
-  4256, // https://wowhead.com/cata/spell=96261/enchant-bracer-major-strength
-  4257, // https://www.wowhead.com/cata/spell=96262/enchant-bracer-mighty-intellect
-  4258, // https://www.wowhead.com/cata/spell=96264/enchant-bracer-agility
-  // Gloves
-  3604, // https://www.wowhead.com/cata/spell=54999/hyperspeed-accelerators
-  4068, // https://www.wowhead.com/cata/spell=74198/enchant-gloves-haste
-  4106, // https://www.wowhead.com/cata/spell=74254/enchant-gloves-mighty-strength
-  4107, // https://www.wowhead.com/cata/spell=74255/enchant-gloves-greater-mastery
-  // Ring
-  4078, // https://www.wowhead.com/cata/spell=74215/enchant-ring-strength
-  4079, // https://www.wowhead.com/cata/spell=74216/enchant-ring-agility
-  4080, // https://www.wowhead.com/cata/spell=74217/enchant-ring-intellect
-  4081, // https://www.wowhead.com/cata/spell=74218/enchant-ring-greater-stamina
+  // Shoulder (Inscription)
+  4803, // Greater Tiger Fang Inscription (Strength)
+  4804, // Greater Tiger Claw Inscription (Agility)
+  4805, // Greater Ox Horn Inscription (Stamina)
+  4806, // Greater Crane Wing Inscription (Intellect)
+  4912, // Secret Ox Horn Inscription (Scribe-only)
+  4913, // Secret Tiger Fang Inscription (Scribe-only)
+  4914, // Secret Tiger Claw Inscription (Scribe-only)
+  4915, // Secret Crane Wing Inscription (Scribe-only)
   // Cloak
-  4096, // https://www.wowhead.com/cata/spell=74240/enchant-cloak-greater-intellect
-  4100, // https://www.wowhead.com/cata/spell=74247/enchant-cloak-greater-critical-strike
-  4115, // https://www.wowhead.com/cata/spell=75172/lightweave-embroidery-rank-2
+  4421, // Enchant Cloak - Accuracy
+  4422, // Enchant Cloak - Greater Protection
+  4423, // Enchant Cloak - Superior Intellect
+  4424, // Enchant Cloak - Superior Critical Strike
+  4892, // Lightweave Embroidery (Rank 3)
+  4893, // Darkglow Embroidery (Rank 3)
+  4894, // Swordguard Embroidery (Rank 3)
+  // Chest
+  4417, // Enchant Chest - Super Resilience
+  4418, // Enchant Chest - Mighty Spirit
+  4419, // Enchant Chest - Glorious Stats
+  4420, // Enchant Chest - Superior Stamina
+  // Bracers
+  4411, // Enchant Bracer - Mastery
+  4412, // Enchant Bracer - Major Dodge
+  4414, // Enchant Bracer - Super Intellect
+  4415, // Enchant Bracer - Exceptional Strength
+  4416, // Enchant Bracer - Greater Agility
+  4875, // Fur Lining - Agility (Rank 3)
+  4877, // Fur Lining - Intellect (Rank 3)
+  4878, // Fur Lining - Stamina (Rank 3)
+  4879, // Fur Lining - Strength (Rank 3)
+  // Gloves
+  4430, // Enchant Gloves - Greater Haste
+  4431, // Enchant Gloves - Superior Expertise
+  4432, // Enchant Gloves - Super Strength
+  4433, // Enchant Gloves - Superior Mastery
+  4898, // Synapse Springs (Mark II) (Engineering)
+  // Legs (leg armors / greater spellthreads)
+  4822, // Shadowleather Leg Armor (Agility)
+  4823, // Angerhide Leg Armor (Strength)
+  4824, // Ironscale Leg Armor (Stamina)
+  4825, // Greater Cerulean Spellthread (Intellect)
+  4826, // Greater Pearlescent Spellthread (Spirit)
+  // Boots
+  4426, // Enchant Boots - Greater Haste
+  4427, // Enchant Boots - Greater Precision
+  4428, // Enchant Boots - Blurred Speed
+  4429, // Enchant Boots - Pandaren's Step
   // Weapon
-  3368, // https://www.wowhead.com/cata/spell=53344/rune-of-the-fallen-crusader
-  3370, // https://www.wowhead.com/cata/spell=53343/rune-of-razorice
-  3847, // https://www.wowhead.com/cata/spell=62158/rune-of-the-stoneskin-gargoyle
-  4097, // https://www.wowhead.com/cata/spell=74242/enchant-weapon-power-torrent
-  4098, // https://www.wowhead.com/cata/spell=74244/enchant-weapon-windwalk
-  4099, // https://www.wowhead.com/cata/spell=74246/enchant-weapon-landslide
-  // 2H Weapon
-  4227, // https://www.wowhead.com/cata/spell=95471/enchant-2h-weapon-mighty-agility
-  // Ranged
-  // Offhand
-  4091, // https://www.wowhead.com/cata/spell=74235/enchant-off-hand-superior-intellect
-  // Shield
-  4085, // https://www.wowhead.com/cata/spell=74226/enchant-shield-mastery
+  4441, // Enchant Weapon - Windsong
+  4442, // Enchant Weapon - Jade Spirit
+  4443, // Enchant Weapon - Elemental Force
+  4444, // Enchant Weapon - Dancing Steel
+  4445, // Enchant Weapon - Colossus
+  4446, // Enchant Weapon - River's Song
+  4434, // Enchant Off-Hand - Major Intellect
+  // Weapon (PvP)
+  5035, // Enchant Weapon - Glorious Tyranny
+  5124, // Enchant Weapon - Spirit of Conquest
+  5125, // Enchant Weapon - Bloody Dancing Steel
+  8550, // Enchant Weapon - Tyranny
 ];
 
 class EnchantChecker extends BaseEnchantChecker {
@@ -135,6 +118,30 @@ class EnchantChecker extends BaseEnchantChecker {
 
   get MaxEnchantIds(): number[] {
     return MAX_ENCHANT_IDS;
+  }
+
+  boxRowPerformance(item: Item, _recommendedEnchantments: number[] | undefined) {
+    // For Classic the MaxEnchantIds list is the curated best-in-slot tier, so any max-tier enchant
+    // is graded Perfect (players legitimately run several top-tier variants per slot — e.g. Greater
+    // vs Secret inscriptions, or Synapse Springs on gloves — and they should all count). A lesser
+    // enchant is OK; a missing one Fails.
+    if (this.hasEnchant(item)) {
+      return this.hasMaxEnchant(item) ? QualitativePerformance.Perfect : QualitativePerformance.Ok;
+    }
+    return QualitativePerformance.Fail;
+  }
+
+  boxRowTooltip(
+    item: Item,
+    slotName: JSX.Element,
+    recommendedEnchantments: EnchantItem[] | undefined,
+  ) {
+    // Don't nag with "but these are recommended" when the slot already has a top-tier enchant; only
+    // surface the recommended best-in-slot enchant when the slot is missing or under-enchanted.
+    if (this.hasEnchant(item) && this.hasMaxEnchant(item)) {
+      return super.boxRowTooltip(item, slotName, undefined);
+    }
+    return super.boxRowTooltip(item, slotName, recommendedEnchantments);
   }
 }
 


### PR DESCRIPTION
Description

Replaces the outdated Cataclysm enchant data in the Classic `EnchantChecker` with Mists of Pandaria (5.4) data:

- Removes the **Head** slot (MoP has no head enchant; the head only takes a meta gem).
- Recognises the current MoP enchants per slot (sourced from wowsims/mop).
- Grades any top-tier MoP enchant as **Perfect** in the Preparation tab, and only surfaces a recommended best-in-slot enchant on missing/weak slots.

Also adds MoP enchant item definitions under `common/ITEMS/classic` so enchant tooltips resolve names correctly, registers **Xinito** as a contributor, and adds a CHANGELOG entry.

Testing

- Test report URL: `/report/4ynbN7ZwK8fpvxhR/50/47`
  (Warcraft Logs source: https://classic.warcraftlogs.com/reports/4ynbN7ZwK8fpvxhR?fight=50&type=damage-done&source=47)

Screenshot:
<img width="1256" height="442" alt="Screenshot 2026-06-06 232458" src="https://github.com/user-attachments/assets/1c1f9ce1-9d7b-4001-9b20-4d7f7d03818e" />