### PR TITLE
Rdruid prepull stacks + s2 tier

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -44,6 +44,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 8, 19), 'Honor combatant-info stack counts when applying buffs already active at pull.', squided),
   change(date(2026, 7, 27), 'Fix reports from previous patches being displayed as from a previous expansion.', Texleretour),
   change(date(2026, 7, 9), 'Add support for spell category filtering on the timeline tab.', Putro),
   change(date(2026, 6, 19), 'Update shared Classic Death Knight enchant checking and gear data to support Frost and Unholy.', Darkfrog),

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
+  change(date(2026, 8, 19), <>Honor pre-pull buff stack counts, and add Season 2 <SpellLink spell={SPELLS.RESTO_DRUID_TIER_36_GENESIS_BUFF}/> tier tracking.</>, squided),
   change(date(2026, 5, 2), <>Fix bug in <SpellLink spell={TALENTS_DRUID.BOND_WITH_NATURE_TALENT}/> statistic.</>, squided),
   change(date(2026, 4, 21), <>Fix bug in <SpellLink spell={TALENTS_DRUID.EVERBLOOM_3_RESTORATION_TALENT}/> statistic to not count SotF consumes during convoke.</>, squided),
   change(date(2026, 4, 21), <>Updates for the 12.0.5 patch.</>, squided),

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,7 +5,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
-  change(date(2026, 8, 19), <>Honor pre-pull buff stack counts, and add Season 2 <SpellLink spell={SPELLS.RESTO_DRUID_TIER_36_GENESIS_BUFF}/> tier tracking.</>, squided),
+  change(date(2026, 8, 19), <>Add Season 2 <SpellLink spell={SPELLS.RESTO_DRUID_TIER_36_GENESIS_BUFF}/> tier tracking.</>, squided),
   change(date(2026, 5, 2), <>Fix bug in <SpellLink spell={TALENTS_DRUID.BOND_WITH_NATURE_TALENT}/> statistic.</>, squided),
   change(date(2026, 4, 21), <>Fix bug in <SpellLink spell={TALENTS_DRUID.EVERBLOOM_3_RESTORATION_TALENT}/> statistic to not count SotF consumes during convoke.</>, squided),
   change(date(2026, 4, 21), <>Updates for the 12.0.5 patch.</>, squided),

--- a/src/analysis/retail/druid/restoration/CombatLogParser.ts
+++ b/src/analysis/retail/druid/restoration/CombatLogParser.ts
@@ -79,6 +79,7 @@ import PatientCustodian from 'analysis/retail/druid/restoration/modules/spells/W
 import VigorousCreepers from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/VigorousCreepers';
 import Liveliness from 'analysis/retail/druid/restoration/modules/spells/Liveliness';
 import S1TierSet from 'analysis/retail/druid/restoration/modules/tier/S1TierSet';
+import S2TierSet from 'analysis/retail/druid/restoration/modules/tier/S2TierSet';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -175,6 +176,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     // Tier Set Modules
     s1TierSet: S1TierSet,
+    s2TierSet: S2TierSet,
   };
 
   static guide = Guide;

--- a/src/analysis/retail/druid/restoration/constants.ts
+++ b/src/analysis/retail/druid/restoration/constants.ts
@@ -94,6 +94,16 @@ export const LIVELINESS_INCREASED_RATE = [
   SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER,
 ];
 
+// Genesis listens to heal events, so Lifebloom is the tick id (33763). No Efflo on Genesis.
+export const GENESIS_BUFFED_HOTS = [
+  SPELLS.REJUVENATION,
+  SPELLS.REJUVENATION_GERMINATION,
+  SPELLS.REGROWTH,
+  SPELLS.WILD_GROWTH,
+  SPELLS.LIFEBLOOM_HOT_HEAL,
+  SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER,
+];
+
 // DoTs that get accelerated by Liveliness for restoration druid.
 export const LIVELINESS_INCREASED_DAMAGE_RATE = [
   SPELLS.MOONFIRE_DEBUFF,

--- a/src/analysis/retail/druid/restoration/format.ts
+++ b/src/analysis/retail/druid/restoration/format.ts
@@ -1,0 +1,10 @@
+import { formatNumber, formatPercentage } from 'common/format';
+
+/**
+ * Formats an overheal amount with its share of raw healing in parentheses.
+ * Example: `12,345 (34.56%)`
+ */
+export function formatOverhealing(overheal: number, effectiveHealing: number): string {
+  const raw = effectiveHealing + overheal;
+  return `${formatNumber(overheal)} (${formatPercentage(raw > 0 ? overheal / raw : 0)}%)`;
+}

--- a/src/analysis/retail/druid/restoration/modules/tier/S2TierSet.tsx
+++ b/src/analysis/retail/druid/restoration/modules/tier/S2TierSet.tsx
@@ -1,0 +1,244 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { TIERS } from 'game/TIERS';
+import SPELLS from 'common/SPELLS';
+import Events, { ApplyBuffEvent, ApplyBuffStackEvent, HealEvent } from 'parser/core/Events';
+import { calculateEffectiveHealing, calculateOverhealing } from 'parser/core/EventCalculateLib';
+import Statistic from 'parser/ui/Statistic';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { formatOverhealing } from 'analysis/retail/druid/restoration/format';
+import { formatNumber } from 'common/format';
+import SpellLink from 'interface/SpellLink';
+import { DRUID_MID2_ID } from 'common/ITEMS';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import BoringItemSetValueText from 'parser/ui/BoringItemSetValueText';
+import { GENESIS_BUFFED_HOTS } from 'analysis/retail/druid/restoration/constants';
+import { isGenesisFromTierCooldown } from 'analysis/retail/druid/restoration/normalizers/CastLinkNormalizer';
+
+const GENESIS_HEALING_INCREASE = 0.15;
+/** With the 4pc, each Genesis application lasts 12s (8s base + 4s from the 4pc). */
+const GENESIS_DURATION_MS = 12_000;
+/** The base (2pc) portion of a Genesis application. Healing during the final 4s of a
+ *  Rejuvenation-granted stack is attributed to the 4pc duration extension. */
+const GENESIS_TWO_PIECE_DURATION_MS = 8_000;
+
+/** A single Genesis application, tracked so overlapping stacks can be attributed individually. */
+interface GenesisStack {
+  start: number;
+  /** granted by a 4pc empowering cast (NS / Tranq / Incarn / Convoke) rather than a Rejuv proc */
+  fromTierCooldown: boolean;
+  /** applied before the pull - always counts fully towards the 2pc */
+  prepull: boolean;
+}
+
+/**
+ * Restoration Druid Season 2 tier set.
+ *
+ * 2pc: Rejuvenation has a 15% chance to grant Genesis, causing all your heal over time effects to
+ *      heal for 15% more for 8 sec. Multiple applications may overlap.
+ * 4pc: Nature's Swiftness, Tranquility, and Incarnation: Tree of Life / Convoke the Spirits have a
+ *      100% chance to grant Genesis, and Genesis duration is increased by 4 sec.
+ *
+ * The bonus healing is measured directly from active Genesis stacks. When the 4pc is equipped the
+ * total is split into a 2pc and 4pc share:
+ *  - 4pc = all healing from stacks granted by the empowering casts (full duration), plus the healing
+ *    that occurs during the final 4s of each Rejuvenation-granted stack (the duration extension).
+ *  - 2pc = the remaining healing (Rejuvenation-granted stacks during their first 8s, and any pre-pull
+ *    stacks which always count fully towards the 2pc).
+ */
+class S2TierSet extends Analyzer {
+  twoPieceHealing = 0;
+  twoPieceOverhealing = 0;
+  fourPieceHealing = 0;
+  fourPieceOverhealing = 0;
+  totalGenesisStackSamples = 0;
+  genesisStackSampleCount = 0;
+  hasFourPiece = false;
+
+  /** Active Genesis applications, in application order (oldest first). Expired entries are pruned. */
+  private genesisStacks: GenesisStack[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.has2PieceByTier(TIERS.MID2);
+    this.hasFourPiece = this.selectedCombatant.has4PieceByTier(TIERS.MID2);
+
+    if (this.hasFourPiece) {
+      this.addEventListener(
+        Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.RESTO_DRUID_TIER_36_GENESIS_BUFF),
+        this.onGenesisApply,
+      );
+      this.addEventListener(
+        Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.RESTO_DRUID_TIER_36_GENESIS_BUFF),
+        this.onGenesisApply,
+      );
+    }
+
+    this.addEventListener(
+      Events.heal.by(SELECTED_PLAYER).spell(GENESIS_BUFFED_HOTS),
+      this.onHotHeal,
+    );
+  }
+
+  private onGenesisApply(event: ApplyBuffEvent | ApplyBuffStackEvent) {
+    this.genesisStacks.push({
+      start: event.timestamp,
+      fromTierCooldown: isGenesisFromTierCooldown(event),
+      prepull: Boolean(event.prepull),
+    });
+  }
+
+  private onHotHeal(event: HealEvent) {
+    const totalGenesisStacks = this.selectedCombatant.getBuffStacks(
+      SPELLS.RESTO_DRUID_TIER_36_GENESIS_BUFF.id,
+      event.timestamp,
+    );
+
+    if (totalGenesisStacks <= 0) {
+      return;
+    }
+
+    this.totalGenesisStackSamples += totalGenesisStacks;
+    this.genesisStackSampleCount += 1;
+
+    const effectiveHealing = calculateEffectiveHealing(
+      event,
+      GENESIS_HEALING_INCREASE * totalGenesisStacks,
+    );
+    const overhealing = calculateOverhealing(event, GENESIS_HEALING_INCREASE * totalGenesisStacks);
+
+    if (!this.hasFourPiece) {
+      // 2pc only: all Genesis healing is 2pc (and the buff lasts 8s, so no stack modelling needed).
+      this.twoPieceHealing += effectiveHealing;
+      this.twoPieceOverhealing += overhealing;
+      return;
+    }
+
+    const fourPieceFraction = this.getFourPieceFraction(event.timestamp, totalGenesisStacks);
+    this.fourPieceHealing += effectiveHealing * fourPieceFraction;
+    this.fourPieceOverhealing += overhealing * fourPieceFraction;
+    this.twoPieceHealing += effectiveHealing * (1 - fourPieceFraction);
+    this.twoPieceOverhealing += overhealing * (1 - fourPieceFraction);
+  }
+
+  /**
+   * Determines what fraction of this heal's Genesis bonus should be credited to the 4pc, by
+   * classifying each active stack. Any stacks not present in our model (e.g. pre-pull stacks that
+   * never produced an application event) default to the 2pc.
+   */
+  private getFourPieceFraction(timestamp: number, totalGenesisStacks: number): number {
+    this.pruneExpiredStacks(timestamp);
+
+    const activeStacks = this.genesisStacks
+      .filter((stack) => timestamp < stack.start + GENESIS_DURATION_MS)
+      // keep the most recently applied stacks if our model has more than the log reports
+      .sort((a, b) => b.start - a.start)
+      .slice(0, totalGenesisStacks);
+
+    let fourPieceStacks = 0;
+    for (const stack of activeStacks) {
+      if (stack.prepull) {
+        // pre-pull stacks always count fully towards the 2pc
+        continue;
+      }
+      if (stack.fromTierCooldown) {
+        fourPieceStacks += 1;
+        continue;
+      }
+      // Rejuvenation proc: healing after the base 8s duration is the 4pc extension
+      if (timestamp - stack.start > GENESIS_TWO_PIECE_DURATION_MS) {
+        fourPieceStacks += 1;
+      }
+    }
+
+    return fourPieceStacks / totalGenesisStacks;
+  }
+
+  private pruneExpiredStacks(timestamp: number) {
+    while (
+      this.genesisStacks.length > 0 &&
+      this.genesisStacks[0].start + GENESIS_DURATION_MS <= timestamp
+    ) {
+      this.genesisStacks.shift();
+    }
+  }
+
+  private get averageGenesisStacks() {
+    if (this.genesisStackSampleCount === 0) {
+      return 0;
+    }
+
+    return this.totalGenesisStackSamples / this.genesisStackSampleCount;
+  }
+
+  private get totalHealing() {
+    return this.twoPieceHealing + this.fourPieceHealing;
+  }
+
+  private get totalOverhealing() {
+    return this.twoPieceOverhealing + this.fourPieceOverhealing;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(1)}
+        category={STATISTIC_CATEGORY.ITEMS}
+        size="flexible"
+        tooltip={
+          <>
+            <SpellLink spell={SPELLS.RESTO_DRUID_TIER_36_GENESIS_BUFF} /> bonus healing:
+            <br />
+            <strong>Total: {formatNumber(this.totalHealing)}</strong>
+            <br />
+            <strong>Avg Genesis stacks: {this.averageGenesisStacks.toFixed(2)}</strong>
+            <br />
+            <strong>
+              Overhealing: {formatOverhealing(this.totalOverhealing, this.totalHealing)}
+            </strong>
+            {this.hasFourPiece && (
+              <>
+                <br />
+                <br />
+                <strong>2pc: {formatNumber(this.twoPieceHealing)}</strong>
+                <br />
+                <strong>4pc: {formatNumber(this.fourPieceHealing)}</strong>
+                <br />
+                <br />
+                The 4pc grants additional{' '}
+                <SpellLink spell={SPELLS.RESTO_DRUID_TIER_36_GENESIS_BUFF} /> stacks from{' '}
+                <SpellLink spell={SPELLS.NATURES_SWIFTNESS} />,{' '}
+                <SpellLink spell={SPELLS.TRANQUILITY_CAST} />, and Incarnation / Convoke, and
+                extends Genesis duration by 4 sec. The 4pc value is all healing from those granted
+                stacks plus the healing during the final 4 sec of each Rejuvenation-granted stack.
+                Pre-pull stacks always count fully towards the 2pc.
+              </>
+            )}
+          </>
+        }
+      >
+        <BoringItemSetValueText setId={DRUID_MID2_ID} title="Restoration Season 2 Tier Set">
+          {this.hasFourPiece ? (
+            <>
+              2pc:
+              <br />
+              <ItemHealingDone amount={this.twoPieceHealing} />
+              <hr />
+              4pc:
+              <br />
+              <ItemHealingDone amount={this.fourPieceHealing} />
+            </>
+          ) : (
+            <>
+              2pc:
+              <br />
+              <ItemHealingDone amount={this.twoPieceHealing} />
+            </>
+          )}
+        </BoringItemSetValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default S2TierSet;

--- a/src/analysis/retail/druid/restoration/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/druid/restoration/normalizers/CastLinkNormalizer.ts
@@ -14,11 +14,15 @@ import {
 } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
 import { TALENTS_DRUID } from 'common/TALENTS';
+import { TIERS } from 'game/TIERS';
 
 const CAST_BUFFER_MS = 150;
 const TRANQ_CHANNEL_BUFFER_MS = 6_000;
 const EVERBLOOM_BUFFER_MS = 1500;
 const CONVOKE_CHANNEL_BUFFER_MS = 4_200;
+// Genesis is granted at the moment the empowering ability is cast, but the applybuff can be logged
+// slightly before/after the cast event, so allow a small window in both directions.
+const GENESIS_PROC_BUFFER_MS = 500;
 
 const APPLIED_HEAL = 'AppliedHeal';
 const FROM_HARDCAST = 'FromHardcast';
@@ -30,6 +34,7 @@ const CAUSED_SUMMON = 'CausedSummon';
 const FROM_EVERBLOOM = 'FromEverbloom';
 const FROM_BLOOM = 'FromBloom';
 const FROM_CONVOKE_SOTF_CONSUME = 'FromConvokeSotfConsume';
+const GENESIS_FROM_TIER_CD = 'GenesisFromTierCooldown';
 
 const EVENT_LINKS: EventLink[] = [
   {
@@ -205,6 +210,25 @@ const EVENT_LINKS: EventLink[] = [
     anyTarget: true,
     maximumLinks: 1,
   },
+  // Season 2 4pc: Nature's Swiftness, Tranquility, and Incarnation: ToL / Convoke the Spirits have a
+  // 100% chance to grant Genesis. Link the Genesis application to the empowering cast so we can tell
+  // 4pc-granted stacks apart from the 2pc Rejuvenation procs (same buff ID).
+  {
+    linkRelation: GENESIS_FROM_TIER_CD,
+    linkingEventId: SPELLS.RESTO_DRUID_TIER_36_GENESIS_BUFF.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
+    referencedEventId: [
+      SPELLS.NATURES_SWIFTNESS.id,
+      SPELLS.TRANQUILITY_CAST.id,
+      TALENTS_DRUID.INCARNATION_TREE_OF_LIFE_TALENT.id,
+      SPELLS.CONVOKE_SPIRITS.id,
+    ],
+    referencedEventType: EventType.Cast,
+    forwardBufferMs: GENESIS_PROC_BUFFER_MS,
+    backwardBufferMs: GENESIS_PROC_BUFFER_MS,
+    anyTarget: true,
+    isActive: (c) => c.has4PieceByTier(TIERS.MID2),
+  },
 ];
 
 /**
@@ -284,6 +308,13 @@ export function getSourceBloom(event: HealEvent): HealEvent | undefined {
     FROM_BLOOM,
     (e): e is HealEvent => e.type === EventType.Heal,
   ).pop();
+}
+
+/** Returns true iff this Genesis application was granted by a Season 2 4pc empowering cast
+ *  (Nature's Swiftness, Tranquility, Incarnation: Tree of Life, or Convoke the Spirits) rather
+ *  than by the 2pc Rejuvenation proc. */
+export function isGenesisFromTierCooldown(event: AbilityEvent<any>): boolean {
+  return HasRelatedEvent(event, GENESIS_FROM_TIER_CD);
 }
 
 export default CastLinkNormalizer;

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -506,6 +506,11 @@ const spells = {
     name: 'Everbloom',
     icon: 'ability_druid_focusedgrowth',
   },
+  RESTO_DRUID_TIER_36_GENESIS_BUFF: {
+    id: 1302255,
+    name: 'Genesis',
+    icon: 'spell_nature_preservation',
+  },
 
   /////////////////////////////////////////////////////////////////////////////
   // GUARDIAN / BEAR

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -372,6 +372,7 @@ class Combatant extends Entity {
         targetID: this.id,
         targetIsFriendly: true,
         start: timestamp,
+        stacks: buff.stacks,
       });
     });
   }

--- a/src/parser/core/Entity.ts
+++ b/src/parser/core/Entity.ts
@@ -378,13 +378,15 @@ abstract class Entity {
   }
 
   // oxlint-disable-next-line typescript-eslint/no-explicit-any -- Baseline suppression. Try to fix if you edit this code.
-  applyBuff(buff: BuffEvent<any> & { start: number }) {
+  applyBuff(buff: BuffEvent<any> & { start: number; stacks?: number }) {
+    // Buffs already active at the pull can start with multiple stacks
+    const stacks = buff.stacks ?? 1;
     this.buffs.push({
       end: null,
-      stackHistory: [{ stacks: 1, timestamp: buff.timestamp }],
       refreshHistory: [],
-      stacks: 1,
       ...buff,
+      stacks,
+      stackHistory: [{ stacks, timestamp: buff.timestamp }],
     });
 
     if (buff.sourceID !== undefined) {


### PR DESCRIPTION
### Description

getBuffStacks at pull now uses the combatant-info stack count, which Genesis overlapping applications need.

### Testing

- Test report URL: http://localhost:3000/report/nL2X8AjMFtfp3w9P/38-Mythic+The+Twin+Fangs+-+Wipe+12+(1:58)/97-Jdotbres/standard/statistics
- Screenshot(s): 
<img width="381" height="358" alt="image" src="https://github.com/user-attachments/assets/de958064-d69f-4e59-986f-41ac045c1fce" />

