### PR TITLE
[Preservation] Echo analyzer fix for Merithra's Blessing

### DIFF
--- a/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/preservation/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 8, 24), <>Update the <SpellLink spell={TALENTS_EVOKER.ECHO_TALENT} /> analyzer to handle <SpellLink spell={SPELLS.MERITHRAS_BLESSING_CAST} /> casts properly when reporting information for <SpellLink spell={TALENTS_EVOKER.TIME_LORD_TALENT} /></>, Harrek),
   change(date(2026, 8, 22), <>Update <SpellLink spell={SPELLS.EMERALD_BLOSSOM} />, <SpellLink spell={TALENTS_EVOKER.ESSENCE_BURST_PRESERVATION_TALENT} />, <SpellLink spell={TALENTS_EVOKER.TITANS_GIFT_TALENT} />, and <SpellLink spell={TALENTS_EVOKER.STASIS_TALENT} /> analysis. Implement <SpellLink spell={TALENTS_EVOKER.INNER_FLAME_TALENT} />, and <SpellLink spell={TALENTS_EVOKER.LIFEFORCE_MENDER_TALENT} /> modules.</>, Harrek),
   change(date(2026, 6, 7), <>Fixed display issues for <SpellLink spell={SPELLS.EMERALD_BLOSSOM} /> and <SpellLink spell={TALENTS_EVOKER.NOZDORMUS_TEACHINGS_TALENT} /> </>, Baumritter),
   change(date(2026, 6, 7), <>Fixed display issues for <SpellLink spell={SPELLS.LEAPING_FLAMES_BUFF} /> </>, Baumritter),

--- a/src/analysis/retail/evoker/preservation/modules/talents/Echo.tsx
+++ b/src/analysis/retail/evoker/preservation/modules/talents/Echo.tsx
@@ -3,6 +3,7 @@ import { TALENTS_EVOKER } from 'common/TALENTS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, {
   CastEvent,
+  GetRelatedEvent,
   GetRelatedEvents,
   HealEvent,
   RemoveBuffEvent,
@@ -16,7 +17,12 @@ import {
   isFromHardcastEcho,
   isFromTAEcho,
 } from '../../normalizers/EventLinking/helpers';
-import { ECHO, ECHO_TEMPORAL_ANOMALY, ECHO_TYPE } from '../../normalizers/EventLinking/constants';
+import {
+  ECHO,
+  ECHO_TEMPORAL_ANOMALY,
+  ECHO_TYPE,
+  MERITHRAS_HEALING,
+} from '../../normalizers/EventLinking/constants';
 import HotTrackerPrevoker from '../core/HotTrackerPrevoker';
 
 class Echo extends Analyzer {
@@ -76,6 +82,15 @@ class Echo extends Analyzer {
       return getEchoTypeForLifebind(event) !== ECHO_TYPE.NONE;
     } else if (spellID === SPELLS.GOLDEN_HOUR_HEAL.id) {
       return getEchoTypeForGoldenHour(event) !== ECHO_TYPE.NONE;
+    } else if (spellID === SPELLS.MERITHRAS_BLESSING_CAST.id) {
+      const cast = GetRelatedEvent<CastEvent>(event, MERITHRAS_HEALING);
+      if (cast) {
+        const healingEvents = GetRelatedEvents<HealEvent>(cast, MERITHRAS_HEALING);
+        const hitIndex = healingEvents.findIndex((healEvent) => healEvent === event);
+        return hitIndex !== undefined && hitIndex >= 5;
+      } else {
+        return false;
+      }
     }
     if (event.tick) {
       if (!this.hotTracker.hots[targetID] || !this.hotTracker.hots[targetID][spellID]) {

--- a/src/analysis/retail/evoker/preservation/normalizers/EventLinking/GreenEventLinks.ts
+++ b/src/analysis/retail/evoker/preservation/normalizers/EventLinking/GreenEventLinks.ts
@@ -117,6 +117,7 @@ export const GREEN_EVENT_LINKS: EventLink[] = [
   },
   {
     linkRelation: MERITHRAS_HEALING,
+    reverseLinkRelation: MERITHRAS_HEALING,
     linkingEventId: SPELLS.MERITHRAS_BLESSING_CAST.id,
     linkingEventType: EventType.Cast,
     referencedEventId: SPELLS.MERITHRAS_BLESSING_CAST.id,


### PR DESCRIPTION
### Description

Update the Echo analyzer to detect hits above the 5th one from the same cast of Merithra's Blessing as coming from echoes. All hits from Merithra's Blessing have the same id and have varying travel times so detecting the origin of each hit isn't really possible. Instead as every cast generates 5 events, we take the first 5 events and assume they come from the original cast and attribute all the others as being generated by echoes

This currently doesn't affect the Echo analyzer at all, but it fixes an error where the Timelord analyzer asking if a specific heal came from an Echo was returning false for all Merithra's Blessing hits

### Testing

- Test report URL: `/report/cyTqg3r672k4CLXz/2-Heroic+Ula'tek+-+Kill+(9:52)/6-Mingevoee/standard/statistics`
- Screenshot(s):

Before:
<img width="229" height="80" alt="image" src="https://github.com/user-attachments/assets/bf5e3ba1-b898-40e1-8fae-bda8d745b3ac" />

After:
<img width="280" height="104" alt="image" src="https://github.com/user-attachments/assets/035c2046-a1bd-4920-861e-029866bac0fc" />
