### PR TITLE
[RDruid] Various Castlink Attribution Fixes

### DIFF
--- a/src/analysis/retail/druid/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/druid/restoration/CHANGELOG.tsx
@@ -5,7 +5,17 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_DRUID } from 'common/TALENTS';
 
 export default [
-    change(
+  change(
+    date(2026, 8, 18),
+    <>
+      Attribute <SpellLink spell={TALENTS_DRUID.OVERGROWTH_TALENT} />,{' '}
+      <SpellLink spell={TALENTS_DRUID.IMPLANT_TALENT} />, and{' '}
+      <SpellLink spell={TALENTS_DRUID.TWIN_SPROUTS_TALENT} /> healing, including Implant blooms from
+      Overgrowth's Wild Growth.
+    </>,
+    squided,
+  ),
+  change(
     date(2026, 8, 28),
     <>
       Add a combined Keeper of the Grove / Wildstalker healing breakdown and statistics for
@@ -29,6 +39,14 @@ export default [
       <SpellLink spell={TALENTS_DRUID.FLASH_OF_CLARITY_TALENT} />,{' '}
       <SpellLink spell={TALENTS_DRUID.PASSING_SEASONS_TALENT} />, and{' '}
       <SpellLink spell={TALENTS_DRUID.VERDANT_HEART_TALENT} />.
+    </>,
+    squided,
+  ),
+  change(
+    date(2026, 8, 27),
+    <>
+      Update for the 12.1 balance pass: Season 2 4pc increases{' '}
+      <SpellLink spell={SPELLS.RESTO_DRUID_TIER_36_GENESIS_BUFF} /> duration by 8 sec (was 4).
     </>,
     squided,
   ),

--- a/src/analysis/retail/druid/restoration/CombatLogParser.ts
+++ b/src/analysis/retail/druid/restoration/CombatLogParser.ts
@@ -87,6 +87,10 @@ import FlowerWalk from 'analysis/retail/druid/restoration/modules/spells/Wildsta
 import LethalPreservation from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/LethalPreservation';
 import ResilientFlourishing from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/ResilientFlourishing';
 import SymbioticBloomDirectClaim from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/SymbioticBloomDirectClaim';
+import Implant from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/Implant';
+import TwinSprouts from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/TwinSprouts';
+import ThrivingGrowth from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/ThrivingGrowth';
+import Overgrowth from 'analysis/retail/druid/restoration/modules/spells/Overgrowth';
 import Liveliness from 'analysis/retail/druid/restoration/modules/spells/Liveliness';
 import PassingSeasons from 'analysis/retail/druid/restoration/modules/spells/PassingSeasons';
 import FlashOfClarity from 'analysis/retail/druid/restoration/modules/spells/FlashOfClarity';
@@ -166,6 +170,7 @@ class CombatLogParser extends CoreCombatLogParser {
     flashOfClarity: FlashOfClarity,
     forestwalk: Forestwalk,
     verdantHeart: VerdantHeart,
+    overgrowth: Overgrowth,
 
     // Hero tree total (aggregates KotG / Wildstalker HPS contributions)
     heroTreeHealing: HeroTreeHealing,
@@ -200,6 +205,9 @@ class CombatLogParser extends CoreCombatLogParser {
     bondWithNature: BondWithNature,
     patientCustodian: PatientCustodian,
     vigorousCreepers: VigorousCreepers,
+    implant: Implant,
+    twinSprouts: TwinSprouts,
+    thrivingGrowth: ThrivingGrowth,
 
     // Mana Tab
     manaTracker: ManaTracker,

--- a/src/analysis/retail/druid/restoration/modules/core/hottracking/HotAttributor.ts
+++ b/src/analysis/retail/druid/restoration/modules/core/hottracking/HotAttributor.ts
@@ -11,13 +11,12 @@ import Events, {
 import HotTracker, { Attribution } from 'parser/shared/modules/HotTracker';
 
 import { REJUVENATION_BUFFS } from '../../../constants';
-import { isFromHardcast } from '../../../normalizers/CastLinkNormalizer';
+import { isFromHardcast, isFromOvergrowth } from '../../../normalizers/CastLinkNormalizer';
 import ConvokeSpiritsResto from 'analysis/retail/druid/restoration/modules/spells/ConvokeSpiritsResto';
 import HotTrackerRestoDruid from '../hottracking/HotTrackerRestoDruid';
 import { TALENTS_DRUID } from 'common/TALENTS';
 import Combatants from 'parser/shared/modules/Combatants';
 import { isConvoking } from 'analysis/retail/druid/shared/spells/ConvokeSpirits';
-import { TIERS } from 'game/TIERS';
 
 /** Maximum time buffer between a hardcast and applybuff to allow attribution */
 const BUFFER_MS = 150;
@@ -54,6 +53,7 @@ class HotAttributor extends Analyzer {
   hasRampantGrowth: boolean;
   hasConvoke: boolean;
   hasEverbloomRank1Effective: boolean;
+  hasOvergrowth: boolean;
 
   /** Special tracker to differentiate PotA procs during Convoke.
    *  We arbitrarily call the first Regrowth hit the 'direct' one, and follow-on ones
@@ -71,6 +71,7 @@ class HotAttributor extends Analyzer {
   powerOfTheArchdruidRejuvAttrib = HotTracker.getNewAttribution('PowerOfTheArchdruid-Rejuv');
   powerOfTheArchdruidRegrowthAttrib = HotTracker.getNewAttribution('PowerOfTheArchdruid-Regrowth');
   rampantGrowthAttrib = HotTracker.getNewAttribution('RampantGrowth');
+  overgrowthAttrib = HotTracker.getNewAttribution('Overgrowth');
   // Convoke handled separately in Resto Convoke module
 
   /** Per-proc tracking of how many PotA extras landed (for use by PowerOfTheArchdruid) */
@@ -86,6 +87,7 @@ class HotAttributor extends Analyzer {
     );
     this.hasRampantGrowth = this.selectedCombatant.hasTalent(TALENTS_DRUID.RAMPANT_GROWTH_TALENT);
     this.hasConvoke = this.selectedCombatant.hasTalent(TALENTS_DRUID.CONVOKE_THE_SPIRITS_TALENT);
+    this.hasOvergrowth = this.selectedCombatant.hasTalent(TALENTS_DRUID.OVERGROWTH_TALENT);
     this.hasEverbloomRank1Effective =
       this.selectedCombatant.hasTalent(TALENTS_DRUID.EVERBLOOM_1_RESTORATION_TALENT) ||
       this.selectedCombatant.hasTalent(TALENTS_DRUID.EVERBLOOM_2_RESTORATION_TALENT) ||
@@ -178,6 +180,9 @@ class HotAttributor extends Analyzer {
     if (event.prepull || isFromHardcast(event)) {
       this.hotTracker.addAttributionFromApply(this.rejuvHardcastAttrib, event);
       this._logAttrib(event, 'Hardcast');
+    } else if (this.hasOvergrowth && isFromOvergrowth(event)) {
+      this.hotTracker.addAttributionFromApply(this.overgrowthAttrib, event);
+      this._logAttrib(event, this.overgrowthAttrib);
     } else if (this.convokeSpirits.active && isConvoking(this.selectedCombatant)) {
       // if we have PotA buff and this isn't the first Rejuv in sequence within buffer - also attribute to PotA
       if (
@@ -287,6 +292,9 @@ class HotAttributor extends Analyzer {
       this.hotTracker.addAttributionFromApply(this.wgHardcastAttrib, event);
       this._logAttrib(event, 'Hardcast');
       // don't clear pending because it hits many targets
+    } else if (this.hasOvergrowth && isFromOvergrowth(event)) {
+      this.hotTracker.addAttributionFromApply(this.overgrowthAttrib, event);
+      this._logAttrib(event, this.overgrowthAttrib);
     } else if (this.convokeSpirits.active && isConvoking(this.selectedCombatant)) {
       // convoke module adds the attribution for Convoke
       this._logAttrib(event, this.convokeSpirits.currentConvokeAttribution);
@@ -296,8 +304,9 @@ class HotAttributor extends Analyzer {
   }
 
   onApplyLb(event: ApplyBuffEvent | RefreshBuffEvent) {
-    if (this.hasEverbloomRank1Effective && event.type === 'refreshbuff' && !isFromHardcast(event)) {
-      this._logAttrib(event, 'Everbloom Stack Gain');
+    if (this.hasOvergrowth && isFromOvergrowth(event)) {
+      this.hotTracker.addAttributionFromApply(this.overgrowthAttrib, event);
+      this._logAttrib(event, this.overgrowthAttrib);
       return;
     }
 

--- a/src/analysis/retail/druid/restoration/modules/features/HeroTreeHealing.tsx
+++ b/src/analysis/retail/druid/restoration/modules/features/HeroTreeHealing.tsx
@@ -24,7 +24,10 @@ import WildstalkersPower from 'analysis/retail/druid/restoration/modules/spells/
 import HarmoniousConstitution from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/HarmoniousConstitution';
 import HuntBeneathTheOpenSkies from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/HuntBeneathTheOpenSkies';
 import StrategicInfusion from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/StrategicInfusion';
+import Implant from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/Implant';
+import TwinSprouts from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/TwinSprouts';
 import BondWithNature from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/BondWithNature';
+import ThrivingGrowth from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/ThrivingGrowth';
 import BurstingGrowth from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/BurstingGrowth';
 import FlowerWalk from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/FlowerWalk';
 import LethalPreservation from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/LethalPreservation';
@@ -44,8 +47,10 @@ interface Contribution {
  * - Dream Surge / Power of the Dream: Dream Bloom split 3/4 vs 1/4 when PotD is taken
  * - Cenarius' Might / Grove's Inspiration / Harmony / Power of Nature: tree rows use
  *   combined-amp shares; solo cards keep full marginal value
+ * - Thriving Growth: SymBloom not claimed by Implant/Twin + oldest-stack mastery
+ * - Implant / Twin Sprouts: direct SymBloom + mastery only (nested VC is in Vigorous Creepers)
  * - Patient Custodian / Root Network / Hunt / Vigorous Creepers: tree totals skip amp on
- *   Symbiotic Bloom ticks (those ticks are already in the healing breakdown)
+ *   SymBloom ticks (already under Thriving Growth / Implant / Twin)
  * - Bond with Nature: full talent value (same as the solo card)
  * - Resilient Flourishing omitted from tree (already in SymBloom rows)
  * - CDR / DR talents omitted (Dryad's Dance, Early Spring, Protective Growth)
@@ -60,6 +65,7 @@ export default class HeroTreeHealing extends Analyzer {
     bounteousBloom: BounteousBloom,
     powerOfTheDream: PowerOfTheDream,
     potentEnchantments: PotentEnchantments,
+    thrivingGrowth: ThrivingGrowth,
     burstingGrowth: BurstingGrowth,
     flowerWalk: FlowerWalk,
     lethalPreservation: LethalPreservation,
@@ -70,6 +76,8 @@ export default class HeroTreeHealing extends Analyzer {
     harmoniousConstitution: HarmoniousConstitution,
     huntBeneathTheOpenSkies: HuntBeneathTheOpenSkies,
     strategicInfusion: StrategicInfusion,
+    implant: Implant,
+    twinSprouts: TwinSprouts,
     bondWithNature: BondWithNature,
   };
 
@@ -81,6 +89,7 @@ export default class HeroTreeHealing extends Analyzer {
   protected bounteousBloom!: BounteousBloom;
   protected powerOfTheDream!: PowerOfTheDream;
   protected potentEnchantments!: PotentEnchantments;
+  protected thrivingGrowth!: ThrivingGrowth;
   protected burstingGrowth!: BurstingGrowth;
   protected flowerWalk!: FlowerWalk;
   protected lethalPreservation!: LethalPreservation;
@@ -91,6 +100,8 @@ export default class HeroTreeHealing extends Analyzer {
   protected harmoniousConstitution!: HarmoniousConstitution;
   protected huntBeneathTheOpenSkies!: HuntBeneathTheOpenSkies;
   protected strategicInfusion!: StrategicInfusion;
+  protected implant!: Implant;
+  protected twinSprouts!: TwinSprouts;
   protected bondWithNature!: BondWithNature;
 
   private readonly isKotg: boolean;
@@ -161,6 +172,11 @@ export default class HeroTreeHealing extends Analyzer {
   private get wsContributions(): Contribution[] {
     return [
       {
+        spell: TALENTS_DRUID.THRIVING_GROWTH_TALENT,
+        healing: this.thrivingGrowth.treeTotalHealing,
+        note: 'Symbiotic Bloom healing not claimed by Implant/Twin Sprouts, plus sole-presence mastery',
+      },
+      {
         spell: TALENTS_DRUID.BURSTING_GROWTH_TALENT,
         healing: this.burstingGrowth.totalHealing,
         note: 'Visible in healing breakdown; no solo card',
@@ -178,17 +194,17 @@ export default class HeroTreeHealing extends Analyzer {
       {
         spell: TALENTS_DRUID.PATIENT_CUSTODIAN_TALENT,
         healing: this.patientCustodian.treeHealing,
-        note: 'Excludes amp on Symbiotic Bloom ticks',
+        note: 'Excludes amp on Symbiotic Bloom ticks (counted under Thriving Growth / Implant / Twin)',
       },
       {
         spell: TALENTS_DRUID.ROOT_NETWORK_TALENT,
         healing: this.rootNetwork.treeHealing,
-        note: 'Excludes amp on Symbiotic Bloom ticks',
+        note: 'Excludes amp on Symbiotic Bloom ticks (counted under Thriving Growth / Implant / Twin)',
       },
       {
         spell: TALENTS_DRUID.VIGOROUS_CREEPERS_TALENT,
         healing: this.vigorousCreepers.treeHealing,
-        note: 'Excludes amp on Symbiotic Bloom ticks',
+        note: 'Excludes amp on Symbiotic Bloom ticks (counted under Thriving Growth / Implant / Twin)',
       },
       {
         spell: TALENTS_DRUID.WILDSTALKERS_POWER_TALENT,
@@ -201,11 +217,21 @@ export default class HeroTreeHealing extends Analyzer {
       {
         spell: TALENTS_DRUID.HUNT_BENEATH_THE_OPEN_SKIES_TALENT,
         healing: this.huntBeneathTheOpenSkies.treeHealing,
-        note: 'Excludes amp on Symbiotic Bloom ticks',
+        note: 'Excludes amp on Symbiotic Bloom ticks (counted under Thriving Growth / Implant / Twin)',
       },
       {
         spell: TALENTS_DRUID.STRATEGIC_INFUSION_TALENT,
         healing: this.strategicInfusion.healing,
+      },
+      {
+        spell: TALENTS_DRUID.IMPLANT_TALENT,
+        healing: this.implant.treeTotalHealing,
+        note: 'Direct Symbiotic Bloom + mastery only (Vigorous Creepers counted separately)',
+      },
+      {
+        spell: TALENTS_DRUID.TWIN_SPROUTS_TALENT,
+        healing: this.twinSprouts.treeTotalHealing,
+        note: 'Direct Symbiotic Bloom + mastery only (Vigorous Creepers counted separately). Timing-based proc detection may overcount unrelated blooms that grow as another expires',
       },
       {
         spell: TALENTS_DRUID.BOND_WITH_NATURE_TALENT,
@@ -269,9 +295,9 @@ export default class HeroTreeHealing extends Analyzer {
             <br />
             Sums each talent's contribution. Stacked KotG percentage buffs on the same heal are
             split so they do not overcount in this total (solo cards still show full marginal
-            value). Amp modules skip Symbiotic Bloom ticks so those ticks are not double-counted.
-            Dream Bloom is split between Dream Surge and Power of the Dream. CDR and
-            damage-reduction talents are omitted.
+            value). Symbiotic Bloom direct healing is split across Thriving Growth, Implant, and
+            Twin Sprouts (amp modules do not also count those ticks). Dream Bloom is split between
+            Dream Surge and Power of the Dream. CDR and damage-reduction talents are omitted.
           </>
         }
         position={STATISTIC_ORDER.CORE(-1)}

--- a/src/analysis/retail/druid/restoration/modules/spells/Overgrowth.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Overgrowth.tsx
@@ -1,0 +1,182 @@
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { ApplyBuffEvent, ApplyBuffStackEvent, HealEvent } from 'parser/core/Events';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import HotAttributor from 'analysis/retail/druid/restoration/modules/core/hottracking/HotAttributor';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import { SpellLink } from 'interface';
+import SPELLS from 'common/SPELLS';
+import { formatOverhealing } from 'analysis/retail/druid/restoration/format';
+import Combatants from 'parser/shared/modules/Combatants';
+import { isImplantFromOvergrowth } from 'analysis/retail/druid/restoration/normalizers/CastLinkNormalizer';
+
+const BASE_BLOOM_DURATION_MS = 6_000;
+const RESILIENT_FLOURISHING_EXTRA_MS = 2_000;
+
+interface BloomInstance {
+  targetId: number;
+  start: number;
+  end: number;
+}
+
+/**
+ * **Overgrowth**
+ *
+ * Nature's Swiftness causes your next Regrowth to also apply Lifebloom,
+ * Rejuvenation, and Wild Growth's heal over time effect.
+ *
+ * With Implant, that WG effect also grows a Symbiotic Bloom. Direct ticks are included
+ * here and still counted under Implant.
+ */
+class Overgrowth extends Analyzer {
+  static dependencies = {
+    hotAttributor: HotAttributor,
+    combatants: Combatants,
+  };
+
+  hotAttributor!: HotAttributor;
+  combatants!: Combatants;
+
+  private hasImplant: boolean;
+  private bloomDurationMs: number;
+  private overgrowthImplantBlooms: BloomInstance[] = [];
+  private implantHealing = 0;
+  private implantOverhealing = 0;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.OVERGROWTH_TALENT);
+    this.hasImplant = this.selectedCombatant.hasTalent(TALENTS_DRUID.IMPLANT_TALENT);
+    this.bloomDurationMs =
+      BASE_BLOOM_DURATION_MS +
+      (this.selectedCombatant.hasTalent(TALENTS_DRUID.RESILIENT_FLOURISHING_TALENT)
+        ? RESILIENT_FLOURISHING_EXTRA_MS
+        : 0);
+
+    if (this.hasImplant) {
+      this.addEventListener(
+        Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER),
+        this.onSymbioticBloomApply,
+      );
+      this.addEventListener(
+        Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER),
+        this.onSymbioticBloomApply,
+      );
+      this.addEventListener(
+        Events.heal.by(SELECTED_PLAYER).spell(SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER),
+        this.onSymbioticBloomHeal,
+      );
+    }
+  }
+
+  private onSymbioticBloomApply(event: ApplyBuffEvent | ApplyBuffStackEvent) {
+    if (!isImplantFromOvergrowth(event)) {
+      return;
+    }
+
+    this.overgrowthImplantBlooms.push({
+      targetId: event.targetID,
+      start: event.timestamp,
+      end: event.timestamp + this.bloomDurationMs,
+    });
+  }
+
+  private getOvergrowthImplantStacks(targetId: number, timestamp: number): number {
+    return this.overgrowthImplantBlooms.filter(
+      (bloom) => bloom.targetId === targetId && bloom.start <= timestamp && timestamp < bloom.end,
+    ).length;
+  }
+
+  private onSymbioticBloomHeal(event: HealEvent) {
+    const target = this.combatants.getEntity(event);
+    if (!target) {
+      return;
+    }
+
+    const overgrowthStacks = this.getOvergrowthImplantStacks(target.id, event.timestamp);
+    if (overgrowthStacks <= 0) {
+      return;
+    }
+
+    const totalStacks = target.getBuffStacks(
+      SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
+      event.timestamp,
+      0,
+      0,
+      this.selectedCombatant.id,
+    );
+    if (totalStacks <= 0) {
+      return;
+    }
+
+    const portion = Math.min(overgrowthStacks, totalStacks) / totalStacks;
+    this.implantHealing += (event.amount + (event.absorbed || 0)) * portion;
+    this.implantOverhealing += (event.overheal || 0) * portion;
+  }
+
+  get hotHealing() {
+    return this.hotAttributor.overgrowthAttrib.healing;
+  }
+
+  get totalHealing() {
+    return this.hotHealing + this.implantHealing;
+  }
+
+  get totalOverhealing() {
+    return this.hotAttributor.overgrowthAttrib.overheal + this.implantOverhealing;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(4)}
+        category={STATISTIC_CATEGORY.TALENTS}
+        size="flexible"
+        tooltip={
+          <>
+            Total healing from HoTs attributed to{' '}
+            <SpellLink spell={TALENTS_DRUID.OVERGROWTH_TALENT} /> on{' '}
+            <SpellLink spell={SPELLS.NATURES_SWIFTNESS} />
+            -empowered <SpellLink spell={SPELLS.REGROWTH} /> casts.
+            {this.hasImplant && this.implantHealing > 0 && (
+              <>
+                {' '}
+                Includes direct healing from the <SpellLink
+                  spell={TALENTS_DRUID.IMPLANT_TALENT}
+                />{' '}
+                <SpellLink spell={SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER} /> grown by Overgrowth's{' '}
+                <SpellLink spell={SPELLS.WILD_GROWTH} /> effect.
+              </>
+            )}
+            <ul>
+              <li>
+                Overgrowth HoTs:{' '}
+                <strong>{this.owner.formatItemHealingDone(this.hotHealing)}</strong>
+              </li>
+              {this.hasImplant && this.implantHealing > 0 && (
+                <li>
+                  <SpellLink spell={TALENTS_DRUID.IMPLANT_TALENT} />{' '}
+                  <SpellLink spell={SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER} />:{' '}
+                  <strong>{this.owner.formatItemHealingDone(this.implantHealing)}</strong>
+                </li>
+              )}
+            </ul>
+            <strong>
+              Overhealing: {formatOverhealing(this.totalOverhealing, this.totalHealing)}
+            </strong>
+          </>
+        }
+      >
+        <BoringSpellValueText spell={TALENTS_DRUID.OVERGROWTH_TALENT}>
+          <ItemPercentHealingDone amount={this.totalHealing} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default Overgrowth;

--- a/src/analysis/retail/druid/restoration/modules/spells/Wildstalker/Implant.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Wildstalker/Implant.tsx
@@ -1,0 +1,299 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Module';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import Events, { ApplyBuffEvent, ApplyBuffStackEvent, HealEvent } from 'parser/core/Events';
+import { calculateEffectiveHealing, calculateOverhealing } from 'parser/core/EventCalculateLib';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import SPELLS from 'common/SPELLS';
+import Combatants from 'parser/shared/modules/Combatants';
+import Lifebloom from 'analysis/retail/druid/restoration/modules/spells/Lifebloom';
+import Mastery from 'analysis/retail/druid/restoration/modules/core/Mastery';
+import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from 'analysis/retail/druid/restoration/constants';
+import { isFromImplant } from 'analysis/retail/druid/restoration/normalizers/CastLinkNormalizer';
+import { formatNumber } from 'common/format';
+import { formatOverhealing } from 'analysis/retail/druid/restoration/format';
+import SpellLink from 'interface/SpellLink';
+import SymbioticBloomDirectClaim from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/SymbioticBloomDirectClaim';
+
+const BASE_BLOOM_DURATION_MS = 6_000;
+const RESILIENT_FLOURISHING_EXTRA_MS = 2_000;
+const VIGOROUS_CREEPERS_HEALING_INCREASE = 0.2;
+
+interface BloomInstance {
+  targetId: number;
+  start: number;
+  end: number;
+}
+
+/**
+ * **Implant**
+ * Hero Talent - Wildstalker
+ *
+ * Casting Swiftmend or Wild Growth grows a Symbiotic Bloom for 6 sec.
+ * Overgrowth's WG effect also triggers Implant (no separate WG cast).
+ *
+ * Linked via FROM_IMPLANT. Credits direct ticks (split across rolling stacks), plus mastery
+ * and nested VC while Implant owns the oldest stack on the target.
+ */
+export default class Implant extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    lifebloom: Lifebloom,
+    mastery: Mastery,
+    symbioticBloomDirectClaim: SymbioticBloomDirectClaim,
+  };
+
+  protected combatants!: Combatants;
+  protected lifebloom!: Lifebloom;
+  protected mastery!: Mastery;
+  protected symbioticBloomDirectClaim!: SymbioticBloomDirectClaim;
+
+  private bloomDurationMs: number;
+  private hasVigorousCreepers: boolean;
+
+  private implantBlooms: BloomInstance[] = [];
+
+  directHealing = 0;
+  directOverhealing = 0;
+  masteryHealing = 0;
+  vigorousCreepersHealing = 0;
+  vigorousCreepersOverhealing = 0;
+  everbloomHealing = 0;
+  bloomsApplied = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.IMPLANT_TALENT);
+    this.hasVigorousCreepers = this.selectedCombatant.hasTalent(
+      TALENTS_DRUID.VIGOROUS_CREEPERS_TALENT,
+    );
+    this.bloomDurationMs =
+      BASE_BLOOM_DURATION_MS +
+      (this.selectedCombatant.hasTalent(TALENTS_DRUID.RESILIENT_FLOURISHING_TALENT)
+        ? RESILIENT_FLOURISHING_EXTRA_MS
+        : 0);
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER),
+      this.onSymbioticBloomApply,
+    );
+    this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER),
+      this.onSymbioticBloomApply,
+    );
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
+  }
+
+  private onSymbioticBloomApply(event: ApplyBuffEvent | ApplyBuffStackEvent) {
+    if (!isFromImplant(event)) {
+      return;
+    }
+
+    this.implantBlooms.push({
+      targetId: event.targetID,
+      start: event.timestamp,
+      end: event.timestamp + this.bloomDurationMs,
+    });
+    this.bloomsApplied += 1;
+  }
+
+  getActiveBloomStacks(targetId: number, timestamp: number): number {
+    return this.implantBlooms.filter(
+      (bloom) => bloom.targetId === targetId && bloom.start <= timestamp && timestamp < bloom.end,
+    ).length;
+  }
+
+  /** @deprecated use {@link getActiveBloomStacks} */
+  private getImplantStacks(targetId: number, timestamp: number): number {
+    return this.getActiveBloomStacks(targetId, timestamp);
+  }
+
+  /**
+   * Fraction of this Symbiotic Bloom heal event counted as Implant direct healing
+   * (0 if not a SymBloom heal or no Implant stacks on the target).
+   */
+  getDirectClaimPortion(event: HealEvent): number {
+    if (event.ability.guid !== SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id) {
+      return 0;
+    }
+
+    const target = this.combatants.getEntity(event);
+    if (!target) {
+      return 0;
+    }
+
+    const implantStacks = this.getImplantStacks(target.id, event.timestamp);
+    if (implantStacks <= 0) {
+      return 0;
+    }
+
+    const totalStacks = target.getBuffStacks(
+      SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
+      event.timestamp,
+      0,
+      0,
+      this.selectedCombatant.id,
+    );
+    if (totalStacks <= 0) {
+      return 0;
+    }
+
+    return Math.min(implantStacks, totalStacks) / totalStacks;
+  }
+
+  private onHeal(event: HealEvent) {
+    if (event.ability.guid === SPELLS.EVERBLOOM_SPLASH_HEAL.id) {
+      this.handleEverbloomSplash(event);
+      return;
+    }
+
+    const target = this.combatants.getEntity(event);
+    if (!target) {
+      return;
+    }
+
+    const implantStacks = this.getImplantStacks(target.id, event.timestamp);
+    if (implantStacks <= 0) {
+      return;
+    }
+
+    if (event.ability.guid === SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id) {
+      const totalStacks = target.getBuffStacks(
+        SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
+        event.timestamp,
+        0,
+        0,
+        this.selectedCombatant.id,
+      );
+      if (totalStacks <= 0) {
+        return;
+      }
+      const portion = Math.min(implantStacks, totalStacks) / totalStacks;
+      const effective = event.amount + (event.absorbed || 0);
+      this.directHealing += effective * portion;
+      this.directOverhealing += (event.overheal || 0) * portion;
+      return;
+    }
+
+    if (!this.symbioticBloomDirectClaim.isMasteryOwner('implant', target.id, event.timestamp)) {
+      return;
+    }
+
+    if (!ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(event.ability.guid)) {
+      return;
+    }
+
+    const decomposed = this.mastery.decomposeHeal(event);
+    if (decomposed) {
+      this.masteryHealing += decomposed.oneStack;
+    }
+
+    if (this.hasVigorousCreepers) {
+      this.vigorousCreepersHealing += calculateEffectiveHealing(
+        event,
+        VIGOROUS_CREEPERS_HEALING_INCREASE,
+      );
+      this.vigorousCreepersOverhealing += calculateOverhealing(
+        event,
+        VIGOROUS_CREEPERS_HEALING_INCREASE,
+      );
+    }
+  }
+
+  /**
+   * Everbloom splash scales off the Lifebloom bloom (already including VC if LB target has
+   * Symbiotic Blooms). Attribute that amp only when Implant alone provides the bloom on LB.
+   */
+  private handleEverbloomSplash(event: HealEvent) {
+    if (!this.hasVigorousCreepers) {
+      return;
+    }
+
+    const lbTargetId = this.lifebloom.activeLifebloomTarget;
+    if (
+      lbTargetId === undefined ||
+      !this.symbioticBloomDirectClaim.isMasteryOwner('implant', lbTargetId, event.timestamp)
+    ) {
+      return;
+    }
+
+    const amount = calculateEffectiveHealing(event, VIGOROUS_CREEPERS_HEALING_INCREASE);
+    this.vigorousCreepersHealing += amount;
+    this.vigorousCreepersOverhealing += calculateOverhealing(
+      event,
+      VIGOROUS_CREEPERS_HEALING_INCREASE,
+    );
+    this.everbloomHealing += amount;
+  }
+
+  get totalHealing() {
+    return this.directHealing + this.masteryHealing + this.vigorousCreepersHealing;
+  }
+
+  /** Direct SymBloom + mastery only (VC is counted on Vigorous Creepers). */
+  get treeTotalHealing() {
+    return this.directHealing + this.masteryHealing;
+  }
+
+  /** Direct + Vigorous Creepers overheal only (mastery overheal omitted). */
+  get reportedOverhealing() {
+    return this.directOverhealing + this.vigorousCreepersOverhealing;
+  }
+
+  get reportedOverhealingEffectiveBase() {
+    return this.directHealing + this.vigorousCreepersHealing;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(5)}
+        category={STATISTIC_CATEGORY.HERO_TALENTS}
+        size="flexible"
+        tooltip={
+          <>
+            Healing from <SpellLink spell={TALENTS_DRUID.IMPLANT_TALENT} />
+            -applied <SpellLink spell={SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER} />:
+            <ul>
+              <li>
+                Direct HoT healing: <strong>{formatNumber(this.directHealing)}</strong>
+              </li>
+              <li>
+                Mastery benefit: <strong>{formatNumber(this.masteryHealing)}</strong> (while Implant
+                owns the oldest active Symbiotic Bloom stack on the target)
+              </li>
+              {this.hasVigorousCreepers && (
+                <li>
+                  <SpellLink spell={TALENTS_DRUID.VIGOROUS_CREEPERS_TALENT} /> amp:{' '}
+                  <strong>{formatNumber(this.vigorousCreepersHealing)}</strong>
+                  {this.everbloomHealing > 0 && (
+                    <>
+                      {' '}
+                      (includes <strong>{formatNumber(this.everbloomHealing)}</strong> from
+                      Everbloom splash)
+                    </>
+                  )}
+                </li>
+              )}
+            </ul>
+            Blooms applied: <strong>{this.bloomsApplied}</strong>
+            <br />
+            <strong>
+              Overhealing:{' '}
+              {formatOverhealing(this.reportedOverhealing, this.reportedOverhealingEffectiveBase)}
+            </strong>{' '}
+            (direct + Vigorous Creepers only)
+          </>
+        }
+      >
+        <BoringSpellValueText spell={TALENTS_DRUID.IMPLANT_TALENT}>
+          <ItemPercentHealingDone amount={this.totalHealing} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/druid/restoration/modules/spells/Wildstalker/SymbioticBloomDirectClaim.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Wildstalker/SymbioticBloomDirectClaim.tsx
@@ -1,25 +1,113 @@
-import Analyzer, { Options } from 'parser/core/Analyzer';
-import { HealEvent } from 'parser/core/Events';
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Module';
+import Events, {
+  HealEvent,
+  ApplyBuffEvent,
+  ApplyBuffStackEvent,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
 import SPELLS from 'common/SPELLS';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import {
+  isFromImplant,
+  isFromTwinSprouts,
+} from 'analysis/retail/druid/restoration/normalizers/CastLinkNormalizer';
+
+export type SymBloomProvider = 'implant' | 'twin' | 'thriving';
+
+const BASE_BLOOM_DURATION_MS = 6_000;
+const RESILIENT_FLOURISHING_EXTRA_MS = 2_000;
+
+interface TrackedBloomStack {
+  targetId: number;
+  provider: SymBloomProvider;
+  start: number;
+  end: number;
+}
 
 /**
  * Shared SymBloom queries for hero-tree nesting.
- * Amp modules skip SymBloom ticks so they are not also counted as HoT amps.
+ * Implant / Twin / Thriving claim all SymBloom ticks, so amp modules skip those.
+ * Mastery (and nested VC) goes to whoever owns the oldest still-active stack.
  */
 export default class SymbioticBloomDirectClaim extends Analyzer {
+  private readonly bloomDurationMs: number;
+  private bloomStacks: TrackedBloomStack[] = [];
+
   constructor(options: Options) {
     super(options);
     this.active = true;
+    this.bloomDurationMs =
+      BASE_BLOOM_DURATION_MS +
+      (this.selectedCombatant.hasTalent(TALENTS_DRUID.RESILIENT_FLOURISHING_TALENT)
+        ? RESILIENT_FLOURISHING_EXTRA_MS
+        : 0);
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER),
+      this.onBloomApply,
+    );
+    this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER),
+      this.onBloomApply,
+    );
+    this.addEventListener(
+      Events.removebuff.by(SELECTED_PLAYER).spell(SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER),
+      this.onBloomRemove,
+    );
   }
 
   /**
    * Fraction of this heal already counted as direct SymBloom healing in the hero tree (0–1).
-   * SymBloom ticks are fully claimed. Other heals: 0.
+   * SymBloom ticks are fully claimed (Implant + Twin + Thriving Growth). Other heals: 0.
    */
   getDirectClaimPortion(event: HealEvent): number {
     if (event.ability.guid !== SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id) {
       return 0;
     }
     return 1;
+  }
+
+  /**
+   * True when this provider owns the oldest still-active SymBloom stack on the target
+   * (that stack is what grants the mastery presence).
+   */
+  isMasteryOwner(provider: SymBloomProvider, targetId: number, timestamp: number): boolean {
+    const oldest = this.getOldestActiveStack(targetId, timestamp);
+    return oldest?.provider === provider;
+  }
+
+  private getOldestActiveStack(targetId: number, timestamp: number): TrackedBloomStack | undefined {
+    let oldest: TrackedBloomStack | undefined;
+    for (const bloom of this.bloomStacks) {
+      if (bloom.targetId !== targetId || bloom.start > timestamp || timestamp >= bloom.end) {
+        continue;
+      }
+      if (!oldest || bloom.start < oldest.start) {
+        oldest = bloom;
+      }
+    }
+    return oldest;
+  }
+
+  private onBloomApply(event: ApplyBuffEvent | ApplyBuffStackEvent) {
+    let provider: SymBloomProvider = 'thriving';
+    if (isFromImplant(event)) {
+      provider = 'implant';
+    } else if (isFromTwinSprouts(event)) {
+      provider = 'twin';
+    }
+
+    this.bloomStacks.push({
+      targetId: event.targetID,
+      provider,
+      start: event.timestamp,
+      end: event.timestamp + this.bloomDurationMs,
+    });
+  }
+
+  private onBloomRemove(event: RemoveBuffEvent) {
+    // Buff fully gone — drop any remaining tracked stacks for this target
+    this.bloomStacks = this.bloomStacks.filter((bloom) => bloom.targetId !== event.targetID);
   }
 }

--- a/src/analysis/retail/druid/restoration/modules/spells/Wildstalker/ThrivingGrowth.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Wildstalker/ThrivingGrowth.tsx
@@ -1,0 +1,205 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Module';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import Events, { HealEvent } from 'parser/core/Events';
+import { calculateEffectiveHealing, calculateOverhealing } from 'parser/core/EventCalculateLib';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import SPELLS from 'common/SPELLS';
+import Combatants from 'parser/shared/modules/Combatants';
+import Lifebloom from 'analysis/retail/druid/restoration/modules/spells/Lifebloom';
+import Mastery from 'analysis/retail/druid/restoration/modules/core/Mastery';
+import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from 'analysis/retail/druid/restoration/constants';
+import { formatNumber } from 'common/format';
+import { formatOverhealing } from 'analysis/retail/druid/restoration/format';
+import SpellLink from 'interface/SpellLink';
+import SymbioticBloomDirectClaim from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/SymbioticBloomDirectClaim';
+import Implant from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/Implant';
+import TwinSprouts from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/TwinSprouts';
+
+const VIGOROUS_CREEPERS_HEALING_INCREASE = 0.2;
+
+/**
+ * **Thriving Growth**
+ * Hero Talent - Wildstalker (keystone)
+ *
+ * Wild Growth, Regrowth, and Efflorescence have a chance to grow Symbiotic Blooms.
+ *
+ * Credits leftover SymBloom ticks (not Implant/Twin), plus mastery while this talent
+ * owns the oldest stack. Tree total is direct + mastery (VC sits on Vigorous Creepers).
+ */
+export default class ThrivingGrowth extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    lifebloom: Lifebloom,
+    mastery: Mastery,
+    symbioticBloomDirectClaim: SymbioticBloomDirectClaim,
+    implant: Implant,
+    twinSprouts: TwinSprouts,
+  };
+
+  protected combatants!: Combatants;
+  protected lifebloom!: Lifebloom;
+  protected mastery!: Mastery;
+  protected symbioticBloomDirectClaim!: SymbioticBloomDirectClaim;
+  protected implant!: Implant;
+  protected twinSprouts!: TwinSprouts;
+
+  private hasVigorousCreepers: boolean;
+
+  directHealing = 0;
+  directOverhealing = 0;
+  masteryHealing = 0;
+  vigorousCreepersHealing = 0;
+  vigorousCreepersOverhealing = 0;
+  everbloomHealing = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.THRIVING_GROWTH_TALENT);
+    this.hasVigorousCreepers = this.selectedCombatant.hasTalent(
+      TALENTS_DRUID.VIGOROUS_CREEPERS_TALENT,
+    );
+
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
+  }
+
+  private onHeal(event: HealEvent) {
+    if (event.ability.guid === SPELLS.EVERBLOOM_SPLASH_HEAL.id) {
+      this.handleEverbloomSplash(event);
+      return;
+    }
+
+    const target = this.combatants.getEntity(event);
+    if (!target) {
+      return;
+    }
+
+    if (event.ability.guid === SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id) {
+      const implantPortion = this.implant.getDirectClaimPortion(event);
+      const twinPortion = this.twinSprouts.getDirectClaimPortion(event);
+      const portion = 1 - Math.min(1, implantPortion + twinPortion);
+      if (portion <= 0) {
+        return;
+      }
+      const effective = event.amount + (event.absorbed || 0);
+      this.directHealing += effective * portion;
+      this.directOverhealing += (event.overheal || 0) * portion;
+      return;
+    }
+
+    if (!this.symbioticBloomDirectClaim.isMasteryOwner('thriving', target.id, event.timestamp)) {
+      return;
+    }
+
+    if (!ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(event.ability.guid)) {
+      return;
+    }
+
+    const decomposed = this.mastery.decomposeHeal(event);
+    if (decomposed) {
+      this.masteryHealing += decomposed.oneStack;
+    }
+
+    if (this.hasVigorousCreepers) {
+      this.vigorousCreepersHealing += calculateEffectiveHealing(
+        event,
+        VIGOROUS_CREEPERS_HEALING_INCREASE,
+      );
+      this.vigorousCreepersOverhealing += calculateOverhealing(
+        event,
+        VIGOROUS_CREEPERS_HEALING_INCREASE,
+      );
+    }
+  }
+
+  private handleEverbloomSplash(event: HealEvent) {
+    if (!this.hasVigorousCreepers) {
+      return;
+    }
+
+    const lbTargetId = this.lifebloom.activeLifebloomTarget;
+    if (
+      lbTargetId === undefined ||
+      !this.symbioticBloomDirectClaim.isMasteryOwner('thriving', lbTargetId, event.timestamp)
+    ) {
+      return;
+    }
+
+    const amount = calculateEffectiveHealing(event, VIGOROUS_CREEPERS_HEALING_INCREASE);
+    this.vigorousCreepersHealing += amount;
+    this.vigorousCreepersOverhealing += calculateOverhealing(
+      event,
+      VIGOROUS_CREEPERS_HEALING_INCREASE,
+    );
+    this.everbloomHealing += amount;
+  }
+
+  get totalHealing() {
+    return this.directHealing + this.masteryHealing + this.vigorousCreepersHealing;
+  }
+
+  /** Direct SymBloom + mastery only (VC is counted on Vigorous Creepers). */
+  get treeTotalHealing() {
+    return this.directHealing + this.masteryHealing;
+  }
+
+  get reportedOverhealing() {
+    return this.directOverhealing + this.vigorousCreepersOverhealing;
+  }
+
+  get reportedOverhealingEffectiveBase() {
+    return this.directHealing + this.vigorousCreepersHealing;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(0)}
+        category={STATISTIC_CATEGORY.HERO_TALENTS}
+        size="flexible"
+        tooltip={
+          <>
+            Healing from <SpellLink spell={SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER} /> not already
+            attributed to <SpellLink spell={TALENTS_DRUID.IMPLANT_TALENT} /> /{' '}
+            <SpellLink spell={TALENTS_DRUID.TWIN_SPROUTS_TALENT} />:
+            <ul>
+              <li>
+                Direct HoT healing: <strong>{formatNumber(this.directHealing)}</strong>
+              </li>
+              <li>
+                Mastery benefit: <strong>{formatNumber(this.masteryHealing)}</strong> (while
+                Thriving Growth owns the oldest active Symbiotic Bloom stack on the target)
+              </li>
+              {this.hasVigorousCreepers && (
+                <li>
+                  <SpellLink spell={TALENTS_DRUID.VIGOROUS_CREEPERS_TALENT} /> amp:{' '}
+                  <strong>{formatNumber(this.vigorousCreepersHealing)}</strong>
+                  {this.everbloomHealing > 0 && (
+                    <>
+                      {' '}
+                      (includes <strong>{formatNumber(this.everbloomHealing)}</strong> from
+                      Everbloom splash)
+                    </>
+                  )}
+                </li>
+              )}
+            </ul>
+            <strong>
+              Overhealing:{' '}
+              {formatOverhealing(this.reportedOverhealing, this.reportedOverhealingEffectiveBase)}
+            </strong>{' '}
+            (direct + Vigorous Creepers only)
+          </>
+        }
+      >
+        <BoringSpellValueText spell={TALENTS_DRUID.THRIVING_GROWTH_TALENT}>
+          <ItemPercentHealingDone amount={this.totalHealing} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/druid/restoration/modules/spells/Wildstalker/TwinSprouts.tsx
+++ b/src/analysis/retail/druid/restoration/modules/spells/Wildstalker/TwinSprouts.tsx
@@ -1,0 +1,301 @@
+import Analyzer, { SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { Options } from 'parser/core/Module';
+import { TALENTS_DRUID } from 'common/TALENTS';
+import Events, { ApplyBuffEvent, ApplyBuffStackEvent, HealEvent } from 'parser/core/Events';
+import { calculateEffectiveHealing, calculateOverhealing } from 'parser/core/EventCalculateLib';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemPercentHealingDone from 'parser/ui/ItemPercentHealingDone';
+import SPELLS from 'common/SPELLS';
+import Combatants from 'parser/shared/modules/Combatants';
+import Lifebloom from 'analysis/retail/druid/restoration/modules/spells/Lifebloom';
+import Mastery from 'analysis/retail/druid/restoration/modules/core/Mastery';
+import { ABILITIES_AFFECTED_BY_HEALING_INCREASES } from 'analysis/retail/druid/restoration/constants';
+import { isFromTwinSprouts } from 'analysis/retail/druid/restoration/normalizers/CastLinkNormalizer';
+import { formatNumber } from 'common/format';
+import { formatOverhealing } from 'analysis/retail/druid/restoration/format';
+import SpellLink from 'interface/SpellLink';
+import SymbioticBloomDirectClaim from 'analysis/retail/druid/restoration/modules/spells/Wildstalker/SymbioticBloomDirectClaim';
+
+const BASE_BLOOM_DURATION_MS = 6_000;
+const RESILIENT_FLOURISHING_EXTRA_MS = 2_000;
+const VIGOROUS_CREEPERS_HEALING_INCREASE = 0.2;
+
+interface BloomInstance {
+  targetId: number;
+  start: number;
+  end: number;
+}
+
+/**
+ * **Twin Sprouts**
+ * Hero Talent - Wildstalker
+ *
+ * When Bloodseeker Vines or Symbiotic Blooms grow, 30% chance another of the same type
+ * grows on a nearby target.
+ *
+ * Linked via FROM_TWIN_SPROUTS. Same attribution as Implant (direct ticks, mastery, nested VC).
+ * Vine procs aren't counted here.
+ */
+export default class TwinSprouts extends Analyzer {
+  static dependencies = {
+    combatants: Combatants,
+    lifebloom: Lifebloom,
+    mastery: Mastery,
+    symbioticBloomDirectClaim: SymbioticBloomDirectClaim,
+  };
+
+  protected combatants!: Combatants;
+  protected lifebloom!: Lifebloom;
+  protected mastery!: Mastery;
+  protected symbioticBloomDirectClaim!: SymbioticBloomDirectClaim;
+
+  private bloomDurationMs: number;
+  private hasVigorousCreepers: boolean;
+
+  private twinBlooms: BloomInstance[] = [];
+
+  directHealing = 0;
+  directOverhealing = 0;
+  masteryHealing = 0;
+  vigorousCreepersHealing = 0;
+  vigorousCreepersOverhealing = 0;
+  everbloomHealing = 0;
+  bloomsApplied = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS_DRUID.TWIN_SPROUTS_TALENT);
+    this.hasVigorousCreepers = this.selectedCombatant.hasTalent(
+      TALENTS_DRUID.VIGOROUS_CREEPERS_TALENT,
+    );
+    this.bloomDurationMs =
+      BASE_BLOOM_DURATION_MS +
+      (this.selectedCombatant.hasTalent(TALENTS_DRUID.RESILIENT_FLOURISHING_TALENT)
+        ? RESILIENT_FLOURISHING_EXTRA_MS
+        : 0);
+
+    this.addEventListener(
+      Events.applybuff.by(SELECTED_PLAYER).spell(SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER),
+      this.onSymbioticBloomApply,
+    );
+    this.addEventListener(
+      Events.applybuffstack.by(SELECTED_PLAYER).spell(SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER),
+      this.onSymbioticBloomApply,
+    );
+    this.addEventListener(Events.heal.by(SELECTED_PLAYER), this.onHeal);
+  }
+
+  private onSymbioticBloomApply(event: ApplyBuffEvent | ApplyBuffStackEvent) {
+    if (!isFromTwinSprouts(event)) {
+      return;
+    }
+
+    this.twinBlooms.push({
+      targetId: event.targetID,
+      start: event.timestamp,
+      end: event.timestamp + this.bloomDurationMs,
+    });
+    this.bloomsApplied += 1;
+  }
+
+  getActiveBloomStacks(targetId: number, timestamp: number): number {
+    return this.twinBlooms.filter(
+      (bloom) => bloom.targetId === targetId && bloom.start <= timestamp && timestamp < bloom.end,
+    ).length;
+  }
+
+  /** @deprecated use {@link getActiveBloomStacks} */
+  private getTwinStacks(targetId: number, timestamp: number): number {
+    return this.getActiveBloomStacks(targetId, timestamp);
+  }
+
+  /**
+   * Fraction of this Symbiotic Bloom heal event counted as Twin Sprouts direct healing
+   * (0 if not a SymBloom heal or no Twin stacks on the target).
+   */
+  getDirectClaimPortion(event: HealEvent): number {
+    if (event.ability.guid !== SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id) {
+      return 0;
+    }
+
+    const target = this.combatants.getEntity(event);
+    if (!target) {
+      return 0;
+    }
+
+    const twinStacks = this.getTwinStacks(target.id, event.timestamp);
+    if (twinStacks <= 0) {
+      return 0;
+    }
+
+    const totalStacks = target.getBuffStacks(
+      SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
+      event.timestamp,
+      0,
+      0,
+      this.selectedCombatant.id,
+    );
+    if (totalStacks <= 0) {
+      return 0;
+    }
+
+    return Math.min(twinStacks, totalStacks) / totalStacks;
+  }
+
+  private onHeal(event: HealEvent) {
+    if (event.ability.guid === SPELLS.EVERBLOOM_SPLASH_HEAL.id) {
+      this.handleEverbloomSplash(event);
+      return;
+    }
+
+    const target = this.combatants.getEntity(event);
+    if (!target) {
+      return;
+    }
+
+    const twinStacks = this.getTwinStacks(target.id, event.timestamp);
+    if (twinStacks <= 0) {
+      return;
+    }
+
+    if (event.ability.guid === SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id) {
+      const totalStacks = target.getBuffStacks(
+        SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
+        event.timestamp,
+        0,
+        0,
+        this.selectedCombatant.id,
+      );
+      if (totalStacks <= 0) {
+        return;
+      }
+      const portion = Math.min(twinStacks, totalStacks) / totalStacks;
+      const effective = event.amount + (event.absorbed || 0);
+      this.directHealing += effective * portion;
+      this.directOverhealing += (event.overheal || 0) * portion;
+      return;
+    }
+
+    if (!this.symbioticBloomDirectClaim.isMasteryOwner('twin', target.id, event.timestamp)) {
+      return;
+    }
+
+    if (!ABILITIES_AFFECTED_BY_HEALING_INCREASES.includes(event.ability.guid)) {
+      return;
+    }
+
+    const decomposed = this.mastery.decomposeHeal(event);
+    if (decomposed) {
+      this.masteryHealing += decomposed.oneStack;
+    }
+
+    if (this.hasVigorousCreepers) {
+      this.vigorousCreepersHealing += calculateEffectiveHealing(
+        event,
+        VIGOROUS_CREEPERS_HEALING_INCREASE,
+      );
+      this.vigorousCreepersOverhealing += calculateOverhealing(
+        event,
+        VIGOROUS_CREEPERS_HEALING_INCREASE,
+      );
+    }
+  }
+
+  private handleEverbloomSplash(event: HealEvent) {
+    if (!this.hasVigorousCreepers) {
+      return;
+    }
+
+    const lbTargetId = this.lifebloom.activeLifebloomTarget;
+    if (
+      lbTargetId === undefined ||
+      !this.symbioticBloomDirectClaim.isMasteryOwner('twin', lbTargetId, event.timestamp)
+    ) {
+      return;
+    }
+
+    const amount = calculateEffectiveHealing(event, VIGOROUS_CREEPERS_HEALING_INCREASE);
+    this.vigorousCreepersHealing += amount;
+    this.vigorousCreepersOverhealing += calculateOverhealing(
+      event,
+      VIGOROUS_CREEPERS_HEALING_INCREASE,
+    );
+    this.everbloomHealing += amount;
+  }
+
+  get totalHealing() {
+    return this.directHealing + this.masteryHealing + this.vigorousCreepersHealing;
+  }
+
+  /** Direct SymBloom + mastery only (VC is counted on Vigorous Creepers). */
+  get treeTotalHealing() {
+    return this.directHealing + this.masteryHealing;
+  }
+
+  get reportedOverhealing() {
+    return this.directOverhealing + this.vigorousCreepersOverhealing;
+  }
+
+  get reportedOverhealingEffectiveBase() {
+    return this.directHealing + this.vigorousCreepersHealing;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.CORE(5)}
+        category={STATISTIC_CATEGORY.HERO_TALENTS}
+        size="flexible"
+        tooltip={
+          <>
+            Healing from <SpellLink spell={TALENTS_DRUID.TWIN_SPROUTS_TALENT} />
+            -procced <SpellLink spell={SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER} /> (blooms that grew on
+            a nearby target as another bloom was applied):
+            <ul>
+              <li>
+                Direct HoT healing: <strong>{formatNumber(this.directHealing)}</strong>
+              </li>
+              <li>
+                Mastery benefit: <strong>{formatNumber(this.masteryHealing)}</strong> (while Twin
+                Sprouts owns the oldest active Symbiotic Bloom stack on the target)
+              </li>
+              {this.hasVigorousCreepers && (
+                <li>
+                  <SpellLink spell={TALENTS_DRUID.VIGOROUS_CREEPERS_TALENT} /> amp:{' '}
+                  <strong>{formatNumber(this.vigorousCreepersHealing)}</strong>
+                  {this.everbloomHealing > 0 && (
+                    <>
+                      {' '}
+                      (includes <strong>{formatNumber(this.everbloomHealing)}</strong> from
+                      Everbloom splash)
+                    </>
+                  )}
+                </li>
+              )}
+            </ul>
+            Procced blooms attributed: <strong>{this.bloomsApplied}</strong>
+            <br />
+            The combat log does not explicitly identify Twin Sprouts procs. This statistic links a
+            new bloom to another recently applied bloom by timing and may overcount if an unrelated
+            bloom grows at the same time.
+            <br />
+            Bloodseeker Vine procs are not included (healing only).
+            <br />
+            <strong>
+              Overhealing:{' '}
+              {formatOverhealing(this.reportedOverhealing, this.reportedOverhealingEffectiveBase)}
+            </strong>{' '}
+            (direct + Vigorous Creepers only)
+          </>
+        }
+      >
+        <BoringSpellValueText spell={TALENTS_DRUID.TWIN_SPROUTS_TALENT}>
+          <ItemPercentHealingDone amount={this.totalHealing} />
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}

--- a/src/analysis/retail/druid/restoration/modules/tier/S2TierSet.tsx
+++ b/src/analysis/retail/druid/restoration/modules/tier/S2TierSet.tsx
@@ -16,9 +16,9 @@ import { GENESIS_BUFFED_HOTS } from 'analysis/retail/druid/restoration/constants
 import { isGenesisFromTierCooldown } from 'analysis/retail/druid/restoration/normalizers/CastLinkNormalizer';
 
 const GENESIS_HEALING_INCREASE = 0.15;
-/** With the 4pc, each Genesis application lasts 12s (8s base + 4s from the 4pc). */
-const GENESIS_DURATION_MS = 12_000;
-/** The base (2pc) portion of a Genesis application. Healing during the final 4s of a
+/** With the 4pc, each Genesis application lasts 16s (8s base + 8s from the 4pc). */
+const GENESIS_DURATION_MS = 16_000;
+/** The base (2pc) portion of a Genesis application. Healing during the final 8s of a
  *  Rejuvenation-granted stack is attributed to the 4pc duration extension. */
 const GENESIS_TWO_PIECE_DURATION_MS = 8_000;
 
@@ -37,12 +37,12 @@ interface GenesisStack {
  * 2pc: Rejuvenation has a 15% chance to grant Genesis, causing all your heal over time effects to
  *      heal for 15% more for 8 sec. Multiple applications may overlap.
  * 4pc: Nature's Swiftness, Tranquility, and Incarnation: Tree of Life / Convoke the Spirits have a
- *      100% chance to grant Genesis, and Genesis duration is increased by 4 sec.
+ *      100% chance to grant Genesis, and Genesis duration is increased by 8 sec.
  *
  * The bonus healing is measured directly from active Genesis stacks. When the 4pc is equipped the
  * total is split into a 2pc and 4pc share:
  *  - 4pc = all healing from stacks granted by the empowering casts (full duration), plus the healing
- *    that occurs during the final 4s of each Rejuvenation-granted stack (the duration extension).
+ *    that occurs during the final 8s of each Rejuvenation-granted stack (the duration extension).
  *  - 2pc = the remaining healing (Rejuvenation-granted stacks during their first 8s, and any pre-pull
  *    stacks which always count fully towards the 2pc).
  */
@@ -209,8 +209,8 @@ class S2TierSet extends Analyzer {
                 <SpellLink spell={SPELLS.RESTO_DRUID_TIER_36_GENESIS_BUFF} /> stacks from{' '}
                 <SpellLink spell={SPELLS.NATURES_SWIFTNESS} />,{' '}
                 <SpellLink spell={SPELLS.TRANQUILITY_CAST} />, and Incarnation / Convoke, and
-                extends Genesis duration by 4 sec. The 4pc value is all healing from those granted
-                stacks plus the healing during the final 4 sec of each Rejuvenation-granted stack.
+                extends Genesis duration by 8 sec. The 4pc value is all healing from those granted
+                stacks plus the healing during the final 8 sec of each Rejuvenation-granted stack.
                 Pre-pull stacks always count fully towards the 2pc.
               </>
             )}

--- a/src/analysis/retail/druid/restoration/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/druid/restoration/normalizers/CastLinkNormalizer.ts
@@ -3,11 +3,12 @@ import EventLinkNormalizer, { EventLink } from 'parser/core/EventLinkNormalizer'
 import {
   AbilityEvent,
   AnyEvent,
-  ApplyBuffEvent,
   CastEvent,
   EventType,
   GetRelatedEvents,
+  HasAbility,
   HasRelatedEvent,
+  HasTarget,
   HealEvent,
   RefreshBuffEvent,
   RemoveBuffEvent,
@@ -23,18 +24,27 @@ const CONVOKE_CHANNEL_BUFFER_MS = 4_200;
 // Genesis is granted at the moment the empowering ability is cast, but the applybuff can be logged
 // slightly before/after the cast event, so allow a small window in both directions.
 const GENESIS_PROC_BUFFER_MS = 500;
+const IMPLANT_BUFFER_MS = 250;
+/** Twin Sprouts grows the new bloom immediately after a parent bloom — allow a short log delay. */
+const TWIN_SPROUTS_BUFFER_MS = 500;
 
 const APPLIED_HEAL = 'AppliedHeal';
 const FROM_HARDCAST = 'FromHardcast';
 const FROM_CONVOKE = 'FromConvoke';
+const FROM_OVERGROWTH = 'FromOvergrowth';
+const CONSUMED_NATURES_SWIFTNESS = 'ConsumedNaturesSwiftness';
+const CAUSED_TOL_REGROWTHS = 'CausedTreeOfLifeRegrowths';
 const FROM_EXPIRING_LIFEBLOOM = 'FromExpiringLifebloom';
 const CAUSED_BLOOM = 'CausedBloom';
 const CAUSED_TICK = 'CausedTick';
 const CAUSED_SUMMON = 'CausedSummon';
 const FROM_EVERBLOOM = 'FromEverbloom';
 const FROM_BLOOM = 'FromBloom';
-const FROM_CONVOKE_SOTF_CONSUME = 'FromConvokeSotfConsume';
 const GENESIS_FROM_TIER_CD = 'GenesisFromTierCooldown';
+const FROM_IMPLANT = 'FromImplant';
+const FROM_TWIN_SPROUTS = 'FromTwinSprouts';
+const CAUSED_TWIN_SPROUTS = 'CausedTwinSprouts';
+const CAUSED_NATURES_BOUNTY = 'CausedNaturesBounty';
 
 const EVENT_LINKS: EventLink[] = [
   {
@@ -75,6 +85,19 @@ const EVENT_LINKS: EventLink[] = [
     forwardBufferMs: CAST_BUFFER_MS,
     backwardBufferMs: CAST_BUFFER_MS,
     additionalCondition: (linkingEvent: AnyEvent) => !HasRelatedEvent(linkingEvent, FROM_CONVOKE),
+  },
+  {
+    // Nature's Bounty: Regrowth's direct heal also heals other allies who have Regrowth
+    // for 10% of that heal.
+    linkRelation: CAUSED_NATURES_BOUNTY,
+    linkingEventId: SPELLS.REGROWTH.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.NATURES_BOUNTY.id,
+    referencedEventType: EventType.Heal,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
+    isActive: (c) => c.hasTalent(TALENTS_DRUID.NATURES_BOUNTY_TALENT),
   },
   {
     linkRelation: FROM_HARDCAST,
@@ -146,6 +169,8 @@ const EVENT_LINKS: EventLink[] = [
   // linking lifebloom's bloom heal to the buff refresh (pandemic) or removal (expiry)
   // that caused it. Uses LIFEBLOOM_BUFF (1227806), not LIFEBLOOM_HOT_HEAL (33763) —
   // 33763 refreshbuffs are Everbloom stack gains and do not indicate a natural bloom.
+  // Must run before the Everbloom link so pandemic refreshes / natural expiries are not
+  // claimed by a nearby Swiftmend.
   {
     linkRelation: FROM_EXPIRING_LIFEBLOOM,
     reverseLinkRelation: CAUSED_BLOOM,
@@ -155,6 +180,35 @@ const EVENT_LINKS: EventLink[] = [
     referencedEventType: [EventType.RefreshBuff, EventType.RemoveBuff],
     forwardBufferMs: CAST_BUFFER_MS,
     backwardBufferMs: CAST_BUFFER_MS,
+  },
+  // linking Swiftmend heals to the 3-bloom Everbloom sequence they trigger
+  {
+    linkRelation: CAUSED_BLOOM,
+    reverseLinkRelation: FROM_EVERBLOOM,
+    linkingEventId: SPELLS.SWIFTMEND.id,
+    linkingEventType: EventType.Heal,
+    referencedEventId: SPELLS.LIFEBLOOM_BLOOM_HEAL.id,
+    referencedEventType: EventType.Heal,
+    forwardBufferMs: EVERBLOOM_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    anyTarget: true,
+    maximumLinks: 3,
+    isActive: (c) => c.hasTalent(TALENTS_DRUID.EVERBLOOM_3_RESTORATION_TALENT),
+    additionalCondition: (_linkingEvent: AnyEvent, referencedEvent: AnyEvent) =>
+      !HasRelatedEvent(referencedEvent, FROM_EVERBLOOM) &&
+      !HasRelatedEvent(referencedEvent, FROM_EXPIRING_LIFEBLOOM),
+  },
+  {
+    // initial Tree of Life shapeshift can instantly apply up to 3 Regrowths
+    linkRelation: CAUSED_TOL_REGROWTHS,
+    reverseLinkRelation: FROM_HARDCAST,
+    linkingEventId: TALENTS_DRUID.INCARNATION_TREE_OF_LIFE_TALENT.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: SPELLS.REGROWTH.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.RefreshBuff, EventType.Heal],
+    forwardBufferMs: 500,
+    anyTarget: true,
+    maximumLinks: 6,
   },
   {
     linkRelation: CAUSED_TICK,
@@ -178,37 +232,16 @@ const EVENT_LINKS: EventLink[] = [
     backwardBufferMs: CAST_BUFFER_MS,
     anyTarget: true,
   },
-  // linking SotF remove-buff events to convoke-generated consume events
+  // linking Everbloom splash healing to the Lifebloom bloom that triggered it
   {
-    linkRelation: APPLIED_HEAL,
-    reverseLinkRelation: FROM_CONVOKE_SOTF_CONSUME,
-    linkingEventId: [
-      SPELLS.REJUVENATION.id,
-      SPELLS.REJUVENATION_GERMINATION.id,
-      SPELLS.REGROWTH.id,
-    ],
-    linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff, EventType.Heal],
-    referencedEventId: SPELLS.SOUL_OF_THE_FOREST_BUFF.id,
-    referencedEventType: EventType.RemoveBuff,
-    forwardBufferMs: CAST_BUFFER_MS,
-    backwardBufferMs: CAST_BUFFER_MS,
-    anyTarget: true,
-    additionalCondition: (linkingEvent: AnyEvent) => HasRelatedEvent(linkingEvent, FROM_CONVOKE),
-  },
-  // linking lifebloom's bloom heal to the apex talent bloom
-  {
-    linkRelation: CAUSED_BLOOM,
-    reverseLinkRelation: FROM_EVERBLOOM,
-    linkingEventId: SPELLS.SOUL_OF_THE_FOREST_BUFF.id,
-    linkingEventType: EventType.RemoveBuff,
+    linkRelation: FROM_BLOOM,
+    linkingEventId: SPELLS.EVERBLOOM_SPLASH_HEAL.id,
+    linkingEventType: EventType.Heal,
     referencedEventId: SPELLS.LIFEBLOOM_BLOOM_HEAL.id,
     referencedEventType: EventType.Heal,
-    forwardBufferMs: EVERBLOOM_BUFFER_MS,
-    backwardBufferMs: EVERBLOOM_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
     anyTarget: true,
-    maximumLinks: 3, // Everbloom rank 4 causes 3 blooms in rapid succession
-    additionalCondition: (linkingEvent: AnyEvent) =>
-      !HasRelatedEvent(linkingEvent, FROM_CONVOKE_SOTF_CONSUME),
+    maximumLinks: 1,
   },
   // linking Verdancy heal to the bloom that triggered it
   {
@@ -241,6 +274,66 @@ const EVENT_LINKS: EventLink[] = [
     anyTarget: true,
     isActive: (c) => c.has4PieceByTier(TIERS.MID2),
   },
+  // Implant: Symbiotic Bloom from Swiftmend (same target)
+  {
+    linkRelation: FROM_IMPLANT,
+    linkingEventId: SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
+    referencedEventId: SPELLS.SWIFTMEND.id,
+    referencedEventType: EventType.Heal,
+    forwardBufferMs: IMPLANT_BUFFER_MS,
+    backwardBufferMs: IMPLANT_BUFFER_MS,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS_DRUID.IMPLANT_TALENT),
+  },
+  // Implant: Symbiotic Bloom from Wild Growth cast
+  {
+    linkRelation: FROM_IMPLANT,
+    linkingEventId: SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
+    referencedEventId: SPELLS.WILD_GROWTH.id,
+    referencedEventType: EventType.Cast,
+    forwardBufferMs: IMPLANT_BUFFER_MS,
+    backwardBufferMs: IMPLANT_BUFFER_MS,
+    anyTarget: true,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS_DRUID.IMPLANT_TALENT),
+    additionalCondition: (bloom: AnyEvent) => !HasRelatedEvent(bloom, FROM_IMPLANT),
+  },
+  // Implant: Symbiotic Bloom from Convoke Wild Growth (no cast event)
+  {
+    linkRelation: FROM_IMPLANT,
+    linkingEventId: SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
+    referencedEventId: SPELLS.WILD_GROWTH.id,
+    referencedEventType: EventType.ApplyBuff,
+    forwardBufferMs: IMPLANT_BUFFER_MS,
+    backwardBufferMs: IMPLANT_BUFFER_MS,
+    anyTarget: true,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS_DRUID.IMPLANT_TALENT),
+    additionalCondition: (bloom: AnyEvent, wgApply: AnyEvent) =>
+      !HasRelatedEvent(bloom, FROM_IMPLANT) && HasRelatedEvent(wgApply, FROM_CONVOKE),
+  },
+  // Twin Sprouts: when a Symbiotic Bloom grows, 30% chance to grow another on a nearby target
+  {
+    linkRelation: FROM_TWIN_SPROUTS,
+    reverseLinkRelation: CAUSED_TWIN_SPROUTS,
+    linkingEventId: SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
+    linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
+    referencedEventId: SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
+    referencedEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
+    backwardBufferMs: TWIN_SPROUTS_BUFFER_MS,
+    anyTarget: true,
+    maximumLinks: 1,
+    isActive: (c) => c.hasTalent(TALENTS_DRUID.TWIN_SPROUTS_TALENT),
+    additionalCondition: (twin: AnyEvent, parent: AnyEvent) =>
+      HasTarget(twin) &&
+      HasTarget(parent) &&
+      twin.targetID !== parent.targetID &&
+      !HasRelatedEvent(twin, FROM_IMPLANT) &&
+      !HasRelatedEvent(parent, CAUSED_TWIN_SPROUTS),
+  },
 ];
 
 /**
@@ -252,11 +345,69 @@ const EVENT_LINKS: EventLink[] = [
  *
  * This normalizer adds links for the buffs Rejuvenation, Regrowth, Wild Growth, Lifebloom,
  * and for the direct heals of Swiftmend and Regrowth, and the self buff from Flourish.
- * A special link key is used when the HoTs were applied by an Overgrowth cast instead of a normal hardcast.
+ *
+ * Overgrowth: Nature's Swiftness + Regrowth applies Rejuv / Lifebloom / Wild Growth with no
+ * separate hardcast of those spells. Those applybuffs are linked to the empowering Regrowth cast
+ * via FROM_OVERGROWTH. NS consumption is detected by linking the Regrowth cast to the Nature's
+ * Swiftness RemoveBuff (hasBuff is unavailable during normalize). Implant Symbiotic Blooms from
+ * that WG effect are linked after FROM_OVERGROWTH is established (same pattern as Convoke WG).
  */
 class CastLinkNormalizer extends EventLinkNormalizer {
   constructor(options: Options) {
-    super(options, EVENT_LINKS);
+    super(options, [
+      ...EVENT_LINKS,
+      // NS consumed by Regrowth (Overgrowth trigger). Must run before Overgrowth HoT links.
+      {
+        linkRelation: CONSUMED_NATURES_SWIFTNESS,
+        linkingEventId: SPELLS.REGROWTH.id,
+        linkingEventType: EventType.Cast,
+        referencedEventId: SPELLS.NATURES_SWIFTNESS.id,
+        referencedEventType: EventType.RemoveBuff,
+        forwardBufferMs: CAST_BUFFER_MS,
+        backwardBufferMs: CAST_BUFFER_MS,
+        anyTarget: true, // NS is on the player; Regrowth targets an ally
+        maximumLinks: 1,
+        isActive: (c) => c.hasTalent(TALENTS_DRUID.OVERGROWTH_TALENT),
+      },
+      // Overgrowth HoTs: Rejuv / Germination / WG / Lifebloom apply from NS+Regrowth (no own cast)
+      {
+        linkRelation: FROM_OVERGROWTH,
+        reverseLinkRelation: APPLIED_HEAL,
+        linkingEventId: [
+          SPELLS.REJUVENATION.id,
+          SPELLS.REJUVENATION_GERMINATION.id,
+          SPELLS.WILD_GROWTH.id,
+          SPELLS.LIFEBLOOM_BUFF.id,
+        ],
+        linkingEventType: [EventType.ApplyBuff, EventType.RefreshBuff],
+        referencedEventId: SPELLS.REGROWTH.id,
+        referencedEventType: EventType.Cast,
+        forwardBufferMs: CAST_BUFFER_MS,
+        backwardBufferMs: CAST_BUFFER_MS,
+        maximumLinks: 1,
+        isActive: (c) => c.hasTalent(TALENTS_DRUID.OVERGROWTH_TALENT),
+        additionalCondition: (linkingEvent: AnyEvent, regrowthCast: AnyEvent) =>
+          !HasRelatedEvent(linkingEvent, FROM_HARDCAST) &&
+          !HasRelatedEvent(linkingEvent, FROM_CONVOKE) &&
+          HasRelatedEvent(regrowthCast, CONSUMED_NATURES_SWIFTNESS),
+      },
+      // Implant: Symbiotic Bloom from Overgrowth Wild Growth (no WG cast — must follow FROM_OVERGROWTH)
+      {
+        linkRelation: FROM_IMPLANT,
+        linkingEventId: SPELLS.SYMBIOTIC_BLOOMS_WILDSTALKER.id,
+        linkingEventType: [EventType.ApplyBuff, EventType.ApplyBuffStack],
+        referencedEventId: SPELLS.WILD_GROWTH.id,
+        referencedEventType: EventType.ApplyBuff,
+        forwardBufferMs: IMPLANT_BUFFER_MS,
+        backwardBufferMs: IMPLANT_BUFFER_MS,
+        anyTarget: true,
+        maximumLinks: 1,
+        isActive: (c) =>
+          c.hasTalent(TALENTS_DRUID.IMPLANT_TALENT) && c.hasTalent(TALENTS_DRUID.OVERGROWTH_TALENT),
+        additionalCondition: (bloom: AnyEvent, wgApply: AnyEvent) =>
+          !HasRelatedEvent(bloom, FROM_IMPLANT) && HasRelatedEvent(wgApply, FROM_OVERGROWTH),
+      },
+    ]);
   }
 }
 
@@ -268,6 +419,35 @@ export function isFromHardcast(event: AbilityEvent<any>): boolean {
 /** Returns true iff the given buff application or heal can be matched back to Convoke */
 export function isFromConvoke(event: AbilityEvent<any>): boolean {
   return HasRelatedEvent(event, FROM_CONVOKE);
+}
+
+/** Returns true iff this Symbiotic Bloom came from Implant (Swiftmend / Wild Growth / Overgrowth) */
+export function isFromImplant(event: AbilityEvent<any>): boolean {
+  return HasRelatedEvent(event, FROM_IMPLANT);
+}
+
+/**
+ * Returns true iff this Implant Symbiotic Bloom was spawned by Overgrowth's Wild Growth effect
+ * (linked to a FROM_OVERGROWTH WG apply, not a WG cast / Swiftmend / Convoke).
+ */
+export function isImplantFromOvergrowth(event: AbilityEvent<any>): boolean {
+  return GetRelatedEvents(event, FROM_IMPLANT).some(
+    (e) =>
+      e.type === EventType.ApplyBuff &&
+      HasAbility(e) &&
+      e.ability.guid === SPELLS.WILD_GROWTH.id &&
+      HasRelatedEvent(e, FROM_OVERGROWTH),
+  );
+}
+
+/** Returns true iff this Symbiotic Bloom grew from a Twin Sprouts proc off another bloom's growth */
+export function isFromTwinSprouts(event: AbilityEvent<any>): boolean {
+  return HasRelatedEvent(event, FROM_TWIN_SPROUTS);
+}
+
+/** Returns true iff the HoT apply/refresh came from Overgrowth (NS+Regrowth) */
+export function isFromOvergrowth(event: AbilityEvent<any>): boolean {
+  return HasRelatedEvent(event, FROM_OVERGROWTH);
 }
 
 /** Returns the hardcast event that caused this buff or heal, if there is one */
@@ -284,6 +464,20 @@ export function getHeals(event: CastEvent): AnyEvent[] {
   return GetRelatedEvents(event, APPLIED_HEAL);
 }
 
+/** Returns true iff the given Regrowth came from the initial Tree of Life shapeshift cast */
+export function isFromTreeOfLifeCast(event: AbilityEvent<any>): boolean {
+  return (
+    HasRelatedEvent(event, CAUSED_TOL_REGROWTHS) ||
+    GetRelatedEvents<CastEvent>(
+      event,
+      FROM_HARDCAST,
+      (e): e is CastEvent =>
+        e.type === EventType.Cast &&
+        e.ability.guid === TALENTS_DRUID.INCARNATION_TREE_OF_LIFE_TALENT.id,
+    ).length > 0
+  );
+}
+
 /** Returns the direct heal event caused by this hardcast, if there is one */
 export function getDirectHeal(event: CastEvent): HealEvent | undefined {
   return getHeals(event)
@@ -291,18 +485,27 @@ export function getDirectHeal(event: CastEvent): HealEvent | undefined {
     .pop();
 }
 
-/** Returns true iff the given bloom heal can be linked to the refresh or removal of a lifebloom
- *  buff - used to differentiate from a Photosynthesis proc */
+/** Returns Nature's Bounty cleave heals caused by this Regrowth cast (excludes primary target) */
+export function getNaturesBountyHeals(event: CastEvent): HealEvent[] {
+  return GetRelatedEvents(
+    event,
+    CAUSED_NATURES_BOUNTY,
+    (e): e is HealEvent => e.type === EventType.Heal,
+  );
+}
+
+/** Returns true iff the given bloom heal can be linked to a Lifebloom buff refresh
+ *  (pandemic) or removal (expiry) - used to differentiate from a Photosynthesis proc */
 export function isFromExpiringLifebloom(event: HealEvent): boolean {
   return HasRelatedEvent(event, FROM_EXPIRING_LIFEBLOOM);
 }
 
-/** Returns true iff the bloom heal can be linked to Everbloom's SotF consume effect */
+/** Returns true iff the bloom heal can be linked to an Everbloom-triggered Swiftmend (hardcast or Convoke) */
 export function isFromEverbloom(event: HealEvent): boolean {
   return HasRelatedEvent(event, FROM_EVERBLOOM);
 }
 
-/** Returns true iff the bloom expiration caused a bloom to proc */
+/** Returns true iff the Lifebloom buff refresh or removal caused a bloom to proc */
 export function causedBloom(event: RemoveBuffEvent | RefreshBuffEvent): boolean {
   return HasRelatedEvent(event, CAUSED_BLOOM);
 }
@@ -311,6 +514,13 @@ export function causedBloom(event: RemoveBuffEvent | RefreshBuffEvent): boolean 
  *  cast ID `TRANQUILITY_CAST`. */
 export function getTranquilityTicks(event: CastEvent): AnyEvent[] {
   return GetRelatedEvents(event, CAUSED_TICK);
+}
+
+/** Returns true iff this Genesis application was granted by a Season 2 4pc empowering cast
+ *  (Nature's Swiftness, Tranquility, Incarnation: Tree of Life, or Convoke the Spirits) rather
+ *  than by the 2pc Rejuvenation proc. */
+export function isGenesisFromTierCooldown(event: AbilityEvent<any>): boolean {
+  return HasRelatedEvent(event, GENESIS_FROM_TIER_CD);
 }
 
 /** Returns the bloom heal event that triggered this Verdancy heal, if linked */

--- a/src/analysis/retail/druid/restoration/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/druid/restoration/normalizers/CastLinkNormalizer.ts
@@ -532,11 +532,4 @@ export function getSourceBloom(event: HealEvent): HealEvent | undefined {
   ).pop();
 }
 
-/** Returns true iff this Genesis application was granted by a Season 2 4pc empowering cast
- *  (Nature's Swiftness, Tranquility, Incarnation: Tree of Life, or Convoke the Spirits) rather
- *  than by the 2pc Rejuvenation proc. */
-export function isGenesisFromTierCooldown(event: AbilityEvent<any>): boolean {
-  return HasRelatedEvent(event, GENESIS_FROM_TIER_CD);
-}
-
 export default CastLinkNormalizer;


### PR DESCRIPTION
### Description
Attribute Overgrowth, Implant, and Twin Sprouts healing, including Implant blooms from Overgrowth's Wild Growth.
Also update S2 Tier to account for buffs 

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/...`
- Screenshot(s):
