### PR TITLE
Update Chrono modules, crit tracker, and support heal events

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/augmentation/CombatLogParser.ts
@@ -27,6 +27,7 @@ import Duplicate from './modules/talents/Duplicate';
 import MightyInferno from './modules/talents/MightyInferno';
 import DoubleTime from './modules/talents/DoubleTime';
 import NozdormuAdept from './modules/talents/NozdormuAdept';
+import GoldenOpportunity from './modules/talents/GoldenOpportunity';
 
 import BuffTrackerGraph from './modules/features/BuffTrackerGraph';
 import BlisteringScalesGraph from './modules/talents/BlisteringScalesGraph';
@@ -73,7 +74,6 @@ import {
   Reverberations,
   Primacy,
   TimeConvergence,
-  GoldenOpportunity,
   MotesOfAcceleration,
   TimeSpiral,
   RefinedEssence,

--- a/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/evoker/augmentation/modules/normalizers/CastLinkNormalizer.ts
@@ -61,6 +61,8 @@ const DREAM_ESSENCE_BURST_CONSUME = 'dreamEssenceBurstConsume';
 export const EMPOWER_SANDS_APPLY = 'empowerSandsApply';
 export const FIRE_BREATH_INFERNOS_APPLY = 'fireBreathInfernosApply';
 export const EMERALD_BLOSSOM_SYMBIOTIC_APPLY = 'emeraldBlossomSymbioticApply';
+const EBON_MIGHT_DOUBLE_TIME_APPLY = 'ebonMightDoubleTimeApply';
+const EONS_DOUBLE_TIME_APPLY = 'eonsDoubleTimeApply';
 
 const PRESCIENCE_BUFFER = 150;
 const CAST_BUFFER_MS = 100;
@@ -425,6 +427,34 @@ const EVENT_LINKS: EventLink[] = [
     isActive: (C) => C.hasTalent(TALENTS.SYMBIOTIC_BLOOM_TALENT),
     maximumLinks: 1,
   },
+  {
+    linkRelation: EBON_MIGHT_DOUBLE_TIME_APPLY,
+    reverseLinkRelation: EBON_MIGHT_DOUBLE_TIME_APPLY,
+    linkingEventId: TALENTS.EBON_MIGHT_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.DOUBLE_TIME_EBON_MIGHT_BUFF.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    anyTarget: true,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    isActive: (C) => C.hasTalent(TALENTS.DOUBLE_TIME_TALENT),
+    maximumLinks: 1,
+  },
+  {
+    linkRelation: EONS_DOUBLE_TIME_APPLY,
+    reverseLinkRelation: EONS_DOUBLE_TIME_APPLY,
+    linkingEventId: TALENTS.BREATH_OF_EONS_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.DOUBLE_TIME_EBON_MIGHT_BUFF.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+    anyTarget: true,
+    forwardBufferMs: BREATH_EBON_BUFFER,
+    isActive: (C) => C.hasTalent(TALENTS.DOUBLE_TIME_TALENT),
+    maximumLinks: 1,
+    additionalCondition(_linkingEvent, referencedEvent) {
+      return !HasRelatedEvent(referencedEvent, EBON_MIGHT_DOUBLE_TIME_APPLY);
+    },
+  },
 ];
 
 class CastLinkNormalizer extends EventLinkNormalizer {
@@ -546,6 +576,13 @@ export function dreamConsumedEssenceBurst(event: CastEvent) {
 
 export function hasEruptionCastLink(event: DamageEvent) {
   return HasRelatedEvent(event, ERUPTION_CAST_DAM_LINK);
+}
+
+export function proccedDoubleTime(event: CastEvent) {
+  return (
+    HasRelatedEvent(event, EBON_MIGHT_DOUBLE_TIME_APPLY) ||
+    HasRelatedEvent(event, EONS_DOUBLE_TIME_APPLY)
+  );
 }
 
 export default CastLinkNormalizer;

--- a/src/analysis/retail/evoker/augmentation/modules/talents/DoubleTime.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/DoubleTime.tsx
@@ -10,17 +10,24 @@ import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import { DOUBLE_TIME_EBON_MIGHT_MULTIPLIER } from 'analysis/retail/evoker/augmentation/constants';
 import { formatNumber, formatPercentage } from 'common/format';
 import TALENTS from 'common/TALENTS/evoker';
-import { proccedDoubleTime } from '../normalizers/CastLinkNormalizer';
+import { ebonIsFromBreath, proccedDoubleTime } from '../normalizers/CastLinkNormalizer';
 import { InformationIcon } from 'interface/icons';
+import { plotOneVariableBinomChart } from 'parser/shared/modules/helpers/Probability';
+import StatTracker from 'parser/shared/modules/StatTracker';
 
 /**
  * Applying Ebon Might has a chance equal to your critical strike chance to grant 50% additional Ebon Might stats for 15 sec.
  * Hardcast Prescience has a chance equal to your critical strike chance to grant 1.5x the normal critical strike chance for 15 sec. [Not trackable]
  */
 class DoubleTime extends Analyzer {
+  static dependencies = {
+    stats: StatTracker,
+  };
+  protected stats!: StatTracker;
   damage = 0;
   procAttempts = 0;
   actualProcs = 0;
+  critChances: number[] = [];
 
   constructor(options: Options) {
     super(options);
@@ -51,13 +58,15 @@ class DoubleTime extends Analyzer {
 
   onEbonCast(event: CastEvent) {
     this.procAttempts++;
+    this.critChances.push(this.stats.currentCritPercentage);
     if (proccedDoubleTime(event)) {
       this.actualProcs++;
     }
   }
 
   onEonsCast(event: CastEvent) {
-    if (!this.selectedCombatant.hasBuff(SPELLS.DOUBLE_TIME_EBON_MIGHT_BUFF.id)) {
+    if (ebonIsFromBreath(event)) {
+      this.critChances.push(this.stats.currentCritPercentage);
       this.procAttempts++;
       if (proccedDoubleTime(event)) {
         this.actualProcs++;
@@ -66,7 +75,7 @@ class DoubleTime extends Analyzer {
   }
 
   statistic() {
-    const procRate = this.actualProcs / (this.actualProcs + this.procAttempts);
+    const procRate = this.actualProcs / this.procAttempts;
     return (
       <Statistic
         position={STATISTIC_ORDER.CORE(13)}
@@ -87,6 +96,8 @@ class DoubleTime extends Analyzer {
             <InformationIcon /> {formatPercentage(procRate, 0)}%<small> proc rate</small>
           </div>
         </TalentSpellText>
+
+        {plotOneVariableBinomChart(this.actualProcs, this.procAttempts, this.critChances)}
       </Statistic>
     );
   }

--- a/src/analysis/retail/evoker/augmentation/modules/talents/DoubleTime.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/DoubleTime.tsx
@@ -1,5 +1,5 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent } from 'parser/core/Events';
+import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
@@ -8,8 +8,10 @@ import TalentSpellText from 'parser/ui/TalentSpellText';
 import SPELLS from 'common/SPELLS';
 import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 import { DOUBLE_TIME_EBON_MIGHT_MULTIPLIER } from 'analysis/retail/evoker/augmentation/constants';
-import { formatNumber } from 'common/format';
+import { formatNumber, formatPercentage } from 'common/format';
 import TALENTS from 'common/TALENTS/evoker';
+import { proccedDoubleTime } from '../normalizers/CastLinkNormalizer';
+import { InformationIcon } from 'interface/icons';
 
 /**
  * Applying Ebon Might has a chance equal to your critical strike chance to grant 50% additional Ebon Might stats for 15 sec.
@@ -17,6 +19,8 @@ import TALENTS from 'common/TALENTS/evoker';
  */
 class DoubleTime extends Analyzer {
   damage = 0;
+  procAttempts = 0;
+  actualProcs = 0;
 
   constructor(options: Options) {
     super(options);
@@ -27,6 +31,16 @@ class DoubleTime extends Analyzer {
       this.onDamage,
       // Healing not included as effect is negligible with Ebon Might no longer buffing healers
     );
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.EBON_MIGHT_TALENT),
+      this.onEbonCast,
+    );
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.BREATH_OF_EONS_TALENT),
+      this.onEonsCast,
+    );
   }
 
   onDamage(event: DamageEvent) {
@@ -35,7 +49,24 @@ class DoubleTime extends Analyzer {
     }
   }
 
+  onEbonCast(event: CastEvent) {
+    this.procAttempts++;
+    if (proccedDoubleTime(event)) {
+      this.actualProcs++;
+    }
+  }
+
+  onEonsCast(event: CastEvent) {
+    if (!this.selectedCombatant.hasBuff(SPELLS.DOUBLE_TIME_EBON_MIGHT_BUFF.id)) {
+      this.procAttempts++;
+      if (proccedDoubleTime(event)) {
+        this.actualProcs++;
+      }
+    }
+  }
+
   statistic() {
+    const procRate = this.actualProcs / (this.actualProcs + this.procAttempts);
     return (
       <Statistic
         position={STATISTIC_ORDER.CORE(13)}
@@ -44,12 +75,17 @@ class DoubleTime extends Analyzer {
         tooltip={
           <>
             <li>Ebon Might damage: {formatNumber(this.damage)}</li>
-            <li>Prescience damage is not trackable on logs.</li>
+            <li>Ebon Might Double-time procs: {formatNumber(this.actualProcs)}</li>
+            <li>Ebon Might Double-time attempts: {formatNumber(this.procAttempts)}</li>
+            <li>Prescience damage and procs are not trackable on logs.</li>
           </>
         }
       >
         <TalentSpellText talent={TALENTS.DOUBLE_TIME_TALENT}>
           <ItemDamageDone amount={this.damage} />
+          <div>
+            <InformationIcon /> {formatPercentage(procRate, 0)}%<small> proc rate</small>
+          </div>
         </TalentSpellText>
       </Statistic>
     );

--- a/src/analysis/retail/evoker/augmentation/modules/talents/GoldenOpportunity.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/GoldenOpportunity.tsx
@@ -21,8 +21,7 @@ import StatTracker from 'parser/shared/modules/StatTracker';
 import { InformationIcon } from 'interface/icons';
 
 /**
- * Aug: Prescience lasts 15% longer.
- * Pres [NYI]: Echo copies 10% more healing.
+ * Prescience lasts 15% longer.
  */
 class GoldenOpportunity extends Analyzer {
   static dependencies = {
@@ -114,7 +113,7 @@ class GoldenOpportunity extends Analyzer {
         <TalentSpellText talent={TALENTS_EVOKER.GOLDEN_OPPORTUNITY_TALENT}>
           <div>
             <InformationIcon /> {formatNumber(this.totalPrescienceExtension)} sec
-            <small> extra duration granted</small>
+            <small> extra duration</small>
           </div>
         </TalentSpellText>
       </Statistic>

--- a/src/analysis/retail/evoker/shared/index.ts
+++ b/src/analysis/retail/evoker/shared/index.ts
@@ -31,7 +31,6 @@ export { default as Chronoflame } from './modules/talents/hero/chronowarden/Chro
 export { default as Reverberations } from './modules/talents/hero/chronowarden/Reverberations';
 export { default as Primacy } from './modules/talents/hero/chronowarden/Primacy';
 export { default as TimeConvergence } from './modules/talents/hero/chronowarden/TimeConvergence';
-export { default as GoldenOpportunity } from './modules/talents/hero/chronowarden/GoldenOpportunity';
 export { default as MotesOfAcceleration } from './modules/talents/hero/chronowarden/MotesOfAcceleration';
 export { default as RefinedEssence } from './modules/talents/hero/scalecommander/RefinedEssence';
 export { default as CommandSquadron } from './modules/talents/hero/scalecommander/CommandSquadron';

--- a/src/analysis/retail/evoker/shared/modules/talents/hero/chronowarden/ChronalDynamo.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/hero/chronowarden/ChronalDynamo.tsx
@@ -1,5 +1,6 @@
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { DamageEvent, HealEvent } from 'parser/core/Events';
+// Add HealEvent import when updating for Pres
+import Events, { DamageEvent } from 'parser/core/Events';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import Statistic from 'parser/ui/Statistic';
@@ -11,7 +12,8 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPECS from 'game/SPECS';
 import { isFromAfterimageDamage } from '../../../normalizers/ChronowardenCastLinkNormalizer';
 import { CHRONAL_DYNAMO_MULTIPLIER } from 'analysis/retail/evoker/shared';
-import { calculateEffectiveDamage, calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
+// Add CalculateEffectiveHealing import when updating for Pres
+import { calculateEffectiveDamage } from 'parser/core/EventCalculateLib';
 
 /**
  * The cast time of Chrono Flames is reduced by 10%.
@@ -25,16 +27,7 @@ class ChronalDynamo extends Analyzer {
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.CHRONAL_DYNAMO_TALENT);
-    if (this.owner.selectedCombatant.specId === SPECS.AUGMENTATION_EVOKER.id) {
-      // As Echo and Lifespark do not exist for Aug, and it has no healing empowers,
-      // no checks are needed for healing events.
-      // Rather than check the player's spec on each event, we can just call a different
-      // handler for heal events depending on spec.
-      this.addEventListener(
-        Events.heal.by(SELECTED_PLAYER).spell(SPELLS.LIVING_FLAME_HEAL),
-        this.onHealAug,
-      );
-    }
+    // Healing handler removed for Aug as not useful info
     // Needs a separate damage handler for Preservation with Lifespark [NYI]
     if (!this.selectedCombatant.hasTalent(TALENTS.LIFESPARK_TALENT)) {
       this.addEventListener(
@@ -42,10 +35,6 @@ class ChronalDynamo extends Analyzer {
         this.onDamageNoLifespark,
       );
     }
-  }
-
-  onHealAug(event: HealEvent) {
-    this.chronalDynamoHealing += calculateEffectiveHealing(event, CHRONAL_DYNAMO_MULTIPLIER);
   }
 
   onDamageNoLifespark(event: DamageEvent) {
@@ -63,11 +52,13 @@ class ChronalDynamo extends Analyzer {
         category={STATISTIC_CATEGORY.HERO_TALENTS}
       >
         <TalentSpellText talent={TALENTS.CHRONAL_DYNAMO_TALENT}>
+          {this.owner.selectedCombatant.specId === SPECS.PRESERVATION_EVOKER.id && (
+            <div>
+              <ItemHealingDone amount={this.chronalDynamoHealing} />
+            </div>
+          )}
           <div>
             <ItemDamageDone amount={this.chronalDynamoDamage} />
-          </div>
-          <div>
-            <ItemHealingDone amount={this.chronalDynamoHealing} />
           </div>
         </TalentSpellText>
       </Statistic>

--- a/src/analysis/retail/evoker/shared/modules/talents/hero/chronowarden/Chronoflame.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/hero/chronowarden/Chronoflame.tsx
@@ -8,6 +8,7 @@ import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import { TALENTS_EVOKER } from 'common/TALENTS';
 import TalentSpellText from 'parser/ui/TalentSpellText';
 import SPELLS from 'common/SPELLS';
+import SPECS from 'game/SPECS';
 
 class Chronoflame extends Analyzer {
   chronoflameHealing = 0;
@@ -16,10 +17,13 @@ class Chronoflame extends Analyzer {
   constructor(options: Options) {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS_EVOKER.CHRONO_FLAME_TALENT);
-    this.addEventListener(
-      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.CHRONO_FLAME_HEAL),
-      this.onChronoHeal,
-    );
+    if (this.owner.selectedCombatant.specId === SPECS.PRESERVATION_EVOKER.id) {
+      // Don't include healing for Aug as not useful info
+      this.addEventListener(
+        Events.heal.by(SELECTED_PLAYER).spell(SPELLS.CHRONO_FLAME_HEAL),
+        this.onChronoHeal,
+      );
+    }
     this.addEventListener(
       Events.damage.by(SELECTED_PLAYER).spell(SPELLS.CHRONO_FLAME_DAMAGE),
       this.onChronoDamage,
@@ -42,11 +46,13 @@ class Chronoflame extends Analyzer {
         category={STATISTIC_CATEGORY.HERO_TALENTS}
       >
         <TalentSpellText talent={TALENTS_EVOKER.CHRONO_FLAME_TALENT}>
+          {this.owner.selectedCombatant.specId === SPECS.PRESERVATION_EVOKER.id && (
+            <div>
+              <ItemHealingDone amount={this.chronoflameHealing} />
+            </div>
+          )}
           <div>
             <ItemDamageDone amount={this.chronoflameDamage} />
-          </div>
-          <div>
-            <ItemHealingDone amount={this.chronoflameHealing} />
           </div>
         </TalentSpellText>
       </Statistic>

--- a/src/common/ITEMS/midnight/trinkets.ts
+++ b/src/common/ITEMS/midnight/trinkets.ts
@@ -11,6 +11,11 @@ const trinkets = {
     name: 'Light of the Cosmic Crescendo',
     icon: 'inv_12_trinket_raid_darkwelle_healer3_cosmiccrescendo',
   },
+  FREIGHTRUNNERS_FLASK: {
+    id: 250215,
+    name: 'Freightrunners Flask',
+    icon: 'inv_alchemy_90_flask_red',
+  },
 } satisfies Record<string, Item>;
 
 export default trinkets;

--- a/src/common/SPELLS/midnight/trinkets.ts
+++ b/src/common/SPELLS/midnight/trinkets.ts
@@ -26,6 +26,11 @@ const spells = {
     name: 'Fanatical Inspiration',
     icon: 'inv_12_trinket_gloriuscrusaderskeepsake',
   },
+  FREIGHTRUNNERS_FLASK: {
+    id: 1250533,
+    name: 'Freightrunners Flask',
+    icon: 'inv_alchemy_90_flask_red',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/parser/core/Events.ts
+++ b/src/parser/core/Events.ts
@@ -547,6 +547,8 @@ export interface HealEvent extends Event<EventType.Heal> {
   mapID: number;
   /** The Item level of the target */
   itemLevel: number;
+  subtractsFromSupportedActor?: boolean;
+  supportID?: number;
 }
 
 export interface BeaconHealEvent extends Omit<HealEvent, 'type'> {

--- a/src/parser/shared/modules/StatTracker.ts
+++ b/src/parser/shared/modules/StatTracker.ts
@@ -67,6 +67,7 @@ class StatTracker extends Analyzer {
     //region Phials
     // TODO: Figure out how to make this work with multiple ranks of phials
     [SPELLS.FLASK_OF_THE_BLOOD_KNIGHTS.id]: { haste: 152 },
+    [SPELLS.FLASK_OF_THE_SHATTERED_SUN.id]: { crit: 165 },
     // endregion
 
     //region Food
@@ -93,6 +94,11 @@ class StatTracker extends Analyzer {
       itemId: ITEMS.QUICKWICK_CANDLESTICK.id,
       haste: (selectedCombatant, item) =>
         calculateSecondaryStatDefault(400, 2365, item?.itemLevel ?? selectedCombatant.ilvl),
+    },
+    [SPELLS.FREIGHTRUNNERS_FLASK.id]: {
+      itemId: ITEMS.FREIGHTRUNNERS_FLASK.id,
+      crit: (selectedCombatant, item) =>
+        calculateSecondaryStatDefault(289, 531, item?.itemLevel ?? selectedCombatant.ilvl),
     },
     // endregion
 


### PR DESCRIPTION
Segregates another Chronowarden module which shares no functionality between specs. Updates Double-time module for Aug.
Adds a buff to the crit tracker as this is used for the new Double-time module.
After checking with Voll, add support info to heal events, as this appears to be a case of just copying the same flags over from damage events.