### PR TITLE
[rShaman] Surging Totem/Healing Rain fix in Guide

### DIFF
--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2026, 8, 23), <>Fixed an error that broke the cast efficiency for <SpellLink spell={SPELLS.SURGING_TOTEM} />. Fixed an issue that prevented the correct calculation of <SpellLink spell={TALENTS.STORMSTREAM_TOTEM_1_RESTORATION_TALENT} /> in the Mana Efficiency section. </>, Naltarunir),
   change(date(2026, 8, 22), <>Updated the <SpellLink spell={TALENTS.REACTIVE_WARDING_TALENT} /> module. Pumped version support for 12.1 </>, Naltarunir),
   change(date(2026, 8, 11), <>Updated the <SpellLink spell={TALENTS.TIDAL_WAVES_TALENT} /> module. Added a new Graph for the gerneration and consumtion of <SpellLink spell={TALENTS.COALESCING_WATER_TALENT} /> . Updated and extended the module for <SpellLink spell={TALENTS.EARTH_SHIELD_TALENT} />. </>, Naltarunir),
   change(date(2026, 8, 9), <>Updated the <SpellLink spell={TALENTS.SPIRIT_LINK_TOTEM_TALENT} /> module to respect the additional damage reduction provided by <SpellLink spell={TALENTS.SPOUTING_SPIRITS_TALENT} /> . Updated the AlwaysBeCasting module to account for <SpellLink spell={TALENTS.STORMSTREAM_TOTEM_1_RESTORATION_TALENT} /> , <SpellLink spell={TALENTS.SURGING_TOTEM_TALENT} /> , <SpellLink spell={TALENTS.ASCENDANCE_RESTORATION_TALENT} /> as well as dispells and purges. Updated and enabled the Defensives-module for rShaman. </>, Naltarunir),

--- a/src/analysis/retail/shaman/restoration/modules/Abilities.ts
+++ b/src/analysis/retail/shaman/restoration/modules/Abilities.ts
@@ -23,16 +23,56 @@ class Abilities extends ClassAbilities {
     const totemCDR = combatant.hasTalent(TALENTS.TOTEMIC_SURGE_TALENT) ? 5 : 0;
     return [
       ...super.spellbook(),
+
+      //Rotational
+      {
+        spell: SPELLS.HEALING_WAVE.id,
+        timelineSortIndex: 13,
+        gcd: {
+          base: 1500,
+        },
+        category: SPELL_CATEGORY.ROTATIONAL,
+        castEfficiency: {
+          suggestion: false,
+          // casts: (castCount) => castCount.casts - (castCount.healingTwHits || 0),
+        },
+      },
+      {
+        spell: SPELLS.HEALING_WAVE.id,
+        name: i18n._(
+          defineMessage({
+            id: 'shaman.restoration.abilities.buffedByTidalWave',
+            message: `Tidal Waved ${SPELLS.HEALING_WAVE.name}`,
+          }),
+        ),
+        timelineSortIndex: 13,
+        gcd: {
+          base: 1500,
+        },
+        category: SPELL_CATEGORY.ROTATIONAL,
+        castEfficiency: {
+          suggestion: false,
+          // casts: (castCount) => castCount.healingTwHits || 0,
+        },
+      },
+      {
+        spell: TALENTS.CHAIN_HEAL_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.CHAIN_HEAL_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        timelineSortIndex: 12,
+        gcd: {
+          base: 1500,
+        },
+      },
       {
         spell: TALENTS.RIPTIDE_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         enabled: combatant.hasTalent(TALENTS.RIPTIDE_TALENT),
-        charges:
-          1 +
-          combatant.getMultipleTalentRanks(
-            TALENTS.ECHO_OF_THE_ELEMENTS_TALENT,
-            TALENTS.ELEMENTAL_REVERB_TALENT,
-          ),
+        charges: combatant.getMultipleTalentRanks(
+          TALENTS.RIPTIDE_TALENT,
+          TALENTS.ECHO_OF_THE_ELEMENTS_TALENT,
+          TALENTS.ELEMENTAL_REVERB_TALENT,
+        ),
         cooldown: 6 - (combatant.hasTalent(TALENTS.RIP_CURRENT_TALENT) ? 1 : 0),
         //"Offering from Beyond" and "Mystic Knowledge" are both handled by dedicated Analyzers
         timelineSortIndex: 11,
@@ -42,14 +82,7 @@ class Abilities extends ClassAbilities {
         castEfficiency: {
           suggestion: false,
         },
-      },
-      {
-        spell: SPELLS.PURIFY_SPIRIT.id, //Baseline for restoration. Spell ID does not change in log if the talent 'Improved Purify Spirit' has been taken.
-        category: SPELL_CATEGORY.UTILITY,
-        cooldown: 8,
-        gcd: {
-          base: 1500,
-        },
+        healSpellIds: [TALENTS.RIPTIDE_TALENT.id],
       },
       {
         spell: [SPELLS.HEALING_STREAM_TOTEM.id],
@@ -98,6 +131,7 @@ class Abilities extends ClassAbilities {
         castEfficiency: {
           suggestion: false,
         },
+        healSpellIds: [SPELLS.STORMSTREAM_TOTEM_HEAL.id],
       },
       {
         spell: TALENTS.HEALING_RAIN_TALENT.id,
@@ -116,7 +150,28 @@ class Abilities extends ClassAbilities {
           averageIssueEfficiency: 0.7,
           recommendedEfficiency: 0.8,
         },
-        healSpellIds: [SPELLS.HEALING_RAIN_HEAL.id],
+        healSpellIds: [
+          SPELLS.HEALING_RAIN_HEAL.id,
+          SPELLS.OVERFLOWING_SHORES_HEAL.id,
+          SPELLS.TIDEWATERS_HEAL.id,
+        ],
+        damageSpellIds: [SPELLS.ACID_RAIN_DAMAGE.id],
+      },
+      {
+        spell: SPELLS.SURGING_TOTEM.id,
+        enabled: combatant.hasTalent(TALENTS.SURGING_TOTEM_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: 30 - totemCDR,
+        timelineSortIndex: 17,
+        gcd: {
+          base: 1500,
+        },
+        healSpellIds: [
+          SPELLS.HEALING_RAIN_HEAL.id,
+          SPELLS.OVERFLOWING_SHORES_HEAL.id,
+          SPELLS.TIDEWATERS_HEAL.id,
+        ],
+        damageSpellIds: [SPELLS.ACID_RAIN_DAMAGE.id],
       },
       {
         spell: SPELLS.HEALING_RAIN_TOTEMIC.id,
@@ -131,12 +186,35 @@ class Abilities extends ClassAbilities {
           // averageIssueEfficiency: 0.5,
           // recommendedEfficiency: 0.7,
         },
-        healSpellIds: [SPELLS.HEALING_RAIN_HEAL.id],
+        healSpellIds: [
+          SPELLS.HEALING_RAIN_HEAL.id,
+          SPELLS.OVERFLOWING_SHORES_HEAL.id,
+          SPELLS.TIDEWATERS_HEAL.id,
+        ],
+        damageSpellIds: [SPELLS.ACID_RAIN_DAMAGE.id],
+      },
+      {
+        spell: SPELLS.DOWNPOUR_ABILITY.id,
+        enabled: combatant.hasTalent(TALENTS.DOWNPOUR_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: 0,
+        gcd: {
+          base: 1500,
+        },
+        charges: combatant.hasTalent(TALENTS.DOUBLE_DIP_TALENT) ? 2 : 1,
+        timelineSortIndex: 20,
+        castEfficiency: {
+          suggestion: false,
+          // majorIssueEfficiency: 0.2,
+          // averageIssueEfficiency: 0.4,
+          // recommendedEfficiency: 0.6,
+        },
+        range: 100,
+        healSpellIds: [SPELLS.DOWNPOUR_HEAL.id],
       },
       {
         spell: TALENTS.UNLEASH_LIFE_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.UNLEASH_LIFE_TALENT),
-        buffSpellId: TALENTS.UNLEASH_LIFE_TALENT.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         cooldown: 20 - (combatant.has2PieceByTier(TIERS.MID1) ? 3 : 0),
         timelineSortIndex: 5,
@@ -149,11 +227,25 @@ class Abilities extends ClassAbilities {
           averageIssueEfficiency: 0.8,
           recommendedEfficiency: 0.9,
         },
+        healSpellIds: [TALENTS.UNLEASH_LIFE_TALENT.id],
       },
+      {
+        spell: SPELLS.ANCESTRAL_SWIFTNESS_CAST.id,
+        enabled: combatant.hasTalent(TALENTS.ANCESTRAL_SWIFTNESS_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        gcd: null,
+        cooldown: 30,
+        castEfficiency: {
+          suggestion: false,
+          majorIssueEfficiency: 0.7,
+          averageIssueEfficiency: 0.8,
+          recommendedEfficiency: 0.9,
+        },
+      },
+      //Cooldowns
       {
         spell: TALENTS.ASCENDANCE_RESTORATION_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.ASCENDANCE_RESTORATION_TALENT),
-        buffSpellId: TALENTS.ASCENDANCE_RESTORATION_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: 180 - (combatant.hasTalent(TALENTS.FIRST_ASCENDANT_TALENT) ? 60 : 0),
         gcd: {
@@ -170,7 +262,6 @@ class Abilities extends ClassAbilities {
       {
         spell: TALENTS.HEALING_TIDE_TOTEM_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.HEALING_TIDE_TOTEM_TALENT),
-        buffSpellId: TALENTS.HEALING_TIDE_TOTEM_TALENT.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: 180 - (combatant.hasTalent(TALENTS.FIRST_ASCENDANT_TALENT) ? 60 : 0) - totemCDR,
         gcd: {
@@ -198,76 +289,9 @@ class Abilities extends ClassAbilities {
           // averageIssueEfficiency: 0.4,
           // recommendedEfficiency: 0.6,
         },
+        healSpellIds: [SPELLS.SPOUTING_SPIRITS.id],
       },
-      {
-        spell: SPELLS.HEALING_WAVE.id,
-        timelineSortIndex: 13,
-        gcd: {
-          base: 1500,
-        },
-        category: SPELL_CATEGORY.OTHERS,
-        castEfficiency: {
-          suggestion: false,
-          // casts: (castCount) => castCount.casts - (castCount.healingTwHits || 0),
-        },
-      },
-      {
-        spell: SPELLS.HEALING_WAVE.id,
-        name: i18n._(
-          defineMessage({
-            id: 'shaman.restoration.abilities.buffedByTidalWave',
-            message: `Tidal Waved ${SPELLS.HEALING_WAVE.name}`,
-          }),
-        ),
-        timelineSortIndex: 13,
-        gcd: {
-          base: 1500,
-        },
-        category: SPELL_CATEGORY.OTHERS,
-        castEfficiency: {
-          suggestion: false,
-          // casts: (castCount) => castCount.healingTwHits || 0,
-        },
-      },
-      {
-        spell: TALENTS.CHAIN_HEAL_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.CHAIN_HEAL_TALENT),
-        buffSpellId: SPELLS.HIGH_TIDE_BUFF.id,
-        category: SPELL_CATEGORY.OTHERS,
-        timelineSortIndex: 12,
-        gcd: {
-          base: 1500,
-        },
-      },
-      {
-        spell: TALENTS.LAVA_BURST_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS.LAVA_BURST_TALENT),
-        buffSpellId: SPELLS.LAVA_SURGE.id,
-        category: SPELL_CATEGORY.HEALER_DAMAGING_SPELL,
-        charges: combatant.hasTalent(TALENTS.ECHO_OF_THE_ELEMENTS_TALENT) ? 2 : 1,
-        timelineSortIndex: 60,
-        cooldown: 8,
-        gcd: {
-          base: 1500,
-        },
-      },
-      {
-        spell: SPELLS.DOWNPOUR_ABILITY.id,
-        enabled: combatant.hasTalent(TALENTS.DOWNPOUR_TALENT),
-        category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 0,
-        gcd: {
-          base: 1500,
-        },
-        charges: combatant.hasTalent(TALENTS.DOUBLE_DIP_TALENT) ? 2 : 1,
-        timelineSortIndex: 20,
-        castEfficiency: {
-          suggestion: false,
-          // majorIssueEfficiency: 0.2,
-          // averageIssueEfficiency: 0.4,
-          // recommendedEfficiency: 0.6,
-        },
-      },
+      //Defensive
       {
         spell: TALENTS.NATURES_GUARDIAN_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.NATURES_GUARDIAN_TALENT),
@@ -275,50 +299,100 @@ class Abilities extends ClassAbilities {
         cooldown: 45 - (combatant.hasTalent(TALENTS.NATURAL_HARMONY_TALENT) ? 15 : 0),
         healSpellIds: [SPELLS.NATURES_GUARDIAN_HEAL.id],
       },
+      //Others
       {
-        spell: TALENTS.SUPPORTIVE_IMBUEMENTS_TALENT.id, //SpellID: 457481
-        category: SPELL_CATEGORY.HIDDEN, //IDK what that means but I guess, hidden means not listed in Ability summary
+        spell: SPELLS.WATER_SHIELD.id,
+        category: SPELL_CATEGORY.OTHERS,
         gcd: {
           base: 1500,
         },
       },
       {
         spell: TALENTS.EARTHLIVING_WEAPON_TALENT.id, //SpellID: 382021
-        category: SPELL_CATEGORY.HIDDEN, //IDK what that means but I guess, hidden means not listed in Ability summary
+        enabled: combatant.hasTalent(TALENTS.EARTHLIVING_WEAPON_TALENT),
+        category: SPELL_CATEGORY.OTHERS,
+        gcd: {
+          base: 1000,
+        },
+        healSpellIds: [SPELLS.EARTHLIVING_WEAPON_HEAL.id],
+      },
+      {
+        spell: SPELLS.TIDECALLERS_GUARD.id,
+        enabled: combatant.hasTalent(TALENTS.SUPPORTIVE_IMBUEMENTS_TALENT),
+        category: SPELL_CATEGORY.OTHERS,
         gcd: {
           base: 1500,
         },
       },
+      //Utility
       {
-        spell: SPELLS.WATER_SHIELD.id,
+        spell: SPELLS.ANCESTRAL_VISION.id,
         category: SPELL_CATEGORY.UTILITY,
         gcd: {
           base: 1500,
         },
+        range: 100,
       },
       {
-        spell: SPELLS.ANCESTRAL_SWIFTNESS_CAST.id,
-        enabled: combatant.hasTalent(TALENTS.ANCESTRAL_SWIFTNESS_TALENT),
-        category: SPELL_CATEGORY.ROTATIONAL,
-        gcd: null,
-        cooldown: 30,
-        castEfficiency: {
-          suggestion: false,
-          majorIssueEfficiency: 0.7,
-          averageIssueEfficiency: 0.8,
-          recommendedEfficiency: 0.9,
-        },
-      },
-      {
-        spell: SPELLS.SURGING_TOTEM.id,
-        enabled: combatant.hasTalent(TALENTS.SURGING_TOTEM_TALENT),
-        category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 30 - totemCDR,
-        timelineSortIndex: 17,
+        spell: SPELLS.PURIFY_SPIRIT.id, //Baseline for restoration. Spell ID does not change in log if the talent 'Improved Purify Spirit' has been taken.
+        category: SPELL_CATEGORY.UTILITY,
+        cooldown: 8,
         gcd: {
-          base: 1000,
+          base: 1500,
         },
-        healSpellIds: [SPELLS.HEALING_RAIN_TOTEMIC.id],
+      },
+      //Damage
+      {
+        spell: SPELLS.LIGHTNING_BOLT.id,
+        category: SPELL_CATEGORY.HEALER_DAMAGING_SPELL,
+        gcd: {
+          base: 1500,
+        },
+      },
+      {
+        spell: SPELLS.FLAME_SHOCK.id,
+        category: SPELL_CATEGORY.HEALER_DAMAGING_SPELL,
+        cooldown: 6,
+        gcd: {
+          base: 1500,
+        },
+        range: 40,
+      },
+      {
+        spell: TALENTS.LAVA_BURST_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.LAVA_BURST_TALENT),
+        category: SPELL_CATEGORY.HEALER_DAMAGING_SPELL,
+        charges: combatant.getMultipleTalentRanks(
+          TALENTS.LAVA_BURST_TALENT,
+          TALENTS.ECHO_OF_THE_ELEMENTS_TALENT,
+          TALENTS.ELEMENTAL_REVERB_TALENT,
+        ),
+        timelineSortIndex: 60,
+        cooldown: 8,
+        gcd: {
+          base: 1500,
+        },
+        range: 40,
+      },
+      {
+        spell: TALENTS.CHAIN_LIGHTNING_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.CHAIN_LIGHTNING_TALENT),
+        category: SPELL_CATEGORY.HEALER_DAMAGING_SPELL,
+        timelineSortIndex: 61,
+        gcd: {
+          base: 1500,
+        },
+        range: 40,
+      },
+      {
+        spell: TALENTS.FROST_SHOCK_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.FROST_SHOCK_TALENT),
+        category: SPELL_CATEGORY.HEALER_DAMAGING_SPELL,
+        timelineSortIndex: 62,
+        gcd: {
+          base: 1500,
+        },
+        range: 40,
       },
     ];
   }

--- a/src/analysis/retail/shaman/restoration/modules/Abilities.ts
+++ b/src/analysis/retail/shaman/restoration/modules/Abilities.ts
@@ -1,10 +1,8 @@
-import { defineMessage } from '@lingui/core/macro';
 import SPELLS from 'common/SPELLS/shaman';
 import TALENTS from 'common/TALENTS/shaman';
 import ClassAbilities from '../../shared/Abilities';
 import { SpellbookAbility } from 'parser/core/modules/Ability';
 import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
-import { i18n } from '@lingui/core';
 import { TIERS } from 'game/TIERS';
 import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from '../constants';
 
@@ -38,24 +36,6 @@ class Abilities extends ClassAbilities {
         },
       },
       {
-        spell: SPELLS.HEALING_WAVE.id,
-        name: i18n._(
-          defineMessage({
-            id: 'shaman.restoration.abilities.buffedByTidalWave',
-            message: `Tidal Waved ${SPELLS.HEALING_WAVE.name}`,
-          }),
-        ),
-        timelineSortIndex: 13,
-        gcd: {
-          base: 1500,
-        },
-        category: SPELL_CATEGORY.ROTATIONAL,
-        castEfficiency: {
-          suggestion: false,
-          // casts: (castCount) => castCount.healingTwHits || 0,
-        },
-      },
-      {
         spell: TALENTS.CHAIN_HEAL_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.CHAIN_HEAL_TALENT),
         category: SPELL_CATEGORY.ROTATIONAL,
@@ -82,7 +62,6 @@ class Abilities extends ClassAbilities {
         castEfficiency: {
           suggestion: false,
         },
-        healSpellIds: [TALENTS.RIPTIDE_TALENT.id],
       },
       {
         spell: [SPELLS.HEALING_STREAM_TOTEM.id],
@@ -131,7 +110,11 @@ class Abilities extends ClassAbilities {
         castEfficiency: {
           suggestion: false,
         },
-        healSpellIds: [SPELLS.STORMSTREAM_TOTEM_HEAL.id],
+        healSpellIds: [
+          SPELLS.STORMSTREAM_TOTEM_HEAL.id,
+          SPELLS.STORMSTREAM_TOTEM.id,
+          SPELLS.STORMSWELL_HEAL.id,
+        ],
       },
       {
         spell: TALENTS.HEALING_RAIN_TALENT.id,
@@ -228,6 +211,17 @@ class Abilities extends ClassAbilities {
           recommendedEfficiency: 0.9,
         },
         healSpellIds: [TALENTS.UNLEASH_LIFE_TALENT.id],
+      },
+      {
+        spell: TALENTS.EARTH_SHIELD_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS.EARTH_SHIELD_TALENT),
+        category: SPELL_CATEGORY.ROTATIONAL,
+        cooldown: 0,
+        timelineSortIndex: 10,
+        gcd: {
+          base: 1500,
+        },
+        healSpellIds: [TALENTS.EARTH_SHIELD_TALENT.id],
       },
       {
         spell: SPELLS.ANCESTRAL_SWIFTNESS_CAST.id,

--- a/src/analysis/retail/shaman/restoration/modules/Buffs.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/Buffs.tsx
@@ -29,7 +29,7 @@ class BUFFS extends CoreAuras {
       {
         spellId: [SPELLS.CALL_OF_THE_ANCESTORS_BUFF.id],
         enabled: combatant.hasTalent(TALENTS.CALL_OF_THE_ANCESTORS_TALENT),
-        triggeredBySpellId: [SPELLS.ANCESTRAL_SWIFTNESS_CAST.id],
+        triggeredBySpellId: [SPELLS.ANCESTRAL_SWIFTNESS_CAST.id, TALENTS.UNLEASH_LIFE_TALENT.id],
         timelineHighlight: false,
       },
       {

--- a/src/analysis/retail/shaman/restoration/modules/talents/totemic/SurgingTotem.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/talents/totemic/SurgingTotem.tsx
@@ -2,7 +2,6 @@ import type { JSX } from 'react';
 import { Trans } from '@lingui/react/macro';
 import SPELLS from 'common/SPELLS';
 import TALENTS, { TALENTS_SHAMAN } from 'common/TALENTS/shaman';
-import { SpellIcon } from 'interface';
 import { SpellLink } from 'interface';
 import { TooltipElement } from 'interface';
 import { explanationAndDataSubsection } from 'interface/guide/components/ExplanationRow';
@@ -249,7 +248,7 @@ class SurgingTotem extends Analyzer {
   subStatistic() {
     return (
       <CastEfficiencyBar
-        spell={SPELLS.HEALING_RAIN_TOTEMIC}
+        spell={SPELLS.SURGING_TOTEM}
         gapHighlightMode={GapHighlight.FullCooldown}
         minimizeIcons
         useThresholds
@@ -265,7 +264,7 @@ class SurgingTotem extends Analyzer {
     return (
       <StatisticBox
         category={STATISTIC_CATEGORY.HERO_TALENTS}
-        icon={<SpellIcon spell={TALENTS.SURGING_TOTEM_TALENT} />}
+        icon={<SpellLink spell={SPELLS.SURGING_TOTEM} />}
         value={`${this.averageHitsPerTick.toFixed(2)}`}
         position={STATISTIC_ORDER.OPTIONAL()}
         label={
@@ -292,7 +291,7 @@ class SurgingTotem extends Analyzer {
       <>
         <div>
           Over the course of the fight, you cast <strong>{this.SurgingTotemCasts.length}</strong>{' '}
-          <SpellLink spell={TALENTS.SURGING_TOTEM_TALENT} /> and consumed{' '}
+          <SpellLink spell={SPELLS.SURGING_TOTEM} /> and consumed{' '}
           <strong>{this.whirlingMotesConsumed[SPELLS.WHIRLING_AIR.id]}</strong>{' '}
           <SpellLink spell={SPELLS.WHIRLING_AIR} />,{' '}
           <strong>{this.whirlingMotesConsumed[SPELLS.WHIRLING_EARTH.id]}</strong>{' '}

--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -10,7 +10,7 @@ const spells = {
     id: 77472,
     name: 'Healing Wave',
     icon: 'spell_nature_healingwavelesser',
-    manaCost: 75000,
+    manaCost: 5950,
   },
   WATER_SHIELD: {
     id: 52127,
@@ -195,7 +195,7 @@ const spells = {
     id: 188196,
     name: 'Lightning Bolt',
     icon: 'spell_nature_lightning',
-    manaCost: 5000,
+    manaCost: 500,
   },
   LIGHTNING_BOLT_INSTANT: {
     id: 214815,
@@ -739,7 +739,7 @@ const spells = {
     id: 8004,
     name: 'Healing Surge',
     icon: 'spell_nature_healingway',
-    manaCost: 110000, // enh/ele cost is higher
+    manaCost: 250000, // enh/ele only
   },
   TIDAL_WAVES_BUFF: {
     id: 53390,

--- a/src/common/SPELLS/shaman.ts
+++ b/src/common/SPELLS/shaman.ts
@@ -17,6 +17,12 @@ const spells = {
     name: 'Water Shield',
     icon: 'ability_shaman_watershield',
   },
+  ANCESTRAL_SPIRIT: {
+    id: 2008,
+    name: 'Ancestral Spirit',
+    icon: 'ability_shaman_watershield',
+    manaCost: 2000,
+  },
   EARTH_SHOCK_OVERLOAD: {
     id: 381725,
     name: 'Earth Shock Overload',
@@ -127,6 +133,21 @@ const spells = {
     id: 269352,
     name: 'Hex',
     icon: 'ability_mount_fossilizedraptor',
+  },
+  HEX_WICKER: {
+    id: 277784,
+    name: 'Hex',
+    icon: 'inv_wickerbeastpet',
+  },
+  HEX_TENDONRIPPER: {
+    id: 277778,
+    name: 'Hex',
+    icon: 'inv_zandalaribabyraptorred',
+  },
+  HEX_HONEY: {
+    id: 309328,
+    name: 'Hex',
+    icon: 'ability_creature_amber_02',
   },
   //Eye of the Twisting Nether Buffs
   SHOCK_OF_THE_TWISTING_NETHER: {
@@ -290,6 +311,7 @@ const spells = {
     id: 188389,
     name: 'Flame Shock',
     icon: 'spell_fire_flameshock',
+    manaCost: 750,
   },
   FLAME_SHOCK_DUPLICATE: {
     id: 470411,
@@ -579,6 +601,7 @@ const spells = {
     id: 462854,
     name: 'Skyfury',
     icon: 'achievement_raidprimalist_windelemental',
+    manaCost: 2500,
   },
   ELEMENTAL_HEALING: {
     id: 198249,
@@ -706,6 +729,12 @@ const spells = {
     icon: 'spell_nature_thunderclap',
   },
   // Restoration Shaman
+  ANCESTRAL_VISION: {
+    id: 212048,
+    name: 'Ancestral Vision',
+    icon: 'spell_shaman_elementaloath',
+    manaCost: 2000,
+  },
   HEALING_SURGE: {
     id: 8004,
     name: 'Healing Surge',
@@ -726,6 +755,7 @@ const spells = {
     id: 5394,
     name: 'Healing Stream Totem',
     icon: 'inv_spear_04',
+    manaCost: 4500,
   },
   HEALING_STREAM_TOTEM_HEAL: {
     id: 52042,
@@ -796,6 +826,11 @@ const spells = {
     // casted by totem
     id: 325174,
     name: 'Spirit Link Totem',
+    icon: 'spell_shaman_spiritlink',
+  },
+  SPOUTING_SPIRITS: {
+    id: 462384,
+    name: 'Spouting Spirits',
     icon: 'spell_shaman_spiritlink',
   },
   CLOUDBURST_TOTEM_HEAL: {
@@ -987,6 +1022,7 @@ const spells = {
     id: 462603,
     name: 'Downpour',
     icon: 'ability_mage_waterjet',
+    manaCost: 4500,
   },
   DOWNPOUR_HEAL: {
     id: 207778,


### PR DESCRIPTION
### Description

- Surging Totem/Healing Rain report fixed for Totemic players in the guide section.
- Overflowing Shores talent is now respected and attributed correctly to Healing Rain in the Mastery Effectiveness Breakdown section. 
- Stormstream Totem and Stormswell Healing is now attributed correctly to Stormstream Totem in the Mana Efficiency section. 
- Unleash Life's direct heal is now attributed correctly to Unleash Life in the Mana Efficiency section.
- Abilities have been sorted to make future changes easier to navigate.

### Testing
WLC compare: https://www.warcraftlogs.com/reports/XM3xdBjY4DCkAN2q/?fight=1&type=healing&source=4
wowA:  /report/XM3xdBjY4DCkAN2q/1-Mythic++Ruby+Life+Pools+-+Kill+(26:21)/4-Naltarunir/standard/statistics

WLC compare: https://www.warcraftlogs.com/reports/YJ31TnZAphzy9GwK?fight=26&type=healing&source=17
wowA:  /report/YJ31TnZAphzy9GwK/26-Mythic+Nek'zali+the+Soulcoiler+-+Kill+(8:51)/17-Please/standard/statistics


<img width="758" height="320" alt="image" src="https://github.com/user-attachments/assets/8fcc084c-a352-4bfa-a625-747ea38a9ad1" />

<img width="753" height="322" alt="image" src="https://github.com/user-attachments/assets/0f88f669-5f0e-41e9-97d1-09005858b20b" />

<img width="1202" height="776" alt="image" src="https://github.com/user-attachments/assets/4da25c0d-d227-491e-b809-1ad4b39cf399" />

<img width="1202" height="776" alt="image" src="https://github.com/user-attachments/assets/c8dee5ad-01cf-4733-ab3c-488951c62eb2" />
