### PR TITLE
[Sub Rogue] - Shadow Dance module update for 12.1

### DIFF
--- a/src/analysis/retail/rogue/subtlety/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/subtlety/CHANGELOG.tsx
@@ -5,13 +5,9 @@ import TALENTS from 'common/TALENTS/rogue';
 import { SpellLink } from 'interface';
 
 export default [
-  change(
-    date(2026, 8, 17),
-    <>
-      Add <SpellLink spell={TALENTS.GOREMAWS_BITE_TALENT} /> to the ability list
-    </>,
-    Earosselot,
-  ),
+  change(date(2026, 8, 23), <>Updating Shadow Dance analysis for Deathstalker and Trickster 12.1</>, Earosselot),
+  change(date(2026, 8, 23), <>Added support for Deathstalker 12.1</>, Earosselot),
+  change(date(2026, 8, 17), <>Add <SpellLink spell={TALENTS.GOREMAWS_BITE_TALENT} /> to the ability list</>, Earosselot),
   change(date(2026, 3, 23), <>Fix Shadow Blades Module</>, Earosselot),
   change(date(2026, 3, 23), <>Adding Shadow Dance Module</>, Earosselot),
   change(date(2026, 3, 20), <>Enable Sublety for midnight</>, Earosselot),

--- a/src/analysis/retail/rogue/subtlety/CHANGELOG.tsx
+++ b/src/analysis/retail/rogue/subtlety/CHANGELOG.tsx
@@ -1,8 +1,17 @@
 import { change, date } from 'common/changelog';
 import { Earosselot } from 'CONTRIBUTORS';
 import SHARED_CHANGELOG from 'analysis/retail/rogue/shared/CHANGELOG';
+import TALENTS from 'common/TALENTS/rogue';
+import { SpellLink } from 'interface';
 
 export default [
+  change(
+    date(2026, 8, 17),
+    <>
+      Add <SpellLink spell={TALENTS.GOREMAWS_BITE_TALENT} /> to the ability list
+    </>,
+    Earosselot,
+  ),
   change(date(2026, 3, 23), <>Fix Shadow Blades Module</>, Earosselot),
   change(date(2026, 3, 23), <>Adding Shadow Dance Module</>, Earosselot),
   change(date(2026, 3, 20), <>Enable Sublety for midnight</>, Earosselot),

--- a/src/analysis/retail/rogue/subtlety/CONFIG.tsx
+++ b/src/analysis/retail/rogue/subtlety/CONFIG.tsx
@@ -3,15 +3,14 @@ import SPECS from 'game/SPECS';
 import CHANGELOG from './CHANGELOG';
 import { Earosselot } from 'CONTRIBUTORS';
 import Config, { SupportLevel } from 'parser/Config';
-import AlertWarning from 'interface/AlertWarning';
 
 const config: Config = {
   // The people that have contributed to this spec recently. People don't have to sign up to be long-time maintainers to be included in this list. If someone built a large part of the spec or contributed something recently to that spec, they can be added to the contributors list. If someone goes MIA, they may be removed after major changes or during a new expansion.
   contributors: [Earosselot],
   branch: GameBranch.Retail,
   // The WoW client patch this spec was last updated.
-  patchCompatibility: '12.0.0',
-  supportLevel: SupportLevel.MaintainedPartial,
+  patchCompatibility: '12.1.0',
+  supportLevel: SupportLevel.MaintainedFull,
   // Explain the status of this spec's analysis here. Try to mention how complete it is, and perhaps show links to places users can learn more.
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
@@ -35,19 +34,10 @@ const config: Config = {
       </p>
     </>
   ),
-  pages: {
-    overview: {
-      notes: (
-        <AlertWarning>
-          This analysis is outdated. Currently the information is not accurate and should not be
-          trusted. Apologies for the delays, I promise I am working on it. <code>@Earosselot</code>
-        </AlertWarning>
-      ),
-    },
-  },
+
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
-    '/report/hfNtY6RbxWZHM2cL/1-Mythic++Priory+of+the+Sacred+Flame+-+Kill+(27:44)/Quietstep/standard',
+    "/report/gJmDfcNjxCX1WVbp/35-Mythic+Nek'zali+the+Soulcoiler+-+Kill+(8:42)/2572-Codeyy/standard/overview",
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/rogue/subtlety/constants.tsx
+++ b/src/analysis/retail/rogue/subtlety/constants.tsx
@@ -18,9 +18,33 @@ export const PANDEMIC_WINDOW = 3000;
 
 const ANIMACHARGED_FINISHER_CP = 7;
 
-const getMaxComboPoints = (c: Combatant) => {
+export const getMaxComboPoints = (c: Combatant) => {
   return 5 + c.getTalentRank(TALENTS.DEEPER_STRATAGEM_TALENT);
 };
+
+/**
+ * Which hero tree the player is running. Both trees are gated behind a talent that is
+ * mandatory within that tree, so the presence of that talent identifies the tree.
+ */
+export enum HeroTree {
+  Deathstalker = 'deathstalker',
+  Trickster = 'trickster',
+  Unknown = 'unknown',
+}
+
+export const getHeroTree = (c: Combatant): HeroTree => {
+  if (c.hasTalent(TALENTS.DARKEST_NIGHT_TALENT)) {
+    return HeroTree.Deathstalker;
+  }
+  if (c.hasTalent(TALENTS.COUP_DE_GRACE_TALENT)) {
+    return HeroTree.Trickster;
+  }
+  return HeroTree.Unknown;
+};
+
+/** Only rank 3 grants the Ancient Arts buff, so the lower ranks are not worth checking. */
+export const hasAncientArts3 = (c: Combatant) =>
+  c.hasTalent(TALENTS.ANCIENT_ARTS_3_SUBTLETY_TALENT);
 
 export const getRuptureDuration = (c: Combatant, cast: CastEvent): number => {
   if (isAnimachargedFinisherCast(c, cast)) {

--- a/src/analysis/retail/rogue/subtlety/guide/CooldownGraphSubsection.tsx
+++ b/src/analysis/retail/rogue/subtlety/guide/CooldownGraphSubsection.tsx
@@ -14,6 +14,7 @@ export interface Cooldown {
 
 const cooldownsToCheck: Cooldown[] = [
   { spell: TALENTS.SHADOW_BLADES_TALENT },
+  { spell: TALENTS.GOREMAWS_BITE_TALENT },
   { spell: SPELLS.SECRET_TECHNIQUE },
   { spell: SPELLS.VANISH },
 ];

--- a/src/analysis/retail/rogue/subtlety/guide/ShadowDanceGuide.tsx
+++ b/src/analysis/retail/rogue/subtlety/guide/ShadowDanceGuide.tsx
@@ -4,7 +4,6 @@ import ShadowDance, { ShadowDanceData } from '../modules/spells/ShadowDance';
 import Analyzer from 'parser/core/Analyzer';
 import SPELLS from 'common/SPELLS/rogue';
 import TALENTS from 'common/TALENTS/rogue';
-import SpellUsable from 'parser/shared/modules/SpellUsable';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { formatPercentage, formatNumber, formatDurationMillisMinSec } from 'common/format';
 import GuideSection from 'interface/guide/components/GuideSection';
@@ -19,92 +18,288 @@ import CastDetail, { type PerCastData } from 'interface/guide/components/CastDet
 import { EventType } from 'parser/core/Events';
 import DamageDone from 'parser/shared/modules/throughput/DamageDone';
 import InformationIcon from 'interface/icons/Information';
+import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
+import { PerformanceMark } from 'interface/guide';
+import { getHeroTree, getMaxComboPoints, HeroTree } from '../constants';
+
+/** One graded aspect of a Shadow Dance window, rendered as its own row in the cast details. */
+interface DanceCheck {
+  label: string;
+  performance: QualitativePerformance;
+  detail: string;
+}
+
+/** Secret Technique should be spent as one of the first finishers of the window. */
+const SECRET_TECHNIQUE_MAX_FINISHER_POSITION = 2;
+
+/** The one Shadow Dance that is expected to happen without Secret Technique ready. */
+const SECOND_DANCE_UNDER_SHADOW_BLADES = 2;
+
+const EVISCERATE_ENERGY_COST = 35;
+const SECRET_TECHNIQUE_ENERGY_COST = 30;
 
 class ShadowDanceGuide extends Analyzer.withDependencies({
   damageDone: DamageDone,
   shadowDance: ShadowDance,
   eventHistory: EventHistory,
-  spellUsable: SpellUsable,
 }) {
   protected damageDone!: DamageDone;
   protected shadowDance!: ShadowDance;
   protected eventHistory!: EventHistory;
-  protected spellUsable!: SpellUsable;
 
-  isTrickster = this.selectedCombatant.hasTalent(TALENTS.UNSEEN_BLADE_TALENT);
-  isDeathstalker = this.selectedCombatant.hasTalent(TALENTS.DEATHSTALKERS_MARK_TALENT);
+  // Derived from the combatant rather than from `this.shadowDance`: injected dependencies are not
+  // usable yet while class fields initialize, but `selectedCombatant` reads through `owner`, which
+  // the Module constructor has already assigned by then.
+  heroTree = getHeroTree(this.selectedCombatant);
+  isTrickster = this.heroTree === HeroTree.Trickster;
+  isDeathstalker = this.heroTree === HeroTree.Deathstalker;
 
   private evaluateShadowDanceUsage(dance: ShadowDanceData) {
-    const energyAtCast = dance.energyAtCast;
-    const comboPointsAtCast = dance.comboPointsAtCast;
-    const hasShadowBladesActive =
-      this.shadowDance.hasShadowBlades &&
-      this.selectedCombatant.hasBuff(TALENTS.SHADOW_BLADES_TALENT, dance.applied);
-    const secTecOnCooldown = this.spellUsable.isOnCooldown(SPELLS.SECRET_TECHNIQUE.id);
-    const cooldownsReady = secTecOnCooldown && !hasShadowBladesActive;
-    const enoughEnergyForEviscerate =
-      hasShadowBladesActive && secTecOnCooldown && energyAtCast < 35;
-    const enoughEnergyForSecTec = !secTecOnCooldown && energyAtCast < 30;
+    const checks = this.isDeathstalker
+      ? this.deathstalkerChecks(dance)
+      : this.tricksterChecks(dance);
+
+    return {
+      timestamp: dance.applied,
+      performance: combineQualitativePerformances(checks.map((check) => check.performance)),
+      checks,
+    };
+  }
+
+  /** Renders each graded aspect as its own row, so a failing check is obvious at a glance. */
+  private renderChecks(checks: DanceCheck[]) {
+    return (
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+        {checks.map((check) => (
+          <li key={check.label}>
+            <PerformanceMark perf={check.performance} /> <strong>{check.label}:</strong>{' '}
+            {check.detail}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  /**
+   * Deathstalker windows are judged on filling every available GCD, pairing Darkest Night
+   * Eviscerates with Ancient Arts, and spending Secret Technique early when it was ready. The
+   * window is only as good as its weakest check.
+   */
+  private deathstalkerChecks(dance: ShadowDanceData): DanceCheck[] {
+    // Secret Technique returns null for the one window where not having it is expected, so that
+    // check drops out of the grade entirely rather than counting as a pass.
+    return [
+      this.evaluateAbilityCount(dance),
+      this.evaluateAncientArtsPairing(dance),
+      this.evaluateSecretTechniqueTiming(dance),
+    ].filter((check) => check !== null);
+  }
+
+  /**
+   * Shadow Dance and Secret Technique are meant to be used together: Secret Technique should be
+   * one of the first two finishers of the window. Being a second or so from coming off cooldown
+   * still counts as usable, since it lands early enough in the window.
+   *
+   * The exception is the second Shadow Dance of a Shadow Blades window, which is expected to be
+   * cast without Secret Technique available.
+   */
+  private evaluateSecretTechniqueTiming(dance: ShadowDanceData): DanceCheck | null {
+    const label = 'Secret Technique';
+    const isSecondDanceUnderShadowBlades =
+      dance.danceIndexInShadowBlades === SECOND_DANCE_UNDER_SHADOW_BLADES;
+
+    if (!this.shadowDance.isSecretTechniqueUsable(dance)) {
+      if (isSecondDanceUnderShadowBlades) {
+        return null;
+      }
+
+      return {
+        label,
+        performance: QualitativePerformance.Fail,
+        detail:
+          'entered Shadow Dance without it available. The two should be used together, except ' +
+          'on the second Shadow Dance of a Shadow Blades window.',
+      };
+    }
+
+    const position = this.shadowDance.getSecretTechniqueFinisherPosition(dance);
+
+    if (position === null) {
+      return {
+        label,
+        performance: QualitativePerformance.Fail,
+        detail: 'was usable in this window but never cast.',
+      };
+    }
+
+    if (position <= SECRET_TECHNIQUE_MAX_FINISHER_POSITION) {
+      return {
+        label,
+        performance: QualitativePerformance.Perfect,
+        detail: `used as finisher #${position}.`,
+      };
+    }
+
+    return {
+      label,
+      performance: QualitativePerformance.Fail,
+      detail:
+        `used as finisher #${position} - it should be one of the first ` +
+        `${SECRET_TECHNIQUE_MAX_FINISHER_POSITION}.`,
+    };
+  }
+
+  /**
+   * As Deathstalker, an Eviscerate cast under Darkest Night should also be buffed by Ancient Arts.
+   * The last cast of the window is exempt, since there is no room left to line the two up.
+   */
+  private evaluateAncientArtsPairing(dance: ShadowDanceData): DanceCheck {
+    const label = 'Ancient Arts pairing';
+    const missed = this.shadowDance.getMissedAncientArtsEviscerates(dance);
+
+    if (missed.length === 0) {
+      return {
+        label,
+        performance: QualitativePerformance.Perfect,
+        detail: 'every Eviscerate under Darkest Night was also buffed by Ancient Arts.',
+      };
+    }
+
+    const timestamps = missed.map((cast) => this.owner.formatTimestamp(cast.timestamp)).join(', ');
+    const single = missed.length === 1;
+
+    return {
+      label,
+      performance: single ? QualitativePerformance.Ok : QualitativePerformance.Fail,
+      detail:
+        `${missed.length} Eviscerate ${single ? 'cast' : 'casts'} under Darkest Night ` +
+        `${single ? 'was' : 'were'} missing Ancient Arts (${timestamps}).`,
+    };
+  }
+
+  /**
+   * How well the window was filled with abilities. Shadow Dance grows with haste through Deepening
+   * Shadows, so the number of GCDs that fit is derived from the window's actual duration.
+   */
+  private evaluateAbilityCount(dance: ShadowDanceData): DanceCheck {
+    const label = 'GCDs used';
     const maxAbilities = Math.ceil(dance.duration / 1000);
     const abilitiesUsed = dance.numberAbilitiesUsed || 0;
 
-    // Cooldown Availability
-    if (cooldownsReady) {
+    if (abilitiesUsed >= maxAbilities) {
       return {
-        timestamp: dance.applied,
-        performance: QualitativePerformance.Fail,
-        reason:
-          'Shadow Dance was used when neither Shadow Blades was active nor Secret Technique was available.',
-      };
-    }
-
-    // Energy check for second SD cast during Shadow Blades
-    if (enoughEnergyForEviscerate) {
-      return {
-        timestamp: dance.applied,
-        performance: QualitativePerformance.Fail,
-        reason: `Entered Shadow Dance without enough energy for Eviscerate(35). Had ${energyAtCast} energy.`,
-      };
-    }
-
-    // Energy check for SD and SecTec (with our without Shadow Blades)
-    if (enoughEnergyForSecTec) {
-      return {
-        timestamp: dance.applied,
-        performance: QualitativePerformance.Fail,
-        reason: `Entered Shadow Dance without enough energy for Secret Technique(30). Had ${energyAtCast} energy.`,
-      };
-    }
-
-    // Combo Point check
-    if (comboPointsAtCast < 6) {
-      return {
-        timestamp: dance.applied,
-        performance: QualitativePerformance.Fail,
-        reason: `Entered Shadow Dance with suboptimal combo points. Had ${comboPointsAtCast} combo points.`,
-      };
-    }
-
-    if (abilitiesUsed === maxAbilities) {
-      return {
-        timestamp: dance.applied,
+        label,
         performance: QualitativePerformance.Perfect,
-        reason: `Excellent Shadow Dance usage! You spend all possible gcds using abilities.`,
+        detail: `used all ${maxAbilities} available GCDs.`,
       };
     }
 
     if (abilitiesUsed === maxAbilities - 1) {
       return {
-        timestamp: dance.applied,
+        label,
         performance: QualitativePerformance.Good,
-        reason: `Good Shadow Dance usage! You could have cast one more ability during this Shadow Dance.`,
+        detail: `${abilitiesUsed} of ${maxAbilities} - one more would fit.`,
       };
     }
 
     return {
-      timestamp: dance.applied,
+      label,
       performance: QualitativePerformance.Fail,
-      reason: `Shadow Dance uptime was suboptimal. You missed ${maxAbilities - abilitiesUsed} abilities.`,
+      detail: `${abilitiesUsed} of ${maxAbilities} - missing ${
+        maxAbilities - abilitiesUsed
+      } abilities.`,
+    };
+  }
+
+  /**
+   * Trickster grades the entry conditions and then how well the window was filled. Every check is
+   * always evaluated so the reader can see the whole picture, not just the first thing that broke.
+   */
+  private tricksterChecks(dance: ShadowDanceData): DanceCheck[] {
+    return [
+      this.evaluateCooldownAlignment(dance),
+      this.evaluateEntryEnergy(dance),
+      this.evaluateEntryComboPoints(dance),
+      this.evaluateAbilityCount(dance),
+    ].filter((check) => check !== null);
+  }
+
+  /** Shadow Dance wants either Secret Technique ready to pair with, or Shadow Blades running. */
+  private evaluateCooldownAlignment(dance: ShadowDanceData): DanceCheck {
+    const label = 'Cooldown alignment';
+
+    if (this.shadowDance.isSecretTechniqueUsable(dance)) {
+      return {
+        label,
+        performance: QualitativePerformance.Perfect,
+        detail: 'paired with Secret Technique.',
+      };
+    }
+
+    if (dance.shadowBladesActive) {
+      return {
+        label,
+        performance: QualitativePerformance.Perfect,
+        detail: 'used during Shadow Blades.',
+      };
+    }
+
+    return {
+      label,
+      performance: QualitativePerformance.Fail,
+      detail: 'neither Shadow Blades was active nor Secret Technique was available.',
+    };
+  }
+
+  /**
+   * Whether there was enough energy to fire the opening finisher immediately. Which finisher that
+   * is depends on whether Secret Technique was ready.
+   */
+  private evaluateEntryEnergy(dance: ShadowDanceData): DanceCheck | null {
+    const label = 'Energy on entry';
+    const secretTechniqueUsable = this.shadowDance.isSecretTechniqueUsable(dance);
+    const { spell, cost } = secretTechniqueUsable
+      ? { spell: 'Secret Technique', cost: SECRET_TECHNIQUE_ENERGY_COST }
+      : { spell: 'Eviscerate', cost: EVISCERATE_ENERGY_COST };
+
+    // Without Secret Technique and without Shadow Blades there is no opener to fund; the cooldown
+    // alignment check already covers that window.
+    if (!secretTechniqueUsable && !dance.shadowBladesActive) {
+      return null;
+    }
+
+    if (dance.energyAtCast >= cost) {
+      return {
+        label,
+        performance: QualitativePerformance.Perfect,
+        detail: `${dance.energyAtCast} energy, enough for ${spell} (${cost}).`,
+      };
+    }
+
+    return {
+      label,
+      performance: QualitativePerformance.Fail,
+      detail: `${dance.energyAtCast} energy, not enough for ${spell} (${cost}).`,
+    };
+  }
+
+  /** Trickster wants to enter at maximum combo points, which Deeper Stratagem raises. */
+  private evaluateEntryComboPoints(dance: ShadowDanceData): DanceCheck {
+    const label = 'Combo points on entry';
+    const max = getMaxComboPoints(this.selectedCombatant);
+
+    if (dance.comboPointsAtCast >= max) {
+      return {
+        label,
+        performance: QualitativePerformance.Perfect,
+        detail: `entered at ${max}.`,
+      };
+    }
+
+    return {
+      label,
+      performance: QualitativePerformance.Fail,
+      detail: `entered with ${dance.comboPointsAtCast} of ${max}.`,
     };
   }
 
@@ -117,53 +312,40 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
     const explanation = (
       <div>
         <p>
-          {shadowDance} is our main short time cooldown. It interacts with several talents in our
-          tree. During {shadowDance} we have increased damage and enhanced combo point and energy
-          generation.
+          {shadowDance} is our main short cooldown: increased damage plus enhanced combo point and
+          energy generation.
         </p>
         In order to maximize damage you want to:
         <ul>
-          {this.isTrickster && <li>Enter with 6+ combo points.</li>}
-          {this.isDeathstalker && <li>Enter with low combo points.</li>}
+          {this.isTrickster && <li>Enter with maximum combo points.</li>}
           <li>
-            Align this cooldown with {secretTechniques}, except in the second use during{' '}
-            {shadowBlades}.
+            Align it with {secretTechniques}, except on the second use during {shadowBlades}.
           </li>
-          <li>
-            Make sure you have enough energy to instantly throw your finisher, this is a common
-            mistake.
-          </li>
-          <li>Cast as many abilities as you can.</li>
+          {this.isTrickster && <li>Have enough energy to throw your finisher instantly.</li>}
+          <li>Fit as many abilities as you can.</li>
+          {this.isDeathstalker && (
+            <li>
+              As Deathstalker, spend {secretTechniques} as one of your first two finishers, and buff
+              every <SpellLink spell={SPELLS.EVISCERATE} /> under{' '}
+              <SpellLink spell={TALENTS.DARKEST_NIGHT_TALENT} /> with{' '}
+              <SpellLink spell={TALENTS.ANCIENT_ARTS_3_SUBTLETY_TALENT} />.
+            </li>
+          )}
         </ul>
         <h5>
           <InformationIcon />
           <i>Haste and GCDs notes</i>
         </h5>
         <p>
-          {shadowDance} duration increases with flat haste stat due to {deepeningShadows}. You will
-          want to fit the maximum amount of GCDs within your {shadowDance}.
-        </p>
-        <p>
-          i.e. if your {shadowDance} lasts 7.1s, you will want to squeeze 8 abilities within it.
-          Sometimes that .1s window is very tight.
-        </p>
-        <p>
-          If youre struggling to squeeze that last ability, you might want to increase your haste a
-          bit. Macros are of particular interest here. They will allow you to send {shadowDance} and
-          the first GCD at the exact same time.
-        </p>
-        <p>
-          Check
+          {deepeningShadows} makes {shadowDance} last longer with haste, so how many GCDs fit
+          changes with your gear: a 7.1s window fits 8 abilities, and that last one is tight.
+          Macroing {shadowDance} with your first GCD sends both at once - see the macro sections on{' '}
           <a href="https://www.wowhead.com/guide/classes/rogue/subtlety/addons-macro-ui-imports#macros-macros-combining-abilities">
-            {' '}
-            wowhead{' '}
-          </a>
-          or
-          <a href="https://www.icy-veins.com/wow/subtlety-rogue-pve-dps-macros-addons">
-            {' '}
-            icy-veins{' '}
-          </a>
-          macros section for more information.
+            wowhead
+          </a>{' '}
+          or{' '}
+          <a href="https://www.icy-veins.com/wow/subtlety-rogue-pve-dps-macros-addons">icy-veins</a>
+          .
         </p>
       </div>
     );
@@ -195,13 +377,35 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
               event.ability.guid === SPELLS.SHURIKEN_STORM.id,
           );
 
-        const casts: CastInSequence[] = castEvents.map((event) => ({
-          timestamp: event.timestamp,
-          spellId: event.ability.guid,
-          spellName: event.ability.name,
-          icon: event.ability.abilityIcon.replace('.jpg', ''),
-          performance: undefined,
-        }));
+        // Keyed on timestamp + spell so two casts sharing a timestamp can't be confused for
+        // each other. Empty for Trickster, where this rule does not apply.
+        const missedAncientArts = new Set(
+          this.shadowDance
+            .getMissedAncientArtsEviscerates(dance)
+            .map((cast) => `${cast.timestamp}-${cast.spellId}`),
+        );
+
+        const casts: CastInSequence[] = castEvents.map((event) => {
+          const missedBuff = missedAncientArts.has(`${event.timestamp}-${event.ability.guid}`);
+
+          return {
+            timestamp: event.timestamp,
+            spellId: event.ability.guid,
+            spellName: event.ability.name,
+            icon: event.ability.abilityIcon.replace('.jpg', ''),
+            performance: missedBuff ? QualitativePerformance.Fail : undefined,
+            // The shared default tooltip only shows the spell name. Timestamps have to be added
+            // here because formatting them relative to the pull needs the parser, which the
+            // sequence component has no access to.
+            tooltip: (
+              <div>
+                <strong>{event.ability.name}</strong>
+                <div>{this.owner.formatTimestamp(event.timestamp)}</div>
+                {missedBuff && <div>Cast under Darkest Night without Ancient Arts</div>}
+              </div>
+            ),
+          };
+        });
 
         dance.numberAbilitiesUsed = castEvents.length;
 
@@ -236,7 +440,7 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
             tooltip: <>Total casts</>,
           },
         ],
-        details: evaluation.reason,
+        details: this.renderChecks(evaluation.checks),
         additionalContent: sequenceEntry
           ? {
               title: 'Cast Sequence',

--- a/src/analysis/retail/rogue/subtlety/guide/ShadowDanceGuide.tsx
+++ b/src/analysis/retail/rogue/subtlety/guide/ShadowDanceGuide.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import type { CSSProperties, JSX } from 'react';
 import EventHistory from 'parser/shared/modules/EventHistory';
 import ShadowDance, { ShadowDanceData } from '../modules/spells/ShadowDance';
 import Analyzer from 'parser/core/Analyzer';
@@ -20,7 +20,7 @@ import DamageDone from 'parser/shared/modules/throughput/DamageDone';
 import InformationIcon from 'interface/icons/Information';
 import { combineQualitativePerformances } from 'common/combineQualitativePerformances';
 import { PerformanceMark } from 'interface/guide';
-import { getHeroTree, getMaxComboPoints, HeroTree } from '../constants';
+import { getMaxComboPoints, HeroTree } from '../constants';
 
 /** One graded aspect of a Shadow Dance window, rendered as its own row in the cast details. */
 interface DanceCheck {
@@ -35,6 +35,13 @@ const SECRET_TECHNIQUE_MAX_FINISHER_POSITION = 2;
 /** The one Shadow Dance that is expected to happen without Secret Technique ready. */
 const SECOND_DANCE_UNDER_SHADOW_BLADES = 2;
 
+const BREAKDOWN_PANEL_STYLE: CSSProperties = {
+  padding: '10px 12px',
+  borderRadius: '6px',
+  border: '1px solid rgba(255,255,255,0.08)',
+  background: 'rgba(0,0,0,0.16)',
+};
+
 const EVISCERATE_ENERGY_COST = 35;
 const SECRET_TECHNIQUE_ENERGY_COST = 30;
 
@@ -47,10 +54,7 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
   protected shadowDance!: ShadowDance;
   protected eventHistory!: EventHistory;
 
-  // Derived from the combatant rather than from `this.shadowDance`: injected dependencies are not
-  // usable yet while class fields initialize, but `selectedCombatant` reads through `owner`, which
-  // the Module constructor has already assigned by then.
-  heroTree = getHeroTree(this.selectedCombatant);
+  heroTree = this.deps.shadowDance.heroTree;
   isTrickster = this.heroTree === HeroTree.Trickster;
   isDeathstalker = this.heroTree === HeroTree.Deathstalker;
 
@@ -66,17 +70,34 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
     };
   }
 
+  /**
+   * One line of inline text for the details TipBox: what held the window back, or a confirmation
+   * when nothing did. The TipBox lays its icon and content out inline, so the full breakdown goes
+   * in the block section below it instead.
+   */
+  private renderSummary(checks: DanceCheck[]): string {
+    const problems = checks.filter((check) => check.performance !== QualitativePerformance.Perfect);
+
+    if (problems.length === 0) {
+      return 'Everything lined up in this window.';
+    }
+
+    return problems.map((check) => `${check.label} - ${check.detail}`).join(' ');
+  }
+
   /** Renders each graded aspect as its own row, so a failing check is obvious at a glance. */
   private renderChecks(checks: DanceCheck[]) {
     return (
-      <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
-        {checks.map((check) => (
-          <li key={check.label}>
-            <PerformanceMark perf={check.performance} /> <strong>{check.label}:</strong>{' '}
-            {check.detail}
-          </li>
-        ))}
-      </ul>
+      <div style={BREAKDOWN_PANEL_STYLE}>
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+          {checks.map((check) => (
+            <li key={check.label}>
+              <PerformanceMark perf={check.performance} /> <strong>{check.label}:</strong>{' '}
+              {check.detail}
+            </li>
+          ))}
+        </ul>
+      </div>
     );
   }
 
@@ -105,26 +126,25 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
    */
   private evaluateSecretTechniqueTiming(dance: ShadowDanceData): DanceCheck | null {
     const label = 'Secret Technique';
-    const isSecondDanceUnderShadowBlades =
-      dance.danceIndexInShadowBlades === SECOND_DANCE_UNDER_SHADOW_BLADES;
-
-    if (!this.shadowDance.isSecretTechniqueUsable(dance)) {
-      if (isSecondDanceUnderShadowBlades) {
-        return null;
-      }
-
-      return {
-        label,
-        performance: QualitativePerformance.Fail,
-        detail:
-          'entered Shadow Dance without it available. The two should be used together, except ' +
-          'on the second Shadow Dance of a Shadow Blades window.',
-      };
-    }
-
     const position = this.shadowDance.getSecretTechniqueFinisherPosition(dance);
 
-    if (position === null) {
+    if (position !== null) {
+      return position <= SECRET_TECHNIQUE_MAX_FINISHER_POSITION
+        ? {
+            label,
+            performance: QualitativePerformance.Perfect,
+            detail: `used as finisher #${position}.`,
+          }
+        : {
+            label,
+            performance: QualitativePerformance.Fail,
+            detail:
+              `used as finisher #${position} - it should be one of the first ` +
+              `${SECRET_TECHNIQUE_MAX_FINISHER_POSITION}.`,
+          };
+    }
+
+    if (this.shadowDance.isSecretTechniqueUsable(dance)) {
       return {
         label,
         performance: QualitativePerformance.Fail,
@@ -132,20 +152,18 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
       };
     }
 
-    if (position <= SECRET_TECHNIQUE_MAX_FINISHER_POSITION) {
-      return {
-        label,
-        performance: QualitativePerformance.Perfect,
-        detail: `used as finisher #${position}.`,
-      };
+    // Not available and not expected to be: the one window where that is intended drops out of the
+    // grade entirely rather than counting as a pass.
+    if (dance.danceIndexInShadowBlades === SECOND_DANCE_UNDER_SHADOW_BLADES) {
+      return null;
     }
 
     return {
       label,
       performance: QualitativePerformance.Fail,
       detail:
-        `used as finisher #${position} - it should be one of the first ` +
-        `${SECRET_TECHNIQUE_MAX_FINISHER_POSITION}.`,
+        'entered Shadow Dance without it available. The two should be used together, except ' +
+        'on the second Shadow Dance of a Shadow Blades window.',
     };
   }
 
@@ -440,13 +458,20 @@ class ShadowDanceGuide extends Analyzer.withDependencies({
             tooltip: <>Total casts</>,
           },
         ],
-        details: this.renderChecks(evaluation.checks),
-        additionalContent: sequenceEntry
-          ? {
-              title: 'Cast Sequence',
-              content: <SpellSequence casts={sequenceEntry.casts} iconSize={40} />,
-            }
-          : undefined,
+        details: this.renderSummary(evaluation.checks),
+        additionalContent: {
+          title: 'Window Breakdown',
+          content: (
+            <div style={{ display: 'grid', gap: '0.9rem' }}>
+              {this.renderChecks(evaluation.checks)}
+              {sequenceEntry && (
+                <div style={BREAKDOWN_PANEL_STYLE}>
+                  <SpellSequence casts={sequenceEntry.casts} iconSize={40} />
+                </div>
+              )}
+            </div>
+          ),
+        },
       };
     });
 

--- a/src/analysis/retail/rogue/subtlety/modules/Abilities.ts
+++ b/src/analysis/retail/rogue/subtlety/modules/Abilities.ts
@@ -116,6 +116,20 @@ class Abilities extends CoreAbilities {
         },
       },
       {
+        spell: TALENTS.GOREMAWS_BITE_TALENT.id,
+        category: SPELL_CATEGORY.COOLDOWNS,
+        cooldown: 45,
+        gcd: {
+          static: 1000,
+        },
+        enabled: combatant.hasTalent(TALENTS.GOREMAWS_BITE_TALENT),
+        castEfficiency: {
+          suggestion: true,
+          recommendedEfficiency: 0.9,
+          extraSuggestion: 'Use Goremaw’s Bite on cooldown, right before your other cooldowns.',
+        },
+      },
+      {
         spell: SPELLS.SECRET_TECHNIQUE.id,
         category: SPELL_CATEGORY.COOLDOWNS,
         cooldown: (haste) => hastedCooldown(25, haste),

--- a/src/analysis/retail/rogue/subtlety/modules/spells/ShadowDance.tsx
+++ b/src/analysis/retail/rogue/subtlety/modules/spells/ShadowDance.tsx
@@ -2,6 +2,7 @@ import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   DamageEvent,
   ApplyBuffEvent,
+  CastEvent,
   GetRelatedEvent,
   GetRelatedEvents,
   EventType,
@@ -13,22 +14,54 @@ import AlwaysBeCasting from 'analysis/retail/rogue/subtlety/modules/features/Alw
 import { ThresholdStyle } from 'parser/core/ParseResults';
 import EnergyTracker from 'analysis/retail/rogue/shared/EnergyTracker';
 import ComboPointTracker from 'analysis/retail/rogue/shared/ComboPointTracker';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+import { getHeroTree, hasAncientArts3, HeroTree } from '../../constants';
+
+/**
+ * Secret Technique coming off cooldown a moment into the window is still expected to be used, so
+ * a cooldown shorter than this counts as available on entry.
+ */
+export const SECRET_TECHNIQUE_GRACE_MS = 2000;
+
+/**
+ * Shadow Dance and Secret Technique are usually sent by the same macro, so their events can land
+ * in either order within a few milliseconds. A Secret Technique cast this close to the window
+ * opening belongs to it, even though SpellUsable has already started its cooldown by then.
+ */
+export const SECRET_TECHNIQUE_PAIRING_BUFFER_MS = 250;
+
+/** The finishers that can be spent inside a Shadow Dance window. */
+const FINISHER_SPELL_IDS: number[] = [
+  SPELLS.EVISCERATE.id,
+  SPELLS.BLACK_POWDER.id,
+  SPELLS.SECRET_TECHNIQUE.id,
+];
 
 export default class ShadowDance extends Analyzer.withDependencies({
   abilityTracker: AbilityTracker,
   alwaysBeCasting: AlwaysBeCasting,
   energyTracker: EnergyTracker,
   comboPointTracker: ComboPointTracker,
+  spellUsable: SpellUsable,
 }) {
   protected abilityTracker!: AbilityTracker;
   protected alwaysBeCasting!: AlwaysBeCasting;
   protected energyTracker!: EnergyTracker;
   protected comboPointTracker!: ComboPointTracker;
+  protected spellUsable!: SpellUsable;
 
   // Conditional talent checks
   hasShadowBlades: boolean = this.selectedCombatant.hasTalent(TALENTS.SHADOW_BLADES_TALENT);
+  heroTree: HeroTree = getHeroTree(this.selectedCombatant);
+  ancientArts3Talented: boolean = hasAncientArts3(this.selectedCombatant);
 
   danceData: ShadowDanceData[] = [];
+
+  /** How many Shadow Dances have been cast so far inside the current Shadow Blades window. */
+  private dancesInCurrentShadowBlades = 0;
+
+  /** Last Secret Technique cast, kept so one fired just before the window still counts as part of it. */
+  private lastSecretTechnique: DanceCast | null = null;
 
   constructor(options: Options) {
     super(options);
@@ -36,24 +69,131 @@ export default class ShadowDance extends Analyzer.withDependencies({
       Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SHADOW_DANCE_BUFF),
       this.onApplyBuff,
     );
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(TALENTS.SHADOW_BLADES_TALENT),
+      this.onShadowBladesApplied,
+    );
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
     this.addEventListener(Events.fightend, this.onFightEnd);
+  }
+
+  /**
+   * The standard opener is Shadow Dance -> Shadow Blades: both are off-GCD and instant, so the
+   * first dance of the pair is already running by the time Shadow Blades lands. A window that is
+   * still open at that point therefore counts as the first dance of this Shadow Blades, otherwise
+   * the dance that follows would be numbered first and the second-dance exemption would land on
+   * the wrong window.
+   */
+  private onShadowBladesApplied(event: ApplyBuffEvent) {
+    const openDance = this.currentDance(event.timestamp);
+
+    this.dancesInCurrentShadowBlades = openDance ? 1 : 0;
+
+    if (openDance) {
+      openDance.danceIndexInShadowBlades = this.dancesInCurrentShadowBlades;
+      // The window was opened a moment before Shadow Blades, so treating it as though Shadow
+      // Blades was not up would misreport the pair as a cooldown misalignment.
+      openDance.shadowBladesActive = true;
+    }
   }
 
   private onApplyBuff(event: ApplyBuffEvent) {
     const damageEvents = this.getDamageEvents(event);
-    const energyAtCast = this.energyTracker.current;
-    const comboPointsAtCast = this.comboPointTracker.current;
-
     const removed = this.getRemoveTimestamp(event);
+    const shadowBladesActive =
+      this.hasShadowBlades &&
+      this.selectedCombatant.hasBuff(TALENTS.SHADOW_BLADES_TALENT.id, event.timestamp);
+
+    if (shadowBladesActive) {
+      this.dancesInCurrentShadowBlades += 1;
+    }
+
+    const pairedSecretTechnique = this.getPairedSecretTechnique(event.timestamp);
+    // Consumed: it belongs to this window and must not be attributed to the next one too.
+    this.lastSecretTechnique = null;
+
     this.danceData.push({
       applied: event.timestamp,
       removed: removed,
       damage: damageEvents,
       totalDamage: this.calculateTotalDamage(damageEvents),
       duration: removed - event.timestamp,
-      energyAtCast: energyAtCast,
-      comboPointsAtCast: comboPointsAtCast,
+      energyAtCast: this.energyTracker.current,
+      comboPointsAtCast: this.comboPointTracker.current,
+      // Read during the event rather than at render time: SpellUsable only describes the current
+      // point in the fight, so reading it later would report the state at fight end for every
+      // window.
+      // Spending it right as the window opens counts as available: the cooldown SpellUsable
+      // reports at this point was started by that very cast.
+      secretTechniqueAvailable:
+        !this.spellUsable.isOnCooldown(SPELLS.SECRET_TECHNIQUE.id) ||
+        pairedSecretTechnique !== null,
+      secretTechniqueCooldownRemaining: this.spellUsable.cooldownRemaining(
+        SPELLS.SECRET_TECHNIQUE.id,
+        event.timestamp,
+      ),
+      shadowBladesActive,
+      danceIndexInShadowBlades: shadowBladesActive ? this.dancesInCurrentShadowBlades : 0,
+      // Seeded with the paired cast so finisher ordering sees it in the right position.
+      casts: pairedSecretTechnique ? [pairedSecretTechnique] : [],
     });
+  }
+
+  /**
+   * A Secret Technique cast in the instant before this window opened, if any. Events from the same
+   * macro can arrive in either order, so one that landed just before still belongs to the window.
+   */
+  private getPairedSecretTechnique(danceTimestamp: number): DanceCast | null {
+    if (
+      !this.lastSecretTechnique ||
+      danceTimestamp - this.lastSecretTechnique.timestamp > SECRET_TECHNIQUE_PAIRING_BUFFER_MS ||
+      this.lastSecretTechnique.timestamp > danceTimestamp
+    ) {
+      return null;
+    }
+
+    return this.lastSecretTechnique;
+  }
+
+  /**
+   * Records every cast that lands inside the current Shadow Dance window, along with the two buffs
+   * we care about at that exact moment. Buff state has to be sampled here — checking it later
+   * would only ever see the end of the fight.
+   */
+  private onCast(event: CastEvent) {
+    const cast: DanceCast = {
+      timestamp: event.timestamp,
+      spellId: event.ability.guid,
+      hasDarkestNight: this.selectedCombatant.hasBuff(
+        SPELLS.DARKEST_NIGHT_BUFF.id,
+        event.timestamp,
+      ),
+      hasAncientArts:
+        this.ancientArts3Talented &&
+        this.selectedCombatant.hasBuff(SPELLS.ANCIENT_ARTS_BUFF.id, event.timestamp),
+    };
+
+    const dance = this.currentDance(event.timestamp);
+
+    if (cast.spellId === SPELLS.SECRET_TECHNIQUE.id) {
+      // Only worth remembering when no window is open - otherwise it already belongs to that one,
+      // and holding on to it could attribute the same cast to a second window as well.
+      this.lastSecretTechnique = dance ? null : cast;
+    }
+
+    if (!dance) {
+      return;
+    }
+
+    dance.casts.push(cast);
+  }
+
+  private currentDance(timestamp: number): ShadowDanceData | undefined {
+    const dance = this.danceData.at(-1);
+    if (!dance || timestamp < dance.applied || timestamp > dance.removed) {
+      return undefined;
+    }
+    return dance;
   }
 
   private getRemoveTimestamp(event: ApplyBuffEvent): number {
@@ -67,6 +207,58 @@ export default class ShadowDance extends Analyzer.withDependencies({
 
   private calculateTotalDamage(damageEvents: DamageEvent[]): number {
     return damageEvents.reduce((total, dmg) => total + dmg.amount + (dmg.absorb || 0), 0);
+  }
+
+  /**
+   * Eviscerates cast under Darkest Night that were missing Ancient Arts.
+   *
+   * The last cast of a Shadow Dance is exempt: there is no room left in the window to line the two
+   * buffs up, so dropping Ancient Arts there is expected rather than a mistake.
+   */
+  getMissedAncientArtsEviscerates(dance: ShadowDanceData): DanceCast[] {
+    const lastCast = dance.casts.at(-1);
+
+    return dance.casts.filter(
+      (cast) =>
+        cast.spellId === SPELLS.EVISCERATE.id &&
+        cast.hasDarkestNight &&
+        !cast.hasAncientArts &&
+        cast !== lastCast,
+    );
+  }
+
+  /**
+   * Position of Secret Technique among the finishers spent in this window, 1-based, or `null` if
+   * it was never cast. Only Eviscerate, Black Powder and Secret Technique count as finishers, so
+   * builders in between do not push the position out.
+   */
+  getSecretTechniqueFinisherPosition(dance: ShadowDanceData): number | null {
+    const finishers = dance.casts.filter((cast) => FINISHER_SPELL_IDS.includes(cast.spellId));
+    const index = finishers.findIndex((cast) => cast.spellId === SPELLS.SECRET_TECHNIQUE.id);
+
+    return index === -1 ? null : index + 1;
+  }
+
+  /**
+   * Whether Secret Technique could realistically be spent in this window.
+   *
+   * Actually casting it inside the window is the strongest possible evidence and is checked first:
+   * cooldown state sampled at the applybuff can be misleading, because Shadow Dance and Secret
+   * Technique are macroed together and SpellUsable may have already started the cooldown from that
+   * very cast by the time the buff event is handled.
+   *
+   * Otherwise it counts as usable when it was off cooldown on entry, or close enough to coming off
+   * that it still fits in the window.
+   */
+  isSecretTechniqueUsable(dance: ShadowDanceData): boolean {
+    if (dance.casts.some((cast) => cast.spellId === SPELLS.SECRET_TECHNIQUE.id)) {
+      return true;
+    }
+
+    return (
+      dance.secretTechniqueAvailable ||
+      dance.secretTechniqueCooldownRemaining <= SECRET_TECHNIQUE_GRACE_MS
+    );
   }
 
   onFightEnd() {
@@ -110,6 +302,13 @@ export default class ShadowDance extends Analyzer.withDependencies({
   }
 }
 
+export interface DanceCast {
+  timestamp: number;
+  spellId: number;
+  hasDarkestNight: boolean;
+  hasAncientArts: boolean;
+}
+
 export interface ShadowDanceData {
   applied: number;
   removed: number;
@@ -120,4 +319,11 @@ export interface ShadowDanceData {
   numberAbilitiesUsed?: number;
   energyAtCast: number;
   comboPointsAtCast: number;
+  secretTechniqueAvailable: boolean;
+  /** Milliseconds left on Secret Technique's cooldown when the window opened; 0 when ready. */
+  secretTechniqueCooldownRemaining: number;
+  shadowBladesActive: boolean;
+  /** 1-based position of this dance within the current Shadow Blades window; 0 when none active. */
+  danceIndexInShadowBlades: number;
+  casts: DanceCast[];
 }

--- a/src/analysis/retail/rogue/subtlety/modules/spells/ShadowDance.tsx
+++ b/src/analysis/retail/rogue/subtlety/modules/spells/ShadowDance.tsx
@@ -30,6 +30,13 @@ export const SECRET_TECHNIQUE_GRACE_MS = 2000;
  */
 export const SECRET_TECHNIQUE_PAIRING_BUFFER_MS = 250;
 
+/**
+ * Ancient Arts has to be set up by an earlier cast, so an Eviscerate with less than a GCD left in
+ * the window could not have been paired with it. Graded on time remaining rather than on being the
+ * last cast, so a lone Eviscerate early in a window is still judged.
+ */
+export const ANCIENT_ARTS_PAIRING_WINDOW_MS = 1000;
+
 /** The finishers that can be spent inside a Shadow Dance window. */
 const FINISHER_SPELL_IDS: number[] = [
   SPELLS.EVISCERATE.id,
@@ -120,11 +127,6 @@ export default class ShadowDance extends Analyzer.withDependencies({
       duration: removed - event.timestamp,
       energyAtCast: this.energyTracker.current,
       comboPointsAtCast: this.comboPointTracker.current,
-      // Read during the event rather than at render time: SpellUsable only describes the current
-      // point in the fight, so reading it later would report the state at fight end for every
-      // window.
-      // Spending it right as the window opens counts as available: the cooldown SpellUsable
-      // reports at this point was started by that very cast.
       secretTechniqueAvailable:
         !this.spellUsable.isOnCooldown(SPELLS.SECRET_TECHNIQUE.id) ||
         pairedSecretTechnique !== null,
@@ -212,18 +214,17 @@ export default class ShadowDance extends Analyzer.withDependencies({
   /**
    * Eviscerates cast under Darkest Night that were missing Ancient Arts.
    *
-   * The last cast of a Shadow Dance is exempt: there is no room left in the window to line the two
-   * buffs up, so dropping Ancient Arts there is expected rather than a mistake.
+   * Casts in the last {@link ANCIENT_ARTS_PAIRING_WINDOW_MS} of the window are exempt: there was
+   * no time left to line the two buffs up, so dropping Ancient Arts there is expected rather than
+   * a mistake.
    */
   getMissedAncientArtsEviscerates(dance: ShadowDanceData): DanceCast[] {
-    const lastCast = dance.casts.at(-1);
-
     return dance.casts.filter(
       (cast) =>
         cast.spellId === SPELLS.EVISCERATE.id &&
         cast.hasDarkestNight &&
         !cast.hasAncientArts &&
-        cast !== lastCast,
+        dance.removed - cast.timestamp > ANCIENT_ARTS_PAIRING_WINDOW_MS,
     );
   }
 
@@ -240,21 +241,10 @@ export default class ShadowDance extends Analyzer.withDependencies({
   }
 
   /**
-   * Whether Secret Technique could realistically be spent in this window.
-   *
-   * Actually casting it inside the window is the strongest possible evidence and is checked first:
-   * cooldown state sampled at the applybuff can be misleading, because Shadow Dance and Secret
-   * Technique are macroed together and SpellUsable may have already started the cooldown from that
-   * very cast by the time the buff event is handled.
-   *
-   * Otherwise it counts as usable when it was off cooldown on entry, or close enough to coming off
-   * that it still fits in the window.
+   * Whether Secret Technique could be spent in this window: it was off cooldown when the window
+   * opened, or close enough to coming off that it still lands early in the window.
    */
   isSecretTechniqueUsable(dance: ShadowDanceData): boolean {
-    if (dance.casts.some((cast) => cast.spellId === SPELLS.SECRET_TECHNIQUE.id)) {
-      return true;
-    }
-
     return (
       dance.secretTechniqueAvailable ||
       dance.secretTechniqueCooldownRemaining <= SECRET_TECHNIQUE_GRACE_MS

--- a/src/common/SPELLS/rogue.ts
+++ b/src/common/SPELLS/rogue.ts
@@ -630,6 +630,22 @@ const spells = {
     icon: 'spell_shadow_ritualofsacrifice',
   },
 
+  DARKEST_NIGHT_BUFF: {
+    id: 457280,
+    name: 'Darkest Night',
+    icon: 'spell_shadow_twilight',
+  },
+  DEATHSTALKERS_MARK_DEBUFF: {
+    id: 457129,
+    name: "Deathstalker's Mark",
+    icon: 'inv_ability_deathstalkerrogue_deathstalkersmark',
+  },
+  ANCIENT_ARTS_BUFF: {
+    id: 1269163,
+    name: 'Ancient Arts',
+    icon: 'inv12_apextalent_rogue_ancientarts',
+  },
+
   // Trickster Hero Talents
   COUP_DE_GRACE_CAST: {
     id: 441776,


### PR DESCRIPTION
### Description

Shadow Dance module update:
- Updated and fixed some issues on Trickster analysis
- Added support for Deathstalker on 12.1

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL (Deathstalker): `/report/98M6hfNApQTRcv2b/26-Heroic+Vashnik+the+Malignant+-+Kill+(9:16)/22-Raistrog/standard`
- Screenshot(s):
<img width="1262" height="662" alt="image" src="https://github.com/user-attachments/assets/c8ae0243-f9f8-4ed7-b0e1-0fd4b8b98183" />

- Test report URL (Trickster): `/report/QJpVNj4XLf82PvGZ/8-Heroic+Nek'zali+the+Soulcoiler+-+Kill+(6:36)/15-%E8%AB%B8%E8%91%9B%E5%A4%A7%E5%8A%9B/standard/overview`
- Screenshot(s):
<img width="1250" height="681" alt="image" src="https://github.com/user-attachments/assets/63b1cdec-8a8a-4faf-b8a5-826bc4f62d4e" />

