### PR TITLE
[Preservation] Update Preservation Evoker analyzer for 12.1

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 8, 22), <>Update <SpellLink spell={SPELLS.EMERALD_BLOSSOM} />, <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT} />, <SpellLink spell={TALENTS_EVOKER.TITANS_GIFT_TALENT} />, and <SpellLink spell={TALENTS_EVOKER.STASIS_TALENT} /> analysis. Implement <SpellLink spell={TALENTS_EVOKER.INNER_FLAME_TALENT} />, and <SpellLink spell={TALENTS_EVOKER.LIFEFORCE_MENDER_TALENT} /> modules.</>, Harrek),
   change(date(2026, 6, 7), <>Fixed display issues for <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> and <SpellLink spell={TALENTS_EVOKER.NOZDORMUS_TEACHINGS_TALENT} /> </>, Baumritter),
   change(date(2026, 6, 7), <>Fixed display issues for <SpellLink spell={SPELLS.LEAPING_FLAMES_BUFF} /> </>, Baumritter),
   change(date(2026, 5, 6), <>Implement <SpellLink spell={TALENTS_EVOKER.TEMPORAL_BURST_TALENT} /> CDR.</>, KYZ),

--- a/src/analysis/retail/evoker/preservation/CONFIG.tsx
+++ b/src/analysis/retail/evoker/preservation/CONFIG.tsx
@@ -10,7 +10,7 @@ const config: Config = {
   contributors: [Harrek],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.7',
+  patchCompatibility: '12.1.0',
   supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.

--- a/src/analysis/retail/evoker/preservation/CombatLogParser.ts
+++ b/src/analysis/retail/evoker/preservation/CombatLogParser.ts
@@ -27,10 +27,12 @@ import RenewingBreath from './modules/talents/RenewingBreath';
 import FieldOfDreams from './modules/talents/FieldOfDreams';
 import FlutteringSeedlings from './modules/talents/FlutteringSeedlings';
 import DreamFlight from './modules/talents/DreamFlight';
+import InnerFlame from './modules/talents/InnerFlame';
 import ExhilBurst from './modules/talents/ExhilBurst';
-//import Stasis from './modules/talents/Stasis';
+import Stasis from './modules/talents/Stasis';
 import TimeOfNeed from './modules/talents/TimeOfNeed';
 import Lifespark from './modules/talents/Lifespark';
+import LifeforceMender from './modules/talents/LifeforceMender';
 import TitansGift from './modules/talents/TitansGift';
 import MerithrasBlessing from './modules/talents/MerithrasBlessing';
 import EnergyLoop from './modules/talents/EnergyLoop';
@@ -124,6 +126,7 @@ class CombatLogParser extends CoreCombatLogParser {
     echoBreakdown: EchoBreakdown,
     dreamBreath: DreamBreath,
     dreamFlight: DreamFlight,
+    innerFlame: InnerFlame,
     livingFlame: LivingFlame,
     masteryEffectiveness: MasteryEffectiveness,
     gracePeriod: GracePeriod,
@@ -131,6 +134,7 @@ class CombatLogParser extends CoreCombatLogParser {
     callOfYsera: CallOfYsera,
     essenceBurst: EssenceBurst,
     titansGift: TitansGift,
+    lifeforceMender: LifeforceMender,
     emeraldBlossom: EmeraldBlossom,
     resonatingSphere: ResonatingSphere,
     timeLord: TimeLord,
@@ -139,7 +143,7 @@ class CombatLogParser extends CoreCombatLogParser {
     fieldOfDreams: FieldOfDreams,
     flutteringSeedlings: FlutteringSeedlings,
     exhilBurst: ExhilBurst,
-    //stasis: Stasis,
+    stasis: Stasis,
     timeOfNeed: TimeOfNeed,
     energyLoop: EnergyLoop,
     sparkOfInsight: SparkOfInsight,

--- a/src/analysis/retail/evoker/preservation/Guide.tsx
+++ b/src/analysis/retail/evoker/preservation/Guide.tsx
@@ -10,31 +10,22 @@ export const GUIDE_CORE_EXPLANATION_PERCENT = 40;
 export const GuideContainer = cssComponent('div', styles.GuideContainer, [] as const);
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
-  const includeTalentSection = false; /*
-    info.combatant.hasTalent(TALENTS_EVOKER.OUROBOROS_TALENT) ||
-    info.combatant.hasTalent(TALENTS_EVOKER.STASIS_TALENT)
-    */
   return (
     <>
       <Section title="Core Spells and Buffs">
-        {modules.merithrasBlessing.guideSubsection}
         {modules.dreamBreath.guideSubsection}
-        {modules.essenceBurst.guideSubsection}
         {info.combatant.hasTalent(TALENTS_EVOKER.TEMPORAL_ANOMALY_TALENT) &&
           modules.resonatingSphere.guideSubsection}
         {modules.emeraldBlossom.guideSubsection}
+        {modules.essenceBurst.guideSubsection}
       </Section>
       <Section title="Healing cooldowns">
         {info.combatant.hasTalent(TALENTS_EVOKER.DREAM_FLIGHT_TALENT) &&
           modules.dreamFlight.guideSubsection}
+        {info.combatant.hasTalent(TALENTS_EVOKER.STASIS_TALENT) && modules.stasis.guideSubsection}
+        {info.combatant.hasTalent(TALENTS_EVOKER.INNER_FLAME_TALENT) &&
+          modules.innerFlame.guideSubsection}
       </Section>
-      {includeTalentSection && (
-        <Section title="Talents">
-          {info.combatant.hasTalent(TALENTS_EVOKER.OUROBOROS_TALENT) &&
-            modules.ouroboros.guideSubsection}
-          {/*info.combatant.hasTalent(TALENTS_EVOKER.STASIS_TALENT) && modules.stasis.guideSubsection*/}
-        </Section>
-      )}
       <PreparationSection />
     </>
   );

--- a/src/analysis/retail/evoker/preservation/constants.ts
+++ b/src/analysis/retail/evoker/preservation/constants.ts
@@ -52,7 +52,6 @@ export const HIT_ECHO_HEALS = [
   SPELLS.DREAM_BREATH_ECHO,
   SPELLS.LIVING_FLAME_HEAL,
   SPELLS.VERDANT_EMBRACE_HEAL,
-  SPELLS.LIFEBIND_HEAL,
   SPELLS.GOLDEN_HOUR_HEAL,
   SPELLS.MERITHRAS_BLESSING_CAST,
 ];
@@ -70,6 +69,7 @@ export const STASIS_CAST_IDS = [
   TALENTS_EVOKER.DREAM_BREATH_TALENT.id,
   SPELLS.DREAM_BREATH_FONT.id,
   SPELLS.NATURALIZE.id,
+  SPELLS.MERITHRAS_BLESSING_CAST.id,
 ];
 
 export const CYCLE_SPELLS = [
@@ -108,6 +108,8 @@ export const TIMELESS_MAGIC = 0.15;
 export const TIMELORD_INCREASE = 0.25;
 export const DOUBLE_TIME_EXTENSION = 2;
 export const LIFEBIND_DURATION = 5000;
+export const INNER_FLAME_STASIS = 15000;
+export const INNER_FLAME_DREAMFLIGHT = 20000;
 
 export function getSpellIds(spells: Spell[]) {
   return spells.map((spell) => spell.id);

--- a/src/analysis/retail/evoker/preservation/modules/features/Abilities.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/features/Abilities.tsx
@@ -3,6 +3,7 @@ import CoreAbilities from 'analysis/retail/evoker/shared/modules/Abilities';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
 import SPELLS from 'common/SPELLS/evoker';
+import { hastedCooldown } from 'common/abilitiesConstants';
 import { EMPOWER_MINIMUM_GCD } from 'analysis/retail/evoker/shared';
 
 class Abilities extends CoreAbilities {
@@ -36,6 +37,7 @@ class Abilities extends CoreAbilities {
           base: EMPOWER_MINIMUM_GCD,
           minimum: EMPOWER_MINIMUM_GCD,
         },
+        charges: combatant.hasTalent(TALENTS.LEGACY_OF_THE_LIFEBINDER_TALENT) ? 2 : 1,
         castEfficiency: {
           suggestion: true,
         },
@@ -54,15 +56,12 @@ class Abilities extends CoreAbilities {
         spell: TALENTS.TIME_DILATION_TALENT.id,
         category: SPELL_CATEGORY.DEFENSIVE,
         cooldown: 60,
-        gcd: {
-          base: 1500,
-        },
         enabled: combatant.hasTalent(TALENTS.TIME_DILATION_TALENT),
       },
       {
         spell: TALENTS.TEMPORAL_ANOMALY_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL_AOE,
-        cooldown: 15 - (combatant.hasTalent(TALENTS.NOZDORMU_ADEPT_TALENT) ? 4 : 0),
+        cooldown: hastedCooldown(15 - (combatant.hasTalent(TALENTS.NOZDORMU_ADEPT_TALENT) ? 4 : 0)),
         gcd: {
           base: 1500,
         },
@@ -101,6 +100,27 @@ class Abilities extends CoreAbilities {
           static: 0,
         },
         enabled: combatant.hasTalent(TALENTS.STASIS_TALENT),
+      },
+      {
+        spell: SPELLS.STASIS_RELEASE.id,
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 90,
+        castEfficiency: {
+          suggestion: true,
+        },
+        gcd: {
+          static: 0,
+        },
+        enabled: combatant.hasTalent(TALENTS.STASIS_TALENT),
+      },
+      {
+        spell: SPELLS.MERITHRAS_BLESSING_CAST.id,
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: 0,
+        gcd: {
+          base: 1500,
+        },
+        enabled: combatant.hasTalent(TALENTS.MERITHRAS_BLESSING_1_PRESERVATION_TALENT),
       },
       ...super.spellbook(),
     ];

--- a/src/analysis/retail/evoker/preservation/modules/talents/EmeraldBlossom.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EmeraldBlossom.tsx
@@ -1,153 +1,144 @@
 import type { JSX } from 'react';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
-import Events, { HealEvent } from 'parser/core/Events';
-import Statistic from 'parser/ui/Statistic';
-import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
-import TalentSpellText from 'parser/ui/TalentSpellText';
+import Events, { HealEvent, CastEvent, GetRelatedEvents } from 'parser/core/Events';
 import { TALENTS_EVOKER } from 'common/TALENTS';
-import { ThresholdStyle } from 'parser/core/ParseResults';
-import ItemHealingDone from 'parser/ui/ItemHealingDone';
-import { getHealEvents, isFromFieldOfDreams } from '../../normalizers/EventLinking/helpers';
 import { SpellLink } from 'interface';
-import { formatNumber, formatPercentage } from 'common/format';
-import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import { formatNumber } from 'common/format';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
-
-const BOUNTIFUL_ADDITIONAL_TARGETS = 2;
-const BASE_TARGETS = 3;
+import CastDetail, {
+  type PerCastData,
+  type PerCastStat,
+} from 'interface/guide/components/CastDetail';
+import { isCastFromEB } from 'analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer';
+import { EMERALD_BLOSSOM_CAST } from '../../normalizers/EventLinking/constants';
 
 class EmeraldBlossom extends Analyzer {
-  bountifulBloomHealing = 0;
-  bountifulBloomOverhealing = 0;
-  extraBountifulHits = 0;
   numBlossoms = 0;
   totalHits = 0;
   totalHealing = 0;
   totalOverhealing = 0;
   countedTimestamps: Set<number> = new Set<number>();
-  castEntries: BoxRowEntry[] = [];
-  bountifulRank = 0;
+  castEntries: PerCastData[] = [];
   goodThreshold = 0;
   perfectThreshold = 0;
   totalCastHits = 0;
 
   constructor(options: Options) {
     super(options);
-    this.bountifulRank = this.selectedCombatant.getTalentRank(
-      TALENTS_EVOKER.BOUNTIFUL_BLOOM_TALENT,
-    );
     this.addEventListener(
-      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.EMERALD_BLOSSOM),
-      this.onHealBatch,
+      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.EMERALD_BLOSSOM_CAST),
+      this.onBlossomCast,
     );
-    this.perfectThreshold = BASE_TARGETS + this.bountifulRank * BOUNTIFUL_ADDITIONAL_TARGETS;
-    this.goodThreshold = BASE_TARGETS - 1 + this.bountifulRank * BOUNTIFUL_ADDITIONAL_TARGETS;
   }
 
-  get averageNumTargets() {
-    return this.totalHits / this.numBlossoms;
-  }
-
-  get averageExtraTargets() {
-    return this.extraBountifulHits / this.numBlossoms;
-  }
-
-  processBatch(events: HealEvent[]) {
-    if (events.some((ev) => isFromFieldOfDreams(ev))) {
-      return;
-    }
-    this.totalCastHits += events.length;
-    let value = QualitativePerformance.Perfect;
-    let effective = 0;
-    let overheal = 0;
-    let timestamp = events.at(0)!.timestamp;
-    events.forEach((ev) => {
-      effective += ev.amount + (ev.absorbed || 0);
-      overheal = ev.overheal || 0;
-      timestamp = timestamp < ev.timestamp ? timestamp : ev.timestamp;
-    });
-    const overhealPercent = overheal / (overheal + effective);
-    if (events.length < this.goodThreshold) {
-      value = QualitativePerformance.Fail;
-    } else if (overhealPercent > 0.7) {
-      value = QualitativePerformance.Ok;
-    } else if (events.length < this.perfectThreshold || overhealPercent > 0.6) {
-      value = QualitativePerformance.Good;
-    }
-    const tooltip = (
-      <>
-        <p>
-          @ <strong>{this.owner.formatTimestamp(timestamp)}</strong>, Targets hit:{' '}
-          <strong>{events.length}</strong>
-        </p>
-        <p>
-          Healing: {formatNumber(effective)} ({formatPercentage(overhealPercent)}% overheal)
-        </p>
-      </>
-    );
-    this.castEntries.push({ value, tooltip });
-  }
-
-  // batch process all healevents for single cast to easily decide which to attribute to bountiful
-  onHealBatch(event: HealEvent) {
-    if (this.countedTimestamps.has(event.timestamp)) {
-      return;
-    }
-
-    const allHealingEvents = getHealEvents(event);
-    this.totalHits += allHealingEvents.length;
-    this.numBlossoms += 1;
-    for (let i = 0; i < allHealingEvents.length; i += 1) {
-      const ev = allHealingEvents[i];
-      this.totalHealing += (ev.amount || 0) + (ev.absorbed || 0);
-      this.totalOverhealing += ev.overheal || 0;
-      if (i >= BASE_TARGETS) {
-        // bountiful blossom target
-        this.bountifulBloomHealing += (ev.amount || 0) + (ev.absorbed || 0);
-        this.bountifulBloomOverhealing += ev.overheal || 0;
-        this.extraBountifulHits += 1;
-      }
-    }
-    this.countedTimestamps.add(event.timestamp);
-    this.processBatch(allHealingEvents);
-  }
-
-  get suggestionThresholds() {
-    return {
-      actual: this.averageNumTargets,
-      isLessThan: {
-        minor: 2.5 + this.bountifulRank * BOUNTIFUL_ADDITIONAL_TARGETS,
-        average: 2 + this.bountifulRank * BOUNTIFUL_ADDITIONAL_TARGETS,
-      },
-      style: ThresholdStyle.NUMBER,
+  onBlossomCast(event: CastEvent) {
+    const blossomHealing = GetRelatedEvents<HealEvent>(event, EMERALD_BLOSSOM_CAST);
+    const blossomHeals = [];
+    const seedlingsHeals = [];
+    const data = {
+      essenceBurst: isCastFromEB(event),
+      totalTargets: 0,
+      blossomTargets: 0,
+      blossomHealing: 0,
+      seedlingsTargets: 0,
+      seedlingsHealing: 0,
     };
-  }
 
-  get avgHitsFromCast() {
-    return this.totalCastHits / this.castEntries.length;
+    blossomHealing.forEach((heal) => {
+      data.totalTargets++;
+      if (heal.ability.guid === SPELLS.FLUTTERING_SEEDLINGS_HEAL.id) {
+        seedlingsHeals.push(heal);
+        data.seedlingsTargets++;
+        data.seedlingsHealing += (heal.amount || 0) + (heal.absorbed || 0);
+      } else {
+        blossomHeals.push(heal);
+        data.blossomTargets++;
+        data.blossomHealing += (heal.amount || 0) + (heal.absorbed || 0);
+      }
+    });
+
+    let info = '';
+    let performance = QualitativePerformance.Perfect;
+    if (!data.essenceBurst) {
+      performance = QualitativePerformance.Fail;
+      info = 'Emerald Blossom should be cast with an essence burst.';
+    } else if (data.totalTargets < 3) {
+      performance = QualitativePerformance.Fail;
+    } else if (data.totalTargets < 5) {
+      performance = QualitativePerformance.Ok;
+    } else if (data.totalTargets < 7) {
+      performance = QualitativePerformance.Good;
+    }
+
+    const stats: PerCastStat[] = [
+      {
+        label: 'Essence',
+        value: data.essenceBurst ? 'Essence Burst' : 'Natural Essence',
+        tooltip: data.essenceBurst
+          ? 'This Blossom was cast while Essence Burst was active.'
+          : 'This Blossom was cast with natural Essence.',
+      },
+      {
+        label: 'Blossom Targets',
+        value: `${data.blossomTargets}`,
+        tooltip: `This cast hit ${data.blossomTargets} targets.`,
+      },
+      {
+        label: 'Blossom Healing',
+        value: formatNumber(data.blossomHealing),
+        tooltip: `Emerald Blossom Healing: ${formatNumber(data.blossomHealing)}.`,
+      },
+      {
+        label: 'Seedlings',
+        value: `${data.seedlingsTargets}`,
+        tooltip: `This Blossom produced ${data.seedlingsTargets} Fluttering Seedlings.`,
+      },
+      {
+        label: 'Seedling Heal',
+        value: formatNumber(data.seedlingsHealing),
+        tooltip: `Healing dealt by Fluttering Seedlings: ${formatNumber(data.seedlingsHealing)}.`,
+      },
+    ];
+
+    const castEntry = {
+      performance: performance,
+      timestamp: this.owner.formatTimestamp(event.timestamp),
+      stats,
+      details: info,
+      tooltip: (
+        <>
+          <p>
+            @ <strong>{this.owner.formatTimestamp(event.timestamp)}</strong>
+          </p>
+        </>
+      ),
+    };
+
+    this.castEntries.push(castEntry);
   }
 
   get guideSubsection(): JSX.Element {
-    const styleObj = {
-      fontSize: 20,
-    };
-    const styleObjInner = {
-      fontSize: 15,
-    };
     const explanation = (
-      <p>
-        <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> is a core spell in the Preservation Evoker kit.
-        It is important to cast it on targets that are nearby other allies and only while you have{' '}
-        <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT} /> available. Every{' '}
-        <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> cast will generate a stack of{' '}
-        <SpellLink spell={TALENTS_EVOKER.TWIN_ECHOES_TALENT} /> which gives you an extra{' '}
-        <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT} /> later on.
-      </p>
+      <>
+        <p>
+          <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> is a core spell in the Preservation Evoker
+          kit and you should use the vast majority of your{' '}
+          <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT} /> on it. Every{' '}
+          <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> cast will generate a stack of{' '}
+          <SpellLink spell={TALENTS_EVOKER.TWIN_ECHOES_TALENT} /> which gives you an extra{' '}
+          <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT} /> later on.
+        </p>
+        <p>
+          Thanks to <SpellLink spell={TALENTS_EVOKER.FLUTTERING_SEEDLINGS_TALENT} /> you don't need
+          to aim the <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> towards a stacked group of
+          players, as any misses will be replaced by seedlings that do a very similar amount of
+          healing.
+        </p>
+      </>
     );
 
     const data =
@@ -162,63 +153,12 @@ class EmeraldBlossom extends Analyzer {
       ) : (
         <div>
           <RoundedPanel>
-            <div>
-              <strong>
-                <SpellLink spell={SPELLS.EMERALD_BLOSSOM_CAST} /> casts
-              </strong>{' '}
-              <small>
-                {' '}
-                - Blue is a perfect cast with {this.perfectThreshold} targets hit, Green is a good
-                cast with {this.goodThreshold} or more with moderate to low overhealing, Yellow is
-                an ok cast with a moderate amount of overheal, and Red is a bad cast with high
-                overheal or few targets hit.
-              </small>
-              <PerformanceBoxRow values={this.castEntries} />
-            </div>
-            <div style={styleObj}>
-              <small style={styleObjInner}>
-                <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> -{' '}
-              </small>
-              <strong>{this.avgHitsFromCast.toFixed(2)}</strong>{' '}
-              <small>
-                average targets hit per <SpellLink spell={SPELLS.EMERALD_BLOSSOM} />
-              </small>
-            </div>
+            <CastDetail title="Emerald Blossom Casts" casts={this.castEntries} />
           </RoundedPanel>
         </div>
       );
 
     return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
-  }
-
-  statistic() {
-    return this.bountifulRank > 0 && this.averageExtraTargets > 0 ? (
-      <Statistic
-        size="flexible"
-        position={STATISTIC_ORDER.CORE(1)}
-        category={STATISTIC_CATEGORY.TALENTS}
-        tooltip={
-          <ul>
-            <li>
-              Total Healing from <SpellLink spell={TALENTS_EVOKER.BOUNTIFUL_BLOOM_TALENT} />:{' '}
-              {formatNumber(this.bountifulBloomHealing)}
-            </li>
-            <li>
-              Total Overhealing from <SpellLink spell={TALENTS_EVOKER.BOUNTIFUL_BLOOM_TALENT} />:{' '}
-              {formatNumber(this.bountifulBloomOverhealing)}
-            </li>
-            <li>
-              Average extra hits from <SpellLink spell={TALENTS_EVOKER.BOUNTIFUL_BLOOM_TALENT} />:{' '}
-              {this.averageExtraTargets.toFixed(2)}
-            </li>
-          </ul>
-        }
-      >
-        <TalentSpellText talent={TALENTS_EVOKER.BOUNTIFUL_BLOOM_TALENT}>
-          <ItemHealingDone amount={this.bountifulBloomHealing} />
-        </TalentSpellText>
-      </Statistic>
-    ) : null;
   }
 }
 

--- a/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/EssenceBurst.tsx
@@ -4,6 +4,8 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import { maybeGetSpell } from 'common/SPELLS';
+import { SpellIcon } from 'interface';
 import { ThresholdStyle } from 'parser/core/ParseResults';
 import Events, {
   EventType,
@@ -24,8 +26,7 @@ import DonutChart from 'parser/ui/DonutChart';
 import { SpellLink } from 'interface';
 import ItemManaGained from 'parser/ui/ItemManaGained';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
-import { RoundedPanel } from 'interface/guide/components/GuideDivs';
-import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
+import CastDetail, { type PerCastData } from 'interface/guide/components/CastDetail';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
@@ -178,7 +179,6 @@ class EssenceBurst extends Analyzer {
     this.casts.forEach((cast) => {
       sourceCount.set(cast.source, (sourceCount.get(cast.source) ?? 0) + 1);
     });
-    console.log(sourceCount);
     const items = [
       {
         color: SPELL_COLORS.MERITHRAS_BLESSING,
@@ -250,27 +250,33 @@ class EssenceBurst extends Analyzer {
       </p>
     );
 
-    const entries: BoxRowEntry[] = [];
-    this.casts.forEach((info) => {
-      let value = QualitativePerformance.Good;
+    const perCastData: PerCastData[] = this.casts.map((info) => {
+      let performance = QualitativePerformance.Perfect;
+      const twinEchoes =
+        (info.spell === TALENTS_EVOKER.ECHO_TALENT.id ||
+          info.spell === SPELLS.EMERALD_BLOSSOM_CAST.id) &&
+        this.selectedCombatant.hasTalent(TALENTS_EVOKER.TWIN_ECHOES_TALENT)
+          ? this.selectedCombatant.getBuffStacks(SPELLS.TWIN_ECHOES_BUFF.id, info.timestamp)
+          : null;
       if (
         !this.selectedCombatant.hasTalent(TALENTS_EVOKER.ENERGY_LOOP_TALENT) &&
         info.spell === SPELLS.DISINTEGRATE.id
       ) {
-        value = QualitativePerformance.Fail;
+        performance = QualitativePerformance.Fail;
       }
       if (info.spell === TALENTS_EVOKER.ECHO_TALENT.id) {
         if (
           !this.selectedCombatant.hasTalent(TALENTS_EVOKER.TWIN_ECHOES_TALENT) ||
           this.selectedCombatant.getBuffStacks(SPELLS.TWIN_ECHOES_BUFF.id, info.timestamp) !== 2
         ) {
-          value = QualitativePerformance.Ok;
+          performance = QualitativePerformance.Good;
         }
       }
       if (info.spell === 0) {
-        value = QualitativePerformance.Fail;
+        performance = QualitativePerformance.Fail;
       }
-      const spellString =
+
+      const details =
         info.spell === 0 ? (
           `Wasted from ${info.expired ? 'expiration' : 'refresh'}`
         ) : (
@@ -278,23 +284,47 @@ class EssenceBurst extends Analyzer {
             Consume ability: <SpellLink spell={info.spell} />
           </>
         );
-      const tooltip = (
-        <>
-          <p>Buff removed @ {this.owner.formatTimestamp(info.timestamp)}</p>
-          {spellString}
-        </>
-      );
-      entries.push({ value, tooltip });
+
+      const spell = maybeGetSpell(info.spell) ?? { name: '' };
+      const stats = [
+        {
+          label: 'Usage',
+          value: info.spell === 0 ? 'Wasted' : <SpellIcon spell={info.spell} />,
+          tooltip:
+            info.spell === 0
+              ? `Wasted from ${info.expired ? 'expiration' : 'refresh'}`
+              : `Consumed with ${spell.name}.`,
+        },
+      ];
+
+      if (twinEchoes !== null) {
+        stats.push({
+          label: 'Twin Echoes',
+          value: twinEchoes.toString(),
+          tooltip:
+            info.spell === 0
+              ? `Wasted from ${info.expired ? 'expiration' : 'refresh'}`
+              : `Consumed with ${spell.name}.`,
+        });
+      }
+
+      return {
+        performance,
+        timestamp: this.owner.formatTimestamp(info.timestamp),
+        details,
+        stats,
+        tooltip: (
+          <>
+            <p>Buff removed @ {this.owner.formatTimestamp(info.timestamp)}</p>
+            {details}
+          </>
+        ),
+      };
     });
 
     const data = (
       <div>
-        <RoundedPanel>
-          <strong>
-            <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT} /> consumptions
-          </strong>
-          <PerformanceBoxRow values={entries} />
-        </RoundedPanel>
+        <CastDetail title="Essence Burst consumptions" casts={perCastData} />
       </div>
     );
 

--- a/src/analysis/retail/evoker/preservation/modules/talents/InnerFlame.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/InnerFlame.tsx
@@ -1,0 +1,99 @@
+import type { JSX } from 'react';
+import SPELLS from 'common/SPELLS';
+import { TALENTS_EVOKER } from 'common/TALENTS';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { ApplyBuffEvent, CastEvent } from 'parser/core/Events';
+import { SubSection } from 'interface/guide';
+import Explanation from 'interface/guide/components/Explanation';
+import CooldownGrid from 'interface/CooldownGrid/CooldownGrid';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { INNER_FLAME_STASIS, INNER_FLAME_DREAMFLIGHT } from '../../constants';
+
+interface InnerFlameWindow {
+  start: number;
+  end: number;
+  sourceSpellId: number;
+  casts: CastEvent[];
+}
+
+class InnerFlame extends Analyzer {
+  windows: InnerFlameWindow[] = [];
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_EVOKER.INNER_FLAME_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.INNER_FLAME),
+      this.onApplyBuff,
+    );
+  }
+
+  onApplyBuff(event: ApplyBuffEvent) {
+    const duration = this.selectedCombatant.hasTalent(TALENTS_EVOKER.STASIS_TALENT)
+      ? INNER_FLAME_STASIS
+      : INNER_FLAME_DREAMFLIGHT;
+    if (!duration) {
+      return;
+    }
+
+    this.windows.push({
+      start: event.timestamp,
+      end: event.timestamp + duration,
+      sourceSpellId: event.ability.guid,
+      casts: [],
+    });
+  }
+
+  get guideSubsection(): JSX.Element {
+    const items = this.windows.map((window) => {
+      const perf = QualitativePerformance.Good;
+      const spellCounts = new Map<number, number>();
+      window.casts.forEach((cast) => {
+        spellCounts.set(cast.ability.guid, (spellCounts.get(cast.ability.guid) ?? 0) + 1);
+      });
+
+      return {
+        perf,
+        checklistItems: [],
+        range: { start: window.start, end: window.end },
+      };
+    });
+
+    return (
+      <SubSection title="Inner Flame">
+        <Explanation>
+          <p>
+            <SpellLink spell={TALENTS_EVOKER.INNER_FLAME_TALENT} /> increases all your healing over
+            time by 50% for the next 15 seconds after using{' '}
+            <SpellLink spell={TALENTS_EVOKER.STASIS_TALENT} /> or 20 seconds after using{' '}
+            <SpellLink spell={TALENTS_EVOKER.DREAM_FLIGHT_TALENT} />. It also increases the chance
+            of triggering <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT} /> by
+            100%.
+          </p>
+          <p>
+            While this effect is active, you should maximize your{' '}
+            <SpellLink spell={TALENTS_EVOKER.DREAM_BREATH_TALENT} /> and{' '}
+            <SpellLink spell={TALENTS_EVOKER.REVERSION_TALENT} /> healing.{' '}
+            <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> is also a very good cast as{' '}
+            <SpellLink spell={TALENTS_EVOKER.CONSUME_FLAME_TALENT} /> also benefits from the
+            increase.
+          </p>
+        </Explanation>
+        <CooldownGrid
+          label={<SpellLink spell={TALENTS_EVOKER.INNER_FLAME_TALENT} />}
+          timeline={{
+            cooldowns: [TALENTS_EVOKER.DREAM_FLIGHT_TALENT, TALENTS_EVOKER.STASIS_TALENT],
+          }}
+          items={items}
+        />
+      </SubSection>
+    );
+  }
+}
+
+export default InnerFlame;

--- a/src/analysis/retail/evoker/preservation/modules/talents/LifeforceMender.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/LifeforceMender.tsx
@@ -1,0 +1,80 @@
+import { formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import { TALENTS_EVOKER } from 'common/TALENTS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { calculateEffectiveDamage, calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
+import Events, { DamageEvent, HealEvent } from 'parser/core/Events';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import ItemHealingDone from 'parser/ui/ItemHealingDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import TalentSpellText from 'parser/ui/TalentSpellText';
+
+class LifeforceMender extends Analyzer {
+  totalIncrease = 0;
+  damageDone = 0;
+  healingDone = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_EVOKER.LIFEFORCE_MENDER_TALENT);
+    if (!this.active) {
+      return;
+    }
+
+    this.totalIncrease =
+      this.selectedCombatant.getTalentRank(TALENTS_EVOKER.LIFEFORCE_MENDER_TALENT) * 0.2;
+
+    this.addEventListener(
+      Events.damage
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.LIVING_FLAME_DAMAGE, SPELLS.FIRE_BREATH_DOT, SPELLS.TWIN_FLAME]),
+      this.onDamage,
+    );
+
+    this.addEventListener(
+      Events.heal
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.LIVING_FLAME_HEAL, SPELLS.LIFE_GIVERS_FLAME_HEAL, SPELLS.TWIN_FLAME_HEAL]),
+      this.onHeal,
+    );
+  }
+
+  onDamage(event: DamageEvent) {
+    this.damageDone += calculateEffectiveDamage(event, this.totalIncrease);
+  }
+
+  onHeal(event: HealEvent) {
+    this.healingDone += calculateEffectiveHealing(event, this.totalIncrease);
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(5)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            <ul>
+              <li>Extra damage from red spells: {formatNumber(this.damageDone)}</li>
+              <li>Extra healing from red spells: {formatNumber(this.healingDone)}</li>
+            </ul>
+          </>
+        }
+      >
+        <TalentSpellText talent={TALENTS_EVOKER.LIFEFORCE_MENDER_TALENT}>
+          <div>
+            <ItemDamageDone amount={this.damageDone} />
+          </div>
+          <div>
+            <ItemHealingDone amount={this.healingDone} />
+          </div>
+        </TalentSpellText>
+      </Statistic>
+    );
+  }
+}
+
+export default LifeforceMender;

--- a/src/analysis/retail/evoker/preservation/modules/talents/MerithrasBlessing.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/MerithrasBlessing.tsx
@@ -1,4 +1,3 @@
-import type { JSX } from 'react';
 import SPELLS from 'common/SPELLS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { CastEvent, HealEvent, RefreshBuffEvent } from 'parser/core/Events';
@@ -8,17 +7,11 @@ import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
 import { SpellLink } from 'interface';
 import { TALENTS_EVOKER } from 'common/TALENTS';
-import { RoundedPanel } from 'interface/guide/components/GuideDivs';
-import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
-import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
-import { BoxRowEntry, PerformanceBoxRow } from 'interface/guide/components/PerformanceBoxRow';
-import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import {
   getEchoConsumptions,
   getMerithrasGeneratingCast,
   getMerithrasHealing,
 } from '../../normalizers/EventLinking/helpers';
-import { formatPercentage, formatNumber } from 'common/format';
 
 interface MerithrasCastData {
   cast: CastEvent;
@@ -96,93 +89,6 @@ class MerithrasBlessing extends Analyzer {
   }
   onAbsorb(event: HealEvent) {
     this.absorbHealing += event.amount + (event.absorbed || 0);
-  }
-
-  get guideSubsection(): JSX.Element {
-    const explanation = (
-      <div>
-        <p>
-          <b>
-            <SpellLink spell={SPELLS.MERITHRAS_BLESSING_CAST} />
-          </b>{' '}
-          is your apex talent and most important spell to consume{' '}
-          <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT} /> with. You aim should be to consume your
-          procs into as many <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT} />
-          es as possible right as damage hits the group
-        </p>
-        <p>
-          It is important that you use your <SpellLink spell={SPELLS.MERITHRAS_BLESSING_CAST} />{' '}
-          procs before <SpellLink spell={TALENTS_EVOKER.DREAM_BREATH_TALENT} /> becomes available,
-          as casting it would overwrite the buff with a new one making you miss out on a cast of it.
-        </p>
-      </div>
-    );
-
-    const allEvents = [
-      ...this.castData.map((cast) => ({
-        type: 'cast' as const,
-        timestamp: cast.cast.timestamp,
-        data: cast,
-      })),
-      ...this.badRefreshes.map((timestamp) => ({
-        type: 'refresh' as const,
-        timestamp,
-      })),
-    ].sort((a, b) => a.timestamp - b.timestamp);
-
-    const entries: BoxRowEntry[] = allEvents.map((ev) => {
-      let value = QualitativePerformance.Good;
-      let tooltip = (
-        <>
-          <SpellLink spell={SPELLS.MERITHRAS_BLESSING_CAST} /> @{' '}
-          {this.owner.formatTimestamp(ev.timestamp)}
-        </>
-      );
-
-      if (ev.type === 'refresh') {
-        value = QualitativePerformance.Fail;
-        tooltip = (
-          <>
-            <div>{tooltip}</div>
-            <div>
-              <SpellLink spell={TALENTS_EVOKER.DREAM_BREATH_TALENT} /> was used while{' '}
-              <SpellLink spell={SPELLS.MERITHRAS_BLESSING_CAST} /> was already active.
-            </div>
-          </>
-        );
-      } else {
-        const castInfo = ev.data!;
-        const totalRawHealing = castInfo.effectiveHealing + castInfo.overhealing;
-        const overhealPercent = totalRawHealing > 0 ? castInfo.overhealing / totalRawHealing : 0;
-        if (overhealPercent > 0.4) value = QualitativePerformance.Ok;
-        tooltip = (
-          <>
-            <div>{tooltip}</div>
-            <div>
-              <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT} />s consumed:{' '}
-              {castInfo.echoConsumptions}{' '}
-            </div>
-            <div>Effective Healing: {formatNumber(castInfo.effectiveHealing)}</div>
-            <div>Overhealing: {formatPercentage(overhealPercent, 1)}%</div>
-          </>
-        );
-      }
-
-      return { value, tooltip };
-    });
-
-    const data = (
-      <div>
-        <RoundedPanel>
-          <strong>
-            <SpellLink spell={TALENTS_EVOKER.MERITHRAS_BLESSING_1_PRESERVATION_TALENT} /> usages
-          </strong>
-          <PerformanceBoxRow values={entries} />
-        </RoundedPanel>
-      </div>
-    );
-
-    return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
   }
 
   statistic() {

--- a/src/analysis/retail/evoker/preservation/modules/talents/Stasis.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/Stasis.tsx
@@ -1,8 +1,11 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_EVOKER } from 'common/TALENTS';
-import { ControlledExpandable, SpellLink, Tooltip } from 'interface';
-import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
+import { SpellLink } from 'interface';
+import { PassFailCheckmark } from 'interface/guide';
+import CastOverview from 'interface/guide/components/CastOverview';
+import CastDetail, { type PerCastData } from 'interface/guide/components/CastDetail';
 import { RoundedPanel } from 'interface/guide/components/GuideDivs';
+import GuideSection from 'interface/guide/components/GuideSection';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   CastEvent,
@@ -12,20 +15,21 @@ import Events, {
 } from 'parser/core/Events';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
 import { GapHighlight } from 'parser/ui/CooldownBar';
-import { QualitativePerformance, getLowestPerf } from 'parser/ui/QualitativePerformance';
+import {
+  QualitativePerformance,
+  getAveragePerf,
+  getLowestPerf,
+} from 'parser/ui/QualitativePerformance';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
-import { PassFailCheckmark, PerformanceMark, SectionHeader } from 'interface/guide';
-import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
-import { getStasisSpell, isStasisForRamp } from '../../normalizers/EventLinking/helpers';
-import { useState, type JSX } from 'react';
+import { getStasisSpell } from '../../normalizers/EventLinking/helpers';
+import type { JSX } from 'react';
 
 interface StasisInfo {
   castTime: number; // when stasis is originally cast
   consumeTime: number; // when stasis is consumed
   spells: [number, number][]; // spells that player cast with stasis
-  forRamp: boolean;
 }
 
 class Stasis extends Analyzer {
@@ -53,7 +57,7 @@ class Stasis extends Analyzer {
   }
 
   onCast(event: CastEvent) {
-    this.curInfo = { castTime: event.timestamp, consumeTime: 0, spells: [], forRamp: false };
+    this.curInfo = { castTime: event.timestamp, consumeTime: 0, spells: [] };
   }
 
   onStackRemoval(event: RemoveBuffStackEvent | RemoveBuffEvent) {
@@ -66,7 +70,6 @@ class Stasis extends Analyzer {
         castTime: this.owner.fight.start_time,
         consumeTime: 0,
         spells: Array(2 - numStacks).fill([0, 0]),
-        forRamp: false,
       };
     }
     const spell = getStasisSpell(event);
@@ -78,7 +81,6 @@ class Stasis extends Analyzer {
   onBuffRemoval(event: RemoveBuffEvent) {
     if (this.curInfo) {
       this.curInfo!.consumeTime = event.timestamp;
-      this.curInfo!.forRamp = isStasisForRamp(event);
       this.stasisInfos.push(this.curInfo!);
       this.curInfo = null;
     }
@@ -95,225 +97,41 @@ class Stasis extends Analyzer {
     );
   }
 
-  getPerfForSpell(spell: number, forRamp: boolean) {
-    if (spell === TALENTS_EVOKER.TEMPORAL_ANOMALY_TALENT.id) {
-      return QualitativePerformance.Good;
-    } else if (spell === SPELLS.EMERALD_BLOSSOM.id) {
-      if (this.selectedCombatant.hasTalent(TALENTS_EVOKER.FIELD_OF_DREAMS_TALENT)) {
-        return QualitativePerformance.Good;
-      } else {
-        return QualitativePerformance.Fail;
-      }
-    } else if (spell === TALENTS_EVOKER.ECHO_TALENT.id) {
-      if (forRamp) {
-        return QualitativePerformance.Good;
-      } else {
-        return QualitativePerformance.Fail;
-      }
-    } else if (spell === TALENTS_EVOKER.CAUTERIZING_FLAME_TALENT.id) {
-      return QualitativePerformance.Fail;
-    } else if (spell === SPELLS.NATURALIZE.id) {
-      return QualitativePerformance.Fail;
-    } else if (spell === TALENTS_EVOKER.REVERSION_TALENT.id) {
-      return QualitativePerformance.Fail;
-    } else if (
+  getPerfForSpell(spell: number) {
+    if (
+      spell === TALENTS_EVOKER.TEMPORAL_ANOMALY_TALENT.id ||
+      spell === SPELLS.EMERALD_BLOSSOM_CAST.id ||
+      spell === SPELLS.MERITHRAS_BLESSING_CAST.id ||
       spell === TALENTS_EVOKER.DREAM_BREATH_TALENT.id ||
       spell === SPELLS.DREAM_BREATH_FONT.id
     ) {
-      if (forRamp) {
-        return QualitativePerformance.Fail;
-      } else {
-        return QualitativePerformance.Good;
-      }
-    } else if (spell === TALENTS_EVOKER.VERDANT_EMBRACE_TALENT.id) {
+      return QualitativePerformance.Good;
+    } else {
       return QualitativePerformance.Fail;
     }
-    return QualitativePerformance.Good;
   }
 
-  getAnalysisForSpell(spellPair: [number, number], forRamp: boolean) {
+  getAnalysisForSpell(spellPair: [number, number]) {
     const [spell, timestamp] = spellPair;
-    {
-      if (spell === TALENTS_EVOKER.TEMPORAL_ANOMALY_TALENT.id) {
-        return (
-          <>
-            <SpellLink spell={TALENTS_EVOKER.TEMPORAL_ANOMALY_TALENT} /> @{' '}
-            {this.owner.formatTimestamp(timestamp)}
-            {'  '}
-            <Tooltip
-              hoverable
-              content={
-                <>
-                  <SpellLink spell={TALENTS_EVOKER.TEMPORAL_ANOMALY_TALENT} /> is always good to
-                  store regardless of situation
-                </>
-              }
-            >
-              <span>
-                <PassFailCheckmark pass />
-              </span>
-            </Tooltip>
-          </>
-        );
-      } else if (spell === SPELLS.EMERALD_BLOSSOM_CAST.id) {
-        if (this.selectedCombatant.hasTalent(TALENTS_EVOKER.FIELD_OF_DREAMS_TALENT)) {
-          return (
-            <>
-              <SpellLink spell={SPELLS.EMERALD_BLOSSOM_CAST} /> @{' '}
-              {this.owner.formatTimestamp(timestamp)}
-              {'  '}
-              <Tooltip
-                hoverable
-                content={
-                  <>
-                    <SpellLink spell={SPELLS.EMERALD_BLOSSOM_CAST} /> is always good to store when
-                    talented into <SpellLink spell={TALENTS_EVOKER.FIELD_OF_DREAMS_TALENT} />
-                  </>
-                }
-              >
-                <span>
-                  <PassFailCheckmark pass />
-                </span>
-              </Tooltip>
-            </>
-          );
-        } else if (!forRamp) {
-          return (
-            <>
-              <SpellLink spell={SPELLS.EMERALD_BLOSSOM_CAST} /> @{' '}
-              {this.owner.formatTimestamp(timestamp)}
-              {'  '}
-              <Tooltip
-                hoverable
-                content={
-                  <>
-                    You should never store <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> if not
-                    talented into <SpellLink spell={TALENTS_EVOKER.FIELD_OF_DREAMS_TALENT} />
-                  </>
-                }
-              >
-                <span>
-                  <PassFailCheckmark pass={false} />
-                </span>
-              </Tooltip>
-            </>
-          );
-        }
-      } else if (spell === TALENTS_EVOKER.CAUTERIZING_FLAME_TALENT.id) {
-        return (
-          <>
-            <SpellLink spell={TALENTS_EVOKER.CAUTERIZING_FLAME_TALENT} /> @{' '}
-            {this.owner.formatTimestamp(timestamp)}
-            {'  '}
-            <Tooltip
-              hoverable
-              content={
-                <>
-                  <SpellLink spell={TALENTS_EVOKER.CAUTERIZING_FLAME_TALENT} /> is not a good spell
-                  to store outside of very niche scenarios
-                </>
-              }
-            >
-              <span>
-                <PassFailCheckmark pass={false} />
-              </span>
-            </Tooltip>
-          </>
-        );
-      } else if (spell === SPELLS.NATURALIZE.id) {
-        return (
-          <>
-            <SpellLink spell={SPELLS.NATURALIZE} /> @ {this.owner.formatTimestamp(timestamp)}
-            {'  '}
-            <Tooltip
-              hoverable
-              content={
-                <>
-                  <SpellLink spell={SPELLS.NATURALIZE} /> is not a good spell to store outside of
-                  very niche scenarios
-                </>
-              }
-            >
-              <span>
-                <PassFailCheckmark pass={false} />
-              </span>
-            </Tooltip>
-          </>
-        );
-      } else if (spell === TALENTS_EVOKER.REVERSION_TALENT.id) {
-        return (
-          <>
-            <SpellLink spell={TALENTS_EVOKER.REVERSION_TALENT} /> @{' '}
-            {this.owner.formatTimestamp(timestamp)}
-            {'  '}
-            <Tooltip
-              hoverable
-              content={
-                <>
-                  <SpellLink spell={TALENTS_EVOKER.REVERSION_TALENT} /> is not a good spell to store
-                  due to its very low mana cost and CD
-                </>
-              }
-            >
-              <span>
-                <PassFailCheckmark pass={false} />
-              </span>
-            </Tooltip>
-          </>
-        );
-      } else if (
-        spell === TALENTS_EVOKER.DREAM_BREATH_TALENT.id ||
-        spell === SPELLS.DREAM_BREATH_FONT.id
-      ) {
-        return (
-          <>
-            <SpellLink spell={TALENTS_EVOKER.DREAM_BREATH_TALENT} /> @{' '}
-            {this.owner.formatTimestamp(timestamp)}
-            {'  '}
-            <Tooltip
-              hoverable
-              content={
-                <>
-                  <SpellLink spell={TALENTS_EVOKER.DREAM_BREATH_TALENT} /> is a very high value
-                  spell to store when not in a ramp due to its high mana cost and CD.
-                </>
-              }
-            >
-              <span>
-                <PassFailCheckmark pass />
-              </span>
-            </Tooltip>
-          </>
-        );
-      } else if (spell === TALENTS_EVOKER.VERDANT_EMBRACE_TALENT.id) {
-        return (
-          <>
-            <SpellLink spell={TALENTS_EVOKER.VERDANT_EMBRACE_TALENT} /> @{' '}
-            {this.owner.formatTimestamp(timestamp)}
-            {'  '}
-            <Tooltip
-              hoverable
-              content={
-                <>
-                  <SpellLink spell={TALENTS_EVOKER.VERDANT_EMBRACE_TALENT} /> is not a high value
-                  spell to store in general compared to other spells. If you are planning to use{' '}
-                  <SpellLink spell={TALENTS_EVOKER.DREAM_BREATH_TALENT} /> inside{' '}
-                  <SpellLink spell={TALENTS_EVOKER.STASIS_TALENT} />, then consider using{' '}
-                  <SpellLink spell={TALENTS_EVOKER.VERDANT_EMBRACE_TALENT} /> prior to{' '}
-                  <SpellLink spell={TALENTS_EVOKER.STASIS_TALENT} />.
-                </>
-              }
-            >
-              <span>
-                <PassFailCheckmark pass={false} />
-              </span>
-            </Tooltip>
-          </>
-        );
-      } else if (spell === 0) {
-        return <>Unknown spell cast before pull</>;
-      }
+    let passMark = false;
+    if (
+      spell === TALENTS_EVOKER.TEMPORAL_ANOMALY_TALENT.id ||
+      spell === SPELLS.EMERALD_BLOSSOM_CAST.id ||
+      spell === SPELLS.MERITHRAS_BLESSING_CAST.id ||
+      spell === TALENTS_EVOKER.DREAM_BREATH_TALENT.id ||
+      spell === SPELLS.DREAM_BREATH_FONT.id
+    ) {
+      passMark = true;
     }
+    return (
+      <>
+        <SpellLink spell={spell} /> @ {this.owner.formatTimestamp(timestamp)}
+        {'  '}
+        <span>
+          <PassFailCheckmark pass={passMark} />
+        </span>
+      </>
+    );
   }
 
   get guideSubsection(): JSX.Element {
@@ -322,75 +140,84 @@ class Stasis extends Analyzer {
         <b>
           <SpellLink spell={TALENTS_EVOKER.STASIS_TALENT} />
         </b>{' '}
-        is a powerful talent that stores your 3 most recent healing spell that will be released with
-        identical targets. Notably, it can not store{' '}
-        <SpellLink spell={TALENTS_EVOKER.DREAM_FLIGHT_TALENT} /> or{' '}
-        <SpellLink spell={TALENTS_EVOKER.REWIND_TALENT} />
-        {
-          <div>
-            In general, you should always store{' '}
-            <SpellLink spell={TALENTS_EVOKER.DREAM_BREATH_TALENT} />,{' '}
-            <SpellLink spell={TALENTS_EVOKER.TEMPORAL_ANOMALY_TALENT} />, and
-            <SpellLink spell={SPELLS.MERITHRAS_BLESSING_CAST} />.
-          </div>
-        }
+        is a powerful healing cooldown that stores up to 3 of your recent healing casts and releases
+        them with the same targets. In general, you should prioritize storing{' '}
+        <SpellLink spell={TALENTS_EVOKER.DREAM_BREATH_TALENT} />,{' '}
+        <SpellLink spell={TALENTS_EVOKER.TEMPORAL_ANOMALY_TALENT} />,{' '}
+        <SpellLink spell={SPELLS.EMERALD_BLOSSOM} />, and{' '}
+        <SpellLink spell={SPELLS.MERITHRAS_BLESSING_CAST} />.
       </p>
     );
-    const data = (
-      <div>
-        <RoundedPanel>
-          <strong>
-            <SpellLink spell={TALENTS_EVOKER.STASIS_TALENT} /> cast efficiency
-          </strong>
-          <div className="flex-main chart" style={{ padding: 15 }}>
-            {this.subStatistic()}
-          </div>
-          {this.stasisInfos.map((info, idx) => {
-            const header = (
-              <>
-                <SpellLink spell={TALENTS_EVOKER.STASIS_TALENT} /> @{' '}
-                {this.owner.formatTimestamp(info.castTime)}
-              </>
-            );
-            const perfs = info.spells.map((spellPair) => {
-              return this.getPerfForSpell(spellPair[0], info.forRamp);
-            });
 
-            const perf = getLowestPerf(perfs);
-            const spells = info.spells;
-            const [isExpanded, setIsExpanded] = useState(false);
-            const combinedHeader =
-              perf !== undefined ? (
-                <div>
-                  {header} &mdash; <PerformanceMark perf={perf} />
-                </div>
-              ) : (
-                header
-              );
-            while (spells.length < 3) {
-              spells.push([0, 0]);
-            }
-            const spellSequence = spells.map((cast, index) => {
-              return <div key={index}>{this.getAnalysisForSpell(cast, info.forRamp)}</div>;
-            });
-            return (
-              <div className="stasis__container" key={idx}>
-                <ControlledExpandable
-                  header={<SectionHeader>{combinedHeader}</SectionHeader>}
-                  element="section"
-                  expanded={isExpanded}
-                  inverseExpanded={() => setIsExpanded(!isExpanded)}
-                >
-                  <div className="stasis__cast-list">{spellSequence}</div>
-                </ControlledExpandable>
-              </div>
-            );
-          })}
-        </RoundedPanel>
-      </div>
+    const perCastData: PerCastData[] = this.stasisInfos.map((info) => {
+      const perfs = info.spells.map((spellPair) => this.getPerfForSpell(spellPair[0]));
+      const perf = getLowestPerf(perfs);
+      const storedSpells = info.spells.map((spellPair, index) => (
+        <div key={`${info.castTime}-${index}`}>{this.getAnalysisForSpell(spellPair)}</div>
+      ));
+
+      return {
+        performance: perf,
+        timestamp: this.owner.formatTimestamp(info.castTime),
+        stats: [],
+        details:
+          storedSpells.length > 0 ? storedSpells : 'No spells were linked for this Stasis cast.',
+        tooltip: (
+          <>
+            <div>
+              Cast: <strong>{this.owner.formatTimestamp(info.castTime)}</strong>
+            </div>
+            <div>
+              Release: <strong>{this.owner.formatTimestamp(info.consumeTime)}</strong>
+            </div>
+          </>
+        ),
+      };
+    });
+
+    const castPerfs = this.stasisInfos.map((info) =>
+      getLowestPerf(info.spells.map((spellPair) => this.getPerfForSpell(spellPair[0]))),
+    );
+    const overallPerf =
+      this.stasisInfos.length > 0 ? getAveragePerf(castPerfs) : QualitativePerformance.Good;
+
+    const overview = (
+      <CastOverview
+        spell={TALENTS_EVOKER.STASIS_TALENT}
+        stats={[
+          {
+            value: `${this.stasisInfos.length}`,
+            label: 'Casts',
+            tooltip: 'Total number of Stasis casts in this fight.',
+            performance: overallPerf,
+          },
+        ]}
+        additionalContent={{
+          title: 'Cast Efficiency',
+          content: this.subStatistic(),
+        }}
+      />
     );
 
-    return explanationAndDataSubsection(explanation, data, GUIDE_CORE_EXPLANATION_PERCENT);
+    const data =
+      this.stasisInfos.length === 0 ? (
+        <RoundedPanel>
+          <strong>
+            No <SpellLink spell={TALENTS_EVOKER.STASIS_TALENT} /> cast.
+          </strong>
+        </RoundedPanel>
+      ) : (
+        <RoundedPanel>
+          {overview}
+          <CastDetail title="Stasis Casts" casts={perCastData} />
+        </RoundedPanel>
+      );
+
+    return (
+      <GuideSection spell={TALENTS_EVOKER.STASIS_TALENT} explanation={explanation}>
+        {data}
+      </GuideSection>
+    );
   }
 
   subStatistic() {

--- a/src/analysis/retail/evoker/preservation/modules/talents/TitansGift.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/TitansGift.tsx
@@ -4,7 +4,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import ItemHealingDone from 'parser/ui/ItemHealingDone';
-import { SpellLink, TooltipElement } from 'interface';
+import { SpellLink } from 'interface';
 import SPELLS from 'common/SPELLS';
 import Events, {
   ApplyBuffEvent,
@@ -21,15 +21,20 @@ import {
 } from '../../normalizers/EventLinking/helpers';
 import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
 import { TITANS_GIFT_INC } from '../../normalizers/EventLinking/constants';
-import { formatPercentage } from 'common/format';
+import { formatNumber, formatPercentage } from 'common/format';
 import { isCastFromEB } from 'analysis/retail/evoker/shared/modules/normalizers/EssenceBurstCastLinkNormalizer';
+import TalentSpellText from 'parser/ui/TalentSpellText';
 
 class TitansGift extends Analyzer {
   //Blossom
   healingAddedToBlossoms = 0;
   totalBlossomsCasted = 0;
   buffedBlossoms = 0;
-  lastCast = 0;
+  lastBlossomCast: CastEvent | null = null;
+  totalBlossomHealing = 0;
+  totalBlossomRawHealing = 0;
+  blossomHealingOnBuffedCasts = 0;
+  blossomRawHealingOnBuffedCasts = 0;
   //Echo
   healingAddedToEcho = 0;
   totalEchoesCasted = 0;
@@ -53,7 +58,9 @@ class TitansGift extends Analyzer {
 
     //Track blossom heals
     this.addEventListener(
-      Events.heal.by(SELECTED_PLAYER).spell(SPELLS.EMERALD_BLOSSOM),
+      Events.heal
+        .by(SELECTED_PLAYER)
+        .spell([SPELLS.EMERALD_BLOSSOM, SPELLS.FLUTTERING_SEEDLINGS_HEAL]),
       this.emeraldBlossomHeal,
     );
 
@@ -61,7 +68,13 @@ class TitansGift extends Analyzer {
     this.addEventListener(
       Events.heal
         .by(SELECTED_PLAYER)
-        .spell([SPELLS.DREAM_BREATH_ECHO, SPELLS.LIVING_FLAME_HEAL, SPELLS.VERDANT_EMBRACE_HEAL]),
+        .spell([
+          SPELLS.DREAM_BREATH_ECHO,
+          SPELLS.REVERSION_ECHO,
+          SPELLS.LIVING_FLAME_HEAL,
+          SPELLS.VERDANT_EMBRACE_HEAL,
+          SPELLS.EMERALD_BLOSSOM_ECHO,
+        ]),
       this.echoHeal,
     );
 
@@ -81,80 +94,152 @@ class TitansGift extends Analyzer {
   //Count total casts
   onBlossomCasts(event: CastEvent) {
     this.totalBlossomsCasted += 1;
+    this.lastBlossomCast = event;
+    if (isCastFromEB(event)) {
+      this.buffedBlossoms += 1;
+    }
   }
 
-  onEchoCasts() {
+  onEchoCasts(event: CastEvent) {
     this.totalEchoesCasted += 1;
+    if (isCastFromEB(event)) {
+      this.buffedEchoes += 1;
+    }
+  }
+
+  private getBlossomCastForEvent(event: HealEvent): CastEvent | null {
+    const linkedCast = getBlossomCast(event);
+    if (linkedCast) {
+      return linkedCast;
+    }
+
+    if (this.lastBlossomCast && event.timestamp - this.lastBlossomCast.timestamp <= 2500) {
+      return this.lastBlossomCast;
+    }
+
+    return null;
   }
 
   //Track blossom healing added
   emeraldBlossomHeal(event: HealEvent) {
-    const blossomCast = getBlossomCast(event);
-    if (blossomCast && isCastFromEB(blossomCast)) {
-      if (this.lastCast != blossomCast.timestamp) {
-        this.buffedBlossoms += 1;
-        this.lastCast = blossomCast.timestamp;
-      }
-      this.healingAddedToBlossoms += calculateEffectiveHealing(event, TITANS_GIFT_INC);
+    const blossomCast = this.getBlossomCastForEvent(event);
+    const effectiveHealing = (event.amount || 0) + (event.absorbed || 0);
+    const rawHealing = effectiveHealing + (event.overheal || 0);
+    this.totalBlossomHealing += effectiveHealing;
+    this.totalBlossomRawHealing += rawHealing;
+
+    if (!blossomCast || !isCastFromEB(blossomCast)) {
+      return;
     }
+
+    this.blossomHealingOnBuffedCasts += effectiveHealing;
+    this.blossomRawHealingOnBuffedCasts += rawHealing;
+    this.healingAddedToBlossoms += calculateEffectiveHealing(event, TITANS_GIFT_INC);
   }
 
   //Track echo healing added
   echoHeal(event: HealEvent | ApplyBuffEvent | RefreshBuffEvent) {
     const echoApplication = getEchoAplication(event);
-    if (echoApplication && isCastFromEB(echoApplication)) {
-      this.buffedEchoes += 1;
-      if (event.type === EventType.Heal) {
-        this.healingAddedToEcho += calculateEffectiveHealing(event, TITANS_GIFT_INC);
-      } else {
-        if (event.ability.name === TALENTS_EVOKER.DREAM_BREATH_TALENT.name) {
-          const dbHealing = getDreamBreathHealing(event);
-          this.healingAddedToEcho += dbHealing.reduce(
-            (prev, cur) => calculateEffectiveHealing(cur, TITANS_GIFT_INC) + prev,
-            0,
-          );
-        } else if (event.ability.name === TALENTS_EVOKER.REVERSION_TALENT.name) {
-          const revHealing = getReversionHealing(event);
-          this.healingAddedToEcho += revHealing.reduce(
-            (prev, cur) => calculateEffectiveHealing(cur, TITANS_GIFT_INC) + prev,
-            0,
-          );
-        }
-      }
+    if (!echoApplication || !isCastFromEB(echoApplication)) {
+      return;
+    }
+
+    if (event.type === EventType.Heal) {
+      this.healingAddedToEcho += calculateEffectiveHealing(event, TITANS_GIFT_INC);
+      return;
+    }
+
+    const spellId = event.ability.guid;
+    if (
+      spellId === TALENTS_EVOKER.DREAM_BREATH_TALENT.id ||
+      spellId === SPELLS.DREAM_BREATH_ECHO.id
+    ) {
+      const dbHealing = getDreamBreathHealing(event);
+      this.healingAddedToEcho += dbHealing.reduce(
+        (prev, cur) => prev + calculateEffectiveHealing(cur, TITANS_GIFT_INC),
+        0,
+      );
+    } else if (
+      spellId === TALENTS_EVOKER.REVERSION_TALENT.id ||
+      spellId === SPELLS.REVERSION_ECHO.id
+    ) {
+      const revHealing = getReversionHealing(event);
+      this.healingAddedToEcho += revHealing.reduce(
+        (prev, cur) => prev + calculateEffectiveHealing(cur, TITANS_GIFT_INC),
+        0,
+      );
     }
   }
 
   statistic() {
     const percentBuffedBlossoms =
       this.totalBlossomsCasted !== 0 ? this.buffedBlossoms / this.totalBlossomsCasted : 0;
-    // Titans Gift for Blossom is way more important right now to match guides, Echo attribution needs more work still so im leaving it for later
+    const percentBuffedEchoes =
+      this.totalEchoesCasted !== 0 ? this.buffedEchoes / this.totalEchoesCasted : 0;
+    const totalHealing = this.healingAddedToBlossoms + this.healingAddedToEcho;
+    const blossomHealingShare =
+      this.totalBlossomHealing > 0
+        ? this.blossomHealingOnBuffedCasts / this.totalBlossomHealing
+        : 0;
+    const attributedShareOfBuffedHealing =
+      this.blossomHealingOnBuffedCasts > 0
+        ? this.healingAddedToBlossoms / this.blossomHealingOnBuffedCasts
+        : 0;
+
     return (
       <Statistic
         position={STATISTIC_ORDER.OPTIONAL(5)}
         size="flexible"
         category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            <div>
+              <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> +{' '}
+              <SpellLink spell={TALENTS_EVOKER.FLUTTERING_SEEDLINGS_TALENT} />:{' '}
+              {formatNumber(this.healingAddedToBlossoms)} (buffed casts: {this.buffedBlossoms}/
+              {this.totalBlossomsCasted}, {formatPercentage(percentBuffedBlossoms)}%)
+            </div>
+            <div>Raw Blossom/Seedling healing: {formatNumber(this.totalBlossomRawHealing)}</div>
+            <div>
+              Effective healing on Blossom/Seedling hits: {formatNumber(this.totalBlossomHealing)}
+            </div>
+            <div>
+              Raw healing on buffed Blossom/Seedling hits:{' '}
+              {formatNumber(this.blossomRawHealingOnBuffedCasts)} (
+              {formatPercentage(blossomHealingShare)}% of all Blossom/Seedling hits)
+            </div>
+            <div>
+              Effective healing on buffed Blossom/Seedling hits:{' '}
+              {formatNumber(this.blossomHealingOnBuffedCasts)}
+            </div>
+            <div>
+              Titans Gift attributed bonus on buffed Blossom/Seedling hits:{' '}
+              {formatPercentage(attributedShareOfBuffedHealing)}% of buffed healing
+            </div>
+            <div>
+              <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT} />:{' '}
+              {formatNumber(this.healingAddedToEcho)} (buffed casts: {this.buffedEchoes}/
+              {this.totalEchoesCasted}, {formatPercentage(percentBuffedEchoes)}%)
+            </div>
+          </>
+        }
       >
+        <TalentSpellText talent={TALENTS_EVOKER.TITANS_GIFT_TALENT}>
+          <ItemHealingDone amount={totalHealing} />
+        </TalentSpellText>
         <div className="pad">
-          <label>
-            <SpellLink spell={TALENTS_EVOKER.TITANS_GIFT_TALENT} />
-          </label>
-          <div className="value">
-            <div>
-              <small>
-                <SpellLink spell={SPELLS.EMERALD_BLOSSOM} />
-              </small>
-            </div>
-            <div>
-              <TooltipElement
-                content={
-                  <>
-                    {this.buffedBlossoms} casts buffed ({formatPercentage(percentBuffedBlossoms)}%)
-                  </>
-                }
-              >
-                <ItemHealingDone amount={this.healingAddedToBlossoms} />
-              </TooltipElement>
-            </div>
+          <div>
+            <small>
+              <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> +{' '}
+              <SpellLink spell={TALENTS_EVOKER.FLUTTERING_SEEDLINGS_TALENT} />:{' '}
+              {formatNumber(this.healingAddedToBlossoms)}
+            </small>
+          </div>
+          <div>
+            <small>
+              <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT} />:{' '}
+              {formatNumber(this.healingAddedToEcho)}
+            </small>
           </div>
         </div>
       </Statistic>

--- a/src/analysis/retail/evoker/preservation/normalizers/EventLinking/BronzeEventLinks.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EventLinking/BronzeEventLinks.ts
@@ -5,6 +5,7 @@ import { EventLink } from 'parser/core/EventLinkNormalizer';
 import {
   EventType,
   CastEvent,
+  EmpowerEndEvent,
   HasRelatedEvent,
   SummonEvent,
   HealEvent,
@@ -62,8 +63,10 @@ export const BRONZE_EVENT_LINKS: EventLink[] = [
     anyTarget: true,
     maximumLinks: 1,
     additionalCondition(linkingEvent, referencedEvent) {
+      const refEvent = referencedEvent as EmpowerEndEvent;
       return (
-        empowerFinishedCasting(referencedEvent as CastEvent) &&
+        refEvent.type === EventType.EmpowerEnd &&
+        refEvent.empowermentLevel > 0 &&
         !HasRelatedEvent(referencedEvent, STASIS)
       );
     },

--- a/src/analysis/retail/evoker/preservation/normalizers/EventLinking/GreenEventLinks.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EventLinking/GreenEventLinks.ts
@@ -10,9 +10,7 @@ import {
 } from 'parser/core/Events';
 import {
   EB_BUFFER_MS,
-  DREAM_BREATH_CALL_OF_YSERA_HOT,
   CAST_BUFFER_MS,
-  DREAM_BREATH_CALL_OF_YSERA,
   EMERALD_BLOSSOM_CAST,
   VERDANT_EMBRACE_BLOSSOM,
   DREAM_BREATH,
@@ -26,37 +24,6 @@ import {
 } from './constants';
 
 export const GREEN_EVENT_LINKS: EventLink[] = [
-  //link Call of Ysera Removal to the heals
-  {
-    linkRelation: DREAM_BREATH_CALL_OF_YSERA_HOT,
-    linkingEventId: [SPELLS.DREAM_BREATH.id, SPELLS.DREAM_BREATH_ECHO.id],
-    linkingEventType: [EventType.ApplyBuff, EventType.Heal],
-    referencedEventId: [TALENTS_EVOKER.DREAM_BREATH_TALENT.id, SPELLS.DREAM_BREATH_FONT.id],
-    referencedEventType: EventType.EmpowerEnd,
-    backwardBufferMs: CAST_BUFFER_MS,
-    anyTarget: true,
-    isActive(c) {
-      return (
-        c.hasTalent(TALENTS_EVOKER.DREAM_BREATH_TALENT) &&
-        c.hasTalent(TALENTS_EVOKER.CALL_OF_YSERA_TALENT)
-      );
-    },
-  },
-  //link Call of Ysera Removal to Dream Breath cast that consumed it
-  {
-    linkRelation: DREAM_BREATH_CALL_OF_YSERA,
-    linkingEventId: SPELLS.CALL_OF_YSERA_BUFF.id,
-    linkingEventType: EventType.RemoveBuff,
-    referencedEventId: [TALENTS_EVOKER.DREAM_BREATH_TALENT.id, SPELLS.DREAM_BREATH_FONT.id],
-    referencedEventType: EventType.EmpowerEnd,
-    maximumLinks: 1,
-    isActive(c) {
-      return (
-        c.hasTalent(TALENTS_EVOKER.DREAM_BREATH_TALENT) &&
-        c.hasTalent(TALENTS_EVOKER.CALL_OF_YSERA_TALENT)
-      );
-    },
-  },
   {
     linkRelation: EMERALD_BLOSSOM_CAST,
     linkingEventId: [SPELLS.EMERALD_BLOSSOM.id, SPELLS.FLUTTERING_SEEDLINGS_HEAL.id],
@@ -65,6 +32,7 @@ export const GREEN_EVENT_LINKS: EventLink[] = [
     referencedEventType: EventType.Cast,
     anyTarget: true,
     maximumLinks: 1,
+    reverseLinkRelation: EMERALD_BLOSSOM_CAST,
     backwardBufferMs: EB_BUFFER_MS + 150,
     additionalCondition(linkingEvent, referencedEvent) {
       return linkingEvent.timestamp - referencedEvent.timestamp > 1450;

--- a/src/analysis/retail/evoker/shared/modules/Abilities.tsx
+++ b/src/analysis/retail/evoker/shared/modules/Abilities.tsx
@@ -12,6 +12,7 @@ import {
   EMPOWER_MINIMUM_GCD,
   HEAVY_WINGBEATS_CDR,
 } from '../constants';
+import { hastedCooldown } from 'common/abilitiesConstants';
 
 const hasFont = (combatant: Combatant) =>
   combatant.hasTalent(TALENTS.FONT_OF_MAGIC_PRESERVATION_TALENT) ||
@@ -107,7 +108,10 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS.VERDANT_EMBRACE_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 24 * interwovenThreadsMultiplier,
+        cooldown:
+          combatant.spec === SPECS.PRESERVATION_EVOKER
+            ? hastedCooldown(18)
+            : 24 * interwovenThreadsMultiplier,
         enabled: combatant.hasTalent(TALENTS.VERDANT_EMBRACE_TALENT),
         gcd: {
           base: 1500,

--- a/src/common/SPELLS/evoker.ts
+++ b/src/common/SPELLS/evoker.ts
@@ -330,6 +330,11 @@ const spells = {
     name: 'Stasis',
     icon: 'ability_evoker_stasis',
   },
+  STASIS_RELEASE: {
+    id: 370564,
+    name: 'Stasis',
+    icon: 'ability_evoker_stasis',
+  },
   INSURANCE_HOT_EVOKER: {
     id: 1215550,
     name: 'Insurance',
@@ -583,6 +588,11 @@ const spells = {
     name: 'Engulf',
     icon: 'inv_ability_flameshaperevoker_engulf',
   },
+  INNER_FLAME: {
+    id: 1242747,
+    name: 'Inner Flame',
+    icon: 'ability_evoker_infernosblessing',
+  },
   CONSUME_FLAME_HEAL: {
     id: 445495,
     name: 'Consume Flame',
@@ -791,6 +801,11 @@ const spells = {
   },
   TWIN_FLAME: {
     id: 1265980,
+    name: 'Twin Flame',
+    icon: 'ability_evoker_infernosblessing',
+  },
+  TWIN_FLAME_HEAL: {
+    id: 1265991,
     name: 'Twin Flame',
     icon: 'ability_evoker_infernosblessing',
   },

--- a/src/common/SPELLS/midnight/trinkets.ts
+++ b/src/common/SPELLS/midnight/trinkets.ts
@@ -36,6 +36,11 @@ const spells = {
     name: "Akilzon's Clarity",
     icon: 'inv_archaeology_70_tauren_drum',
   },
+  LIGHTS_BLESSING: {
+    id: 1263768,
+    name: "Light's Blessing",
+    icon: 'inv_lightforgedmatrixability_lightsjudgment',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
+++ b/src/parser/core/CASTS_THAT_ARENT_CASTS.ts
@@ -58,7 +58,9 @@ const spells: number[] = [
   //region Evoker
   SPELLS.VERDANT_EMBRACE_HEAL.id,
   SPELLS.TWIN_FLAME.id,
+  SPELLS.TWIN_FLAME_HEAL.id,
   SPELLS.CHARGED_BLAST.id,
+  SPELLS.DREAM_BREATH.id,
   //endregion
 
   //region Hunter
@@ -178,6 +180,7 @@ const spells: number[] = [
 
   //region trinket
   SPELLS.EYE_OF_THE_DROWNING_VOID.id,
+  SPELLS.LIGHTS_BLESSING.id,
   //endregion
   //region Embellishments
   //endregion


### PR DESCRIPTION
### Description

- Update Emerald Blossom analyzer to use <CastDetail> and better reflect current guidance
- Update Essence Burst analyzer to use <CastDetail> and better reflect current guidance
- Fixed and reenabled Stasis analyzer. Also changed the display to <CastDetail>
- Fixed values in Titans Gift analyzer
- Implemented Inner Flame analyzer in the major cooldown section
- Implement statistics for Lifeforce Mender

### Testing

- Test report URL: `/report/fmP8aTqpKDHXwvZ9/38-Heroic+The+Twin+Fangs+-+Kill+(8:12)/11-Evoulker/standard/overview`
- Screenshot(s):
<img width="1031" height="384" alt="image" src="https://github.com/user-attachments/assets/e9b071d6-2b89-48d7-b287-782a7849f5e1" />
<img width="1050" height="377" alt="image" src="https://github.com/user-attachments/assets/b29fb383-4551-422a-970f-e8ff5d9289b5" />
<img width="1032" height="531" alt="image" src="https://github.com/user-attachments/assets/93203d67-df58-45d3-ac79-276814ecc144" />
<img width="1043" height="491" alt="image" src="https://github.com/user-attachments/assets/a5ba76f2-e530-4c32-869c-a4a86b478995" />
