### PR TITLE
Add ignore list and overlay options to BuffCountGraph

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -8,8 +8,8 @@ export default [
   change(
     date(2026, 8, 19),
     <>
-      Improve the HoT graph: ignore pets/duplicate applies, and overlay series so Rejuvenation is
-      not inflated by Wild Growth.
+      Improve the HoT graph: ignore pets and duplicate applies, and include{' '}
+      <SpellLink spell={SPELLS.REGROWTH} />.
     </>,
     squided,
   ),

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -8,6 +8,14 @@ export default [
   change(
     date(2026, 8, 19),
     <>
+      Improve the HoT graph: ignore pets/duplicate applies and stop stacking series so Rejuvenation
+      is not inflated by Wild Growth.
+    </>,
+    squided,
+  ),
+  change(
+    date(2026, 8, 19),
+    <>
       Rework the <SpellLink spell={SPELLS.WILD_GROWTH} /> guide section and allow CastDetail stats
       to be ungraded or limited to a subset of performance grades.
     </>,

--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -8,8 +8,8 @@ export default [
   change(
     date(2026, 8, 19),
     <>
-      Improve the HoT graph: ignore pets/duplicate applies and stop stacking series so Rejuvenation
-      is not inflated by Wild Growth.
+      Improve the HoT graph: ignore pets/duplicate applies, and overlay series so Rejuvenation is
+      not inflated by Wild Growth.
     </>,
     squided,
   ),

--- a/src/analysis/retail/druid/restoration/modules/features/HotCountGraph.tsx
+++ b/src/analysis/retail/druid/restoration/modules/features/HotCountGraph.tsx
@@ -25,8 +25,6 @@ class HotCountGraph extends BuffCountGraph {
   };
   combatants!: Combatants;
   convokeSpirits!: ConvokeSpiritsResto;
-  /** Overlay series so Rejuv/WG/Regrowth each show their true count, not a stacked total. */
-  protected stackBuffSeries = false;
 
   constructor(options: Options) {
     super(options);

--- a/src/analysis/retail/druid/restoration/modules/features/HotCountGraph.tsx
+++ b/src/analysis/retail/druid/restoration/modules/features/HotCountGraph.tsx
@@ -25,6 +25,8 @@ class HotCountGraph extends BuffCountGraph {
   };
   combatants!: Combatants;
   convokeSpirits!: ConvokeSpiritsResto;
+  /** Overlay series so Rejuv/WG/Regrowth each show their true count, not a stacked total. */
+  protected stackBuffSeries = false;
 
   constructor(options: Options) {
     super(options);

--- a/src/analysis/retail/druid/restoration/modules/features/HotCountGraph.tsx
+++ b/src/analysis/retail/druid/restoration/modules/features/HotCountGraph.tsx
@@ -1,8 +1,9 @@
 import SPELLS from 'common/SPELLS';
 import SpellLink from 'interface/SpellLink';
-import Events from 'parser/core/Events';
+import Events, { ApplyBuffEvent, ApplyDebuffEvent } from 'parser/core/Events';
 import { Options } from 'parser/core/Module';
 import BuffCountGraph, { GraphedSpellSpec } from 'parser/shared/modules/BuffCountGraph';
+import Combatants from 'parser/shared/modules/Combatants';
 import Panel from 'parser/ui/Panel';
 
 import ConvokeSpiritsResto from 'analysis/retail/druid/restoration/modules/spells/ConvokeSpiritsResto';
@@ -19,8 +20,10 @@ const CONVOKE_WITH_FLOURISH_SPEC_NAME = 'Convoke w/ Flourish Tranquility';
 class HotCountGraph extends BuffCountGraph {
   static dependencies = {
     ...BuffCountGraph.dependencies,
+    combatants: Combatants,
     convokeSpirits: ConvokeSpiritsResto,
   };
+  combatants!: Combatants;
   convokeSpirits!: ConvokeSpiritsResto;
 
   constructor(options: Options) {
@@ -30,6 +33,11 @@ class HotCountGraph extends BuffCountGraph {
     }
   }
 
+  /** Don't count HoTs on pets / NPCs — only raid/party players matter for ramp evaluation */
+  protected shouldCountBuff(event: ApplyBuffEvent | ApplyDebuffEvent): boolean {
+    return this.combatants.getEntity(event) !== null;
+  }
+
   buffSpecs(): GraphedSpellSpec[] {
     const buffSpecs: GraphedSpellSpec[] = [];
     buffSpecs.push({
@@ -37,6 +45,7 @@ class HotCountGraph extends BuffCountGraph {
       color: '#a010a0',
     });
     buffSpecs.push({ spells: SPELLS.WILD_GROWTH, color: '#20b020' });
+    buffSpecs.push({ spells: SPELLS.REGROWTH, color: '#0e7010' });
     if (isWildstalker(this.selectedCombatant)) {
       buffSpecs.push({
         spells: [SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER],
@@ -83,8 +92,8 @@ class HotCountGraph extends BuffCountGraph {
             This graph shows the number of HoTs you had active over the course of the encounter. It
             can help you evaluate how effective you were at 'ramping' before using your cooldowns.
             Having a <SpellLink spell={SPELLS.WILD_GROWTH} /> and several{' '}
-            <SpellLink spell={SPELLS.REJUVENATION} /> out before casting{' '}
-            <SpellLink spell={SPELLS.TRANQUILITY_CAST} /> or{' '}
+            <SpellLink spell={SPELLS.REJUVENATION} /> / <SpellLink spell={SPELLS.REGROWTH} /> out
+            before casting <SpellLink spell={SPELLS.TRANQUILITY_CAST} /> or{' '}
             <SpellLink spell={SPELLS.CONVOKE_SPIRITS} /> can drastically increase their
             effectiveness.
           </>

--- a/src/parser/shared/modules/BuffCountGraph.tsx
+++ b/src/parser/shared/modules/BuffCountGraph.tsx
@@ -113,12 +113,6 @@ abstract class BuffCountGraph extends Analyzer {
   }
 
   /**
-   * When true (the default), area series are stacked so the chart height is total buffs out,
-   * split by type. Set to false to overlay series so each shows its own count.
-   */
-  protected stackBuffSeries = true;
-
-  /**
    * Adds a vertical rule line for the given tracker at the given timestamp
    * @param trackerName the name of the tracker this rule line is for -
    *     will determine the line's color and its name in the legend
@@ -241,7 +235,6 @@ abstract class BuffCountGraph extends Analyzer {
         y: {
           field: 'Count',
           type: 'quantitative' as const,
-          ...(this.stackBuffSeries ? {} : { stack: null }),
         },
       },
       transform: [

--- a/src/parser/shared/modules/BuffCountGraph.tsx
+++ b/src/parser/shared/modules/BuffCountGraph.tsx
@@ -113,6 +113,12 @@ abstract class BuffCountGraph extends Analyzer {
   }
 
   /**
+   * When true (the default), area series are stacked so the chart height is total buffs out,
+   * split by type. Set to false to overlay series so each shows its own count.
+   */
+  protected stackBuffSeries = true;
+
+  /**
    * Adds a vertical rule line for the given tracker at the given timestamp
    * @param trackerName the name of the tracker this rule line is for -
    *     will determine the line's color and its name in the legend
@@ -235,9 +241,7 @@ abstract class BuffCountGraph extends Analyzer {
         y: {
           field: 'Count',
           type: 'quantitative' as const,
-          // Overlap series instead of stacking — stacked areas make early legend
-          // entries look massively inflated (e.g. Rejuv = Rejuv+WG+...).
-          stack: null,
+          ...(this.stackBuffSeries ? {} : { stack: null }),
         },
       },
       transform: [

--- a/src/parser/shared/modules/BuffCountGraph.tsx
+++ b/src/parser/shared/modules/BuffCountGraph.tsx
@@ -1,7 +1,6 @@
 import Spell from 'common/SPELLS/Spell';
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
-  AbilityEvent,
   ApplyBuffEvent,
   ApplyDebuffEvent,
   CastEvent,
@@ -44,6 +43,11 @@ abstract class BuffCountGraph extends Analyzer {
   graphData: GraphData[];
   /** Timestamp of the last data points added - used to avoid adding duplicate data on same timestamp */
   lastTimestamp: number;
+  /**
+   * Active buff instances keyed by target+spell. Used so a duplicate applybuff (without a matching
+   * remove) can't inflate the count — same semantics as HotTracker.
+   */
+  private activeBuffKeys = new Set<string>();
 
   protected constructor(options: Options) {
     super(options);
@@ -101,6 +105,14 @@ abstract class BuffCountGraph extends Analyzer {
   }
 
   /**
+   * Override to ignore buffs that shouldn't contribute to the graph (e.g. HoTs on pets).
+   * Only consulted on apply — removes are gated by whether the apply was counted.
+   */
+  protected shouldCountBuff(_event: ApplyBuffEvent | ApplyDebuffEvent): boolean {
+    return true;
+  }
+
+  /**
    * Adds a vertical rule line for the given tracker at the given timestamp
    * @param trackerName the name of the tracker this rule line is for -
    *     will determine the line's color and its name in the legend
@@ -124,15 +136,33 @@ abstract class BuffCountGraph extends Analyzer {
   }
 
   onBuffApplied(event: ApplyBuffEvent | ApplyDebuffEvent) {
+    if (!this.shouldCountBuff(event)) {
+      return;
+    }
+    const key = this._buffKey(event);
+    if (this.activeBuffKeys.has(key)) {
+      // Duplicate applybuff with no prior remove — don't inflate the count
+      return;
+    }
+    this.activeBuffKeys.add(key);
     this._onBuffChanged(event, 1);
   }
 
   onBuffRemoved(event: RemoveBuffEvent | RemoveDebuffEvent) {
+    const key = this._buffKey(event);
+    if (!this.activeBuffKeys.has(key)) {
+      // Never counted (filtered apply, phantom remove, or duplicate remove)
+      return;
+    }
+    this.activeBuffKeys.delete(key);
     this._onBuffChanged(event, -1);
   }
 
-  // oxlint-disable-next-line typescript-eslint/no-explicit-any -- Baseline suppression. Try to fix if you edit this code.
-  _onBuffChanged(event: AbilityEvent<any>, change: number) {
+  private _buffKey(event: GraphBuffEvent): string {
+    return `${event.targetID}-${event.ability.guid}`;
+  }
+
+  _onBuffChanged(event: GraphBuffEvent, change: number) {
     const applicableTrackers = this.buffTrackerLookup[event.ability.guid];
     if (!applicableTrackers) {
       // shouldn't be possible if the setup code works right...
@@ -205,6 +235,9 @@ abstract class BuffCountGraph extends Analyzer {
         y: {
           field: 'Count',
           type: 'quantitative' as const,
+          // Overlap series instead of stacking — stacked areas make early legend
+          // entries look massively inflated (e.g. Rejuv = Rejuv+WG+...).
+          stack: null,
         },
       },
       transform: [
@@ -415,6 +448,8 @@ abstract class BuffCountGraph extends Analyzer {
 }
 
 export default BuffCountGraph;
+
+type GraphBuffEvent = ApplyBuffEvent | ApplyDebuffEvent | RemoveBuffEvent | RemoveDebuffEvent;
 
 /**
  * Specification of a buff or cast to be graphed


### PR DESCRIPTION
### Description

Resto HoT graph now ignores pets/duplicate applies and overlays HoTs instead of stacking them.

### Testing

- Test report URL: `report/nL2X8AjMFtfp3w9P/38-Mythic+The+Twin+Fangs+-+Wipe+12+(1:58)/97-Jdotbres/standard`
- Screenshot(s):
New: 
<img width="1276" height="277" alt="image" src="https://github.com/user-attachments/assets/907022aa-4b48-4abf-96e2-55d669945f52" />
Old:
<img width="904" height="314" alt="image" src="https://github.com/user-attachments/assets/7dcf7cdd-af82-4951-9d25-484d7f45eec1" />
