### PR TITLE
[Beast Mastery] Fix Wild Thrash not having a GCD/cooldown entry on th…

### DIFF
--- a/src/analysis/retail/hunter/beastmastery/modules/Abilities.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/Abilities.tsx
@@ -42,6 +42,15 @@ class Abilities extends CoreAbilities {
         },
       },
       {
+        spell: TALENTS.WILD_THRASH_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.WILD_THRASH_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: 8,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
         spell: TALENTS.BARBED_SHOT_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.BARBED_SHOT_TALENT),
         category: SPELL_CATEGORY.ROTATIONAL,


### PR DESCRIPTION
### Description

Fix Wild Thrash not being treated as having a GCD or CD in the Timeline, making reviewing BM Hunter AoE rotations very difficult.

### Testing

- Test report URL: reports/a:M4QL9vW1N7PwTzgV/?fight=1&source=2&type=damage-done
- Screenshot(s): 

Before: https://cdn.discordapp.com/attachments/1180513280867971079/1524725542878842880/image.png?ex=6a50cad1&is=6a4f7951&hm=bef242a2bdfe90d07cafe121673c92b5e65319e67b5bfe97482e902ced34773c&
After: https://vlkjthxts7tpcf.is-ne.at/7JLKX0rix
