### PR TITLE
Fix logs from previous patches showing up as previous expansion

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -37,12 +37,14 @@ import {
   Ateis,
   Xinito,
   Darkfrog,
+  Texleretour
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 7, 27), 'Fix reports from previous patches being displayed as from a previous expansion.', Texleretour),
   change(date(2026, 7, 9), 'Add support for spell category filtering on the timeline tab.', Putro),
   change(date(2026, 6, 19), 'Update shared Classic Death Knight enchant checking and gear data to support Frost and Unholy.', Darkfrog),
   change(date(2026, 6, 6), 'Update the Classic (Mists of Pandaria) enchant checker: drop the Head slot (MoP has no head enchant), recognise current MoP enchants, and grade top-tier enchants as Perfect in the Preparation tab.', Xinito),

--- a/src/interface/report/PATCHES.ts
+++ b/src/interface/report/PATCHES.ts
@@ -26,11 +26,19 @@ const PATCHES: Patch[] = [
     expansion: Expansion.Midnight,
   },
   {
-    name: '12.0.1',
-    timestamp: 1772496000000, // Tue, Mar 3, 2026 at 01:00:00 UTC+01:00
+    name: '12.0.5',
+    timestamp: 1776808800000, // Wed Apr 3, 2026 at 22:00:00 UTC
     urlPrefix: '',
-    isCurrent: true,
-    gameVersion: 1, // retail
+    isCurrent: false,
+    gameVersion: 1,
+    expansion: Expansion.Midnight,
+  },
+  {
+    name: '12.0.1',
+    timestamp: 1772496000000, // Tue Mar 3, 2026 at 01:00:00 UTC+01:00
+    urlPrefix: '',
+    isCurrent: false,
+    gameVersion: 1,
     expansion: Expansion.Midnight,
   },
   {

--- a/src/interface/report/PATCHES.ts
+++ b/src/interface/report/PATCHES.ts
@@ -23,7 +23,15 @@ const PATCHES: Patch[] = [
     urlPrefix: '',
     isCurrent: true,
     gameVersion: 1, // retail
-    expansion: Expansion.TheWarWithin,
+    expansion: Expansion.Midnight,
+  },
+  {
+    name: '12.0.1',
+    timestamp: 1772496000000, // Tue, Mar 3, 2026 at 01:00:00 UTC+01:00
+    urlPrefix: '',
+    isCurrent: true,
+    gameVersion: 1, // retail
+    expansion: Expansion.Midnight,
   },
   {
     name: '5.5.0',

--- a/src/interface/report/PATCHES.ts
+++ b/src/interface/report/PATCHES.ts
@@ -27,7 +27,7 @@ const PATCHES: Patch[] = [
   },
   {
     name: '12.0.5',
-    timestamp: 1776808800000, // Wed Apr 3, 2026 at 22:00:00 UTC
+    timestamp: 1776780000000, // GMT: Tue Apr 21, 2026 at 14:00:00 GMT+0000
     urlPrefix: '',
     isCurrent: false,
     gameVersion: 1,
@@ -35,7 +35,7 @@ const PATCHES: Patch[] = [
   },
   {
     name: '12.0.1',
-    timestamp: 1772496000000, // Tue Mar 3, 2026 at 01:00:00 UTC+01:00
+    timestamp: 1772496000000, // GMT: Tue Mar 3, 2026 at 0:00:00 GMT+0000
     urlPrefix: '',
     isCurrent: false,
     gameVersion: 1,


### PR DESCRIPTION
### Description

Since #7971, Midnight reports from before 12.0.7 show up as part of a previous expansion.
This PR fixes it by adding the 12.0.1 patch in PATCHES.ts, as a safegaurd if the log is older than current patch.
I'm not so sure about the timestamp.

### Testing
This log shows the previous expansion alert on live: /report/DcAZhjG6gfFKtyNR/33-Mythic+Lightblinded+Vanguard+-+Kill+(7:17)/8-Eisenpelz/standard/overview
