### PR TITLE
Rdruid Mastery Attribution Fixes

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -6,6 +6,15 @@ import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
   change(
+    date(2026, 8, 18),
+    <>
+      Count <SpellLink spell={TALENTS_DRUID.EVERBLOOM_2_RESTORATION_TALENT} /> splash and{' '}
+      <SpellLink spell={TALENTS_DRUID.SYMBIOTIC_RELATIONSHIP_TALENT} /> copies in Mastery: Harmony
+      using the source heal's HoTs instead of treating them as non-mastery healing.
+    </>,
+    squided,
+  ),
+  change(
     date(2026, 8, 19),
     <>
       Improve the HoT graph: ignore pets and duplicate applies, and include{' '}

--- a/src/analysis/retail/druid/restoration/constants.ts
+++ b/src/analysis/retail/druid/restoration/constants.ts
@@ -8,28 +8,22 @@ export const REJUVENATION_BUFFS: Spell[] = [SPELLS.REJUVENATION, SPELLS.REJUVENA
 /** Given count of Druid HoTs on target, gets the multiplier against mastery val to apply */
 export function masteryHotCountToMult(hotsOn: number): number {
   if (hotsOn > 10) {
-    return 3.65;
+    return MASTERY_HOT_COUNT_TO_MULT_TABLE[10];
   }
   return MASTERY_HOT_COUNT_TO_MULT_TABLE[hotsOn];
 }
-const MASTERY_HOT_COUNT_TO_MULT_TABLE = [
-  0,
-  1,
-  1.7,
-  2.3,
-  2.8,
-  3.2,
-  3.5,
-  3.7,
-  3.8,
-  3.85,
-  3.65, // loses value here, probably a bug
-];
+/** Diminishing increments: +0.7, +0.6, ... +0.1, +0.05, +0.025 */
+const MASTERY_HOT_COUNT_TO_MULT_TABLE = [0, 1, 1.7, 2.3, 2.8, 3.2, 3.5, 3.7, 3.8, 3.85, 3.875];
 
 /** Additional mastery stacks granted by Harmonius Blooming talent */
 export const HARMONIUS_BLOOMING_EXTRA_STACKS = 2;
 
-/** This is also the list of spell IDs that are boosted by Druid's mastery */
+/**
+ * Heals that independently benefit from Mastery based on HoTs on *that heal's target*.
+ * Copy heals (Everbloom splash, Symbiotic Relationship) are omitted: they inherit the
+ * source heal's mastery and do not double-dip from HoTs on the copy's target.
+ * Mastery.ts attributes those using the source's stack snapshot.
+ */
 export const ABILITIES_AFFECTED_BY_HEALING_INCREASES: number[] = [
   SPELLS.REJUVENATION.id,
   SPELLS.REJUVENATION_GERMINATION.id,
@@ -42,7 +36,6 @@ export const ABILITIES_AFFECTED_BY_HEALING_INCREASES: number[] = [
   SPELLS.SWIFTMEND.id,
   SPELLS.TRANQUILITY_HEAL.id,
   SPELLS.EFFLORESCENCE_HEAL.id,
-  SPELLS.GROVE_TENDING.id,
   SPELLS.VERDANCY.id,
   SPELLS.GROVE_GUARDIANS_SWIFTMEND.id,
   SPELLS.GROVE_GUARDIANS_NOURISH.id,
@@ -70,9 +63,6 @@ export const MASTERY_STACK_BUFF_IDS: number[] = [
   SPELLS.REJUVENATION_GERMINATION.id,
   SPELLS.REGROWTH.id,
   SPELLS.WILD_GROWTH.id,
-  SPELLS.CULTIVATION.id,
-  SPELLS.SPRING_BLOSSOMS.id,
-  SPELLS.CENARION_WARD_HEAL.id,
   SPELLS.FRENZIED_REGENERATION.id,
   SPELLS.LIFEBLOOM_BUFF.id,
   SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
@@ -87,6 +77,16 @@ export function hotBuffIdForHeal(healId: number): number {
   return HEAL_TO_HOT_BUFF_ID[healId] ?? healId;
 }
 
+export const PATIENT_CUSTODIAN_HOTS = [
+  SPELLS.REJUVENATION,
+  SPELLS.REJUVENATION_GERMINATION,
+  SPELLS.REGROWTH,
+  SPELLS.WILD_GROWTH,
+  SPELLS.LIFEBLOOM_HOT_HEAL,
+  SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER,
+  SPELLS.THRIVING_VEGETATION,
+];
+
 // Flourish tracks auras, so Lifebloom is the buff id (1227806).
 export const FLOURISH_EXTENDED_HOTS = [
   SPELLS.REJUVENATION,
@@ -96,7 +96,17 @@ export const FLOURISH_EXTENDED_HOTS = [
   SPELLS.LIFEBLOOM_BUFF,
 ];
 
-// Liveliness listens to heal events, so Lifebloom is the tick id (33763).
+// Genesis / Liveliness listen to heal events, so Lifebloom is the tick id (33763). No Efflo on Genesis.
+export const GENESIS_BUFFED_HOTS = [
+  SPELLS.REJUVENATION,
+  SPELLS.REJUVENATION_GERMINATION,
+  SPELLS.REGROWTH,
+  SPELLS.WILD_GROWTH,
+  SPELLS.LIFEBLOOM_HOT_HEAL,
+  SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER,
+];
+
+// Liveliness also speeds Efflo (Flourish does not). Do not reuse FLOURISH_EXTENDED_HOTS here.
 export const LIVELINESS_INCREASED_RATE = [
   SPELLS.REJUVENATION,
   SPELLS.REJUVENATION_GERMINATION,
@@ -104,16 +114,6 @@ export const LIVELINESS_INCREASED_RATE = [
   SPELLS.WILD_GROWTH,
   SPELLS.LIFEBLOOM_HOT_HEAL,
   SPELLS.EFFLORESCENCE_HEAL,
-  SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER,
-];
-
-// Genesis listens to heal events, so Lifebloom is the tick id (33763). No Efflo on Genesis.
-export const GENESIS_BUFFED_HOTS = [
-  SPELLS.REJUVENATION,
-  SPELLS.REJUVENATION_GERMINATION,
-  SPELLS.REGROWTH,
-  SPELLS.WILD_GROWTH,
-  SPELLS.LIFEBLOOM_HOT_HEAL,
   SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER,
 ];
 

--- a/src/analysis/retail/druid/restoration/modules/core/Mastery.ts
+++ b/src/analysis/retail/druid/restoration/modules/core/Mastery.ts
@@ -1,7 +1,13 @@
-import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
 import Entity from 'parser/core/Entity';
 import { calculateEffectiveHealing } from 'parser/core/EventCalculateLib';
-import Events, { AbsorbedEvent, FightEndEvent, HealEvent } from 'parser/core/Events';
+import Events, {
+  AbsorbedEvent,
+  ApplyBuffEvent,
+  FightEndEvent,
+  HealEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
 import Combatants from 'parser/shared/modules/Combatants';
 import STAT from 'parser/shared/modules/features/STAT';
 import HealingValue from 'parser/shared/modules/HealingValue';
@@ -17,6 +23,7 @@ import {
   DOUBLE_MASTERY_BENEFIT_IDS,
   hotBuffIdForHeal,
 } from 'analysis/retail/druid/restoration/constants';
+import { getSourceBloom } from 'analysis/retail/druid/restoration/normalizers/CastLinkNormalizer';
 
 const DEBUG = false;
 
@@ -43,6 +50,30 @@ class Mastery extends Analyzer {
   druidSpellNoMasteryHealing = 0;
   masteryTimesHealing = 0;
 
+  /** Extra healing from Harmonius Blooming's bonus LB stacks (DR-aware). */
+  harmoniusBloomingHealing = 0;
+  harmoniusBloomingOverheal = 0;
+  /** Harmonius Blooming extra-stack healing on Everbloom splash (subset of {@link harmoniusBloomingHealing}). */
+  harmoniusBloomingEverbloomSplashHealing = 0;
+  harmoniusBloomingEverbloomSplashOverheal = 0;
+  /**
+   * Mastery stack snapshot at each Lifebloom bloom, keyed by `timestamp:targetID`.
+   * Everbloom splash copies the bloom amount (including that mastery) and does not
+   * re-apply mastery from HoTs on the splash target — look up this snapshot instead.
+   */
+  private bloomMasterySnapshots = new Map<string, MasteryStackSnapshot>();
+  /** Ally currently bonded by Symbiotic Relationship. */
+  private bondedAllyId: number | undefined;
+  /**
+   * Stacks that scaled the most recent self-heal (for the 10% copy to the bonded ally).
+   * Includes 0-stack snapshots so trinket self-heals don't inherit a stale HoT count.
+   */
+  private lastSelfHealMastery: MasteryStackSnapshot = { hotsOn: [], hotCount: 0 };
+  /**
+   * Stacks that scaled the most recent heal on the bonded ally (for the 8% copy back to self).
+   */
+  private lastBondedAllyHealMastery: MasteryStackSnapshot = { hotsOn: [], hotCount: 0 };
+
   // tracks mastery attribution by spell
   spellAttributions: MasteryAttributionsBySpell = {};
 
@@ -67,8 +98,17 @@ class Mastery extends Analyzer {
       this.spellAttributions[id] = new MasterySpellAttribution();
     });
 
-    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
+    // Player heals + pet heals that benefit from Mastery (e.g. Grove Guardian Wild Growth).
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER | SELECTED_PLAYER_PET), this.onHeal);
     this.addEventListener(Events.absorbed.by(SELECTED_PLAYER), this.onAbsorbed);
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(TALENTS_DRUID.SYMBIOTIC_RELATIONSHIP_TALENT),
+      this.onSymbioticRelationshipApply,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(TALENTS_DRUID.SYMBIOTIC_RELATIONSHIP_TALENT),
+      this.onSymbioticRelationshipRemove,
+    );
 
     // for outputting final computed values when debug is enabled
     DEBUG && this.addEventListener(Events.fightend, this.onFightEnd);
@@ -88,65 +128,44 @@ class Mastery extends Analyzer {
       this.spellAttributions[attributionSpellId].direct += healVal.effective;
     }
 
+    // Copy heals inherit the source heal's mastery and do not double-dip from dest HoTs.
+    const replicationSnapshot = this._snapshotForReplicationHeal(event);
+    if (replicationSnapshot) {
+      this._tallyMasteryAffectedHeal(
+        event,
+        healVal,
+        replicationSnapshot.hotsOn,
+        replicationSnapshot.hotCount,
+        1,
+        attributionSpellId,
+      );
+      return;
+    }
+    if (this._isReplicationHeal(spellId)) {
+      this.totalNoMasteryHealing += healVal.effective;
+      return;
+    }
+
     if (ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(spellId)) {
       const hotsOn = this.getHotsOn(target);
-      const hasDoubleMasteryBenefit = DOUBLE_MASTERY_BENEFIT_IDS.includes(spellId);
-      const numHotsOn = this.getHotCount(target) * (hasDoubleMasteryBenefit ? 2 : 1);
-      const decomposedHeal = this._decompHeal(healVal, numHotsOn);
+      const hotCount = this.getHotCount(target);
+      const masteryBenefitMult = DOUBLE_MASTERY_BENEFIT_IDS.includes(spellId) ? 2 : 1;
 
-      if (DEBUG) {
-        let logPrefix = 'ALL-EFFECTIVE';
-        if (healVal.effective === 0) {
-          logPrefix = 'ALL-OVERHEAL';
-        } else if (healVal.overheal > 0) {
-          logPrefix = 'PARTIAL-EFFECTIVE';
-        }
-        console.log(
-          `${logPrefix} - ${event.ability.name}: ${healVal.effective.toFixed(
-            0,
-          )} (O: ${healVal.overheal.toFixed(
-            0,
-          )}) // Mastery: ${this.statTracker.currentMasteryPercentage.toFixed(
-            2,
-          )} Hots: ${numHotsOn} EffMult: ${decomposedHeal.effectiveStackMult}`,
-        );
+      if (spellId === SPELLS.LIFEBLOOM_BLOOM_HEAL.id) {
+        this.bloomMasterySnapshots.set(this._bloomKey(event), { hotsOn, hotCount });
       }
 
-      this.totalNoMasteryHealing += decomposedHeal.noMastery;
-      this.druidSpellNoMasteryHealing += decomposedHeal.noMastery;
-      this.masteryTimesHealing += decomposedHeal.noMastery * decomposedHeal.effectiveStackMult;
-
-      // tally benefits for spells
-      hotsOn
-        .filter((hotOn) => hotOn !== attributionSpellId) // don't double count
-        .forEach((hotOn) => this._tallyMasteryBenefit(hotOn, spellId, decomposedHeal.oneStack));
-
-      // tally benefits for ratings buffs
-      this.selectedCombatant
-        .activeBuffs()
-        .filter(
-          (buff) =>
-            this.statTracker.statBuffs[buff.ability.guid] &&
-            this.statTracker.statBuffs[buff.ability.guid].mastery,
-        )
-        .forEach((buff) => {
-          const buffId = buff.ability.guid;
-          const statBuff = this.statTracker.statBuffs[buffId];
-          if (!this.buffAttributions[buffId]) {
-            this.buffAttributions[buffId] = new MasteryBuffAttribution(
-              this.statTracker.getBuffValue(statBuff, statBuff.mastery),
-            );
-          }
-
-          this.buffAttributions[buffId].attributable += calculateEffectiveHealing(
-            event,
-            decomposedHeal.relativeBuffBenefit(
-              this.buffAttributions[buffId].buffAmount * buff.stacks,
-            ),
-          );
-        });
+      this._tallyMasteryAffectedHeal(
+        event,
+        healVal,
+        hotsOn,
+        hotCount,
+        masteryBenefitMult,
+        attributionSpellId,
+      );
     } else {
       this.totalNoMasteryHealing += healVal.effective;
+      this._rememberSourceHealMastery(event, [], 0);
     }
   }
 
@@ -170,17 +189,33 @@ class Mastery extends Analyzer {
     return this.spellAttributions[healId].direct;
   }
 
-  /*
-   * Gets the total mastery healing attributed to the given resto HoT ID
-   */
-  /**
-   * The mastery healing attributed to the given resto HoT ID.
-   * This is healing done by *other* spells that were boosted by the presence
-   * of this HoT on the same target.
-   * @param healId the spell ID of the HoT
-   */
+  /** Mastery healing this HoT granted to *other* spells on the same target. */
   getMasteryHealing(healId: number) {
     return this.spellAttributions[healId].totalMastery;
+  }
+
+  getMasteryOverhealing(healId: number) {
+    return this.spellAttributions[healId].totalMasteryOverheal;
+  }
+
+  getHarmoniusBloomingHealing(): number {
+    return this.harmoniusBloomingHealing;
+  }
+
+  getHarmoniusBloomingOverhealing(): number {
+    return this.harmoniusBloomingOverheal;
+  }
+
+  getHarmoniusBloomingEverbloomSplashHealing(): number {
+    return this.harmoniusBloomingEverbloomSplashHealing;
+  }
+
+  getHarmoniusBloomingEverbloomSplashOverhealing(): number {
+    return this.harmoniusBloomingEverbloomSplashOverheal;
+  }
+
+  getBondedAllyId(): number | undefined {
+    return this.bondedAllyId;
   }
 
   /*
@@ -253,42 +288,254 @@ class Mastery extends Analyzer {
     return hotsOn.length + extraStacks;
   }
 
+  private _bloomKey(bloom: HealEvent): string {
+    return `${bloom.timestamp}:${bloom.targetID}`;
+  }
+
+  private _isReplicationHeal(spellId: number): boolean {
+    return (
+      spellId === SPELLS.EVERBLOOM_SPLASH_HEAL.id ||
+      spellId === SPELLS.SYMBIOTIC_RELATIONSHIP_HEAL.id
+    );
+  }
+
+  private onSymbioticRelationshipApply = (event: ApplyBuffEvent): void => {
+    if (event.targetID !== this.selectedCombatant.id) {
+      this.bondedAllyId = event.targetID;
+    }
+  };
+
+  private onSymbioticRelationshipRemove = (event: RemoveBuffEvent): void => {
+    if (event.targetID === this.bondedAllyId) {
+      this.bondedAllyId = undefined;
+    }
+  };
+
+  /**
+   * Stacks that actually scaled a copy heal. Everbloom splash uses the source bloom;
+   * Symbiotic Relationship uses the preceding self-heal (10% to ally) or bonded-ally heal
+   * (8% back to self).
+   */
+  private _snapshotForReplicationHeal(event: HealEvent): MasteryStackSnapshot | undefined {
+    const spellId = event.ability.guid;
+    if (spellId === SPELLS.EVERBLOOM_SPLASH_HEAL.id) {
+      const sourceBloom = getSourceBloom(event);
+      if (!sourceBloom) {
+        return undefined;
+      }
+      return this.bloomMasterySnapshots.get(this._bloomKey(sourceBloom));
+    }
+    if (spellId === SPELLS.SYMBIOTIC_RELATIONSHIP_HEAL.id) {
+      if (event.targetID === this.selectedCombatant.id) {
+        return this.lastBondedAllyHealMastery;
+      }
+      this.bondedAllyId = event.targetID;
+      return this.lastSelfHealMastery;
+    }
+    return undefined;
+  }
+
+  /** Remember stacks used on this heal so a following Symbiotic Relationship copy can inherit them. */
+  private _rememberSourceHealMastery(event: HealEvent, hotsOn: number[], hotCount: number): void {
+    if (event.ability.guid === SPELLS.SYMBIOTIC_RELATIONSHIP_HEAL.id) {
+      return;
+    }
+    const snapshot = { hotsOn, hotCount };
+    if (event.targetID === this.selectedCombatant.id) {
+      this.lastSelfHealMastery = snapshot;
+    } else if (this._isBondedAllyTarget(event.targetID)) {
+      this.bondedAllyId = event.targetID;
+      this.lastBondedAllyHealMastery = snapshot;
+    }
+  }
+
+  private _isBondedAllyTarget(targetId: number): boolean {
+    if (this.bondedAllyId === targetId) {
+      return true;
+    }
+    const ally = this.combatants.getEntities()[targetId];
+    return (
+      ally?.hasBuff(
+        TALENTS_DRUID.SYMBIOTIC_RELATIONSHIP_TALENT.id,
+        null,
+        0,
+        0,
+        this.selectedCombatant.id,
+      ) ?? false
+    );
+  }
+
+  /**
+   * Shared attribution path for heals that benefit from Mastery.
+   * `hotsOn` / `hotCount` must already reflect the stacks that actually scaled the heal
+   * (the healed target for normal spells, the Lifebloom target for Everbloom splash).
+   */
+  private _tallyMasteryAffectedHeal(
+    event: HealEvent,
+    healVal: HealingValue,
+    hotsOn: number[],
+    hotCount: number,
+    masteryBenefitMult: number,
+    attributionSpellId: number,
+  ): void {
+    const decomposedHeal = this._decompHeal(healVal, hotCount, masteryBenefitMult);
+
+    if (DEBUG) {
+      let logPrefix = 'ALL-EFFECTIVE';
+      if (healVal.effective === 0) {
+        logPrefix = 'ALL-OVERHEAL';
+      } else if (healVal.overheal > 0) {
+        logPrefix = 'PARTIAL-EFFECTIVE';
+      }
+      console.log(
+        `${logPrefix} - ${event.ability.name}: ${healVal.effective.toFixed(
+          0,
+        )} (O: ${healVal.overheal.toFixed(
+          0,
+        )}) // Mastery: ${this.statTracker.currentMasteryPercentage.toFixed(
+          2,
+        )} Hots: ${hotCount} EffMult: ${decomposedHeal.effectiveStackMult}`,
+      );
+    }
+
+    this.totalNoMasteryHealing += decomposedHeal.noMastery;
+    this.druidSpellNoMasteryHealing += decomposedHeal.noMastery;
+    this.masteryTimesHealing += decomposedHeal.noMastery * decomposedHeal.effectiveStackMult;
+
+    if (this.extraLbStacks > 0 && hotsOn.includes(this.lbBuffId)) {
+      this._tallyHarmoniusBlooming(healVal, hotCount, masteryBenefitMult, event);
+    }
+
+    hotsOn
+      .filter((hotOn) => hotOn !== attributionSpellId)
+      .forEach((hotOn) =>
+        this._tallyMasteryBenefit(
+          hotOn,
+          event.ability.guid,
+          decomposedHeal.oneStack,
+          decomposedHeal.oneStackOverheal,
+        ),
+      );
+
+    this.selectedCombatant
+      .activeBuffs()
+      .filter(
+        (buff) =>
+          this.statTracker.statBuffs[buff.ability.guid] &&
+          this.statTracker.statBuffs[buff.ability.guid].mastery,
+      )
+      .forEach((buff) => {
+        const buffId = buff.ability.guid;
+        const statBuff = this.statTracker.statBuffs[buffId];
+        if (!this.buffAttributions[buffId]) {
+          this.buffAttributions[buffId] = new MasteryBuffAttribution(
+            this.statTracker.getBuffValue(statBuff, statBuff.mastery),
+          );
+        }
+
+        this.buffAttributions[buffId].attributable += calculateEffectiveHealing(
+          event,
+          decomposedHeal.relativeBuffBenefit(
+            this.buffAttributions[buffId].buffAmount * buff.stacks,
+          ),
+        );
+      });
+
+    this._rememberSourceHealMastery(event, hotsOn, hotCount);
+  }
+
   /**
    * Tallies a heal with spellAttributions
    * @param hotId the ID of the HoT on the healed target
    * @param healId the ID of the heal being boosted
    * @param amount the amount of the boost
+   * @param overhealAmount the overheal attributable to one stack of this HoT
    */
-  _tallyMasteryBenefit(hotId: number, healId: number, amount: number): void {
-    const hotMastery = this.spellAttributions[hotId].mastery;
-    const adjustedAmount = hotId === this.lbBuffId ? amount * (1 + this.extraLbStacks) : amount;
-    if (hotMastery[healId]) {
-      hotMastery[healId] += adjustedAmount;
+  _tallyMasteryBenefit(
+    hotId: number,
+    healId: number,
+    amount: number,
+    overhealAmount: number,
+  ): void {
+    const attribution = this.spellAttributions[hotId];
+    const stackMult = hotId === this.lbBuffId ? 1 + this.extraLbStacks : 1;
+    const adjustedAmount = amount * stackMult;
+    const adjustedOverheal = overhealAmount * stackMult;
+
+    if (attribution.mastery[healId]) {
+      attribution.mastery[healId] += adjustedAmount;
     } else {
-      hotMastery[healId] = adjustedAmount;
+      attribution.mastery[healId] = adjustedAmount;
+    }
+
+    if (attribution.masteryOverheal[healId]) {
+      attribution.masteryOverheal[healId] += adjustedOverheal;
+    } else {
+      attribution.masteryOverheal[healId] = adjustedOverheal;
     }
   }
 
-  // a version of _decompHeal for call by external modules, takes the heal event
   decomposeHeal(event: HealEvent): DecomposedHeal | null {
+    const healVal = HealingValue.fromEvent(event);
+    const replicationSnapshot = this._snapshotForReplicationHeal(event);
+    if (replicationSnapshot) {
+      return this._decompHeal(healVal, replicationSnapshot.hotCount);
+    }
+    if (this._isReplicationHeal(event.ability.guid)) {
+      return this._decompHeal(healVal, 0);
+    }
     const target = this.combatants.getEntity(event);
     if (target === null) {
       return null;
     }
-    const healVal = HealingValue.fromEvent(event);
-    return this._decompHeal(healVal, this.getHotCount(target));
+    const masteryBenefitMult = DOUBLE_MASTERY_BENEFIT_IDS.includes(event.ability.guid) ? 2 : 1;
+    return this._decompHeal(healVal, this.getHotCount(target), masteryBenefitMult);
+  }
+
+  /**
+   * Extra stacks are the marginal (highest) ones, so overheal comes off them first.
+   * Credits (mult(n) - mult(n - extraLbStacks)) * masteryPct * rawNoMastery.
+   */
+  _tallyHarmoniusBlooming(
+    healVal: HealingValue,
+    hotCount: number,
+    masteryBenefitMult: number,
+    event: HealEvent,
+  ): void {
+    const masteryBonus = this.statTracker.currentMasteryPercentage;
+    const multWith = masteryHotCountToMult(hotCount);
+    const multWithout = masteryHotCountToMult(hotCount - this.extraLbStacks);
+    const healMasteryMultWith = 1 + multWith * masteryBonus * masteryBenefitMult;
+    const healMasteryMultWithout = 1 + multWithout * masteryBonus * masteryBenefitMult;
+    const rawNoMasteryHealing = healVal.raw / healMasteryMultWith;
+
+    const extraStacksRaw =
+      rawNoMasteryHealing * (multWith - multWithout) * masteryBonus * masteryBenefitMult;
+    const rawWithout = rawNoMasteryHealing * healMasteryMultWithout;
+    const extraStacksEffective = Math.max(
+      0,
+      Math.min(extraStacksRaw, healVal.effective - rawWithout),
+    );
+    const extraStacksOverheal = extraStacksRaw - extraStacksEffective;
+
+    this.harmoniusBloomingHealing += extraStacksEffective;
+    this.harmoniusBloomingOverheal += extraStacksOverheal;
+
+    if (event.ability.guid === SPELLS.EVERBLOOM_SPLASH_HEAL.id) {
+      this.harmoniusBloomingEverbloomSplashHealing += extraStacksEffective;
+      this.harmoniusBloomingEverbloomSplashOverheal += extraStacksOverheal;
+    }
   }
 
   /**
    * Decomposes a heal's amount to show the amounts attributable to mastery
-   * @param healVal the HealingValue being decomposed
-   * @param hotCount the number of HoTs present on the target which provide Mastery boost
+   * @param masteryBenefitMult extra multiplier on the mastery bonus (2 for GG Nourish). DR table still uses hotCount.
    */
-  _decompHeal(healVal: HealingValue, hotCount: number): DecomposedHeal {
+  _decompHeal(healVal: HealingValue, hotCount: number, masteryBenefitMult = 1): DecomposedHeal {
     // mastery diminishing returns with more HoTs on - do the table lookup and get overall bonus
     const hotMult = masteryHotCountToMult(hotCount);
     const masteryBonus = this.statTracker.currentMasteryPercentage;
-    const healBonus = hotMult * masteryBonus;
+    const healBonus = hotMult * masteryBonus * masteryBenefitMult;
     const healMasteryMult = 1 + healBonus;
     // the raw healing this spell would have done if it benefitted from zero mastery stacks
     const rawNoMasteryHealing = healVal.raw / healMasteryMult;
@@ -297,16 +544,20 @@ class Mastery extends Analyzer {
 
     // because Mastery is a bonus on top of the base healing, all overhealing is counted against Mastery
     const effectiveMasteryHealing = healVal.effective - noMasteryHealing;
+    const rawMasteryHealing = healVal.raw - rawNoMasteryHealing;
+    const masteryOverheal = Math.max(0, rawMasteryHealing - effectiveMasteryHealing);
     // when Mastery bonus is partially but not completely overhealing, the stacks equally share attribution
-    const oneStackMasteryHealingEffective = effectiveMasteryHealing / hotCount;
+    const oneStackMasteryHealingEffective = hotCount > 0 ? effectiveMasteryHealing / hotCount : 0;
+    const oneStackMasteryOverheal = hotCount > 0 ? masteryOverheal / hotCount : 0;
 
     const oneStackMasteryHealingRaw = rawNoMasteryHealing * masteryBonus;
     // the multiplier of mastery that we actually benefitted from once overheal is considered.
-    const effectiveStackMult = effectiveMasteryHealing / oneStackMasteryHealingRaw;
+    const effectiveStackMult =
+      oneStackMasteryHealingRaw > 0 ? effectiveMasteryHealing / oneStackMasteryHealingRaw : 0;
 
     const relativeBuffBenefit = (buffRating: number) => {
       const buffBonus =
-        (hotCount * buffRating) /
+        (hotCount * buffRating * masteryBenefitMult) /
         this.statTracker.ratingNeededForNextPercentage(
           this.statTracker.currentMasteryRating,
           this.statTracker.statBaselineRatingPerPercent[STAT.MASTERY],
@@ -318,10 +569,19 @@ class Mastery extends Analyzer {
     return {
       noMastery: noMasteryHealing,
       oneStack: oneStackMasteryHealingEffective,
+      oneStackOverheal: oneStackMasteryOverheal,
       effectiveStackMult,
       relativeBuffBenefit,
     };
   }
+}
+
+/**
+ * Mastery stacks that actually scaled a heal (and any copy heals that inherit it).
+ */
+interface MasteryStackSnapshot {
+  hotsOn: number[];
+  hotCount: number;
 }
 
 /**
@@ -335,14 +595,20 @@ type MasteryAttributionsBySpell = Record<number, MasterySpellAttribution>;
 class MasterySpellAttribution {
   direct: number; // the direct healing from the HoT, should be same as entry in WCL. Includes benefit from own stack of Mastery.
   mastery: Record<number, number>; // a mapping from spell ID to how much this HoT boosted it via Mastery.
+  masteryOverheal: Record<number, number>; // parallel to mastery, overheal from the Mastery boost.
 
   constructor() {
     this.direct = 0;
     this.mastery = {};
+    this.masteryOverheal = {};
   }
 
   get totalMastery(): number {
     return Object.values(this.mastery).reduce((s, v) => s + v, 0);
+  }
+
+  get totalMasteryOverheal(): number {
+    return Object.values(this.masteryOverheal).reduce((s, v) => s + v, 0);
   }
 
   get total(): number {
@@ -376,6 +642,8 @@ interface DecomposedHeal {
   noMastery: number;
   /** The amount of effective heal added per stack of mastery */
   oneStack: number;
+  /** The amount of overheal attributable per stack of mastery */
+  oneStackOverheal: number;
   /** Multiplier of our mastery that we actually benefitted from once overheal is considered */
   effectiveStackMult: number;
   /** Function from mastery buff rating to heal attributable to that buff */

--- a/src/analysis/retail/druid/restoration/modules/core/hottracking/HotTrackerRestoDruid.tsx
+++ b/src/analysis/retail/druid/restoration/modules/core/hottracking/HotTrackerRestoDruid.tsx
@@ -13,9 +13,9 @@ import {
   ABILITIES_AFFECTED_BY_HEALING_INCREASES,
   MASTERY_STACK_BUFF_IDS,
 } from 'analysis/retail/druid/restoration/constants';
+import { getSourceBloom } from 'analysis/retail/druid/restoration/normalizers/CastLinkNormalizer';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
-export const GERMINATION_ATT_NAME = 'Germination extension';
 export const IMP_REJUV_ATT_NAME = 'Improved Rejuvenation extension';
 export const THRIVING_VEG_ATT_NAME = 'Thriving Vegetation extension';
 
@@ -39,13 +39,31 @@ class HotTrackerRestoDruid extends HotTracker {
   onHeal(event: HealEvent) {
     // find if spell benefits from mastery and if there are other HoTs possibly boosting it on the same target
     const spellId = event.ability.guid;
-    if (!ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(spellId)) {
+    const sourceBloom =
+      spellId === SPELLS.EVERBLOOM_SPLASH_HEAL.id ? getSourceBloom(event) : undefined;
+    const isSymbioticRelationshipCopy = spellId === SPELLS.SYMBIOTIC_RELATIONSHIP_HEAL.id;
+    if (
+      !ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(spellId) &&
+      !sourceBloom &&
+      !isSymbioticRelationshipCopy
+    ) {
       return;
     }
-    const targetId = event.targetID;
+    // Copy heals inherit mastery from HoTs on the source target, not the copy's target.
+    let targetId: number | undefined = sourceBloom?.targetID ?? event.targetID;
+    if (isSymbioticRelationshipCopy) {
+      targetId =
+        event.targetID === this.selectedCombatant.id
+          ? this.mastery.getBondedAllyId()
+          : this.selectedCombatant.id;
+    }
+    if (targetId === undefined) {
+      return;
+    }
     const trackersOnTarget: TrackersBySpell | undefined = this.hots[targetId];
-    const buffSpellId = this.getBuffSpellIdForHeal(spellId);
-    if (!trackersOnTarget || !trackersOnTarget[buffSpellId]) {
+    const buffSpellId =
+      sourceBloom || isSymbioticRelationshipCopy ? undefined : this.getBuffSpellIdForHeal(spellId);
+    if (!trackersOnTarget || (buffSpellId !== undefined && !trackersOnTarget[buffSpellId])) {
       return;
     }
     // figure out the amount of healing attributable to each stack
@@ -56,22 +74,24 @@ class HotTrackerRestoDruid extends HotTracker {
     const oneStackHealing = decomposedHeal.oneStack;
 
     // for each mastery stack HoT on the same target, one stack of healing
-    const ourTracker = trackersOnTarget[buffSpellId];
-    const ourAttributions = this._getActiveAttributions(ourTracker);
+    const ourAttributions =
+      buffSpellId !== undefined ? this._getActiveAttributions(trackersOnTarget[buffSpellId]) : [];
     Object.keys(trackersOnTarget).forEach((id) => {
       const nid = Number(id);
       if (buffSpellId === nid || !MASTERY_STACK_BUFF_IDS.includes(nid)) {
         return; // must give a mastery stack and not be the current heal
       }
 
-      // TODO handle multi-stack LB here
       const tracker = trackersOnTarget[nid];
       const otherAttributions = this._getActiveAttributions(tracker);
-      // attribute to the other HoT the healing it caused here due to its mastery stack
+      // Lifebloom provides extra Mastery stacks with Harmonius Blooming, so it credits multiple
+      // stacks of healing - mirrors Mastery._tallyMasteryBenefit's stackMult.
+      const stackMult = nid === this.mastery.lbBuffId ? 1 + this.mastery.extraLbStacks : 1;
+      // attribute to the other HoT the healing it caused here due to its mastery stack(s)
       otherAttributions.forEach((att) => {
         // avoid cross attributing between two things with same attribution - will cause double count
         if (!ourAttributions.includes(att)) {
-          att.healing += oneStackHealing;
+          att.healing += oneStackHealing * stackMult;
         }
       });
     });
@@ -94,13 +114,11 @@ class HotTrackerRestoDruid extends HotTracker {
     const impRejuvRank = this.selectedCombatant.getTalentRank(
       TALENTS_DRUID.LINGERING_HEALING_TALENT,
     );
-    const germinationRank = this.selectedCombatant.getTalentRank(TALENTS_DRUID.GERMINATION_TALENT);
     const thrivingVegetationRank = this.selectedCombatant.getTalentRank(
       TALENTS_DRUID.THRIVING_VEGETATION_TALENT,
     );
 
     const improvedRejuvenationAtt = HotTracker.getNewAttribution(IMP_REJUV_ATT_NAME);
-    const germinationAtt = HotTracker.getNewAttribution(GERMINATION_ATT_NAME);
     const thrivingVegetationAtt = HotTracker.getNewAttribution(THRIVING_VEG_ATT_NAME);
 
     return [
@@ -108,19 +126,13 @@ class HotTrackerRestoDruid extends HotTracker {
         spell: SPELLS.REJUVENATION,
         duration: 12000,
         tickPeriod: 3000,
-        baseExtensions: [
-          { attribution: germinationAtt, amount: germinationRank * 2000 },
-          { attribution: improvedRejuvenationAtt, amount: impRejuvRank * 3000 },
-        ],
+        baseExtensions: [{ attribution: improvedRejuvenationAtt, amount: impRejuvRank * 3000 }],
       },
       {
         spell: SPELLS.REJUVENATION_GERMINATION,
         duration: 12000,
         tickPeriod: 3000,
-        baseExtensions: [
-          { attribution: germinationAtt, amount: germinationRank * 2000 },
-          { attribution: improvedRejuvenationAtt, amount: impRejuvRank * 3000 },
-        ],
+        baseExtensions: [{ attribution: improvedRejuvenationAtt, amount: impRejuvRank * 3000 }],
       },
       {
         spell: SPELLS.REGROWTH,
@@ -142,44 +154,12 @@ class HotTrackerRestoDruid extends HotTracker {
         tickPeriod: 1000,
       },
       {
-        spell: SPELLS.CENARION_WARD_HEAL,
-        duration: 8000,
-        tickPeriod: 2000,
-      },
-      {
-        spell: SPELLS.CULTIVATION,
-        duration: 6000,
-        tickPeriod: 2000,
-      },
-      {
-        spell: SPELLS.SPRING_BLOSSOMS,
-        duration: 6000,
-        tickPeriod: 2000,
-        noHaste: true,
-      },
-      {
         spell: SPELLS.TRANQUILITY_HEAL,
         duration: 8000,
         tickPeriod: 2000,
         refreshNoPandemic: true,
       },
-      {
-        spell: SPELLS.ADAPTIVE_SWARM_HEAL,
-        duration: 12000,
-        tickPeriod: 2000,
-      },
-      {
-        spell: SPELLS.RENEWING_BLOOM,
-        duration: 8000,
-        tickPeriod: 1000,
-      },
-      {
-        spell: SPELLS.GROVE_TENDING,
-        duration: 9000,
-        tickPeriod: 3000,
-      },
-      // Wildstalker's Symbiotic Bloom appears to largely not interact with extensions
-      // and other similar mechanics, so is inteniontally left out of this list.
+      // Symbiotic Bloom mostly ignores extensions, so it's left out on purpose.
     ];
   }
 }

--- a/src/analysis/retail/druid/restoration/modules/features/AverageHots.tsx
+++ b/src/analysis/retail/druid/restoration/modules/features/AverageHots.tsx
@@ -1,5 +1,6 @@
 import SPELLS from 'common/SPELLS';
-import { SpellIcon } from 'interface';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import { SpellIcon, SpellLink } from 'interface';
 import Analyzer from 'parser/core/Analyzer';
 import BoringValue from 'parser/ui/BoringValueText';
 import Statistic from 'parser/ui/Statistic';
@@ -31,20 +32,26 @@ class AverageHots extends Analyzer {
         tooltip={
           <>
             <p>
-              This is the average effective multiplier of your mastery your heals benefitted from,
-              weighted by healing done (for example if had 10% mastery and mastery increased your
-              heals by an average of 17%, the listed number would be 1.7).
+              Mastery Multiplier is the average increase to your healing from Mastery, weighted by
+              healing done. For example, if you have 10% Mastery and your healing is increased by an
+              average of 17%, this number would be 1.7.
             </p>
             <p>
-              This number should not be read as a performance metric but rather a function of talent
-              choices and healing style. Talents that spread extra HoTs like Cultivation or Spring
-              Blossoms will increase this number, while playing in larger groups will tend to reduce
-              this number.
+              This is not a performance metric. It mostly reflects your talent choices and healing
+              style. Talents that apply more HoTs will generally increase this number, while healing
+              in larger groups will tend to lower it.
             </p>
             <p>
-              This number includes all your healing, even heals that don't benefit from mastery
-              (like Trinkets, potions, Renewal, etc..) Your average mastery multiplier counting only
-              heals that benefit from mastery is <strong>{avgDruidBenefitMult}</strong>.
+              This number includes all of your healing, including spells that do not benefit from
+              Mastery such as Trinkets, potions, and Renewal. If you only look at healing that can
+              benefit from Mastery, the average multiplier is <strong>{avgDruidBenefitMult}</strong>
+              .
+            </p>
+            <p>
+              <SpellLink spell={TALENTS_DRUID.EVERBLOOM_2_RESTORATION_TALENT} /> splash healing and{' '}
+              <SpellLink spell={TALENTS_DRUID.SYMBIOTIC_RELATIONSHIP_TALENT} /> use the Mastery from
+              HoTs on the target of the original heal. They do not use the HoTs on the ally who
+              receives the resulting heal.
             </p>
           </>
         }

--- a/src/analysis/retail/druid/restoration/modules/spells/Germination.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Germination.tsx
@@ -1,28 +1,21 @@
 import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
-import HotTrackerRestoDruid, {
-  GERMINATION_ATT_NAME,
-} from 'analysis/retail/druid/restoration/modules/core/hottracking/HotTrackerRestoDruid';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import { TALENTS_DRUID } from 'common/TALENTS';
-import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import { Options } from 'parser/core/Module';
 import Events from 'parser/core/Events';
 import SPELLS from 'common/SPELLS';
 import { SpellIcon, SpellLink } from 'interface';
-import { formatPercentage } from 'common/format';
 
 /**
  * **Germination**
  * Spec Talent Tier 12
  *
- * You can apply Rejuvenation twice to the same target. Rejuvenation's duration is increased by 2 sec.
+ * You can apply Rejuvenation twice to the same target.
  */
-export default class Germination extends Analyzer.withDependencies({
-  hotTracker: HotTrackerRestoDruid,
-}) {
+export default class Germination extends Analyzer {
   totalRejuvs = 0;
   germs = 0;
 
@@ -60,12 +53,10 @@ export default class Germination extends Analyzer.withDependencies({
   }
 
   statistic() {
-    const extraDurationHealing =
-      this.deps.hotTracker.getAttribution(GERMINATION_ATT_NAME)?.healing || 0;
     return (
       <Statistic
         size="flexible"
-        position={STATISTIC_ORDER.OPTIONAL(12)} // number based on talent row
+        position={STATISTIC_ORDER.OPTIONAL(6)} // number based on talent row
         category={STATISTIC_CATEGORY.TALENTS}
         tooltip={
           <>
@@ -74,23 +65,12 @@ export default class Germination extends Analyzer.withDependencies({
               <SpellLink spell={SPELLS.REJUVENATION} /> applications, <strong>{this.germs}</strong>{' '}
               were the 2nd on target (<SpellLink spell={SPELLS.REJUVENATION_GERMINATION} />)
             </p>
-            <p>
-              <strong>
-                {formatPercentage(this.owner.getPercentageOfTotalHealingDone(extraDurationHealing))}
-                %
-              </strong>{' '}
-              is the percentage of total healing attributable specifically to the extra 2 seconds of
-              Rejuv duration.
-            </p>
           </>
         }
       >
         <BoringSpellValueText spell={TALENTS_DRUID.GERMINATION_TALENT}>
           <SpellIcon spell={SPELLS.REJUVENATION_GERMINATION} /> {this.germs} /{' '}
           <SpellIcon spell={SPELLS.REJUVENATION} /> {this.totalRejuvs}
-          <br />
-          <ItemPercentHealingDone amount={extraDurationHealing} />
-          <small> from +2 sec</small>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/analysis/retail/druid/restoration/modules/spells/HarmoniusBlooming.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/HarmoniusBlooming.tsx
@@ -1,13 +1,14 @@
 import Analyzer, { Options } from 'parser/core/Analyzer';
 import Mastery from 'analysis/retail/druid/restoration/modules/core/Mastery';
 import { TALENTS_DRUID } from 'common/TALENTS';
-import SPELLS from 'common/SPELLS';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
 import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
 import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
 import { HARMONIUS_BLOOMING_EXTRA_STACKS } from 'analysis/retail/druid/restoration/constants';
+import { formatOverhealing } from 'analysis/retail/druid/restoration/format';
+import { SpellLink } from 'interface';
 
 /**
  *
@@ -29,18 +30,20 @@ class HarmoniusBlooming extends Analyzer {
   }
 
   /**
-   * The healing due only to the extra stacks from the talent.
-   * Healing due to all the stacks is already added by the Mastery module,
-   * so here we simply do the math to get the portion from only the extra stacks.
+   * Extra Lifebloom stacks on mastery-affected heals, including Everbloom splash
+   * which inherits the bloom target's mastery (no splash-target double-dip).
    */
   get extraStacksHealing() {
-    const totalMasteryHealing = this.mastery.getMasteryHealing(SPELLS.LIFEBLOOM_BUFF.id);
-    const portionFromExtraStacks =
-      HARMONIUS_BLOOMING_EXTRA_STACKS / (HARMONIUS_BLOOMING_EXTRA_STACKS + 1);
-    return totalMasteryHealing * portionFromExtraStacks;
+    return this.mastery.getHarmoniusBloomingHealing();
+  }
+
+  get extraStacksOverhealing() {
+    return this.mastery.getHarmoniusBloomingOverhealing();
   }
 
   statistic() {
+    const everbloomSplashHealing = this.mastery.getHarmoniusBloomingEverbloomSplashHealing();
+
     return (
       <Statistic
         size="flexible"
@@ -50,6 +53,20 @@ class HarmoniusBlooming extends Analyzer {
           <>
             This is the healing enabled by the extra {HARMONIUS_BLOOMING_EXTRA_STACKS} stacks of
             Mastery from Harmonius Blooming.
+            {everbloomSplashHealing > 0 && (
+              <>
+                <br />
+                Includes <strong>
+                  {this.owner.formatItemHealingDone(everbloomSplashHealing)}
+                </strong>{' '}
+                from <SpellLink spell={TALENTS_DRUID.EVERBLOOM_2_RESTORATION_TALENT} /> splash
+                inheriting the amplified Lifebloom blooms.
+              </>
+            )}
+            <br />
+            <strong>
+              Overhealing: {formatOverhealing(this.extraStacksOverhealing, this.extraStacksHealing)}
+            </strong>
           </>
         }
       >

--- a/src/common/SPELLS/druid.ts
+++ b/src/common/SPELLS/druid.ts
@@ -512,6 +512,13 @@ const spells = {
     name: 'Everbloom',
     icon: 'ability_druid_focusedgrowth',
   },
+  // 10% of self-healing to bonded ally / 8% of bonded-ally healing back to self.
+  // Copies the source heal amount (does not independently apply dest mastery).
+  SYMBIOTIC_RELATIONSHIP_HEAL: {
+    id: 474760,
+    name: 'Symbiotic Relationship',
+    icon: 'ability_druid_focusedgrowth',
+  },
   RESTO_DRUID_TIER_36_GENESIS_BUFF: {
     id: 1302255,
     name: 'Genesis',


### PR DESCRIPTION
### Description

Count Everbloom splash and Symbiotic Relationship copies in Mastery using the source heal's HoTs.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/...`
- Screenshot(s):
