### PR TITLE
Add Unbound Flame IDs

### DIFF
--- a/src/analysis/retail/evoker/devastation/modules/Abilities.tsx
+++ b/src/analysis/retail/evoker/devastation/modules/Abilities.tsx
@@ -46,6 +46,15 @@ class Abilities extends CoreAbilities {
         range: BASE_EVOKER_RANGE,
         enabled: combatant.hasTalent(TALENTS.AZURE_SWEEP_TALENT),
       },
+      {
+        spell: SPELLS.UNBOUND_FLAME.id,
+        category: SPELL_CATEGORY.ROTATIONAL,
+        gcd: {
+          base: 1500,
+        },
+        range: BASE_EVOKER_RANGE,
+        enabled: combatant.hasTalent(TALENTS.RISING_FURY_3_DEVASTATION_TALENT),
+      },
       //endregion
       //region Cooldowns
       {

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -829,6 +829,21 @@ const spells = {
     name: 'Magnified Fate',
     icon: 'abilit_evoker_masterylifebinder_black',
   },
+  UNBOUND_FLAME: {
+    id: 1292321,
+    name: 'Unbound Flame',
+    icon: 'inv_ability_flameshaperevoker_engulf',
+  },
+  UNBOUND_FLAME_BUFF: {
+    id: 1292323,
+    name: 'Unbound Flame',
+    icon: 'inv_ability_flameshaperevoker_engulf',
+  },
+  UNBOUND_FLAME_DAMAGE: {
+    id: 1292322,
+    name: 'Unbound Flame',
+    icon: 'inv_ability_flameshaperevoker_engulf',
+  },
   // endregion
 } satisfies Record<string, Spell>;
 


### PR DESCRIPTION
Add cast, damage, and buff IDs for Unbound Flame to `evoker.ts` and `Abilities.tsx`.