### PR TITLE
[Affliction Warlock] - Haunt baseline damage increase update, 12.1 update

### DIFF
--- a/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 
 export default [
+  change(date(2026, 8, 15), "Update Haunt baseline percent increase, update Compatibility for 12.1.0", Katorri),
   change(date(2026, 5, 31), "Add Always Be Casting guide section; adjust DoT Uptimes guide section; add contextual tip to UA uptime section for cleave/AoE fights; register SiphonLife analyzer and correct damage bonus from 20% to 30%; remove outdated Darkglare dot extension tracking.", Katorri),
   change(date(2026, 4, 21), "Spec compatibility updated for 12.0.5", Katorri),
   change(date(2026, 3, 22), <>Created an analyzer for the cooldown reduction on <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> based on <SpellLink spell={TALENTS.CULL_THE_WEAK_TALENT} />.</>, Katorri),

--- a/src/analysis/retail/warlock/affliction/CONFIG.tsx
+++ b/src/analysis/retail/warlock/affliction/CONFIG.tsx
@@ -11,7 +11,7 @@ const CONFIG: Config = {
   contributors: [Katorri],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.7',
+  patchCompatibility: '12.1.0',
   supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/warlock/affliction/modules/analyzers/Haunt.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/analyzers/Haunt.tsx
@@ -24,7 +24,7 @@ class Haunt extends Analyzer {
   }
 
   get hauntDamageBonus() {
-    return 0.12 + this.shadowOfNathrezaBonus;
+    return 0.16 + this.shadowOfNathrezaBonus;
   }
 
   get uptime() {

--- a/src/analysis/retail/warlock/affliction/modules/guide/DotUptimesGuide.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/guide/DotUptimesGuide.tsx
@@ -49,7 +49,7 @@ class DotUptimesGuide extends Analyzer {
                 <>
                   Haunt's damage bonus:
                   <ul>
-                    <li>+12% baseline</li>
+                    <li>+16% baseline</li>
                     {this.haunt.shadowOfNathrezaBonus > 0 && (
                       <li>
                         +{formatPercentage(this.haunt.shadowOfNathrezaBonus, 0)}% from{' '}


### PR DESCRIPTION
### Description

Updates Aff Lock support for patch 12.1. 

Haunt's baseline damage bonus increased from 12% to 16% (`0.12` > `0.16`) to match the 12.1 spell data change.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/qdGa21vBHtLJrgnb/27-Heroic+Lightblinded+Vanguard+-+Kill+(3:28)/1-Katorriwl/standard`
- Screenshot(s):
<img width="529" height="192" alt="image" src="https://github.com/user-attachments/assets/9d62595f-e510-4a39-b972-5653d782e0dc" />
