### PR TITLE
Frost Mage: bump patch compatibility to 12.0.7

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -3072,3 +3072,8 @@ export const Azortharion: Contributor = {
     'Icy-Veins BM Guide': 'https://www.icy-veins.com/wow/beast-mastery-hunter-pve-dps-guide',
   },
 };
+
+export const KushGene: Contributor = {
+  nickname: 'KushGene',
+  github: 'KushGene',
+};

--- a/src/analysis/retail/mage/frost/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/frost/CHANGELOG.tsx
@@ -1,8 +1,9 @@
 import { change, date } from 'common/changelog';
-import { Sharrq, Earosselot, Dambroda } from 'CONTRIBUTORS';
+import { Sharrq, Earosselot, Dambroda, KushGene } from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2026, 7, 25), <>Bumped patch compatibility to 12.0.7. No spell changes were needed for Frost Mage this patch.</>, KushGene),
   change(date(2026, 3, 29), <>Updated feedback for Ice Lance and Flurry usage. Added Glaciate and Spellfrost Teachings CDR statistics.</>, Dambroda),
   change(date(2026, 3, 6), <>Removed myself as a maintainer.</>, Sharrq),
   change(date(2026, 2, 22), <>Ray of Frost update.</>, Earosselot),

--- a/src/analysis/retail/mage/frost/CONFIG.tsx
+++ b/src/analysis/retail/mage/frost/CONFIG.tsx
@@ -9,7 +9,7 @@ const config: Config = {
   contributors: [Earosselot],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.0',
+  patchCompatibility: '12.0.7',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more. If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (


### PR DESCRIPTION
## Summary

Frost Mage was the only Mage spec still at `12.0.0` and was skipped by `976350b` (which bumped all 12.0.5 specs to 12.0.7).

## Verification

**No spell, talent, defensive or utility data changes needed** — verified against Icy Veins, Method and Wowhead, which all independently confirm Frost Mage received no direct changes in 12.0.7. Cross-checked against Wowhead:

- `Ray of Frost` (205021): 60s CD, 8 Freezing stacks over the channel — matches `RayOfFrost.tsx` (`hits === 8`) and `Abilities.tsx` (`cooldown: 60`)
- `Frozen Orb` (84714): 60s CD, instant — matches `Abilities.tsx`
- Talent IDs already regenerated in `ac6ec09c` for 12.0.7
- Shared defensives (`IceBlock`, `IceCold`, `ElementalBarrier`) reference current talent IDs

## Out of scope

The only Frost Mage hotfix in the 12.0.7 cycle (June 30, 2026) was PvP-only:

> Ray of Frost damage decreased by 20% in PvP combat. All damage increased 3% in PvP combat.


## Changes

- `src/analysis/retail/mage/frost/CONFIG.tsx`: `patchCompatibility` `12.0.0` → `12.0.7`
- `src/analysis/retail/mage/frost/CHANGELOG.tsx`: added changelog entry
- `src/CONTRIBUTORS.ts`: added `KushGene` contributor entry