### PR TITLE
[Devastation] Empower Analyzer

### DIFF
--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import ItemSetLink from 'interface/ItemSetLink';
 import { EVOKER_MID1_ID } from 'common/ITEMS';
 
 export default [
+  change(date(2026, 6, 12), <>Added statistic for tracking empower rank usage.</>, Baumritter),
   change(date(2026, 6, 7), <>Fixed display issues for <SpellLink spell={SPELLS.LEAPING_FLAMES_BUFF} /> </>, Baumritter),
   change(date(2026, 6, 3), <>Updated display of <SpellLink spell={SPELLS.DISINTEGRATE} /> modules</>, Baumritter),
   change(date(2026, 6, 1), <>Updated display of <SpellLink spell={TALENTS.DRAGONRAGE_TALENT} /> module</>, Baumritter),

--- a/src/analysis/retail/evoker/devastation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/devastation/CombatLogParser.ts
@@ -79,6 +79,7 @@ import MID1Devastation2P from './modules/midnight/MID1Devastation2P';
 import MID1Devastation4P from './modules/midnight/MID1Devastation4P';
 import RisingFury from './modules/talents/RisingFury';
 import DragonrageNormalizer from './modules/normalizers/DragonrageNormalizer';
+import EmpowerAnalyzer from '../shared/modules/core/EmpowerAnalyzer';
 
 class CombatLogParser extends MainCombatLogParser {
   static specModules = {
@@ -113,6 +114,7 @@ class CombatLogParser extends MainCombatLogParser {
     // Core
     abilities: Abilities,
     buffs: Buffs,
+    empowerAnalyzer: EmpowerAnalyzer,
 
     // Normalizer
     castLinkNormalizer: CastLinkNormalizer,


### PR DESCRIPTION
### Description

Enabled the EmpowerAnalyzer statistics module for Devastation.
Empower Ranks are about as important on Dev as on Aug so the module is likely gonna be helpful

