### PR TITLE
[Warlock] - [Destruction] [Demonology] update Destro and Demo compatibility for 12.1

### DIFF
--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import { Katorri } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2026, 8, 18), "Update compatibility for 12.1", Katorri),
   change(date(2026, 4, 23), "Update spec Compatibility for 12.0.5", Katorri),
   change(date(2026, 4, 3), "Overhaul Demonic Tyrant guide with weighted scoring, add Diabolist support, and improved resource/cooldown tracking in Tyrant windows.", Katorri),
   change(date(2026, 3, 20), "Add Demonic Healthstone Tracker, update guide structure, fix timestamp issues on Demonic Tyrant windows.", Katorri),

--- a/src/analysis/retail/warlock/demonology/CONFIG.tsx
+++ b/src/analysis/retail/warlock/demonology/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Zyer, Gazh, Leftyxiv, Katorri } from 'CONTRIBUTORS';
+import { Katorri } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 import Config, { SupportLevel } from 'parser/Config';
@@ -7,17 +7,17 @@ import CHANGELOG from './CHANGELOG';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Zyer, Gazh, Leftyxiv, Katorri],
+  contributors: [Katorri],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.7',
+  patchCompatibility: '12.1.0',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
       Hey there! Thanks for checking out the Demonology Analyzer. If you have any feedback or
-      suggestions, feel free to reach out to me via Discord (you can reach me @zyer on either the{' '}
+      suggestions, feel free to reach out to me via Discord (you can reach me @Katorri on either the{' '}
       <a href="https://discord.com/invite/AxphPxU" target="_blank" rel="noopener noreferrer">
         WoWAnalyzer
       </a>{' '}

--- a/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import {Katorri} from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2026, 8, 18), "Update compatibility for 12.1", Katorri),
   change(date(2026, 4, 21), "Spec compatibility updated for 12.0.5", Katorri),
   change(date(2026, 3, 28), "Add Backdraft analyzer and guide. Updated from Partial to Full support", Katorri),
   change(date(2026, 3, 20), "Add Demonic Healthstone Tracker, update guide structure.", Katorri),

--- a/src/analysis/retail/warlock/destruction/CONFIG.tsx
+++ b/src/analysis/retail/warlock/destruction/CONFIG.tsx
@@ -1,4 +1,4 @@
-import { Gazh, Katorri } from 'CONTRIBUTORS';
+import { Katorri } from 'CONTRIBUTORS';
 import GameBranch from 'game/GameBranch';
 import SPECS from 'game/SPECS';
 
@@ -7,10 +7,10 @@ import { SupportLevel } from 'parser/Config';
 
 export default {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
-  contributors: [Gazh, Katorri],
+  contributors: [Katorri],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.7',
+  patchCompatibility: '12.1.0',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.


### PR DESCRIPTION
### Description

updates Destro and Demo patch compatibility to 12.1

updates contributors in both to remove those who haven't contributed this expansion

