### PR TITLE
[Arcane Mage] Prismatic Bolt and Arcane Orb fixes.

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -17,6 +17,7 @@ const prismaticBolt = <SpellLink spell={SPELLS.PRISMATIC_BOLT} />
 const cumulativePower = <SpellLink spell={SPELLS.CUMULATIVE_POWER_BUFF} />;
 
 export default [
+  change(date(2026, 8, 29), <>Fixed {prismaticBolt} not being accounted for on {arcaneMissiles} Cast Delay.</>, Sharrq),
   change(date(2026, 8, 29), <>Fixed the logic that determined how many targets {arcaneOrb} hit.</>, Sharrq),
   change(date(2026, 8, 29), <>Fixed {prismaticBolt}, again. It now correctly identifies munched procs that were actually munched.</>, Sharrq),
   change(date(2026, 8, 26), <>Removed guidance about holding {arcaneBarrage} if {touchOfTheMagi} is coming soon.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -17,6 +17,8 @@ const prismaticBolt = <SpellLink spell={SPELLS.PRISMATIC_BOLT} />
 const cumulativePower = <SpellLink spell={SPELLS.CUMULATIVE_POWER_BUFF} />;
 
 export default [
+  change(date(2026, 8, 29), <>Fixed the logic that determined how many targets {arcaneOrb} hit.</>, Sharrq),
+  change(date(2026, 8, 29), <>Fixed {prismaticBolt}, again. It now correctly identifies munched procs that were actually munched.</>, Sharrq),
   change(date(2026, 8, 26), <>Removed guidance about holding {arcaneBarrage} if {touchOfTheMagi} is coming soon.</>, Sharrq),
   change(date(2026, 8, 26), <>Fixed a tooltip on {prismaticBolt} that listed targets hit instead of {cumulativePower} stacks.</>, Sharrq),
   change(date(2026, 8, 22), <>Adjusted {arcaneOrb} conditions for Sunfury to mark casts with without 4 Arcane Charges as good.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CONFIG.tsx
+++ b/src/analysis/retail/mage/arcane/CONFIG.tsx
@@ -59,7 +59,7 @@ const config: Config = {
     overview: {
       notes: (
         <AlertWarning>
-          This spec has been fully updated for Midnight Season 2 (As of August 26). If anything is
+          This spec has been fully updated for Midnight Season 2 (As of August 29). If anything is
           missing or incorrect, please ping <code>@Sharrq</code> in the Altered Time Discord.
         </AlertWarning>
       ),

--- a/src/analysis/retail/mage/arcane/analyzers/ArcaneMissiles.tsx
+++ b/src/analysis/retail/mage/arcane/analyzers/ArcaneMissiles.tsx
@@ -85,6 +85,7 @@ export default class ArcaneMissiles extends Analyzer {
           SPELLS.ARCANE_BARRAGE,
           SPELLS.ARCANE_EXPLOSION,
           TALENTS.ARCANE_SURGE_TALENT,
+          SPELLS.PRISMATIC_BOLT,
         ],
         startTimestamp: m.channelEnd,
         count: 1,

--- a/src/analysis/retail/mage/arcane/analyzers/PrismaticBolt.tsx
+++ b/src/analysis/retail/mage/arcane/analyzers/PrismaticBolt.tsx
@@ -10,6 +10,7 @@ import Events, {
   GetRelatedEvent,
   GetRelatedEvents,
   RefreshBuffEvent,
+  RemoveBuffEvent,
 } from 'parser/core/Events';
 import { TIERS } from 'game/TIERS';
 
@@ -33,12 +34,16 @@ export default class PrismaticBolt extends Analyzer {
     const refresh: RefreshBuffEvent | undefined = GetRelatedEvent(event, EventType.RefreshBuff);
     const cast: CastEvent | undefined = GetRelatedEvent(event, EventType.Cast);
     const damage: DamageEvent[] | undefined = GetRelatedEvents(event, EventType.Damage);
+    const remove: RemoveBuffEvent | undefined = GetRelatedEvent(event, EventType.RemoveBuff);
+    const munched = !cast && !!refresh;
+    const expired = !cast && !!remove;
 
     this.prismaticBolts.push({
       timestamp: event.timestamp,
       cast,
       damage,
-      munched: refresh !== undefined,
+      munched,
+      expired,
       has4pc: this.selectedCombatant.has4PieceByTier(TIERS.MID2),
       hasClearcasting: this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE),
       hasArcaneSoul: this.selectedCombatant.hasBuff(SPELLS.ARCANE_SOUL_BUFF),
@@ -59,6 +64,7 @@ export interface PrismaticBoltCast {
   cast?: CastEvent;
   damage?: DamageEvent[];
   munched: boolean;
+  expired: boolean;
   targetsHit: number;
   has4pc: boolean;
   hasClearcasting: boolean;

--- a/src/analysis/retail/mage/arcane/guide/ArcaneOrb.tsx
+++ b/src/analysis/retail/mage/arcane/guide/ArcaneOrb.tsx
@@ -23,10 +23,8 @@ class ArcaneOrbGuide extends Analyzer {
   isSpellslinger: boolean = this.selectedCombatant.hasTalent(TALENTS.SPLINTERSTORM_TALENT);
 
   private evaluateOrbCast(cast: ArcaneOrbCast): CastEvaluation {
-    const hitTargets = cast.targetsHit > 0;
-
     // FAIL CONDITIONS
-    if (!hitTargets) {
+    if (cast.targetsHit === 0) {
       return {
         timestamp: cast.timestamp,
         performance: QualitativePerformance.Fail,

--- a/src/analysis/retail/mage/arcane/guide/PrismaticBolt.tsx
+++ b/src/analysis/retail/mage/arcane/guide/PrismaticBolt.tsx
@@ -22,6 +22,56 @@ class PrismaticBoltGuide extends Analyzer {
   isSunfury: boolean = this.selectedCombatant.hasTalent(TALENTS.MEMORY_OF_ALAR_TALENT);
   isSpellslinger: boolean = this.selectedCombatant.hasTalent(TALENTS.SPLINTERSTORM_TALENT);
 
+  private getCastStats(cast: PrismaticBoltCast): PerCastStat[] {
+    if (cast.munched) {
+      return [
+        {
+          value: 'Yes',
+          label: 'Munched Proc',
+          tooltip: <>Whether the proc was munched (overwritten) or not.</>,
+        },
+      ];
+    }
+
+    if (cast.expired) {
+      return [
+        {
+          value: 'Yes',
+          label: 'Expired Proc',
+          tooltip: <>Whether the proc expired (fell off unused) or not.</>,
+        },
+      ];
+    }
+
+    return [
+      {
+        value: formatDurationMillisMinSec(cast.delay || 0, 1),
+        label: 'Delay until Cast',
+        tooltip: (
+          <>
+            The amount of time from when the player got the Prismatic Bolt buff until they cast
+            Prismatic Bolt.
+          </>
+        ),
+      },
+      {
+        value: cast.salvoStacks,
+        label: 'Arcane Salvo Stacks',
+        tooltip: <>The number of Arcane Salvo stacks the player had.</>,
+      },
+      cast.has4pc && {
+        value: cast.cumulativePowerStacks,
+        label: 'Cumulative Power Stacks',
+        tooltip: <>The number of Cumulative Power stacks the player had.</>,
+      },
+      {
+        value: cast.targetsHit,
+        label: 'Targets Hit',
+        tooltip: <>The number of targets hit by Prismatic Bolt.</>,
+      },
+    ].filter(Boolean) as PerCastStat[];
+  }
+
   private evaluatePrismaticBolt(pb: PrismaticBoltCast): CastEvaluation {
     // FAIL CONDITIONS
     if (pb.munched && !pb.hasArcaneSoul) {
@@ -32,11 +82,11 @@ class PrismaticBoltGuide extends Analyzer {
       };
     }
 
-    if (!pb.cast) {
+    if (pb.expired) {
       return {
         timestamp: pb.timestamp,
         performance: QualitativePerformance.Fail,
-        reason: `No Prismatic Bolt cast found.`,
+        reason: `Prismatic Bolt expired.`,
       };
     }
 
@@ -152,10 +202,10 @@ class PrismaticBoltGuide extends Analyzer {
       <>
         <p>
           <b>{prismaticBolt}</b> is Arcane's new apex talent, added in 12.1, and is very strong. It
-          is a large contributor to your DPS and it does not stack, so $
-          {this.isSunfury && `unless ${arcaneSoul} is active`}you should make sure you are spending
-          it as quickly as possible to avoid munching (overwritting) it. Follow the below guidelines
-          to get the most out of each cast.
+          is a large contributor to your DPS and it does not stack, so
+          {this.isSunfury ? <> unless {arcaneSoul} is active</> : ''} you should make sure you are
+          spending it as quickly as possible to avoid munching (overwritting) it. Follow the below
+          guidelines to get the most out of each cast.
         </p>
         {this.isSpellslinger && (
           <p>
@@ -198,39 +248,7 @@ class PrismaticBoltGuide extends Analyzer {
       return {
         performance: evaluation.performance,
         timestamp: this.owner.formatTimestamp(cast.timestamp),
-        stats: [
-          cast.munched && {
-            value: cast.munched ? 'Yes' : 'No',
-            label: 'Munched Proc',
-            tooltip: <>Whether the proc was munched (overwritten) or not.</>,
-          },
-          !cast.munched && {
-            value: formatDurationMillisMinSec(cast.delay || 0, 1),
-            label: 'Delay until Cast',
-            tooltip: (
-              <>
-                The amount of time from when the player got the Prismatic Bolt buff until they cast
-                Prismatic Bolt.
-              </>
-            ),
-          },
-          !cast.munched && {
-            value: cast.salvoStacks,
-            label: 'Arcane Salvo Stacks',
-            tooltip: <>The number of Arcane Salvo stacks the player had.</>,
-          },
-          !cast.munched &&
-            cast.has4pc && {
-              value: cast.cumulativePowerStacks,
-              label: 'Cumulative Power Stacks',
-              tooltip: <>The number of Cumulative Power stacks the player had.</>,
-            },
-          !cast.munched && {
-            value: cast.targetsHit,
-            label: 'Targets Hit',
-            tooltip: <>The number of targets hit by Prismatic Bolt.</>,
-          },
-        ].filter(Boolean) as PerCastStat[],
+        stats: this.getCastStats(cast),
         details: evaluation.reason,
       };
     });

--- a/src/analysis/retail/mage/arcane/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/mage/arcane/normalizers/CastLinkNormalizer.ts
@@ -63,7 +63,7 @@ const EVENT_LINKS = createEventLinks(
     links: [
       link(EventType.Damage, {
         id: SPELLS.ARCANE_ORB_DAMAGE.id,
-        forwardBuffer: 2500,
+        forwardBuffer: 1000,
         anyTarget: true,
         condition: (linking, referenced) => !HasRelatedEvent(referenced, EventType.Cast),
       }),
@@ -185,12 +185,20 @@ const EVENT_LINKS = createEventLinks(
     spell: SPELLS.PRISMATIC_BOLT_BUFF.id,
     parentType: [EventType.ApplyBuff, EventType.RefreshBuff],
     links: [
-      link(EventType.RemoveBuff, { maxLinks: 1, forwardBuffer: 60_000 }),
       link(EventType.RefreshBuff, {
         maxLinks: 1,
         forwardBuffer: 60_000,
         condition: (linkingEvent, referencedEvent) => linkingEvent !== referencedEvent,
       }),
+      link(EventType.RemoveBuff, {
+        maxLinks: 1,
+        forwardBuffer: 60_000,
+        condition: (linkingEvent, referencedEvent) => {
+          const refresh = GetRelatedEvent(linkingEvent, EventType.RefreshBuff);
+          return !refresh || referencedEvent.timestamp < refresh.timestamp;
+        },
+      }),
+      link(EventType.BeginCast, { maxLinks: 1, backwardBuffer: 2500 }),
       link(EventType.Cast, {
         id: SPELLS.PRISMATIC_BOLT.id,
         maxLinks: 1,


### PR DESCRIPTION
- Fixed the description of Prismatic Bolt to remove the busted Arcane Soul link ([object Object])
- Fixed the logic around munched procs and expired procs (again)
- Fixed the counting of targets hit on Arcane Orb.
- Fixed Prismatic Bolt casts not being accounted for on Arcane Missile Channel Delay