### PR TITLE
[Warrior][Arms][Fury] APL and violation tooltip cleanup

### DIFF
--- a/src/analysis/retail/warrior/arms/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/arms/CHANGELOG.tsx
@@ -2,7 +2,8 @@ import { Nevdok } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2026, 8, 213), 'Midnight season 2 APL updates', Nevdok),
+  change(date(2026, 8, 29), 'APL cleanup and cleaner violation tooltips', Nevdok),
+  change(date(2026, 8, 13), 'Midnight season 2 APL updates', Nevdok),
   change(date(2026, 4, 25), 'Fix Heroic Strike tracking, update APL', Nevdok),
   change(date(2026, 4, 3), 'Fix apex talent CS cdr', Nevdok),
   change(date(2026, 3, 14), 'Midnight season 1 APL updates', Nevdok),

--- a/src/analysis/retail/warrior/arms/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/warrior/arms/modules/core/AplCheck.tsx
@@ -22,16 +22,25 @@ export const apl = (info: PlayerInfo): Apl => {
   const executeThreshold = info.combatant.hasTalent(TALENTS.MASSACRE_SPEC_TALENT)
     ? MASSACRE_EXECUTE_THRESHOLD
     : DEFAULT_EXECUTE_THRESHOLD;
-  const executeUsable = cnd.or(
-    cnd.buffPresent(SPELLS.SUDDEN_DEATH_TALENT_BUFF),
-    cnd.and(
-      cnd.inExecute(executeThreshold),
-      cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 200 }),
-    ),
-  );
+
   const executeSpell = info.combatant.hasTalent(TALENTS.MASSACRE_SPEC_TALENT)
     ? SPELLS.EXECUTE_GLYPHED
     : SPELLS.EXECUTE;
+  const executeUsable = {
+    ...cnd.or(
+      cnd.buffPresent(SPELLS.SUDDEN_DEATH_TALENT_BUFF),
+      cnd.and(
+        cnd.inExecute(executeThreshold),
+        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 200 }),
+      ),
+    ),
+    describe: () => (
+      <>
+        <SpellLink spell={executeSpell} /> was usable, or{' '}
+        <SpellLink spell={SPELLS.SUDDEN_DEATH_TALENT_BUFF} /> was active
+      </>
+    ),
+  };
 
   return info.combatant.hasTalent(TALENTS.SLAYERS_DOMINANCE_TALENT)
     ? buildSlayerApl(executeThreshold, executeUsable, executeSpell)
@@ -78,7 +87,10 @@ export const buildSlayerApl = (
     // OP inside execute with 2opp
     {
       spell: SPELLS.OVERPOWER,
-      condition: cnd.and(cnd.buffStacks(SPELLS.OPPORTUNIST, { atLeast: 2 }), executeUsable),
+      condition: cnd.and(
+        cnd.buffStacks(SPELLS.OPPORTUNIST, { atLeast: 2 }),
+        cnd.inExecute(executeThreshold),
+      ),
       description: (
         <>
           Cast <SpellLink spell={SPELLS.OVERPOWER} /> while in execute range with 2 stacks of{' '}
@@ -90,11 +102,19 @@ export const buildSlayerApl = (
     // Exe in execute with SD
     {
       spell: executeSpell,
-      condition: cnd.and(
-        executeUsable,
-        cnd.inExecute(executeThreshold),
-        cnd.buffPresent(SPELLS.SUDDEN_DEATH_TALENT_BUFF),
-      ),
+      condition: {
+        ...cnd.and(
+          executeUsable,
+          cnd.inExecute(executeThreshold),
+          cnd.buffPresent(SPELLS.SUDDEN_DEATH_TALENT_BUFF),
+        ),
+        describe: () => (
+          <>
+            you were in execute range with <SpellLink spell={SPELLS.SUDDEN_DEATH_TALENT_BUFF} />{' '}
+            active
+          </>
+        ),
+      },
       description: (
         <>
           Cast <SpellLink spell={executeSpell} /> while in execute range with{' '}
@@ -106,11 +126,14 @@ export const buildSlayerApl = (
     // Exe in execute
     {
       spell: executeSpell,
-      condition: cnd.and(
-        executeUsable,
-        cnd.inExecute(executeThreshold),
-        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 400 }),
-      ),
+      condition: {
+        ...cnd.and(
+          executeUsable,
+          cnd.inExecute(executeThreshold),
+          cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 400 }),
+        ),
+        describe: () => <>you were in execute range with at least 40 rage</>,
+      },
       description: (
         <>
           Cast <SpellLink spell={executeSpell} /> while in execute range with at least 40 rage
@@ -225,13 +248,22 @@ export const buildColossusApl = (
     // MS in exe
     {
       spell: SPELLS.MORTAL_STRIKE,
-      condition: cnd.and(
-        cnd.inExecute(executeThreshold),
-        cnd.or(
-          cnd.buffStacks(SPELLS.EXECUTIONERS_PRECISION_DEBUFF, { atLeast: 2 }),
-          cnd.buffStacks(SPELLS.COLOSSAL_MIGHT, { atMost: 9 }),
+      condition: {
+        ...cnd.and(
+          cnd.inExecute(executeThreshold),
+          cnd.or(
+            cnd.buffStacks(SPELLS.EXECUTIONERS_PRECISION_DEBUFF, { atLeast: 2 }),
+            cnd.buffStacks(SPELLS.COLOSSAL_MIGHT, { atMost: 9 }),
+          ),
         ),
-      ),
+        describe: () => (
+          <>
+            in execute range with 2 stacks of{' '}
+            <SpellLink spell={SPELLS.EXECUTIONERS_PRECISION_DEBUFF} /> or below 10 stacks of{' '}
+            <SpellLink spell={SPELLS.COLOSSAL_MIGHT} />
+          </>
+        ),
+      },
       description: (
         <>
           Cast <SpellLink spell={SPELLS.MORTAL_STRIKE} /> in execute range with 2 stacks of{' '}
@@ -259,11 +291,18 @@ export const buildColossusApl = (
     // Exe with DW and high rage
     {
       spell: executeSpell,
-      condition: cnd.and(
-        cnd.inExecute(executeThreshold),
-        cnd.hasTalent(TALENTS.DEEP_WOUNDS_TALENT),
-        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 750 }),
-      ),
+      condition: {
+        ...cnd.and(
+          cnd.inExecute(executeThreshold),
+          cnd.hasTalent(TALENTS.DEEP_WOUNDS_TALENT),
+          cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 750 }),
+        ),
+        describe: () => (
+          <>
+            you were above 75 rage with <SpellLink spell={TALENTS.DEEP_WOUNDS_TALENT} /> talented
+          </>
+        ),
+      },
       description: (
         <>
           Cast <SpellLink spell={executeSpell} /> with above 75 rage if{' '}
@@ -286,11 +325,14 @@ export const buildColossusApl = (
     // exe in exe
     {
       spell: executeSpell,
-      condition: cnd.and(
-        executeUsable,
-        cnd.inExecute(executeThreshold),
-        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 750 }),
-      ),
+      condition: {
+        ...cnd.and(
+          executeUsable,
+          cnd.inExecute(executeThreshold),
+          cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 750 }),
+        ),
+        describe: () => <>you were above 75 rage in execute range</>,
+      },
       description: (
         <>
           Cast <SpellLink spell={executeSpell} /> in execute range while above 75 rage
@@ -329,10 +371,7 @@ export const buildColossusApl = (
     // Exe with 2 SD
     {
       spell: executeSpell,
-      condition: cnd.and(
-        executeUsable,
-        cnd.buffStacks(SPELLS.SUDDEN_DEATH_TALENT_BUFF, { atLeast: 2 }),
-      ),
+      condition: cnd.buffStacks(SPELLS.SUDDEN_DEATH_TALENT_BUFF, { atLeast: 2 }),
       description: (
         <>
           Cast <SpellLink spell={executeSpell} /> with 2 stacks of{' '}
@@ -366,7 +405,7 @@ export const buildColossusApl = (
     // OP no exe
     {
       spell: SPELLS.OVERPOWER,
-      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold))),
+      condition: cnd.not(cnd.inExecute(executeThreshold)),
       description: (
         <>
           Cast <SpellLink spell={SPELLS.OVERPOWER} />
@@ -377,7 +416,7 @@ export const buildColossusApl = (
     // slam
     {
       spell: SPELLS.SLAM,
-      condition: cnd.and(cnd.not(cnd.inExecute(executeThreshold))),
+      condition: cnd.not(cnd.inExecute(executeThreshold)),
       description: (
         <>
           Cast <SpellLink spell={SPELLS.SLAM} />

--- a/src/analysis/retail/warrior/fury/CHANGELOG.tsx
+++ b/src/analysis/retail/warrior/fury/CHANGELOG.tsx
@@ -2,7 +2,8 @@ import { Gambyt, Nevdok } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
-  change(date(2026, 8, 213), 'Midnight season 2 APL updates', Nevdok),
+  change(date(2026, 8, 29), 'APL cleanup and cleaner violation tooltips', Nevdok),
+  change(date(2026, 8, 13), 'Midnight season 2 APL updates', Nevdok),
   change(date(2026, 4, 25), 'Minor APL updates', Nevdok),
   change(date(2026, 4, 9), 'Fix max casts for Thunder Blast', Gambyt),
   change(date(2026, 4, 3), 'More midnight season 1 APL updates', Nevdok),

--- a/src/analysis/retail/warrior/fury/modules/core/AplCheck.tsx
+++ b/src/analysis/retail/warrior/fury/modules/core/AplCheck.tsx
@@ -37,13 +37,20 @@ export const apl = (info: PlayerInfo): Apl => {
   const executeSpell = info.combatant.hasTalent(TALENTS.MASSACRE_FURY_TALENT)
     ? SPELLS.EXECUTE_FURY_MASSACRE
     : SPELLS.EXECUTE_FURY;
-  const rampageUsable = cnd.or(
-    cnd.and(
-      cnd.buffPresent(SPELLS.RECKLESSNESS),
-      cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 - apexRampageRageReduction }),
+  const rampageUsable = {
+    ...cnd.or(
+      cnd.and(
+        cnd.buffPresent(SPELLS.RECKLESSNESS),
+        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 - apexRampageRageReduction }),
+      ),
+      cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 }),
     ),
-    cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: 800 }),
-  );
+    describe: () => (
+      <>
+        <SpellLink spell={SPELLS.RAMPAGE} /> was usable
+      </>
+    ),
+  };
 
   return info.combatant.hasTalent(TALENTS.SLAYERS_DOMINANCE_TALENT)
     ? buildSlayerApl(
@@ -85,11 +92,18 @@ export const buildSlayerApl = (
     // high rage rampage during reck
     {
       spell: SPELLS.RAMPAGE,
-      condition: cnd.and(
-        cnd.buffPresent(SPELLS.RECKLESSNESS),
-        rampageUsable,
-        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
-      ),
+      condition: {
+        ...cnd.and(
+          cnd.buffPresent(SPELLS.RECKLESSNESS),
+          rampageUsable,
+          cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
+        ),
+        describe: () => (
+          <>
+            above {rampageRageThreshold / 10} rage during <SpellLink spell={SPELLS.RECKLESSNESS} />
+          </>
+        ),
+      },
       description: (
         <>
           Cast <SpellLink spell={SPELLS.RAMPAGE} /> above {rampageRageThreshold / 10} rage during{' '}
@@ -101,14 +115,23 @@ export const buildSlayerApl = (
     // rampage during reck before BS
     {
       spell: SPELLS.RAMPAGE,
-      condition: cnd.and(
-        cnd.buffPresent(SPELLS.RECKLESSNESS),
-        rampageUsable,
-        cnd.spellAvailable(SPELLS.BLADESTORM),
-      ),
+      condition: {
+        ...cnd.and(
+          cnd.buffPresent(SPELLS.RECKLESSNESS),
+          rampageUsable,
+          cnd.spellAvailable(SPELLS.BLADESTORM),
+        ),
+        describe: () => (
+          <>
+            during <SpellLink spell={SPELLS.RECKLESSNESS} /> before{' '}
+            <SpellLink spell={SPELLS.BLADESTORM} />
+          </>
+        ),
+      },
       description: (
         <>
-          Cast <SpellLink spell={SPELLS.RAMPAGE} /> during <SpellLink spell={SPELLS.RECKLESSNESS} />
+          Cast <SpellLink spell={SPELLS.RAMPAGE} /> during <SpellLink spell={SPELLS.RECKLESSNESS} />{' '}
+          before <SpellLink spell={SPELLS.BLADESTORM} />
         </>
       ),
     },
@@ -117,7 +140,6 @@ export const buildSlayerApl = (
     {
       spell: executeSpell,
       condition: cnd.and(
-        executeUsable,
         cnd.buffPresent(SPELLS.RECKLESSNESS),
         cnd.buffPresent(SPELLS.SUDDEN_DEATH_TALENT_BUFF),
       ),
@@ -187,10 +209,13 @@ export const buildSlayerApl = (
     // high rage ramp
     {
       spell: SPELLS.RAMPAGE,
-      condition: cnd.and(
-        cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
-        rampageUsable,
-      ),
+      condition: {
+        ...cnd.and(
+          cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
+          rampageUsable,
+        ),
+        describe: () => <>above {rampageRageThreshold / 10} rage</>,
+      },
       description: (
         <>
           Cast <SpellLink spell={SPELLS.RAMPAGE} /> above {rampageRageThreshold / 10} rage
@@ -256,13 +281,21 @@ export const buildThaneApl = (
     // Enrage or high rage ramp
     {
       spell: SPELLS.RAMPAGE,
-      condition: cnd.and(
-        rampageUsable,
-        cnd.or(
-          cnd.buffMissing(SPELLS.ENRAGE),
-          cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
+      condition: {
+        ...cnd.and(
+          rampageUsable,
+          cnd.or(
+            cnd.buffMissing(SPELLS.ENRAGE),
+            cnd.hasResource(RESOURCE_TYPES.RAGE, { atLeast: rampageRageThreshold }),
+          ),
         ),
-      ),
+        describe: () => (
+          <>
+            <SpellLink spell={SPELLS.ENRAGE} /> was missing, or above {rampageRageThreshold / 10}{' '}
+            rage during <SpellLink spell={SPELLS.RECKLESSNESS} />
+          </>
+        ),
+      },
       description: (
         <>
           Cast <SpellLink spell={SPELLS.RAMPAGE} /> above {rampageRageThreshold / 10} rage, or to


### PR DESCRIPTION
### Description

- Fix goofed changelog dates from https://github.com/WoWAnalyzer/WoWAnalyzer/pull/8007 oops
- Minor APL adjustments
- override a few rule `describe()` functions to provide more clear tooltips in their violation explainers

### Testing

- Test report URL: `/report/P2z3pJrqc4v6Z1dB/60/7`, `/report/zZ16pdqGtQNCRP2h/19-Mythic+Nek'zali+the+Soulcoiler+-+Kill+(5:00)/412-Titangrowl/standard`, `/report/4jvB9GDFYf7PcnzT/23-Mythic+The+Lost+Explorers+-+Kill+(6:27)/5-Murtag/standard/overview`
- Screenshot(s):
Before: 
<img width="563" height="151" alt="image" src="https://github.com/user-attachments/assets/7731f9cf-3f1a-4ea4-82d8-b15548a41ff5" />


After: 
<img width="536" height="126" alt="image" src="https://github.com/user-attachments/assets/1f12f3ed-cc91-4d52-a65d-d1b04dc31777" />
