### PR TITLE
feat(windwalker): update hero talent APL priorities

### DIFF
--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -6,6 +6,17 @@ import SpellLink from 'interface/SpellLink';
 
 export default [
   change(
+    date(2026, 7, 22),
+    <>
+      Updated Shado-Pan and Conduit of the Celestials APL priorities for{' '}
+      <SpellLink spell={TALENTS.WHIRLING_DRAGON_PUNCH_TALENT} />,{' '}
+      <SpellLink spell={TALENTS.ZENITH_STOMP_TALENT} />, and{' '}
+      <SpellLink spell={SPELLS.FISTS_OF_FURY_CAST} />, including Bloodlust-aware energy capping and
+      <SpellLink spell={TALENTS.HARMONIC_COMBO_TALENT} /> Chi costs.
+    </>,
+    Durpn,
+  ),
+  change(
     date(2026, 6, 29), 
     <>
       Added <SpellLink spell={TALENTS.SAVE_THEM_ALL_TALENT} /> module.

--- a/src/analysis/retail/monk/windwalker/CONFIG.tsx
+++ b/src/analysis/retail/monk/windwalker/CONFIG.tsx
@@ -10,8 +10,8 @@ const config: Config = {
   contributors: [Durpn],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.7',
-  supportLevel: SupportLevel.MaintainedFull,
+  patchCompatibility: '12.1.0',
+  supportLevel: SupportLevel.MaintainedPartial,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (

--- a/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/Abilities.tsx
@@ -1,6 +1,5 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
-import { TIERS } from 'game/TIERS';
 import CoreAbilities from 'parser/core/modules/Abilities';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
@@ -8,8 +7,6 @@ import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
 class Abilities extends CoreAbilities {
   spellbook(): SpellbookAbility[] {
     const combatant = this.selectedCombatant;
-    const hasMidnight4pc = combatant.has4PieceByTier(TIERS.MID1);
-    const windwalkerTierCooldownReduction = hasMidnight4pc ? 5 : 0;
     const communionWithWindReduction = combatant.hasTalent(TALENTS_MONK.COMMUNION_WITH_WIND_TALENT)
       ? 5
       : 0;
@@ -47,7 +44,7 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS_MONK.WHIRLING_DRAGON_PUNCH_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 35 - communionWithWindReduction - windwalkerTierCooldownReduction,
+        cooldown: 35 - communionWithWindReduction,
         gcd: {
           static: 1000,
         },
@@ -179,7 +176,7 @@ class Abilities extends CoreAbilities {
       {
         spell: TALENTS_MONK.STRIKE_OF_THE_WINDLORD_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
-        cooldown: 35 - communionWithWindReduction - windwalkerTierCooldownReduction,
+        cooldown: 35 - communionWithWindReduction,
         gcd: {
           static: 1000,
         },

--- a/src/analysis/retail/monk/windwalker/modules/apl/ConduitOfTheCelestialsApl.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/apl/ConduitOfTheCelestialsApl.tsx
@@ -12,15 +12,16 @@ import {
   describe,
   hasResource,
   hasTalent,
+  inBloodlust,
+  not,
   or,
   spellCooldownRemaining,
 } from 'parser/shared/metrics/apl/conditions';
 import {
   aboutToCapEnergy,
   buildComboStrikesApl,
-  danceOfChiJiExpiring,
-  notAtTwoBlackoutKickStacks,
-  notInZenithWithObsidianSpiral,
+  getZenithDurationMs,
+  notEnoughChiForFistsOfFury,
   optionalTouchOfDeath,
   whirlingDragonPunchReady,
 } from './common';
@@ -44,20 +45,25 @@ const activeHotJSRemaining = (range: { atLeast?: number; atMost?: number }) =>
 
 const celestialConduitCastable = buffPresent(SPELLS.CELESTIAL_CONDUIT_CASTABLE_WW);
 
+const xuenNotReadySoon = or(
+  not(hasTalent(TALENTS.INVOKE_XUEN_THE_WHITE_TIGER_TALENT)),
+  spellCooldownRemaining(TALENTS.INVOKE_XUEN_THE_WHITE_TIGER_TALENT, { atLeast: 10000 }),
+);
+
 export default function conduitOfTheCelestialsApl(combatant: Combatant): Apl {
   return buildComboStrikesApl([
     {
-      spell: TALENTS.FISTS_OF_FURY_TALENT,
-      condition: describe(activeHotJSRemaining({ atMost: 1000 }), () => (
-        <>
-          <SpellLink spell={SPELLS.HEART_OF_THE_JADE_SERPENT_BUFF} /> has less than 1 second
-          remaining
-        </>
-      )),
-    },
-    {
       spell: SPELLS.TOUCH_OF_DEATH,
       condition: optionalTouchOfDeath,
+    },
+    {
+      spell: TALENTS.WHIRLING_DRAGON_PUNCH_TALENT,
+      condition: describe(and(whirlingDragonPunchReady, xuenNotReadySoon), () => (
+        <>
+          <SpellLink spell={TALENTS.INVOKE_XUEN_THE_WHITE_TIGER_TALENT} /> will not be available
+          within 10 seconds
+        </>
+      )),
     },
     {
       spell: TALENTS.CELESTIAL_CONDUIT_WINDWALKER_TALENT,
@@ -68,27 +74,56 @@ export default function conduitOfTheCelestialsApl(combatant: Combatant): Apl {
       )),
     },
     {
-      spell: TALENTS.WHIRLING_DRAGON_PUNCH_TALENT,
-      condition: whirlingDragonPunchReady,
-    },
-    {
-      spell: SPELLS.TIGER_PALM,
+      spell: TALENTS.ZENITH_STOMP_TALENT,
       condition: describe(
-        and(
-          hasResource(RESOURCE_TYPES.CHI, { atMost: 3 }),
-          notAtTwoBlackoutKickStacks,
-          aboutToCapEnergy(combatant),
-          notInZenithWithObsidianSpiral,
+        or(
+          hasResource(RESOURCE_TYPES.CHI, { atMost: 2 }),
+          and(
+            buffPresent(TALENTS.ZENITH_TALENT),
+            buffRemaining(TALENTS.ZENITH_TALENT, getZenithDurationMs(combatant), { atMost: 3000 }),
+          ),
         ),
         () => (
           <>
-            you have less than 4 <SpellLink spell={RESOURCE_TYPES.CHI} />, fewer than 2 stacks of{' '}
-            <SpellLink spell={SPELLS.COMBO_BREAKER_BUFF} />, and are about to cap energy
+            you are low on <SpellLink spell={RESOURCE_TYPES.CHI} /> or{' '}
+            <SpellLink spell={TALENTS.ZENITH_TALENT} /> is almost over
           </>
         ),
       ),
     },
-    TALENTS.STRIKE_OF_THE_WINDLORD_TALENT,
+    {
+      spell: TALENTS.FISTS_OF_FURY_TALENT,
+      condition: describe(activeHotJSRemaining({ atMost: 1000 }), () => (
+        <>
+          <SpellLink spell={SPELLS.HEART_OF_THE_JADE_SERPENT_BUFF} /> has less than 1 second
+          remaining
+        </>
+      )),
+    },
+    {
+      spell: SPELLS.TIGER_PALM,
+      condition: describe(
+        or(
+          and(
+            hasResource(RESOURCE_TYPES.CHI, { atMost: 3 }),
+            aboutToCapEnergy(combatant),
+            not(buffPresent(TALENTS.ZENITH_TALENT)),
+            not(inBloodlust()),
+          ),
+          and(
+            spellCooldownRemaining(TALENTS.FISTS_OF_FURY_TALENT, { atMost: 1 }),
+            notEnoughChiForFistsOfFury(combatant),
+          ),
+        ),
+        () => (
+          <>
+            you are about to cap energy outside <SpellLink spell={TALENTS.ZENITH_TALENT} /> or do
+            not have enough <SpellLink spell={RESOURCE_TYPES.CHI} /> for{' '}
+            <SpellLink spell={TALENTS.FISTS_OF_FURY_TALENT} />
+          </>
+        ),
+      ),
+    },
     TALENTS.FISTS_OF_FURY_TALENT,
     {
       spell: SPELLS.RUSHING_WIND_KICK_CAST,
@@ -96,59 +131,64 @@ export default function conduitOfTheCelestialsApl(combatant: Combatant): Apl {
     },
     {
       spell: SPELLS.SPINNING_CRANE_KICK,
+      condition: describe(buffPresent(SPELLS.UNBROKEN_RHYTHM_BUFF), () => (
+        <>
+          you have <SpellLink spell={SPELLS.UNBROKEN_RHYTHM_BUFF} />
+        </>
+      )),
+    },
+    TALENTS.RISING_SUN_KICK_TALENT,
+    {
+      spell: SPELLS.BLACKOUT_KICK,
       condition: describe(
-        and(danceOfChiJiExpiring, notAtTwoBlackoutKickStacks, notInZenithWithObsidianSpiral),
+        or(
+          buffPresent(SPELLS.COMBO_BREAKER_BUFF),
+          and(buffPresent(TALENTS.ZENITH_TALENT), hasTalent(TALENTS.OBSIDIAN_SPIRAL_TALENT)),
+        ),
         () => (
           <>
-            <SpellLink spell={SPELLS.DANCE_OF_CHI_JI_BUFF} /> has less than 4 seconds remaining, and
-            you have fewer than 2 stacks of <SpellLink spell={SPELLS.COMBO_BREAKER_BUFF} />
+            you have <SpellLink spell={SPELLS.COMBO_BREAKER_BUFF} /> or{' '}
+            <SpellLink spell={TALENTS.ZENITH_TALENT} /> is active with{' '}
+            <SpellLink spell={TALENTS.OBSIDIAN_SPIRAL_TALENT} />
           </>
         ),
       ),
     },
-    TALENTS.RISING_SUN_KICK_TALENT,
-    TALENTS.ZENITH_STOMP_TALENT,
     {
-      spell: SPELLS.TIGER_PALM,
+      spell: SPELLS.SPINNING_CRANE_KICK,
       condition: describe(
-        or(
-          and(
-            spellCooldownRemaining(TALENTS.STRIKE_OF_THE_WINDLORD_TALENT, { atMost: 1 }),
-            hasResource(RESOURCE_TYPES.CHI, { atMost: 1 }),
-          ),
-          and(
-            spellCooldownRemaining(TALENTS.FISTS_OF_FURY_TALENT, { atMost: 1 }),
-            hasResource(RESOURCE_TYPES.CHI, { atMost: 2 }),
-          ),
-          and(
-            hasTalent(TALENTS.RUSHING_WIND_KICK_WINDWALKER_TALENT),
-            buffPresent(SPELLS.RUSHING_WIND_KICK_BUFF),
-            spellCooldownRemaining(SPELLS.RUSHING_WIND_KICK_CAST, { atMost: 1 }),
-            hasResource(RESOURCE_TYPES.CHI, { atMost: 1 }),
-          ),
-          and(danceOfChiJiExpiring, hasResource(RESOURCE_TYPES.CHI, { atMost: 1 })),
-          and(
-            spellCooldownRemaining(TALENTS.RISING_SUN_KICK_TALENT, { atMost: 1 }),
-            hasResource(RESOURCE_TYPES.CHI, { atMost: 1 }),
+        and(
+          buffPresent(TALENTS.ZENITH_TALENT),
+          or(
+            hasResource(RESOURCE_TYPES.CHI, { atLeast: 5 }),
+            buffPresent(SPELLS.DANCE_OF_CHI_JI_BUFF),
           ),
         ),
-        () => <>a higher-priority chi spender is ready, and you do not have enough chi for it</>,
+        () => (
+          <>
+            <SpellLink spell={TALENTS.ZENITH_TALENT} /> is active and you either have more than 4{' '}
+            <SpellLink spell={RESOURCE_TYPES.CHI} /> or{' '}
+            <SpellLink spell={SPELLS.DANCE_OF_CHI_JI_BUFF} />
+          </>
+        ),
       ),
     },
     {
-      spell: SPELLS.BLACKOUT_KICK,
-      condition: describe(buffPresent(SPELLS.COMBO_BREAKER_BUFF), () => (
+      spell: SPELLS.TIGER_PALM,
+      condition: hasResource(RESOURCE_TYPES.CHI, { atMost: 1 }),
+    },
+    {
+      spell: SPELLS.SPINNING_CRANE_KICK,
+      condition: describe(buffPresent(SPELLS.DANCE_OF_CHI_JI_BUFF), () => (
         <>
-          you have <SpellLink spell={SPELLS.COMBO_BREAKER_BUFF} />
+          you have <SpellLink spell={SPELLS.DANCE_OF_CHI_JI_BUFF} />
         </>
       )),
     },
-    TALENTS.SLICING_WINDS_TALENT,
     {
-      spell: SPELLS.SPINNING_CRANE_KICK,
-      condition: buffPresent(SPELLS.DANCE_OF_CHI_JI_BUFF),
+      spell: SPELLS.TIGER_PALM,
+      condition: hasResource(RESOURCE_TYPES.CHI, { atMost: 4 }),
     },
     SPELLS.BLACKOUT_KICK,
-    SPELLS.TIGER_PALM,
   ]);
 }

--- a/src/analysis/retail/monk/windwalker/modules/apl/ShadoPanApl.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/apl/ShadoPanApl.tsx
@@ -7,18 +7,21 @@ import { Apl } from 'parser/shared/metrics/apl';
 import {
   and,
   buffPresent,
+  buffRemaining,
   describe,
   hasResource,
   hasTalent,
+  inBloodlust,
+  not,
   or,
   spellCooldownRemaining,
 } from 'parser/shared/metrics/apl/conditions';
 import {
   aboutToCapEnergy,
   buildComboStrikesApl,
-  danceOfChiJiExpiring,
+  getZenithDurationMs,
   notAtTwoBlackoutKickStacks,
-  notInZenithWithObsidianSpiral,
+  notEnoughChiForFistsOfFury,
   optionalTouchOfDeath,
   whirlingDragonPunchReady,
 } from './common';
@@ -34,23 +37,48 @@ export default function shadoPanApl(combatant: Combatant): Apl {
       condition: whirlingDragonPunchReady,
     },
     {
-      spell: SPELLS.TIGER_PALM,
+      spell: TALENTS.ZENITH_STOMP_TALENT,
       condition: describe(
-        and(
-          hasResource(RESOURCE_TYPES.CHI, { atMost: 3 }),
-          notAtTwoBlackoutKickStacks,
-          aboutToCapEnergy(combatant),
-          notInZenithWithObsidianSpiral,
+        or(
+          hasResource(RESOURCE_TYPES.CHI, { atMost: 2 }),
+          and(
+            buffPresent(TALENTS.ZENITH_TALENT),
+            buffRemaining(TALENTS.ZENITH_TALENT, getZenithDurationMs(combatant), { atMost: 3000 }),
+          ),
         ),
         () => (
           <>
-            you have less than 4 <SpellLink spell={RESOURCE_TYPES.CHI} />, fewer than 2 stacks of{' '}
-            <SpellLink spell={SPELLS.COMBO_BREAKER_BUFF} />, and are about to cap energy
+            you are low on <SpellLink spell={RESOURCE_TYPES.CHI} /> or{' '}
+            <SpellLink spell={TALENTS.ZENITH_TALENT} /> is almost over
           </>
         ),
       ),
     },
-    TALENTS.STRIKE_OF_THE_WINDLORD_TALENT,
+    {
+      spell: SPELLS.TIGER_PALM,
+      condition: describe(
+        or(
+          and(
+            hasResource(RESOURCE_TYPES.CHI, { atMost: 3 }),
+            aboutToCapEnergy(combatant),
+            not(buffPresent(TALENTS.ZENITH_TALENT)),
+            not(inBloodlust()),
+            notAtTwoBlackoutKickStacks,
+          ),
+          and(
+            spellCooldownRemaining(TALENTS.FISTS_OF_FURY_TALENT, { atMost: 1 }),
+            notEnoughChiForFistsOfFury(combatant),
+          ),
+        ),
+        () => (
+          <>
+            you are about to cap energy outside <SpellLink spell={TALENTS.ZENITH_TALENT} /> or do
+            not have enough <SpellLink spell={RESOURCE_TYPES.CHI} /> for{' '}
+            <SpellLink spell={TALENTS.FISTS_OF_FURY_TALENT} />
+          </>
+        ),
+      ),
+    },
     TALENTS.FISTS_OF_FURY_TALENT,
     {
       spell: SPELLS.RUSHING_WIND_KICK_CAST,
@@ -59,53 +87,28 @@ export default function shadoPanApl(combatant: Combatant): Apl {
     {
       spell: SPELLS.SPINNING_CRANE_KICK,
       condition: describe(
-        and(danceOfChiJiExpiring, notAtTwoBlackoutKickStacks, notInZenithWithObsidianSpiral),
+        and(buffPresent(SPELLS.DANCE_OF_CHI_JI_BUFF), buffPresent(SPELLS.UNBROKEN_RHYTHM_BUFF)),
         () => (
           <>
-            <SpellLink spell={SPELLS.DANCE_OF_CHI_JI_BUFF} /> has less than 4 seconds remaining, and
-            you have fewer than 2 stacks of <SpellLink spell={SPELLS.COMBO_BREAKER_BUFF} />
+            you have <SpellLink spell={SPELLS.DANCE_OF_CHI_JI_BUFF} /> and{' '}
+            <SpellLink spell={SPELLS.UNBROKEN_RHYTHM_BUFF} />
           </>
         ),
       ),
     },
     TALENTS.RISING_SUN_KICK_TALENT,
-    TALENTS.ZENITH_STOMP_TALENT,
-    {
-      spell: SPELLS.TIGER_PALM,
-      condition: describe(
-        or(
-          and(
-            spellCooldownRemaining(TALENTS.STRIKE_OF_THE_WINDLORD_TALENT, { atMost: 1 }),
-            hasResource(RESOURCE_TYPES.CHI, { atMost: 1 }),
-          ),
-          and(
-            spellCooldownRemaining(TALENTS.FISTS_OF_FURY_TALENT, { atMost: 1 }),
-            hasResource(RESOURCE_TYPES.CHI, { atMost: 2 }),
-          ),
-          and(
-            hasTalent(TALENTS.RUSHING_WIND_KICK_WINDWALKER_TALENT),
-            buffPresent(SPELLS.RUSHING_WIND_KICK_BUFF),
-            spellCooldownRemaining(SPELLS.RUSHING_WIND_KICK_CAST, { atMost: 1 }),
-            hasResource(RESOURCE_TYPES.CHI, { atMost: 1 }),
-          ),
-          and(danceOfChiJiExpiring, hasResource(RESOURCE_TYPES.CHI, { atMost: 1 })),
-          and(
-            spellCooldownRemaining(TALENTS.RISING_SUN_KICK_TALENT, { atMost: 1 }),
-            hasResource(RESOURCE_TYPES.CHI, { atMost: 1 }),
-            notInZenithWithObsidianSpiral,
-          ),
-        ),
-        () => <>a higher-priority chi spender is ready, and you do not have enough chi for it</>,
-      ),
-    },
     {
       spell: SPELLS.BLACKOUT_KICK,
       condition: describe(
-        or(buffPresent(SPELLS.COMBO_BREAKER_BUFF), buffPresent(TALENTS.ZENITH_TALENT)),
+        or(
+          buffPresent(SPELLS.COMBO_BREAKER_BUFF),
+          and(buffPresent(TALENTS.ZENITH_TALENT), hasTalent(TALENTS.OBSIDIAN_SPIRAL_TALENT)),
+        ),
         () => (
           <>
             you have <SpellLink spell={SPELLS.COMBO_BREAKER_BUFF} /> or{' '}
-            <SpellLink spell={TALENTS.ZENITH_TALENT} /> is active
+            <SpellLink spell={TALENTS.ZENITH_TALENT} /> is active with{' '}
+            <SpellLink spell={TALENTS.OBSIDIAN_SPIRAL_TALENT} />
           </>
         ),
       ),
@@ -113,22 +116,38 @@ export default function shadoPanApl(combatant: Combatant): Apl {
     {
       spell: SPELLS.SPINNING_CRANE_KICK,
       condition: describe(
-        and(buffPresent(TALENTS.ZENITH_TALENT), hasResource(RESOURCE_TYPES.CHI, { atLeast: 4 })),
+        and(
+          buffPresent(TALENTS.ZENITH_TALENT),
+          or(
+            hasResource(RESOURCE_TYPES.CHI, { atLeast: 5 }),
+            buffPresent(SPELLS.DANCE_OF_CHI_JI_BUFF),
+          ),
+        ),
         () => (
           <>
-            <SpellLink spell={TALENTS.ZENITH_TALENT} /> is active and you have more than 3{' '}
-            <SpellLink spell={RESOURCE_TYPES.CHI} />
+            <SpellLink spell={TALENTS.ZENITH_TALENT} /> is active and you either have more than 4{' '}
+            <SpellLink spell={RESOURCE_TYPES.CHI} /> or{' '}
+            <SpellLink spell={SPELLS.DANCE_OF_CHI_JI_BUFF} />
           </>
         ),
       ),
     },
-    TALENTS.SLICING_WINDS_TALENT,
+    {
+      spell: SPELLS.TIGER_PALM,
+      condition: hasResource(RESOURCE_TYPES.CHI, { atMost: 1 }),
+    },
     {
       spell: SPELLS.SPINNING_CRANE_KICK,
-      condition: buffPresent(SPELLS.DANCE_OF_CHI_JI_BUFF),
+      condition: describe(buffPresent(SPELLS.DANCE_OF_CHI_JI_BUFF), () => (
+        <>
+          you have <SpellLink spell={SPELLS.DANCE_OF_CHI_JI_BUFF} />
+        </>
+      )),
+    },
+    {
+      spell: SPELLS.TIGER_PALM,
+      condition: hasResource(RESOURCE_TYPES.CHI, { atMost: 4 }),
     },
     SPELLS.BLACKOUT_KICK,
-    SPELLS.SPINNING_CRANE_KICK,
-    SPELLS.TIGER_PALM,
   ]);
 }

--- a/src/analysis/retail/monk/windwalker/modules/apl/common.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/apl/common.tsx
@@ -25,6 +25,7 @@ import {
 import { ABILITIES_AFFECTED_BY_MASTERY } from '../../constants';
 
 const DANCE_OF_CHI_JI_DURATION_MS = 15000;
+export const BASE_ZENITH_DURATION_MS = 20000;
 
 const MASTERY_AFFECTED_IDS = new Set(ABILITIES_AFFECTED_BY_MASTERY.map((spell) => spell.id));
 
@@ -143,6 +144,14 @@ export const aboutToCapEnergy = (combatant: Combatant) =>
       0.85,
   });
 
+export function fistsOfFuryChiCost(combatant: Combatant) {
+  return combatant.hasTalent(TALENTS.HARMONIC_COMBO_TALENT) ? 2 : 3;
+}
+
+export function notEnoughChiForFistsOfFury(combatant: Combatant) {
+  return hasResource(RESOURCE_TYPES.CHI, { atMost: fistsOfFuryChiCost(combatant) - 1 });
+}
+
 /**
  * Combo Breaker is considered "not capped" until Blackout Kick! reaches 2
  * stacks, which is the point where further proc value can be lost.
@@ -181,6 +190,12 @@ export const danceOfChiJiExpiring = and(
   buffPresent(SPELLS.DANCE_OF_CHI_JI_BUFF),
   buffRemaining(SPELLS.DANCE_OF_CHI_JI_BUFF, DANCE_OF_CHI_JI_DURATION_MS, { atMost: 4000 }),
 );
+
+export function getZenithDurationMs(combatant: Combatant) {
+  return (
+    BASE_ZENITH_DURATION_MS + (combatant.hasTalent(TALENTS.DRINKING_HORN_COVER_TALENT) ? 5000 : 0)
+  );
+}
 
 /**
  * Touch of Death castability depends on game state the analyzer does not

--- a/src/analysis/retail/monk/windwalker/modules/talents/Zenith.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/talents/Zenith.tsx
@@ -22,6 +22,7 @@ import Statistic from 'parser/ui/Statistic';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import { STATISTIC_ORDER } from 'parser/ui/StatisticBox';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import { getZenithDurationMs } from '../apl/common';
 
 const ADDITIONAL_BLACKOUT_KICK_CDR_MS = 1000;
 const TOTM_CONSUME_WINDOW_MS = 400;
@@ -43,7 +44,7 @@ class Zenith extends Analyzer.withDependencies({
   private currentZenithStompStacks = 0;
   private readonly hasObsidianSpiral: boolean = false;
   private readonly additionalZenithStompCharges: number = 0;
-  private readonly zenithDurationMs: number = 15000;
+  private readonly zenithDurationMs: number = 0;
   private lastBlackoutKickTimestamp = 0;
 
   constructor(options: Options) {
@@ -58,9 +59,7 @@ class Zenith extends Analyzer.withDependencies({
     )
       ? 2
       : 0;
-    this.zenithDurationMs =
-      15000 +
-      (this.selectedCombatant.hasTalent(TALENTS_MONK.DRINKING_HORN_COVER_TALENT) ? 5000 : 0);
+    this.zenithDurationMs = getZenithDurationMs(this.selectedCombatant);
 
     this.addEventListener(
       Events.cast.by(SELECTED_PLAYER).spell(TALENTS_MONK.ZENITH_TALENT),

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -864,6 +864,11 @@ const spells = {
     name: 'Extra Kick',
     icon: 'inv_flaming_splinter',
   },
+  UNBROKEN_RHYTHM_BUFF: {
+    id: 1297033,
+    name: 'Unbroken Rhythm',
+    icon: 'ability_monk_boughstrike',
+  },
 
   // Windwalker Spells
   COMBO_STRIKES: {

--- a/src/parser/core/Combatant.test.jsx
+++ b/src/parser/core/Combatant.test.jsx
@@ -1,4 +1,5 @@
 import COMBATANTINFO from 'parser/core/tests/COMBATANTINFO.json';
+import SPELLS from 'common/SPELLS';
 
 import { FullCombatant } from './Combatant';
 
@@ -124,6 +125,63 @@ describe('Combatant', () => {
     it('returns false when neither weapon carries the enchant', () => {
       // mainhand 128868 has no permanentEnchant in the fixture
       expect(getCombatant().hasWeaponEnchant({ effectId: 99999 })).toBe(false);
+    });
+  });
+
+  describe('inBloodlust', () => {
+    it('returns true when a bloodlust-family buff is active', () => {
+      const combatant = getCombatant();
+      combatant.applyBuff({
+        type: 'applybuff',
+        timestamp: 10,
+        ability: {
+          guid: SPELLS.HEROISM.id,
+          name: SPELLS.HEROISM.name,
+          type: 0,
+          abilityIcon: SPELLS.HEROISM.icon,
+        },
+        sourceID: 22,
+        sourceIsFriendly: true,
+        targetID: combatant.id,
+        targetIsFriendly: true,
+      });
+
+      expect(combatant.inBloodlust()).toBe(true);
+    });
+
+    it('returns true when a bloodlust-family buff is present prepull', () => {
+      const combatant = getCombatant(null, {
+        ...COMBATANTINFO,
+        auras: [
+          {
+            ability: SPELLS.TIME_WARP.id,
+            icon: `${SPELLS.TIME_WARP.icon}.jpg`,
+            source: 22,
+          },
+        ],
+      });
+
+      expect(combatant.inBloodlust()).toBe(true);
+    });
+
+    it('returns false when only unrelated buffs are active', () => {
+      const combatant = getCombatant();
+      combatant.applyBuff({
+        type: 'applybuff',
+        timestamp: 10,
+        ability: {
+          guid: SPELLS.STORMLASH.id,
+          name: SPELLS.STORMLASH.name,
+          type: 0,
+          abilityIcon: SPELLS.STORMLASH.icon,
+        },
+        sourceID: 22,
+        sourceIsFriendly: true,
+        targetID: combatant.id,
+        targetIsFriendly: true,
+      });
+
+      expect(combatant.inBloodlust()).toBe(false);
     });
   });
 

--- a/src/parser/core/Combatant.ts
+++ b/src/parser/core/Combatant.ts
@@ -1,5 +1,6 @@
 import { Enchant } from 'common/ITEMS/Item';
 import { TIER_BY_CLASSES } from 'common/ITEMS';
+import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
 import { getClassBySpecId } from 'game/CLASSES';
 import GEAR_SLOTS from 'game/GEAR_SLOTS';
 import Faction, { factionFromWclId } from 'game/Faction';
@@ -27,6 +28,7 @@ interface Spell {
 
 export type GearSlotName = keyof typeof GEAR_SLOTS;
 export type SlotMap<T> = Partial<Record<GearSlotName, T>>;
+const BLOODLUST_BUFF_IDS = Object.keys(BLOODLUST_BUFFS).map(Number);
 
 class Combatant extends Entity {
   readonly player: PlayerInfo;
@@ -231,6 +233,10 @@ class Combatant extends Entity {
       this.getGear('MAINHAND')?.permanentEnchant === enchant.effectId ||
       this.getGear('OFFHAND')?.permanentEnchant === enchant.effectId
     );
+  }
+
+  inBloodlust(forTimestamp: number | null = null): boolean {
+    return BLOODLUST_BUFF_IDS.some((spellId) => this.hasBuff(spellId, forTimestamp));
   }
 
   // region Gear

--- a/src/parser/shared/metrics/apl/conditions/inBloodlust.tsx
+++ b/src/parser/shared/metrics/apl/conditions/inBloodlust.tsx
@@ -1,0 +1,34 @@
+import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
+import { EventType } from 'parser/core/Events';
+
+import { Condition, tenseAlt } from '../index';
+
+/**
+ * Tracks any Bloodlust-family haste buff as an APL condition.
+ */
+export default function inBloodlust(): Condition<boolean> {
+  let playerId: number;
+  return {
+    key: 'inBloodlust',
+    init: (info) => {
+      playerId = info.playerId;
+      return info.combatant.inBloodlust();
+    },
+    update: (state, event) => {
+      switch (event.type) {
+        case EventType.ApplyBuff:
+          return event.targetID === playerId && event.ability.guid in BLOODLUST_BUFFS
+            ? true
+            : state;
+        case EventType.RemoveBuff:
+          return event.targetID === playerId && event.ability.guid in BLOODLUST_BUFFS
+            ? false
+            : state;
+        default:
+          return state;
+      }
+    },
+    validate: (state) => state,
+    describe: (tense) => <>you {tenseAlt(tense, 'are', 'were')} in Bloodlust</>,
+  };
+}

--- a/src/parser/shared/metrics/apl/conditions/index.tsx
+++ b/src/parser/shared/metrics/apl/conditions/index.tsx
@@ -7,6 +7,7 @@ export { default as spellAvailable } from './spellAvailable';
 export { default as spellCooldownRemaining } from './spellCooldownRemaining';
 export { default as buffRemaining } from './buffRemaining';
 export { default as hasResource } from './hasResource';
+export { default as inBloodlust } from './inBloodlust';
 export { default as inExecute } from './inExecute';
 export { default as or } from './or';
 export { default as not } from './not';


### PR DESCRIPTION
### Description

Add shared Bloodlust detection and account for Harmonic Combo's reduced Fists of Fury Chi cost in APL resource checks.

Update Shado-Pan and Conduit of the Celestials priorities for Whirling Dragon Punch, Zenith Stomp, Fists of Fury, Tiger Palm, and hero-talent-specific proc windows. Remove obsolete Midnight Season 1 four-piece cooldown adjustments.

### Testing

- Test report URL: `/report/...`
- Screenshot(s):

<img width="1132" height="881" alt="image" src="https://github.com/user-attachments/assets/792de325-5c84-4791-9b6f-15fea813d886" />
<img width="1092" height="865" alt="image" src="https://github.com/user-attachments/assets/7d093f6f-38e0-45e4-8708-ec8011251521" />
