### PR TITLE
Update Diverted Power and Double-time modules

### DIFF
--- a/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/augmentation/CHANGELOG.tsx
@@ -5,6 +5,7 @@ import TALENTS from 'common/TALENTS/evoker';
 import SPELLS from 'common/SPELLS';
 
 export default [
+  change(date(2026, 8, 29), <>Updated <SpellLink spell={TALENTS.DIVERTED_POWER_TALENT} /> and <SpellLink spell={TALENTS.DOUBLE_TIME_TALENT} /> modules.</>, KYZ),
   change(date(2026, 8, 11), <>Updated for 12.1.</>, KYZ),
   change(date(2026, 6, 7), <>Fixed display issues for <SpellLink spell={SPELLS.LEAPING_FLAMES_BUFF} /> </>, Baumritter),
   change(date(2026, 5, 14), <>Update <SpellLink spell={TALENTS.MIGHTY_INFERNO_TALENT} /> module to include DPS from extension.</>, KYZ),

--- a/src/analysis/retail/evoker/augmentation/constants.tsx
+++ b/src/analysis/retail/evoker/augmentation/constants.tsx
@@ -46,6 +46,7 @@ export const MAX_SKIP_CDR_BASE = 20000;
 export const MAX_SKIP_CDR_TT = 30000;
 export const MAX_SKIP_CDR_TB = 25700;
 export const MAX_SKIP_CDR_TT_TB = 38550;
+export const OVERLORD_MAX_MOTES = 3;
 
 // Breath of Eons multiplier
 export const BREATH_OF_EONS_MULTIPLIER = 0.1;

--- a/src/analysis/retail/evoker/augmentation/modules/abilities/SandsOfTime.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/abilities/SandsOfTime.tsx
@@ -30,6 +30,7 @@ interface PossibleExtends {
   event: CastEvent | EmpowerEndEvent;
   extendedEbonMight: boolean;
   extendedDuplicate: boolean;
+  allowFailedExtend: boolean;
 }
 
 class SandsOfTime extends Analyzer {
@@ -45,6 +46,7 @@ class SandsOfTime extends Analyzer {
   empowers = [SPELLS.FIRE_BREATH, SPELLS.FIRE_BREATH_FONT, SPELLS.UPHEAVAL, SPELLS.UPHEAVAL_FONT];
   canExtendDuplicate = this.selectedCombatant.hasTalent(TALENTS.DUPLICATE_2_AUGMENTATION_TALENT);
   duplicateActive = false;
+  hasDoubleTime = this.selectedCombatant.hasTalent(TALENTS.DOUBLE_TIME_TALENT);
   constructor(options: Options) {
     super(options);
 
@@ -87,6 +89,9 @@ class SandsOfTime extends Analyzer {
       event: event,
       extendedEbonMight: Boolean(this.ebonMightActive),
       extendedDuplicate: Boolean(this.duplicateActive && this.canExtendDuplicate),
+      // For some reason, attempting to get Double Time info in finalize() throws an error, so this is done here instead.
+      allowFailedExtend:
+        event.ability.guid === TALENTS.BREATH_OF_EONS_TALENT.id && this.hasDoubleTime,
     };
 
     this.extendAttempts.push(extendAttempts);
@@ -100,6 +105,7 @@ class SandsOfTime extends Analyzer {
   private sandOfTimeUsage(possibleExtends: PossibleExtends): SpellUse {
     let extendedEbonMight = possibleExtends.extendedEbonMight;
     let extendedDuplicate = possibleExtends.extendedDuplicate;
+    const allowFailedExtend = possibleExtends.allowFailedExtend;
     if (failedEbonMightExtension(possibleExtends.event)) {
       extendedEbonMight = false;
     }
@@ -112,7 +118,9 @@ class SandsOfTime extends Analyzer {
         ? QualitativePerformance.Perfect
         : extendedEbonMight
           ? QualitativePerformance.Good
-          : QualitativePerformance.Fail;
+          : allowFailedExtend
+            ? QualitativePerformance.Ok
+            : QualitativePerformance.Fail;
     const summary = (
       <div>
         Extended with <SpellLink spell={spell} />
@@ -129,6 +137,12 @@ class SandsOfTime extends Analyzer {
         <div>
           You extended your <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> buff by casting{' '}
           <SpellLink spell={spell} />. Good job!
+        </div>
+      ) : allowFailedExtend ? (
+        <div>
+          <SpellLink spell={TALENTS.EBON_MIGHT_TALENT} /> wasn't active, but this is acceptable when
+          using <SpellLink spell={spell} /> to try and proc{' '}
+          <SpellLink spell={TALENTS.DOUBLE_TIME_TALENT} />.
         </div>
       ) : (
         <div>

--- a/src/analysis/retail/evoker/augmentation/modules/talents/Overlord.tsx
+++ b/src/analysis/retail/evoker/augmentation/modules/talents/Overlord.tsx
@@ -10,6 +10,7 @@ import TalentSpellText from 'parser/ui/TalentSpellText';
 import { VersatilityIcon } from 'interface/icons';
 import { SpellLink } from 'interface';
 import { hasEruptionCastLink } from '../normalizers/CastLinkNormalizer';
+import { OVERLORD_MAX_MOTES } from 'analysis/retail/evoker/augmentation/constants';
 
 /**
  * Triggers an Eruption at the first 3 enemies hit by Breath of Eons / Deep Breath. These Eruptions are guaranteed to spawn a Mote of Possibility.
@@ -66,7 +67,7 @@ class Overlord extends Analyzer {
   }
 
   onApplyDebuff(event: ApplyDebuffEvent) {
-    if (this.motesSinceLastCast < 3) {
+    if (this.motesSinceLastCast < OVERLORD_MAX_MOTES) {
       this.motesSpawned += 1;
       this.motesSinceLastCast += 1;
     }

--- a/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
+++ b/src/analysis/retail/evoker/devastation/CHANGELOG.tsx
@@ -7,6 +7,7 @@ import ItemSetLink from 'interface/ItemSetLink';
 import { EVOKER_MID1_ID } from 'common/ITEMS';
 
 export default [
+  change(date(2026, 8, 29), <>Updated <SpellLink spell={TALENTS.DIVERTED_POWER_TALENT} /> module.</>, KYZ),
   change(date(2026, 6, 12), <>Fixed display error of <SpellLink spell={SPELLS.DISINTEGRATE} /> module</>, Baumritter),
   change(date(2026, 6, 12), <>Added statistic for tracking empower rank usage.</>, Baumritter),
   change(date(2026, 6, 7), <>Fixed display issues for <SpellLink spell={SPELLS.LEAPING_FLAMES_BUFF} /> </>, Baumritter),

--- a/src/analysis/retail/evoker/shared/modules/talents/hero/scalecommander/DivertedPower.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/hero/scalecommander/DivertedPower.tsx
@@ -59,7 +59,6 @@ class DivertedPower extends Analyzer {
     if (!enemy || !enemy.getBuff(SPELLS.BOMBARDMENTS_DEBUFF.id)) {
       return;
     }
-
     this.procAttempts += 1;
   }
 

--- a/src/analysis/retail/evoker/shared/modules/talents/hero/scalecommander/DivertedPower.tsx
+++ b/src/analysis/retail/evoker/shared/modules/talents/hero/scalecommander/DivertedPower.tsx
@@ -17,11 +17,16 @@ import {
 import { formatPercentage } from 'common/format';
 import Soup from 'interface/icons/Soup';
 import { InformationIcon } from 'interface/icons';
+import Enemies from 'parser/shared/modules/Enemies';
 
 /**
  * Bombardments have a chance to generate Essence Burst.
  */
 class DivertedPower extends Analyzer {
+  static dependencies = {
+    enemies: Enemies,
+  };
+  protected enemies!: Enemies;
   essenceBurstGenerated = 0;
   essenceBurstWasted = 0;
 
@@ -38,13 +43,24 @@ class DivertedPower extends Analyzer {
   }
 
   onDamage(event: DamageEvent) {
-    this.procAttempts += 1;
-
     if (eventGeneratedEB(event, EBSource.DivertedPower)) {
       this.essenceBurstGenerated += 1;
     } else if (eventWastedEB(event, EBSource.DivertedPower)) {
       this.essenceBurstWasted -= 1;
     }
+    // Proccing Bombardments yourself triggers both the damage event
+    // and the support event. Ignore one of those to avoid double counting.
+    if (event.supportID === this.owner.selectedCombatant.id) {
+      return;
+    }
+    // Reduce the number of proc attempts to 1 or 2 per Bombardments proc, even in AOE.
+    // To-do: Try and improve this to just 1 per Bombardments proc, even if the debuff is spread.
+    const enemy = this.enemies.getEntity(event);
+    if (!enemy || !enemy.getBuff(SPELLS.BOMBARDMENTS_DEBUFF.id)) {
+      return;
+    }
+
+    this.procAttempts += 1;
   }
 
   get procRate() {


### PR DESCRIPTION
Updates the Diverted Power module to attempt to only count each Bombardments proc as a proc attempt, rather than every Bombardments hit.
Updates the Sands of Time module to not count Eons casts outside of Ebon Might as a fail, if the player has Double-time.

Before:

<img width="403" height="165" alt="dp1" src="https://github.com/user-attachments/assets/035bbe9a-3472-4fe6-8435-b88493b29243" />
<img width="864" height="311" alt="eons1" src="https://github.com/user-attachments/assets/5f53714b-d38c-4695-9042-dee083fe692c" />

After:
<img width="399" height="169" alt="dp2" src="https://github.com/user-attachments/assets/068cc160-ad8d-471e-96dd-47166d429ffc" />
<img width="880" height="301" alt="eons2" src="https://github.com/user-attachments/assets/682a05bb-5098-4f88-9074-e43b5d8c0720" />