### PR TITLE
[Arcane Mage] Prismatic Bolt, Arcane Barrage, and Arcane Orb Fixes/Improvements

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -14,8 +14,11 @@ const arcaneSalvo = <SpellLink spell={TALENTS.ARCANE_SALVO_TALENT} />
 const presenceOfMind = <SpellLink spell={TALENTS.PRESENCE_OF_MIND_TALENT} />
 const clearcasting = <SpellLink spell={SPELLS.CLEARCASTING_ARCANE} />
 const prismaticBolt = <SpellLink spell={SPELLS.PRISMATIC_BOLT} />
+const cumulativePower = <SpellLink spell={SPELLS.CUMULATIVE_POWER_BUFF} />;
 
 export default [
+  change(date(2026, 8, 26), <>Removed guidance about holding {arcaneBarrage} if {touchOfTheMagi} is coming soon.</>, Sharrq),
+  change(date(2026, 8, 26), <>Fixed a tooltip on {prismaticBolt} that listed targets hit instead of {cumulativePower} stacks.</>, Sharrq),
   change(date(2026, 8, 22), <>Adjusted {arcaneOrb} conditions for Sunfury to mark casts with without 4 Arcane Charges as good.</>, Sharrq),
   change(date(2026, 8, 22), <>Added {prismaticBolt} to the ability spellbook.</>, Sharrq),
   change(date(2026, 8, 22), <>Update {prismaticBolt} logic to be cleaner and to check for munched procs.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -21,7 +21,7 @@ export default [
   change(date(2026, 8, 22), <>Update {prismaticBolt} logic to be cleaner and to check for munched procs.</>, Sharrq),
   change(date(2026, 8, 15), <>Updated spec compatability to 12.1.</>, Sharrq),
   change(date(2026, 8, 15), <>Added support for {prismaticBolt}.</>, Sharrq),
-  change(date(2026, 8, 15), <>Replaced the Arcane Mana Management chart with a new heatmap visualization</>, Sharrq),
+  change(date(2026, 8, 15), <>Replaced the Arcane Mana Management chart with a new heatmap visualization.</>, Sharrq),
   change(date(2026, 8, 15), <>Updated the {arcaneBarrage}, {arcaneMissiles}, {arcaneOrb}, {arcaneSurge}, and {touchOfTheMagi} conditions for 12.1.</>, Sharrq),
   change(date(2026, 4, 26), <>Removed {arcaneCharge}s check from {touchOfTheMagi} for Spellslinger.</>, Sharrq),
   change(date(2026, 4, 21), <>Updated Spec Compatability to 12.0.5.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -16,6 +16,9 @@ const clearcasting = <SpellLink spell={SPELLS.CLEARCASTING_ARCANE} />
 const prismaticBolt = <SpellLink spell={SPELLS.PRISMATIC_BOLT} />
 
 export default [
+  change(date(2026, 8, 22), <>Adjusted {arcaneOrb} conditions for Sunfury to mark casts with without 4 Arcane Charges as good.</>, Sharrq),
+  change(date(2026, 8, 22), <>Added {prismaticBolt} to the ability spellbook.</>, Sharrq),
+  change(date(2026, 8, 22), <>Update {prismaticBolt} logic to be cleaner and to check for munched procs.</>, Sharrq),
   change(date(2026, 8, 15), <>Updated spec compatability to 12.1.</>, Sharrq),
   change(date(2026, 8, 15), <>Added support for {prismaticBolt}.</>, Sharrq),
   change(date(2026, 8, 15), <>Replaced the Arcane Mana Management chart with a new heatmap visualization</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CONFIG.tsx
+++ b/src/analysis/retail/mage/arcane/CONFIG.tsx
@@ -59,14 +59,14 @@ const config: Config = {
     overview: {
       notes: (
         <AlertWarning>
-          This spec has been fully updated for Midnight Season 2 (As of August 15). If anything is
+          This spec has been fully updated for Midnight Season 2 (As of August 22). If anything is
           missing or incorrect, please ping <code>@Sharrq</code> in the Altered Time Discord.
         </AlertWarning>
       ),
     },
   },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/report/ar37HGqfWFLNk8w6/26-Heroic+Vorasius+-+Kill+(4:07)/189-Alysseda/standard',
+  exampleReport: '/reports/vFkVyAND3J8dCrWg?fight=37&type=damage-done',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/mage/arcane/CONFIG.tsx
+++ b/src/analysis/retail/mage/arcane/CONFIG.tsx
@@ -59,7 +59,7 @@ const config: Config = {
     overview: {
       notes: (
         <AlertWarning>
-          This spec has been fully updated for Midnight Season 2 (As of August 22). If anything is
+          This spec has been fully updated for Midnight Season 2 (As of August 26). If anything is
           missing or incorrect, please ping <code>@Sharrq</code> in the Altered Time Discord.
         </AlertWarning>
       ),

--- a/src/analysis/retail/mage/arcane/CONFIG.tsx
+++ b/src/analysis/retail/mage/arcane/CONFIG.tsx
@@ -66,7 +66,8 @@ const config: Config = {
     },
   },
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
-  exampleReport: '/reports/vFkVyAND3J8dCrWg?fight=37&type=damage-done',
+  exampleReport:
+    '/report/vFkVyAND3J8dCrWg/37-Heroic+Nymrissa+Wavecaller+-+Kill+(5:23)/111-Yasury/standard',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/mage/arcane/analyzers/PrismaticBolt.tsx
+++ b/src/analysis/retail/mage/arcane/analyzers/PrismaticBolt.tsx
@@ -9,6 +9,7 @@ import Events, {
   EventType,
   GetRelatedEvent,
   GetRelatedEvents,
+  RefreshBuffEvent,
 } from 'parser/core/Events';
 import { TIERS } from 'game/TIERS';
 
@@ -19,46 +20,48 @@ export default class PrismaticBolt extends Analyzer {
     super(options);
     this.active = this.selectedCombatant.hasTalent(TALENTS.PRISMATIC_BOLT_3_ARCANE_TALENT);
     this.addEventListener(
-      Events.cast.by(SELECTED_PLAYER).spell(SPELLS.PRISMATIC_BOLT),
-      this.onBoltCast,
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.PRISMATIC_BOLT_BUFF),
+      this.onBoltApply,
+    );
+    this.addEventListener(
+      Events.refreshbuff.by(SELECTED_PLAYER).spell(SPELLS.PRISMATIC_BOLT_BUFF),
+      this.onBoltApply,
     );
   }
 
-  onBoltCast(event: CastEvent) {
-    const cumulativePowerStacks = this.selectedCombatant.getBuffStacks(
-      SPELLS.CUMULATIVE_POWER_BUFF,
-    );
-    const salvoStacks = this.selectedCombatant.getBuffStacks(SPELLS.ARCANE_SALVO_BUFF);
-    const hasClearcasting = this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE);
-    const has4pc = this.selectedCombatant.has4PieceByTier(TIERS.MID2);
-
-    const damageEvents: DamageEvent[] = GetRelatedEvents(event, EventType.Damage) || [];
-    const targetsHit = damageEvents.length;
-
-    const applyBuff: ApplyBuffEvent | undefined = GetRelatedEvent(event, EventType.ApplyBuff);
-    const delay = applyBuff && event.timestamp - applyBuff.timestamp;
-
-    this.log(applyBuff);
-    this.log(damageEvents);
+  onBoltApply(event: ApplyBuffEvent | RefreshBuffEvent) {
+    const refresh: RefreshBuffEvent | undefined = GetRelatedEvent(event, EventType.RefreshBuff);
+    const cast: CastEvent | undefined = GetRelatedEvent(event, EventType.Cast);
+    const damage: DamageEvent[] | undefined = GetRelatedEvents(event, EventType.Damage);
 
     this.prismaticBolts.push({
       timestamp: event.timestamp,
-      targetsHit,
-      cumulativePowerStacks,
-      salvoStacks,
-      hasClearcasting,
-      has4pc,
-      delay,
+      cast,
+      damage,
+      munched: refresh !== undefined,
+      has4pc: this.selectedCombatant.has4PieceByTier(TIERS.MID2),
+      hasClearcasting: this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE),
+      targetsHit: damage?.length || 0,
+      cumulativePowerStacks: cast
+        ? this.selectedCombatant.getBuffStacks(SPELLS.CUMULATIVE_POWER_BUFF, cast.timestamp)
+        : 0,
+      salvoStacks: cast
+        ? this.selectedCombatant.getBuffStacks(SPELLS.ARCANE_SALVO_BUFF, cast.timestamp)
+        : 0,
+      delay: cast ? cast.timestamp - event.timestamp : undefined,
     });
   }
 }
 
 export interface PrismaticBoltCast {
   timestamp: number;
+  cast?: CastEvent;
+  damage?: DamageEvent[];
+  munched: boolean;
   targetsHit: number;
+  has4pc: boolean;
+  hasClearcasting: boolean;
   cumulativePowerStacks: number;
   salvoStacks: number;
-  hasClearcasting: boolean;
-  has4pc: boolean;
   delay?: number;
 }

--- a/src/analysis/retail/mage/arcane/analyzers/PrismaticBolt.tsx
+++ b/src/analysis/retail/mage/arcane/analyzers/PrismaticBolt.tsx
@@ -41,6 +41,7 @@ export default class PrismaticBolt extends Analyzer {
       munched: refresh !== undefined,
       has4pc: this.selectedCombatant.has4PieceByTier(TIERS.MID2),
       hasClearcasting: this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE),
+      hasArcaneSoul: this.selectedCombatant.hasBuff(SPELLS.ARCANE_SOUL_BUFF),
       targetsHit: damage?.length || 0,
       cumulativePowerStacks: cast
         ? this.selectedCombatant.getBuffStacks(SPELLS.CUMULATIVE_POWER_BUFF, cast.timestamp)
@@ -61,6 +62,7 @@ export interface PrismaticBoltCast {
   targetsHit: number;
   has4pc: boolean;
   hasClearcasting: boolean;
+  hasArcaneSoul: boolean;
   cumulativePowerStacks: number;
   salvoStacks: number;
   delay?: number;

--- a/src/analysis/retail/mage/arcane/core/Abilities.tsx
+++ b/src/analysis/retail/mage/arcane/core/Abilities.tsx
@@ -55,6 +55,15 @@ class Abilities extends CoreAbilities {
           base: 1500,
         },
       },
+      {
+        spell: SPELLS.PRISMATIC_BOLT.id,
+        buffSpellId: SPELLS.PRISMATIC_BOLT_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS.PRISMATIC_BOLT_3_ARCANE_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        gcd: {
+          base: 1500,
+        },
+      },
 
       // Cooldowns
       {

--- a/src/analysis/retail/mage/arcane/guide/ArcaneBarrage.tsx
+++ b/src/analysis/retail/mage/arcane/guide/ArcaneBarrage.tsx
@@ -2,12 +2,7 @@ import { type JSX } from 'react';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/mage';
 import { SpellLink, SpellIcon } from 'interface';
-import {
-  formatPercentage,
-  formatDuration,
-  formatNumber,
-  formatDurationMillisMinSec,
-} from 'common/format';
+import { formatPercentage, formatNumber } from 'common/format';
 import GuideSection from 'interface/guide/components/GuideSection';
 import CastDetail, {
   type PerCastData,
@@ -52,13 +47,6 @@ class ArcaneBarrageGuide extends Analyzer {
     }
 
     // FAIL CONDITIONS
-    if (cast.touchCD < 5000 && cast.touchCD > 500) {
-      return {
-        timestamp: cast.cast.timestamp,
-        performance: QualitativePerformance.Fail,
-        reason: `Touch of the Magi available soon (${formatDurationMillisMinSec(cast.touchCD)})`,
-      };
-    }
 
     // PERFECT CONDITIONS
     if (this.isSpellslinger && cast.salvoStacks === 20 && hasMaxCharges) {
@@ -147,11 +135,11 @@ class ArcaneBarrageGuide extends Analyzer {
     }
 
     // OK CONDITIONS
-    if (this.isSpellslinger && cast.salvoStacks < 15 && cast.touchCD > 5000) {
+    if (this.isSpellslinger && cast.salvoStacks < 15) {
       return {
         timestamp: cast.cast.timestamp,
         performance: QualitativePerformance.Ok,
-        reason: `Had ${cast.salvoStacks} Arcane Salvo stacks with ${formatDurationMillisMinSec(cast.touchCD)} CD remaining on Touch of the Magi.`,
+        reason: `Had ${cast.salvoStacks} Arcane Salvo stacks.`,
       };
     }
 
@@ -222,10 +210,6 @@ class ArcaneBarrageGuide extends Analyzer {
           mana costs and damage. In order to maintain the damage increase as long as possible, you
           should only cast {arcaneBarrage} under the below conditions, and should always aim to have
           4 {arcaneCharge}s before casting {arcaneBarrage}.
-        </p>
-        <p>
-          Regardless of the below, if {touchOfTheMagi} will be available in the next 4-5 seconds,
-          you should hold {arcaneBarrage} for {touchOfTheMagi}.
         </p>
         {this.isSpellslinger && (
           <ul>
@@ -305,13 +289,6 @@ class ArcaneBarrageGuide extends Analyzer {
                   ))}
                 </>
               ),
-            }
-          : undefined,
-        cast.touchCD
-          ? {
-              label: 'Touch CD',
-              value: formatDuration(cast.touchCD, 1),
-              tooltip: `Cooldown Remaining on Touch of the Magi`,
             }
           : undefined,
       ].filter(Boolean) as PerCastStat[];

--- a/src/analysis/retail/mage/arcane/guide/ArcaneOrb.tsx
+++ b/src/analysis/retail/mage/arcane/guide/ArcaneOrb.tsx
@@ -34,11 +34,11 @@ class ArcaneOrbGuide extends Analyzer {
       };
     }
 
-    if (this.isSunfury && cast.chargesBefore >= 2) {
+    if (this.isSunfury && cast.chargesBefore === 4) {
       return {
         timestamp: cast.timestamp,
         performance: QualitativePerformance.Fail,
-        reason: `Had ${cast.chargesBefore} Arcane Charges before Arcane Orb.`,
+        reason: `Had 4 Arcane Charges before Arcane Orb.`,
       };
     }
 
@@ -67,19 +67,10 @@ class ArcaneOrbGuide extends Analyzer {
       };
     }
 
-    if (this.isSunfury && cast.chargesBefore === 0) {
+    if (this.isSunfury && cast.chargesBefore < 4) {
       return {
         timestamp: cast.timestamp,
         performance: QualitativePerformance.Good,
-        reason: `Had no Arcane Charges before Arcane Orb.`,
-      };
-    }
-
-    // OK CONDITIONS
-    if (this.isSunfury && cast.chargesBefore > 0) {
-      return {
-        timestamp: cast.timestamp,
-        performance: QualitativePerformance.Ok,
         reason: `Had ${cast.chargesBefore} Arcane Charges before Arcane Orb.`,
       };
     }
@@ -113,7 +104,9 @@ class ArcaneOrbGuide extends Analyzer {
         )}
         {this.isSunfury && (
           <ul>
-            <li>You have no {arcaneCharge}s.</li>
+            <li>
+              It will cap your {arcaneCharge}s or you have no {arcaneCharge}s
+            </li>
           </ul>
         )}
       </>

--- a/src/analysis/retail/mage/arcane/guide/PrismaticBolt.tsx
+++ b/src/analysis/retail/mage/arcane/guide/PrismaticBolt.tsx
@@ -24,7 +24,15 @@ class PrismaticBoltGuide extends Analyzer {
 
   private evaluatePrismaticBolt(pb: PrismaticBoltCast): CastEvaluation {
     // FAIL CONDITIONS
-    if (!pb.delay) {
+    if (pb.munched) {
+      return {
+        timestamp: pb.timestamp,
+        performance: QualitativePerformance.Fail,
+        reason: `Prismatic Bolt munched (overwritten).`,
+      };
+    }
+
+    if (!pb.cast) {
       return {
         timestamp: pb.timestamp,
         performance: QualitativePerformance.Fail,
@@ -181,7 +189,12 @@ class PrismaticBoltGuide extends Analyzer {
         performance: evaluation.performance,
         timestamp: this.owner.formatTimestamp(cast.timestamp),
         stats: [
-          {
+          cast.munched && {
+            value: cast.munched ? 'Yes' : 'No',
+            label: 'Munched Proc',
+            tooltip: <>Whether the proc was munched (overwritten) or not.</>,
+          },
+          !cast.munched && {
             value: formatDurationMillisMinSec(cast.delay || 0, 1),
             label: 'Delay until Cast',
             tooltip: (
@@ -191,15 +204,21 @@ class PrismaticBoltGuide extends Analyzer {
               </>
             ),
           },
-          {
+          !cast.munched && {
             value: cast.salvoStacks,
             label: 'Arcane Salvo Stacks',
             tooltip: <>The number of Arcane Salvo stacks the player had.</>,
           },
-          {
-            value: cast.cumulativePowerStacks,
-            label: 'Cumulative Power Stacks',
-            tooltip: <>The number of Cumulative Power stacks the player had.</>,
+          !cast.munched &&
+            cast.has4pc && {
+              value: cast.cumulativePowerStacks,
+              label: 'Cumulative Power Stacks',
+              tooltip: <>The number of Cumulative Power stacks the player had.</>,
+            },
+          !cast.munched && {
+            value: cast.targetsHit,
+            label: 'Targets Hit',
+            tooltip: <>The number of targets hit by Prismatic Bolt.</>,
           },
         ].filter(Boolean) as PerCastStat[],
         details: evaluation.reason,

--- a/src/analysis/retail/mage/arcane/guide/PrismaticBolt.tsx
+++ b/src/analysis/retail/mage/arcane/guide/PrismaticBolt.tsx
@@ -24,11 +24,11 @@ class PrismaticBoltGuide extends Analyzer {
 
   private evaluatePrismaticBolt(pb: PrismaticBoltCast): CastEvaluation {
     // FAIL CONDITIONS
-    if (pb.munched) {
+    if (pb.munched && !pb.hasArcaneSoul) {
       return {
         timestamp: pb.timestamp,
         performance: QualitativePerformance.Fail,
-        reason: `Prismatic Bolt munched (overwritten).`,
+        reason: `Prismatic Bolt munched (overwritten) without Arcane Soul.`,
       };
     }
 
@@ -86,6 +86,14 @@ class PrismaticBoltGuide extends Analyzer {
       };
     }
 
+    if (pb.munched && pb.hasArcaneSoul) {
+      return {
+        timestamp: pb.timestamp,
+        performance: QualitativePerformance.Good,
+        reason: `Proc was munched (overwritten), but Arcane Soul was active.`,
+      };
+    }
+
     // OK CONDITIONS
     if (this.isSpellslinger && pb.salvoStacks < 13) {
       return {
@@ -121,7 +129,7 @@ class PrismaticBoltGuide extends Analyzer {
       return {
         timestamp: pb.timestamp,
         performance: QualitativePerformance.Ok,
-        reason: `had ${pb.cumulativePowerStacks} targets.`,
+        reason: `Had ${pb.cumulativePowerStacks} Cumulative Power stacks.`,
       };
     }
 
@@ -138,14 +146,16 @@ class PrismaticBoltGuide extends Analyzer {
     const arcaneSalvo = <SpellLink spell={TALENTS.ARCANE_SALVO_TALENT} />;
     const clearcasting = <SpellLink spell={SPELLS.CLEARCASTING_ARCANE} />;
     const cumulativePower = <SpellLink spell={SPELLS.CUMULATIVE_POWER_BUFF} />;
+    const arcaneSoul = <SpellLink spell={SPELLS.ARCANE_SOUL_BUFF} />;
 
     const explanation = (
       <>
         <p>
           <b>{prismaticBolt}</b> is Arcane's new apex talent, added in 12.1, and is very strong. It
-          is a large contributor to your DPS and it does not stack, so you should make sure you are
-          spending it as quickly as possible while following the below guidelines to get the most
-          out of each cast.
+          is a large contributor to your DPS and it does not stack, so $
+          {this.isSunfury && `unless ${arcaneSoul} is active`}you should make sure you are spending
+          it as quickly as possible to avoid munching (overwritting) it. Follow the below guidelines
+          to get the most out of each cast.
         </p>
         {this.isSpellslinger && (
           <p>

--- a/src/analysis/retail/mage/arcane/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/arcane/normalizers/CastLinkNormalizer.ts
@@ -183,25 +183,43 @@ const EVENT_LINKS = createEventLinks(
   },
   {
     spell: SPELLS.PRISMATIC_BOLT_BUFF.id,
-    parentType: [EventType.ApplyBuff],
-    reverseRelation: EventType.ApplyBuff,
+    parentType: [EventType.ApplyBuff, EventType.RefreshBuff],
     links: [
-      link(EventType.Damage, {
-        id: SPELLS.PRISMATIC_BOLT.id,
-        anyTarget: true,
+      link(EventType.RemoveBuff, { maxLinks: 1, forwardBuffer: 60_000 }),
+      link(EventType.RefreshBuff, {
+        maxLinks: 1,
         forwardBuffer: 60_000,
-        condition: (linkingEvent, referencedEvent) => {
-          const buffEnd = GetRelatedEvent(linkingEvent, EventType.RemoveBuff);
-          return buffEnd ? referencedEvent.timestamp < buffEnd.timestamp + 2000 : false;
-        },
+        condition: (linkingEvent, referencedEvent) => linkingEvent !== referencedEvent,
       }),
       link(EventType.Cast, {
         id: SPELLS.PRISMATIC_BOLT.id,
         maxLinks: 1,
         anyTarget: true,
         forwardBuffer: 60_000,
+        condition: (linkingEvent, referencedEvent) => {
+          const buffEnd = GetRelatedEvent(linkingEvent, EventType.RemoveBuff);
+          const buffRefresh = GetRelatedEvent(linkingEvent, EventType.RefreshBuff);
+          const end =
+            buffEnd && buffRefresh
+              ? Math.min(buffEnd.timestamp, buffRefresh.timestamp)
+              : buffEnd?.timestamp || buffRefresh?.timestamp;
+          return end && referencedEvent.timestamp < end + 10 ? true : false;
+        },
       }),
-      link(EventType.RemoveBuff, { maxLinks: 1, forwardBuffer: 60_000 }),
+      link(EventType.Damage, {
+        id: SPELLS.PRISMATIC_BOLT.id,
+        anyTarget: true,
+        forwardBuffer: 60_000,
+        condition: (linkingEvent, referencedEvent) => {
+          const buffEnd = GetRelatedEvent(linkingEvent, EventType.RemoveBuff);
+          const buffRefresh = GetRelatedEvent(linkingEvent, EventType.RefreshBuff);
+          const end =
+            buffEnd && buffRefresh
+              ? Math.min(buffEnd.timestamp, buffRefresh.timestamp)
+              : buffEnd?.timestamp || buffRefresh?.timestamp;
+          return end && referencedEvent.timestamp < end + 2000 ? true : false;
+        },
+      }),
     ],
   },
   {


### PR DESCRIPTION
- Updated Prismatic Bolt to check for munched procs and reorganized the data collection and cast links for it.
- Added Prismatic Bolt to the Spellbook.
- Updated Arcane Orb to make Orb Casts for Sunfury good if they had < 4 arcane charges.
- Fixed a typo in Prismatic Bolt that referred to targets hit instead of cumulative power stacks.
- Removed the guidance to hold Arcane Barrage if Touch of the Magi will be available in 4-5 seconds.
- updated the sample log