### PR TITLE
[Mistweaver] Fix miscounting Lifecycles buffs

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 6, 23), <>Fixed an issue with miscounting crits and wasted stacks of <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> via <SpellLink spell={TALENTS_MONK.LIFECYCLES_TALENT}/>.</>, swirl),
   change(date(2026, 6, 11), <>Removed <SpellLink spell={TALENTS_MONK.JADEFIRE_STOMP_TALENT} /> and <SpellLink spell={TALENTS_MONK.JADE_EMPOWERMENT_TALENT} /> from APL checks.</>, swirl),
   change(date(2026, 5, 27), <>Tightened <SpellLink spell={TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT} /> performance criteria.</>, swirl),
   change(date(2026, 5, 18), <>Fixed <SpellLink spell={TALENTS_MONK.VEIL_OF_PRIDE_TALENT} /> correctly evaluating 0-cloud casts.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ManaTeaSources.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ManaTeaSources.tsx
@@ -3,7 +3,12 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { SpellLink } from 'interface';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { ApplyBuffEvent, ApplyBuffStackEvent, RefreshBuffEvent } from 'parser/core/Events';
+import Events, {
+  ApplyBuffEvent,
+  ApplyBuffStackEvent,
+  RefreshBuffEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
 import DonutChart from 'parser/ui/DonutChart';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -36,6 +41,18 @@ class ManaTeaSources extends Analyzer {
       Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.MANA_TEA_STACK),
       this.onStackWaste,
     );
+    this.addEventListener(
+      Events.removebuff
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.LIFECYCLES_ENVELOPING_MIST_BUFF, SPELLS.LIFECYCLES_VIVIFY_BUFF]),
+      this.onLifecyclesBuffFellOff,
+    );
+    this.addEventListener(
+      Events.refreshbuff
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.LIFECYCLES_ENVELOPING_MIST_BUFF, SPELLS.LIFECYCLES_VIVIFY_BUFF]),
+      this.onLifecyclesBuffFellOff,
+    );
   }
 
   onStackGain(event: ApplyBuffStackEvent | ApplyBuffEvent) {
@@ -43,6 +60,12 @@ class ManaTeaSources extends Analyzer {
       this.lifecyclesStacks.usedStacks += 1;
     } else {
       this.naturalStacks.usedStacks += 1;
+    }
+  }
+
+  onLifecyclesBuffFellOff(event: RemoveBuffEvent | RefreshBuffEvent) {
+    if (!isMTStackFromLifeCycles(event)) {
+      this.lifecyclesStacks.wastedStacks += 1;
     }
   }
 

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -295,7 +295,7 @@ export function getManaTeaChannelDuration(event: ApplyBuffEvent) {
 }
 
 export function isMTStackFromLifeCycles(
-  event: ApplyBuffEvent | RefreshBuffEvent | ApplyBuffStackEvent,
+  event: ApplyBuffEvent | RefreshBuffEvent | ApplyBuffStackEvent | RemoveBuffEvent,
 ) {
   return HasRelatedEvent(event, LIFECYCLES);
 }

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/ManaTeaEventLinks.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/ManaTeaEventLinks.ts
@@ -1,7 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { EventLink } from 'parser/core/EventLinkNormalizer';
-import { EventType } from 'parser/core/Events';
+import { EventType, HasRelatedEvent } from 'parser/core/Events';
 import {
   MANA_TEA_CHANNEL,
   MAX_MT_CHANNEL,
@@ -70,8 +70,15 @@ export const MANA_TEA_EVENT_LINKS: EventLink[] = [
     linkingEventType: EventType.RemoveBuff,
     referencedEventId: SPELLS.MANA_TEA_STACK.id,
     referencedEventType: [EventType.ApplyBuffStack, EventType.ApplyBuff, EventType.RefreshBuff],
-    forwardBufferMs: MAX_MT_CHANNEL,
-    maximumLinks: 1,
+    backwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 2,
+    additionalCondition(linkingEvent, referencedEvent) {
+      // a refresh-only event (no stack change) only counts if mana tea didn't actually gain a stack here
+      return (
+        referencedEvent.type !== EventType.RefreshBuff ||
+        !HasRelatedEvent(referencedEvent, MT_STACK_CHANGE)
+      );
+    },
     isActive(c) {
       return c.hasTalent(TALENTS_MONK.LIFECYCLES_TALENT);
     },


### PR DESCRIPTION
### Description

Lifecycles order of events seems to have changed since its initial implementation - mana tea stack gain is prior to lifecycles buff removal, thus the forward buffer wasn't effective here (not sure why it was set to MAX_MT_CHANNEL anyways) and miscounting buffs attributed to it negatively. Similarly, we should count a max of 2 BuffStack events here, as Lifecycles can crit, and those shouldn't be attributed to mana tea its' self.

Added an exclusion of RefreshBuff events for those that have an accompanying BuffStack event, since ones that _only_ have RefreshBuff are essentially capped at 20 mana tea stacks, and wasting your stack usage. 

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `http://localhost:3000/report/B8VwcqFbZvDKaHrC/6-Mythic+Lightblinded+Vanguard+-+Wipe+4+(5:39)/20-Popimonk/standard/about`
- Screenshot(s):
- 
<img width="550" height="484" alt="image" src="https://github.com/user-attachments/assets/498bd9de-ff2b-4821-9ed9-adf858547485" />
<img width="556" height="467" alt="image" src="https://github.com/user-attachments/assets/33b27758-4452-4e18-88b0-d70b5adc796d" />

