### PR TITLE
[Mistweaver] Remove JFS and JE from APL

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 6, 11), <>Removed <SpellLink spell={TALENTS_MONK.JADEFIRE_STOMP_TALENT} /> and <SpellLink spell={TALENTS_MONK.JADE_EMPOWERMENT_TALENT} /> from APL checks.</>, swirl),
   change(date(2026, 5, 27), <>Tightened <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> performance criteria.</>, swirl),
   change(date(2026, 5, 18), <>Fixed <SpellLink spell={TALENTS_MONK.VEIL_OF_PRIDE_TALENT} /> correctly evaluating 0-cloud casts.</>, swirl),
   change(date(2026, 5, 16), <>Refreshed UI elements of the performance modules in the Overview tab.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/modules/core/apl/AplCheck.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/apl/AplCheck.tsx
@@ -137,24 +137,7 @@ const commonTop = [
   MANA_TEA_20_STACKS,
 ];
 
-const atMissingCondition = cnd.buffMissing(SPELLS.JT_BUFF, {
-  duration: 15000,
-  timeRemaining: 1500,
-});
-
-const JFS_AT = {
-  spell: talents.JADEFIRE_STOMP_TALENT,
-  condition: atMissingCondition,
-};
-
-const JE_JFS = {
-  spell: SPELLS.CRACKLING_JADE_LIGHTNING,
-  condition: cnd.optionalRule(
-    cnd.and(cnd.buffPresent(SPELLS.JT_BUFF), cnd.buffPresent(SPELLS.JADE_EMPOWERMENT_BUFF)),
-  ),
-};
-
-const RM_AT_CORE = [JE_JFS, ZP_VIVIFY_5_REMS, JFS_AT, VIVIFY_8_REMS];
+const RM_AT_CORE = [ZP_VIVIFY_5_REMS, VIVIFY_8_REMS];
 
 const rotation_rm_at_sg = build([
   {


### PR DESCRIPTION
### Description

Neither Jadefire Stomp as an active ability nor Jadefire Teachings or Jade Empowerment exist as buffs anymore. Removed from APL checks.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/YjnxM1bAwZFm87Jh/9-Mythic++Windrunner+Spire+-+Kill+(31:48)/5-Sazzy/standard`
- Screenshot(s):


Removed:
<img width="695" height="145" alt="image" src="https://github.com/user-attachments/assets/21ce2e15-21e4-4fdb-9825-a5c474075b3a" />
