### PR TITLE
Add inaccuracy warnings for certain specs.

### DIFF
--- a/src/analysis/retail/evoker/augmentation/modules/midnight/MID2Augmentation4P.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/midnight/MID2Augmentation4P.tsx
@@ -3,7 +3,7 @@ import TALENTS from 'common/TALENTS/evoker';
 
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
-import Events, { DamageEvent } from 'parser/core/Events';
+import Events, { ApplyBuffEvent, DamageEvent } from 'parser/core/Events';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import { MID2_AUGMENTATION_4PC_DAMAGE_MULTIPLIER } from '../../constants';
 
@@ -13,12 +13,20 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { TIERS } from 'game/TIERS';
 import { formatNumber } from 'common/format';
 import SpellLink from 'interface/SpellLink';
+import SPECS from 'game/SPECS';
+import Combatants from 'parser/shared/modules/Combatants';
 
 /**
  * (4) Set Augmentation: Upheaval increases the damage and healing dealt by Fate Mirror by 200% for 8 sec.
  */
 class MID2Augmentation4P extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+  };
+  protected combatants!: Combatants;
   extraDamage = 0;
+  hasReceivedExternalPrescience = false;
+  retHasTriggeredFateMirror = false;
 
   constructor(options: Options) {
     super(options);
@@ -28,11 +36,38 @@ class MID2Augmentation4P extends Analyzer {
       this.onDamage,
       // Healing not included as Prescience will usually be going on DPS.
     );
+
+    this.addEventListener(
+      Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.PRESCIENCE_BUFF),
+      this.onReceiveBuff,
+    );
   }
 
   onDamage(event: DamageEvent) {
     if (this.selectedCombatant.hasBuff(SPELLS.MAGNIFIED_FATE_BUFF.id)) {
+      const playerId = event.supportID ? event.supportID : event.sourceID;
+      if (
+        this.hasReceivedExternalPrescience &&
+        playerId === this.selectedCombatant.id &&
+        !this.selectedCombatant.hasOwnBuff(SPELLS.PRESCIENCE_BUFF.id)
+      ) {
+        // This damage belongs to another Aug, ignore it
+        return;
+      } else if (
+        event.supportID &&
+        this.combatants.players[event.supportID].spec === SPECS.RETRIBUTION_PALADIN
+      ) {
+        // This might come from Execution Sentence, which over-attributes
+        this.retHasTriggeredFateMirror = true;
+      }
+
       this.extraDamage += calculateEffectiveDamage(event, MID2_AUGMENTATION_4PC_DAMAGE_MULTIPLIER);
+    }
+  }
+
+  onReceiveBuff(event: ApplyBuffEvent) {
+    if (event.sourceID != this.owner.selectedCombatant.id) {
+      this.hasReceivedExternalPrescience = true;
     }
   }
 
@@ -45,6 +80,19 @@ class MID2Augmentation4P extends Analyzer {
         tooltip={
           <>
             <li>Damage: {formatNumber(this.extraDamage)}</li>
+            {this.hasReceivedExternalPrescience && (
+              <li>
+                You received {<SpellLink spell={TALENTS.PRESCIENCE_TALENT} />} from another Evoker,
+                which can cause these damage numbers to be too large.
+              </li>
+            )}
+            {this.retHasTriggeredFateMirror && (
+              <li>
+                A Retribution Paladin triggered your{' '}
+                {<SpellLink spell={TALENTS.FATE_MIRROR_TALENT} />}, which can cause these numbers to
+                be too large.
+              </li>
+            )}
           </>
         }
       >

--- a/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/MightyInferno.tsx
@@ -23,6 +23,8 @@ import TALENTS from 'common/TALENTS/evoker';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import { InformationIcon } from 'interface/icons';
 import { SpellLink } from 'interface/index';
+import SPECS from 'game/SPECS';
+import Combatants from 'parser/shared/modules/Combatants';
 
 interface infernoApplication {
   playerID: number;
@@ -35,14 +37,17 @@ interface infernoApplication {
 class MightyInferno extends Analyzer {
   static dependencies = {
     stats: StatTracker,
+    combatants: Combatants,
   };
   protected stats!: StatTracker;
+  protected combatants!: Combatants;
   ampedDamage = 0;
   extensionDamage = 0;
   infernoApps: infernoApplication[] = [];
   totalInfernosExtension = 0;
-  // This can mess with the results.
+  // These can mess with the results.
   hasReceivedExternalInfernos = false;
+  retHasTriggeredInfernos = false;
 
   constructor(options: Options) {
     super(options);
@@ -80,9 +85,16 @@ class MightyInferno extends Analyzer {
       playerId === this.selectedCombatant.id &&
       !this.selectedCombatant.hasOwnBuff(SPELLS.INFERNOS_BLESSING_BUFF.id)
     ) {
-      // This damage belongs to another Aug
+      // This damage belongs to another Aug, ignore it
       return;
+    } else if (
+      event.supportID &&
+      this.combatants.players[event.supportID].spec === SPECS.RETRIBUTION_PALADIN
+    ) {
+      // This might come from Execution Sentence, which over-attributes
+      this.retHasTriggeredInfernos = true;
     }
+
     const ampDamage = calculateEffectiveDamage(event, MIGHTY_INFERNO_DAMAGE_MULTIPLIER);
     this.ampedDamage += ampDamage;
     const index = this.infernoApps.findIndex((app) => app.playerID === playerId);
@@ -155,6 +167,13 @@ class MightyInferno extends Analyzer {
               <li>
                 You received {<SpellLink spell={TALENTS.INFERNOS_BLESSING_TALENT} />} from another
                 Evoker, which can cause these damage numbers to be too large.
+              </li>
+            )}
+            {this.retHasTriggeredInfernos && (
+              <li>
+                A Retribution Paladin triggered your{' '}
+                {<SpellLink spell={TALENTS.INFERNOS_BLESSING_TALENT} />}, which can cause these
+                numbers to be too large.
               </li>
             )}
           </>


### PR DESCRIPTION
The tier set module, like Mighty Inferno, can be inaccurate if the player has their own Prescience buff and also another player's Prescience buff, when Fate Mirror triggers from them personally and Magnified Fate is active.

Both tier set and Mighty Inferno can be inaccurate on Ret Paladins due to Execution Sentence over-attributing Fate Mirror and Inferno's Blessing. This appears to be the only current case in game of another ability attributing those abilities at all.