### PR TITLE
[Warlock] [Destruction] Fix typo in ImmolateUptime

### DIFF
--- a/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
@@ -3,6 +3,7 @@ import {Katorri} from 'CONTRIBUTORS';
 
 // prettier-ignore
 export default [
+  change(date(2026, 8, 26), "Fix typo in Dot Uptimes", Katorri),
   change(date(2026, 8, 18), "Update compatibility for 12.1", Katorri),
   change(date(2026, 4, 21), "Spec compatibility updated for 12.0.5", Katorri),
   change(date(2026, 3, 28), "Add Backdraft analyzer and guide. Updated from Partial to Full support", Katorri),

--- a/src/analysis/retail/warlock/destruction/modules/guide/ImmolateUptime.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/guide/ImmolateUptime.tsx
@@ -36,7 +36,7 @@ class ImmolateUptime extends Analyzer {
         {this.selectedCombatant.hasTalent(TALENTS_WARLOCK.WITHER_TALENT) && (
           <p>
             When playing Hellcaller, maintain <SpellLink spell={SPELLS.WITHER_DEBUFF} />. This DoT
-            contributes a massive amount of damage and nables rotational synergies with{' '}
+            contributes a massive amount of damage and enables rotational synergies with{' '}
             <SpellLink spell={SPELLS.CONFLAGRATE} /> and other Destruction talents.
           </p>
         )}


### PR DESCRIPTION
### Description

Small typo in Immolate Uptime file fixed 

### Testing
- Test report URL: `/report/zqaCtxWMT92f6nkZ/49-Heroic+The+Twin+Fangs+-+Wipe+8+(7:54)/3-Katorrí/standard`
- Screenshot(s):

<img width="394" height="228" alt="image" src="https://github.com/user-attachments/assets/c4538655-2b99-41c5-957a-359079cb1be6" />
<img width="399" height="226" alt="image" src="https://github.com/user-attachments/assets/991b8ee4-e618-4bcb-9414-9f43e0565703" />
