### PR TITLE
[Affliction Warlock] New Dark Harvest analyzer and guide with CDR efficiency from Cull the Weak

### DIFF
--- a/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 
 export default [
+  change(date(2026, 8, 15), <>Create <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> guide section tracking per-cast DoT coverage across every target it hits and <SpellLink spell={TALENTS.CULL_THE_WEAK_TALENT} /> CDR efficiency.</>, Katorri),
   change(date(2026, 8, 15), "Update Haunt baseline percent increase, update Compatibility for 12.1.0", Katorri),
   change(date(2026, 5, 31), "Add Always Be Casting guide section; adjust DoT Uptimes guide section; add contextual tip to UA uptime section for cleave/AoE fights; register SiphonLife analyzer and correct damage bonus from 20% to 30%; remove outdated Darkglare dot extension tracking.", Katorri),
   change(date(2026, 4, 21), "Spec compatibility updated for 12.0.5", Katorri),

--- a/src/analysis/retail/warlock/affliction/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/affliction/CombatLogParser.ts
@@ -28,6 +28,7 @@ import { UnendingResolve, DarkPact, DemonicCircle, DemonicHealthstone } from '..
 import Guide from './Guide';
 import CullTheWeak from './modules/analyzers/CulltheWeak';
 import SiphonLife from './modules/analyzers/SiphonLife';
+import DarkHarvest from './modules/analyzers/DarkHarvest';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -64,6 +65,9 @@ class CombatLogParser extends CoreCombatLogParser {
     grimoireOfSacrifice: GrimoireOfSacrifice,
     haunt: Haunt,
     nightfall: Nightfall,
+    // DarkHarvest must be listed before CullTheWeak so its event handlers fire first,
+    // allowing it to read the pre-reduction cooldown state on each UA/SoC cast.
+    darkHarvest: DarkHarvest,
     cullTheWeak: CullTheWeak,
     siphonLife: SiphonLife,
 

--- a/src/analysis/retail/warlock/affliction/Guide.tsx
+++ b/src/analysis/retail/warlock/affliction/Guide.tsx
@@ -6,6 +6,7 @@ import ResourceUsage from './modules/guide/ResourceUsage';
 import DefensivesGuide from '../shared/Defensives';
 import UnstableAfflictionGuide from './modules/guide/UnstableAfflictionGuide';
 import { DemonicHealthstoneGuide } from '../shared/DHSGuide';
+import DarkHarvestGuide from './modules/guide/DarkHarvestGuide';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
@@ -25,6 +26,13 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
       <Section title="Cooldown Usage">
         <CooldownSubsection />
       </Section>
+
+      {/* Dark Harvest Section */}
+      {modules.darkHarvest.active && (
+        <Section title="Dark Harvest">
+          <DarkHarvestGuide />
+        </Section>
+      )}
 
       {/* Defensives Section with Healthstone Tracker */}
       <Section title="Defensives">

--- a/src/analysis/retail/warlock/affliction/modules/analyzers/CulltheWeak.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/analyzers/CulltheWeak.tsx
@@ -12,6 +12,8 @@ class CullTheWeak extends Analyzer.withDependencies({
 }) {
   effectiveCdrMs = 0;
   wastedCdrMs = 0;
+  uaCastCount = 0;
+  socCastCount = 0;
 
   constructor(options: Options) {
     super(options);
@@ -29,11 +31,17 @@ class CullTheWeak extends Analyzer.withDependencies({
     );
   }
 
-  onCast(_event: CastEvent) {
+  onCast(event: CastEvent) {
     const actualReduction = this.deps.spellUsable.reduceCooldown(targetSpellId, CDR_MS);
 
     this.effectiveCdrMs += actualReduction;
     this.wastedCdrMs += CDR_MS - actualReduction;
+
+    if (event.ability.guid === SPELLS.UNSTABLE_AFFLICTION.id) {
+      this.uaCastCount += 1;
+    } else {
+      this.socCastCount += 1;
+    }
   }
 }
 

--- a/src/analysis/retail/warlock/affliction/modules/analyzers/CulltheWeak.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/analyzers/CulltheWeak.tsx
@@ -3,6 +3,9 @@ import Events, { CastEvent } from 'parser/core/Events';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 
 const CDR_MS = 1500;
 const targetSpellId = TALENTS.DARK_HARVEST_TALENT.id;
@@ -42,6 +45,16 @@ class CullTheWeak extends Analyzer.withDependencies({
     } else {
       this.socCastCount += 1;
     }
+  }
+
+  statistic() {
+    return (
+      <Statistic category={STATISTIC_CATEGORY.TALENTS} size="flexible">
+        <BoringSpellValueText spell={TALENTS.CULL_THE_WEAK_TALENT}>
+          {(this.wastedCdrMs / 1000).toFixed(1)}s <small>CDR wasted</small>
+        </BoringSpellValueText>
+      </Statistic>
+    );
   }
 }
 

--- a/src/analysis/retail/warlock/affliction/modules/analyzers/DarkHarvest.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/analyzers/DarkHarvest.tsx
@@ -1,3 +1,4 @@
+import { formatThousands } from 'common/format';
 import SPELLS from 'common/SPELLS/warlock';
 import TALENTS from 'common/TALENTS/warlock';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
@@ -5,6 +6,10 @@ import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
 import Enemy from 'parser/core/Enemy';
 import Enemies from 'parser/shared/modules/Enemies';
 import SpellUsable from 'parser/shared/modules/SpellUsable';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import TalentSpellText from 'parser/ui/TalentSpellText';
 
 const CDR_PER_CAST_MS = 1500;
 // Base channel duration (unreduced by haste), used as an upper bound for matching damage to casts.
@@ -43,6 +48,7 @@ class DarkHarvest extends Analyzer {
   hauntActive = false;
   hasCullTheWeak = false;
   casts: DarkHarvestCastData[] = [];
+  private totalDamage = 0;
 
   // Running totals accumulated since the last DH cast
   private currentWindowCdrMs = 0;
@@ -126,6 +132,8 @@ class DarkHarvest extends Analyzer {
   }
 
   onDarkHarvestDamage(event: DamageEvent) {
+    this.totalDamage += event.amount + (event.absorbed || 0);
+
     const cast = this.casts[this.casts.length - 1];
     if (!cast || event.timestamp - cast.timestamp > CHANNEL_DURATION_MS) {
       // No open channel this damage tick could belong to — shouldn't normally happen.
@@ -152,6 +160,20 @@ class DarkHarvest extends Analyzer {
     if (this.hauntActive && target.hasBuff(TALENTS.HAUNT_TALENT.id, ts)) {
       cast.hauntActiveOnHit = true;
     }
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={`${formatThousands(this.totalDamage)} total damage`}
+      >
+        <TalentSpellText talent={TALENTS.DARK_HARVEST_TALENT}>
+          <ItemDamageDone amount={this.totalDamage} />
+        </TalentSpellText>
+      </Statistic>
+    );
   }
 }
 

--- a/src/analysis/retail/warlock/affliction/modules/analyzers/DarkHarvest.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/analyzers/DarkHarvest.tsx
@@ -1,0 +1,158 @@
+import SPELLS from 'common/SPELLS/warlock';
+import TALENTS from 'common/TALENTS/warlock';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { CastEvent, DamageEvent } from 'parser/core/Events';
+import Enemy from 'parser/core/Enemy';
+import Enemies from 'parser/shared/modules/Enemies';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+
+const CDR_PER_CAST_MS = 1500;
+// Base channel duration (unreduced by haste), used as an upper bound for matching damage to casts.
+const CHANNEL_DURATION_MS = 3000;
+
+/** One enemy that was actually struck (and had its DoTs consumed) by a Dark Harvest channel. */
+export interface DarkHarvestHit {
+  target: Enemy;
+  hadAgony: boolean;
+  hadCorruption: boolean; // Corruption or Wither depending on talents
+  hadUA: boolean | null; // null when Unstable Affliction is not talented
+}
+
+export interface DarkHarvestCastData {
+  event: CastEvent; // the raw cast event, used by SpellUsageSubSection for timestamps
+  timestamp: number;
+  hits: DarkHarvestHit[]; // every enemy actually struck during the channel; empty = wasted cast
+  hauntActiveOnHit: boolean; // Haunt only affects one enemy at a time, so this is per-cast not per-hit
+  cdrGainedMs: number; // total theoretical CDR from UA/SoC casts in the window (numCasts * 1.5s)
+  effectiveCdrMs: number; // CDR that actually reduced the cooldown
+  wastedCdrMs: number; // CDR applied when DH was already off cooldown
+  uaCastsInWindow: number;
+  socCastsInWindow: number;
+}
+
+class DarkHarvest extends Analyzer {
+  static dependencies = {
+    enemies: Enemies,
+    spellUsable: SpellUsable,
+  };
+  protected enemies!: Enemies;
+  protected spellUsable!: SpellUsable;
+
+  witherActive = false;
+  uaActive = false;
+  hauntActive = false;
+  hasCullTheWeak = false;
+  casts: DarkHarvestCastData[] = [];
+
+  // Running totals accumulated since the last DH cast
+  private currentWindowCdrMs = 0;
+  private currentWindowEffectiveCdrMs = 0;
+  private currentWindowWastedCdrMs = 0;
+  private currentWindowUaCasts = 0;
+  private currentWindowSocCasts = 0;
+
+  get fightStart() {
+    return this.owner.fight.start_time;
+  }
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.DARK_HARVEST_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.witherActive = this.selectedCombatant.hasTalent(TALENTS.WITHER_TALENT);
+    this.uaActive = this.selectedCombatant.hasTalent(TALENTS.UNSTABLE_AFFLICTION_TALENT);
+    this.hauntActive = this.selectedCombatant.hasTalent(TALENTS.HAUNT_TALENT);
+    this.hasCullTheWeak = this.selectedCombatant.hasTalent(TALENTS.CULL_THE_WEAK_TALENT);
+
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.DARK_HARVEST_TALENT),
+      this.onDarkHarvestCast,
+    );
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER).spell(SPELLS.DARK_HARVEST_DAMAGE),
+      this.onDarkHarvestDamage,
+    );
+
+    if (this.hasCullTheWeak) {
+      this.addEventListener(
+        Events.cast
+          .by(SELECTED_PLAYER)
+          .spell([SPELLS.UNSTABLE_AFFLICTION, SPELLS.SEED_OF_CORRUPTION_DEBUFF]),
+        this.onCdrCast,
+      );
+    }
+  }
+
+  // Each UA or SoC cast contributes 1.5s of CDR to the current DH window.
+  onCdrCast(event: CastEvent) {
+    this.currentWindowCdrMs += CDR_PER_CAST_MS;
+    if (this.spellUsable.isOnCooldown(TALENTS.DARK_HARVEST_TALENT.id)) {
+      const remaining = this.spellUsable.cooldownRemaining(TALENTS.DARK_HARVEST_TALENT.id);
+      const effective = Math.min(CDR_PER_CAST_MS, remaining);
+      this.currentWindowEffectiveCdrMs += effective;
+      this.currentWindowWastedCdrMs += CDR_PER_CAST_MS - effective;
+    } else {
+      this.currentWindowWastedCdrMs += CDR_PER_CAST_MS;
+    }
+    if (event.ability.guid === SPELLS.UNSTABLE_AFFLICTION.id) {
+      this.currentWindowUaCasts += 1;
+    } else {
+      this.currentWindowSocCasts += 1;
+    }
+  }
+
+  onDarkHarvestCast(event: CastEvent) {
+    this.casts.push({
+      event,
+      timestamp: event.timestamp,
+      hits: [],
+      hauntActiveOnHit: false,
+      cdrGainedMs: this.currentWindowCdrMs,
+      effectiveCdrMs: this.currentWindowEffectiveCdrMs,
+      wastedCdrMs: this.currentWindowWastedCdrMs,
+      uaCastsInWindow: this.currentWindowUaCasts,
+      socCastsInWindow: this.currentWindowSocCasts,
+    });
+
+    // Reset window counters for the next cast
+    this.currentWindowCdrMs = 0;
+    this.currentWindowEffectiveCdrMs = 0;
+    this.currentWindowWastedCdrMs = 0;
+    this.currentWindowUaCasts = 0;
+    this.currentWindowSocCasts = 0;
+  }
+
+  onDarkHarvestDamage(event: DamageEvent) {
+    const cast = this.casts[this.casts.length - 1];
+    if (!cast || event.timestamp - cast.timestamp > CHANNEL_DURATION_MS) {
+      // No open channel this damage tick could belong to — shouldn't normally happen.
+      return;
+    }
+
+    const target = this.enemies.getEntity(event);
+    if (!target) {
+      return;
+    }
+    // The channel ticks repeatedly; only record each struck enemy once per cast.
+    if (cast.hits.some((hit) => hit.target === target)) {
+      return;
+    }
+
+    const ts = event.timestamp;
+    const corruptionId = this.witherActive ? SPELLS.WITHER_DEBUFF.id : SPELLS.CORRUPTION_DEBUFF.id;
+    cast.hits.push({
+      target,
+      hadAgony: target.hasBuff(SPELLS.AGONY.id, ts),
+      hadCorruption: target.hasBuff(corruptionId, ts),
+      hadUA: this.uaActive ? target.hasBuff(TALENTS.UNSTABLE_AFFLICTION_TALENT.id, ts) : null,
+    });
+    if (this.hauntActive && target.hasBuff(TALENTS.HAUNT_TALENT.id, ts)) {
+      cast.hauntActiveOnHit = true;
+    }
+  }
+}
+
+export default DarkHarvest;

--- a/src/analysis/retail/warlock/affliction/modules/guide/DarkHarvestGuide.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/guide/DarkHarvestGuide.tsx
@@ -1,0 +1,384 @@
+import type { JSX } from 'react';
+import { useMemo } from 'react';
+import SPELLS from 'common/SPELLS/warlock';
+import TALENTS from 'common/TALENTS/warlock';
+import { SpellLink } from 'interface';
+import { useAnalyzer, Section } from 'interface/guide';
+import GuideSection from 'interface/guide/components/GuideSection';
+import CastDetail, {
+  type PerCastData,
+  type PerCastStat,
+} from 'interface/guide/components/CastDetail';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import SpellUsageSubSection from 'parser/core/SpellUsage/SpellUsageSubSection';
+import { type SpellUse } from 'parser/core/SpellUsage/core';
+import DarkHarvest, {
+  type DarkHarvestCastData,
+  type DarkHarvestHit,
+} from '../analyzers/DarkHarvest';
+import CullTheWeak from '../analyzers/CulltheWeak';
+
+const CDR_MS = 1500;
+
+// Rates per-cast CDR efficiency by what fraction of theoretical CDR was actually effective.
+function cdrEfficiencyPerformance(effectiveMs: number, totalMs: number): QualitativePerformance {
+  if (totalMs === 0) return QualitativePerformance.Perfect;
+  const ratio = effectiveMs / totalMs;
+  if (ratio >= 0.9) return QualitativePerformance.Perfect;
+  if (ratio >= 0.75) return QualitativePerformance.Good;
+  if (ratio >= 0.5) return QualitativePerformance.Ok;
+  return QualitativePerformance.Fail;
+}
+
+// Converts a fight-relative millisecond offset to "M:SS" display format.
+function formatTimestamp(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}:${sec.toString().padStart(2, '0')}`;
+}
+
+// Missing periodic effects (Agony, Corruption/Wither, UA if talented) on this hit; Haunt is separate.
+// UA only counts against single-target casts — keeping it on every cleave target isn't realistic.
+function missingDotCount(hit: DarkHarvestHit, scoreUA: boolean): number {
+  return [!hit.hadAgony, !hit.hadCorruption, scoreUA && hit.hadUA === false].filter(Boolean).length;
+}
+
+function missingToPerformance(missing: number): QualitativePerformance {
+  if (missing === 0) return QualitativePerformance.Perfect;
+  if (missing === 1) return QualitativePerformance.Good;
+  if (missing === 2) return QualitativePerformance.Ok;
+  return QualitativePerformance.Fail;
+}
+
+function castPerformance(cast: DarkHarvestCastData): QualitativePerformance {
+  if (cast.hits.length === 0) return QualitativePerformance.Fail;
+  const scoreUA = cast.hits.length === 1;
+  const worstMissing = Math.max(...cast.hits.map((hit) => missingDotCount(hit, scoreUA)));
+  return missingToPerformance(worstMissing);
+}
+
+type MissingDot = 'agony' | 'corruption' | 'ua';
+
+function getMissingDots(hit: DarkHarvestHit): MissingDot[] {
+  const missing: MissingDot[] = [];
+  if (!hit.hadAgony) missing.push('agony');
+  if (!hit.hadCorruption) missing.push('corruption');
+  if (hit.hadUA === false) missing.push('ua');
+  return missing;
+}
+
+// Targets are identified by count, not name, since cleave adds are often duplicate-named.
+function getDotDetails(cast: DarkHarvestCastData, witherActive: boolean): JSX.Element {
+  const corruptionSpell = witherActive ? SPELLS.WITHER_DEBUFF : SPELLS.CORRUPTION_DEBUFF;
+  const missingDotLink: Record<MissingDot, JSX.Element> = {
+    agony: <SpellLink spell={SPELLS.AGONY} />,
+    corruption: <SpellLink spell={corruptionSpell} />,
+    ua: <SpellLink spell={TALENTS.UNSTABLE_AFFLICTION_TALENT} />,
+  };
+
+  const groups = new Map<string, { missing: MissingDot[]; count: number }>();
+  for (const hit of cast.hits) {
+    const missing = getMissingDots(hit);
+    const key = missing.join(',');
+    const group = groups.get(key);
+    if (group) {
+      group.count += 1;
+    } else {
+      groups.set(key, { missing, count: 1 });
+    }
+  }
+
+  return (
+    <>
+      {cast.hits.length === 0 ? (
+        <p>
+          No enemy was afflicted by your periodic effects when this channel went out — the entire
+          cooldown was wasted.
+        </p>
+      ) : (
+        <>
+          <p>{cast.hits.length} target(s) hit.</p>
+          <ul>
+            {Array.from(groups.values()).map(({ missing, count }) => (
+              <li key={missing.join(',')}>
+                {count} target{count !== 1 ? 's' : ''}:{' '}
+                {missing.length === 0 ? (
+                  'all periodic effects active'
+                ) : (
+                  <>
+                    missing{' '}
+                    {missing.map((dot, i) => (
+                      <span key={dot}>
+                        {i > 0 && ', '}
+                        {missingDotLink[dot]}
+                      </span>
+                    ))}
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+          {cast.hits.length > 1 && cast.hits.some((h) => h.hadUA !== null) && (
+            <p>
+              <SpellLink spell={TALENTS.UNSTABLE_AFFLICTION_TALENT} /> isn't expected on every
+              cleave target, so it isn't scored on multi-target casts.
+            </p>
+          )}
+          {cast.hauntActiveOnHit && (
+            <p>
+              <SpellLink spell={TALENTS.HAUNT_TALENT} /> was active on one of the targets,
+              amplifying the damage dealt to it.
+            </p>
+          )}
+        </>
+      )}
+    </>
+  );
+}
+
+export default function DarkHarvestGuide(): JSX.Element | null {
+  const darkHarvest = useAnalyzer(DarkHarvest);
+  const cullTheWeak = useAnalyzer(CullTheWeak);
+
+  const { dotCastData, cdrUses } = useMemo((): {
+    dotCastData: PerCastData[];
+    cdrUses: SpellUse[];
+  } => {
+    if (!darkHarvest) return { dotCastData: [], cdrUses: [] };
+
+    const { witherActive, uaActive } = darkHarvest;
+    const fightStart = darkHarvest.fightStart;
+
+    // Fixed set of summary stat cards, regardless of hit count.
+    const dotCastData: PerCastData[] = darkHarvest.casts.map((cast) => {
+      let stats: PerCastStat[];
+      if (cast.hits.length === 0) {
+        stats = [
+          {
+            label: 'Targets Hit',
+            value: '0',
+            performance: QualitativePerformance.Fail,
+            tooltip: 'No afflicted enemy was in range — the cooldown was completely wasted.',
+          },
+        ];
+      } else {
+        const scoreUA = uaActive && cast.hits.length === 1;
+        const requiredDots = 2 + (scoreUA ? 1 : 0); // Agony, Corruption/Wither, and UA on single-target casts
+        const missingCounts = cast.hits.map((hit) => missingDotCount(hit, scoreUA));
+        const fullyCovered = missingCounts.filter((m) => m === 0).length;
+        const worstMissing = Math.max(...missingCounts);
+        stats = [
+          {
+            label: 'Targets Hit',
+            value: String(cast.hits.length),
+            performance: QualitativePerformance.Perfect,
+            tooltip: `${cast.hits.length} target(s) struck by this channel.`,
+          },
+          {
+            label: 'Full Coverage',
+            value: `${fullyCovered}/${cast.hits.length}`,
+            performance:
+              fullyCovered === cast.hits.length
+                ? QualitativePerformance.Perfect
+                : missingToPerformance(worstMissing),
+            tooltip: `${fullyCovered} of ${cast.hits.length} struck targets had every periodic effect active.`,
+          },
+          {
+            label: 'Worst Coverage',
+            value: `${requiredDots - worstMissing}/${requiredDots}`,
+            performance: missingToPerformance(worstMissing),
+            tooltip:
+              worstMissing === 0
+                ? 'Every struck target had full coverage.'
+                : `The worst-covered target was missing ${worstMissing} of ${requiredDots} periodic effects.`,
+          },
+        ];
+      }
+      return {
+        performance: castPerformance(cast),
+        timestamp: formatTimestamp(cast.timestamp - fightStart),
+        stats,
+        details: getDotDetails(cast, witherActive),
+      };
+    });
+
+    // One SpellUse per DH cast; first cast has nothing to measure, rest need at least one UA/SoC in window.
+    const firstCast = darkHarvest.casts[0];
+    const firstCastUse: SpellUse | null = firstCast
+      ? {
+          event: firstCast.event,
+          performance: QualitativePerformance.Perfect,
+          performanceExplanation: 'First Dark Harvest cast — nothing to measure.',
+          checklistItems: [
+            {
+              check: 'first-cast',
+              timestamp: firstCast.timestamp,
+              performance: QualitativePerformance.Perfect,
+              summary: 'First cast',
+              details: (
+                <p>
+                  This is the first <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> cast. There is
+                  there is no previous cast to measure CDR efficiency from.
+                </p>
+              ),
+            },
+          ],
+        }
+      : null;
+
+    const windowUses = darkHarvest.casts
+      .slice(1)
+      .filter((cast) => cast.cdrGainedMs > 0)
+      .map((cast) => ({
+        event: cast.event,
+        performance: cdrEfficiencyPerformance(cast.effectiveCdrMs, cast.cdrGainedMs),
+        checklistItems: [
+          {
+            check: 'effective',
+            timestamp: cast.timestamp,
+            performance: QualitativePerformance.Perfect,
+            summary: `${(cast.effectiveCdrMs / 1000).toFixed(1)}s effective CDR`,
+            details: (
+              <>
+                <p>Casts that reduced the cooldown since the previous Dark Harvest:</p>
+                <ul>
+                  {cast.uaCastsInWindow > 0 && (
+                    <li>
+                      <SpellLink spell={SPELLS.UNSTABLE_AFFLICTION} />: {cast.uaCastsInWindow} cast
+                      {cast.uaCastsInWindow !== 1 ? 's' : ''} (
+                      {(cast.uaCastsInWindow * 1.5).toFixed(1)}s)
+                    </li>
+                  )}
+                  {cast.socCastsInWindow > 0 && (
+                    <li>
+                      <SpellLink spell={SPELLS.SEED_OF_CORRUPTION_DEBUFF} />:{' '}
+                      {cast.socCastsInWindow} cast{cast.socCastsInWindow !== 1 ? 's' : ''} (
+                      {(cast.socCastsInWindow * 1.5).toFixed(1)}s)
+                    </li>
+                  )}
+                </ul>
+                <p>
+                  {(cast.effectiveCdrMs / 1000).toFixed(1)}s of the{' '}
+                  {(cast.cdrGainedMs / 1000).toFixed(1)}s generated actually reduced the cooldown.
+                </p>
+              </>
+            ),
+          },
+          {
+            check: 'wasted',
+            timestamp: cast.timestamp,
+            performance:
+              cast.wastedCdrMs < CDR_MS
+                ? QualitativePerformance.Perfect
+                : QualitativePerformance.Ok,
+            summary:
+              cast.wastedCdrMs < CDR_MS
+                ? 'All CDR was effective'
+                : `${(cast.wastedCdrMs / 1000).toFixed(1)}s excess CDR`,
+            details:
+              cast.wastedCdrMs < CDR_MS ? (
+                <p>
+                  <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> was on cooldown for every
+                  contributing cast — all CDR was effective.
+                </p>
+              ) : (
+                <p>
+                  {(cast.wastedCdrMs / 1000).toFixed(1)}s of CDR was generated after{' '}
+                  <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> was already off cooldown. A
+                  small amount is expected when casting{' '}
+                  <SpellLink spell={SPELLS.UNSTABLE_AFFLICTION} /> or{' '}
+                  <SpellLink spell={SPELLS.SEED_OF_CORRUPTION_DEBUFF} /> to set up DoTs before
+                  pressing <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} />. Try to cast it as soon
+                  as your DoTs are in place.
+                </p>
+              ),
+          },
+        ],
+      }));
+
+    const cdrUses: SpellUse[] = [...(firstCastUse ? [firstCastUse] : []), ...windowUses];
+
+    return { dotCastData, cdrUses };
+  }, [darkHarvest]);
+
+  if (!darkHarvest) return null;
+
+  const { witherActive, uaActive, hauntActive } = darkHarvest;
+  const corruptionSpell = witherActive ? SPELLS.WITHER_DEBUFF : SPELLS.CORRUPTION_DEBUFF;
+  const hasCullTheWeak = cullTheWeak?.active ?? false;
+
+  const dotExplanation = (
+    <>
+      <p>
+        <b>
+          <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> is a channel (3 seconds base, reduced by
+          haste) that consumes your periodic effects off every currently afflicted enemy it can
+          reach — it isn't tied to a single target.
+        </b>
+      </p>
+      <p>
+        Casting it while nothing is afflicted wastes the entire cooldown. Before pressing it, make
+        sure <SpellLink spell={SPELLS.AGONY} /> and <SpellLink spell={corruptionSpell} /> are active
+        on your target
+        {uaActive && (
+          <>
+            , along with <SpellLink spell={TALENTS.UNSTABLE_AFFLICTION_TALENT} />
+          </>
+        )}
+        . On cleave, more afflicted targets in range means more value from a single cast.
+      </p>
+      {hauntActive && (
+        <p>
+          <SpellLink spell={TALENTS.HAUNT_TALENT} /> doesn't affect who{' '}
+          <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> hits, but it amplifies all damage taken
+          by whatever it's active on — keep it up on the target you most want{' '}
+          <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> to hit hardest.
+        </p>
+      )}
+    </>
+  );
+
+  const cdrExplanation = (
+    <>
+      <p>
+        <SpellLink spell={TALENTS.CULL_THE_WEAK_TALENT} /> reduces{' '}
+        <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} />
+        's cooldown by 1.5s per <SpellLink spell={SPELLS.UNSTABLE_AFFLICTION} /> or{' '}
+        <SpellLink spell={SPELLS.SEED_OF_CORRUPTION_DEBUFF} /> cast. If{' '}
+        <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> is already off cooldown, that reduction is
+        wasted — some waste is expected when those casts are also setting up DoTs before you press{' '}
+        <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} />.
+      </p>
+      <p>
+        Cast <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> as soon as your DoTs are up to
+        minimize how much CDR goes to waste.
+      </p>
+    </>
+  );
+
+  return (
+    <>
+      <Section title="Dark Harvest">
+        <GuideSection spell={TALENTS.DARK_HARVEST_TALENT} explanation={dotExplanation}>
+          <CastDetail title="Dark Harvest Casts" casts={dotCastData} />
+        </GuideSection>
+      </Section>
+      {hasCullTheWeak && cdrUses.length > 0 && (
+        <Section title="Cull the Weak CDR Efficiency">
+          <SpellUsageSubSection
+            title="Cull the Weak CDR Efficiency"
+            explanation={cdrExplanation}
+            uses={cdrUses}
+            castBreakdownSmallText={
+              <>
+                - Each box represents one Dark Harvest cast, colored by how efficiently you reduced
+                its cooldown since the previous one.
+              </>
+            }
+          />
+        </Section>
+      )}
+    </>
+  );
+}

--- a/src/analysis/retail/warlock/affliction/modules/guide/DarkHarvestGuide.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/guide/DarkHarvestGuide.tsx
@@ -77,17 +77,15 @@ function getDotDetails(cast: DarkHarvestCastData, witherActive: boolean): JSX.El
     ua: <SpellLink spell={TALENTS.UNSTABLE_AFFLICTION_TALENT} />,
   };
 
-  const groups = new Map<string, { missing: MissingDot[]; count: number }>();
+  const missingCounts: Record<MissingDot, number> = { agony: 0, corruption: 0, ua: 0 };
   for (const hit of cast.hits) {
-    const missing = getMissingDots(hit);
-    const key = missing.join(',');
-    const group = groups.get(key);
-    if (group) {
-      group.count += 1;
-    } else {
-      groups.set(key, { missing, count: 1 });
+    for (const dot of getMissingDots(hit)) {
+      missingCounts[dot] += 1;
     }
   }
+  const dotsMissingAnywhere = (['agony', 'corruption', 'ua'] as MissingDot[]).filter(
+    (dot) => missingCounts[dot] > 0,
+  );
 
   return (
     <>
@@ -99,26 +97,17 @@ function getDotDetails(cast: DarkHarvestCastData, witherActive: boolean): JSX.El
       ) : (
         <>
           <p>{cast.hits.length} target(s) hit.</p>
-          <ul>
-            {Array.from(groups.values()).map(({ missing, count }) => (
-              <li key={missing.join(',')}>
-                {count} target{count !== 1 ? 's' : ''}:{' '}
-                {missing.length === 0 ? (
-                  'all periodic effects active'
-                ) : (
-                  <>
-                    missing{' '}
-                    {missing.map((dot, i) => (
-                      <span key={dot}>
-                        {i > 0 && ', '}
-                        {missingDotLink[dot]}
-                      </span>
-                    ))}
-                  </>
-                )}
-              </li>
-            ))}
-          </ul>
+          {dotsMissingAnywhere.length === 0 ? (
+            <p>All periodic effects were active on every target.</p>
+          ) : (
+            <ul>
+              {dotsMissingAnywhere.map((dot) => (
+                <li key={dot}>
+                  {missingCounts[dot]}/{cast.hits.length} targets missing {missingDotLink[dot]}
+                </li>
+              ))}
+            </ul>
+          )}
           {cast.hits.length > 1 && cast.hits.some((h) => h.hadUA !== null) && (
             <p>
               <SpellLink spell={TALENTS.UNSTABLE_AFFLICTION_TALENT} /> isn't expected on every

--- a/src/analysis/retail/warlock/affliction/modules/guide/DarkHarvestGuide.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/guide/DarkHarvestGuide.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import SPELLS from 'common/SPELLS/warlock';
 import TALENTS from 'common/TALENTS/warlock';
 import { SpellLink } from 'interface';
-import { useAnalyzer, Section } from 'interface/guide';
+import { useAnalyzer } from 'interface/guide';
 import GuideSection from 'interface/guide/components/GuideSection';
 import CastDetail, {
   type PerCastData,
@@ -358,25 +358,21 @@ export default function DarkHarvestGuide(): JSX.Element | null {
 
   return (
     <>
-      <Section title="Dark Harvest">
-        <GuideSection spell={TALENTS.DARK_HARVEST_TALENT} explanation={dotExplanation}>
-          <CastDetail title="Dark Harvest Casts" casts={dotCastData} />
-        </GuideSection>
-      </Section>
+      <GuideSection spell={TALENTS.DARK_HARVEST_TALENT} explanation={dotExplanation}>
+        <CastDetail title="Dark Harvest Casts" casts={dotCastData} />
+      </GuideSection>
       {hasCullTheWeak && cdrUses.length > 0 && (
-        <Section title="Cull the Weak CDR Efficiency">
-          <SpellUsageSubSection
-            title="Cull the Weak CDR Efficiency"
-            explanation={cdrExplanation}
-            uses={cdrUses}
-            castBreakdownSmallText={
-              <>
-                - Each box represents one Dark Harvest cast, colored by how efficiently you reduced
-                its cooldown since the previous one.
-              </>
-            }
-          />
-        </Section>
+        <SpellUsageSubSection
+          title="Cull the Weak CDR Efficiency"
+          explanation={cdrExplanation}
+          uses={cdrUses}
+          castBreakdownSmallText={
+            <>
+              - Each box represents one Dark Harvest cast, colored by how efficiently you reduced
+              its cooldown since the previous one.
+            </>
+          }
+        />
       )}
     </>
   );

--- a/src/analysis/retail/warlock/affliction/modules/guide/DarkHarvestGuide.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/guide/DarkHarvestGuide.tsx
@@ -69,7 +69,11 @@ function getMissingDots(hit: DarkHarvestHit): MissingDot[] {
 }
 
 // Targets are identified by count, not name, since cleave adds are often duplicate-named.
-function getDotDetails(cast: DarkHarvestCastData, witherActive: boolean): JSX.Element {
+function getDotDetails(
+  cast: DarkHarvestCastData,
+  witherActive: boolean,
+  hauntActive: boolean,
+): JSX.Element {
   const corruptionSpell = witherActive ? SPELLS.WITHER_DEBUFF : SPELLS.CORRUPTION_DEBUFF;
   const missingDotLink: Record<MissingDot, JSX.Element> = {
     agony: <SpellLink spell={SPELLS.AGONY} />,
@@ -114,12 +118,18 @@ function getDotDetails(cast: DarkHarvestCastData, witherActive: boolean): JSX.El
               cleave target, so it isn't scored on multi-target casts.
             </p>
           )}
-          {cast.hauntActiveOnHit && (
-            <p>
-              <SpellLink spell={TALENTS.HAUNT_TALENT} /> was active on one of the targets,
-              amplifying the damage dealt to it.
-            </p>
-          )}
+          {hauntActive &&
+            (cast.hauntActiveOnHit ? (
+              <p>
+                <SpellLink spell={TALENTS.HAUNT_TALENT} /> was active on one of the targets,
+                amplifying the damage dealt to it.
+              </p>
+            ) : (
+              <p>
+                <SpellLink spell={TALENTS.HAUNT_TALENT} /> wasn't active on any of the targets — no
+                damage was amplified.
+              </p>
+            ))}
         </>
       )}
     </>
@@ -136,7 +146,7 @@ export default function DarkHarvestGuide(): JSX.Element | null {
   } => {
     if (!darkHarvest) return { dotCastData: [], cdrUses: [] };
 
-    const { witherActive, uaActive } = darkHarvest;
+    const { witherActive, uaActive, hauntActive } = darkHarvest;
     const fightStart = darkHarvest.fightStart;
 
     // Fixed set of summary stat cards, regardless of hit count.
@@ -188,7 +198,7 @@ export default function DarkHarvestGuide(): JSX.Element | null {
         performance: castPerformance(cast),
         timestamp: formatTimestamp(cast.timestamp - fightStart),
         stats,
-        details: getDotDetails(cast, witherActive),
+        details: getDotDetails(cast, witherActive, hauntActive),
       };
     });
 

--- a/src/common/SPELLS/warlock.ts
+++ b/src/common/SPELLS/warlock.ts
@@ -218,6 +218,12 @@ const spells = {
     name: 'Agony',
     icon: 'spell_shadow_curseofsargeras',
   },
+  // Dark Harvest's damage-tick spell ID, distinct from TALENTS.DARK_HARVEST_TALENT.id (1257052).
+  DARK_HARVEST_DAMAGE: {
+    id: 1257065,
+    name: 'Dark Harvest',
+    icon: 'inv_ability_warlock_soulrot',
+  },
   CORRUPTION_CAST: {
     id: 172,
     name: 'Corruption',


### PR DESCRIPTION
### Description

Adds a new "Dark Harvest" guide section for Affliction Warlock, tracking:

- **DoT coverage per cast** — Dark Harvest is a channel that consumes your periodic effects (Agony, Corruption/Wither, Unstable Affliction) off every currently-afflicted enemy it can reach, not a single fixed target. This tracks every enemy actually struck by each channel and scores how many of your DoTs were active on them, with a "wasted cooldown" call-out for casts that hit nothing. Unstable Affliction is only scored on single-target casts, since keeping it up on every cleave target isn't realistic. Haunt is reported separately as a damage amplifier rather than a coverage requirement, since it doesn't affect who Dark Harvest hits.
- **Cull the Weak CDR efficiency** — tracks how much of the 1.5s cooldown reduction from Unstable Affliction/Seed of Corruption casts actually reduced Dark Harvest's cooldown vs. was wasted because it was already off cooldown.

### Testing

- Test report URL: `/report/g1TMLbZfqGdKAykY/13-Mythic+Vorasius+-+Kill+(5:12)/1-Katorrí/standard/overview`
- Screenshot(s):
<img width="1282" height="644" alt="image" src="https://github.com/user-attachments/assets/90354625-b3eb-433a-bdf3-cccf22e9f340" />

<img width="1284" height="456" alt="image" src="https://github.com/user-attachments/assets/4ed66935-9a22-4861-ae5b-b7ea8d94e542" />

<img width="1290" height="929" alt="image" src="https://github.com/user-attachments/assets/3556efa2-6bb3-43d0-b458-77ed26e10c40" />
