### PR TITLE
fix page crash in tooltip handling of MitigationSegments

### DIFF
--- a/src/interface/guide/components/MajorDefensives/MitigationSegments.tsx
+++ b/src/interface/guide/components/MajorDefensives/MitigationSegments.tsx
@@ -37,6 +37,7 @@ export const MitigationTooltipSegment = ({
 
   return (
     <div
+      ref={innerRef}
       {...rest}
       className={clsx(styles.MitigationTooltipSegment, className)}
       style={{ width: actualWidth, '--color': color }}


### PR DESCRIPTION
the `innerRef` was being passed into it as required, but not supplied as an argument

testable in the Death Strike Usage section of this page: http://localhost:3000/report/BGdPxwYt6fcA8qmD/3-Mythic++Windrunner+Spire+-+Kill+(21:16)/1-Jerrila/standard/overview
<img width="725" height="160" alt="image" src="https://github.com/user-attachments/assets/f81aa958-51c6-44f4-9c75-6c100bafb494" />
