### PR TITLE
[rShaman] mastery calculations hotfix for venomcursed cantrip items

### DIFF
--- a/src/analysis/retail/shaman/restoration/modules/core/DeepHealing.ts
+++ b/src/analysis/retail/shaman/restoration/modules/core/DeepHealing.ts
@@ -58,9 +58,20 @@ class StatTracker extends CoreStatTracker {
     return super.baseMasteryPercentage + (this.bonusMasterySpellpoints * coefficient) / 100;
   }
 
-  /** Mastery percentage coming from mastery *rating* — gear, gems, enchants, food, flask, procs. */
+  /**
+ * Mastery percentage coming from mastery *rating* — gear, gems, enchants, food, flask, procs.
+ *
   get gearMasteryPercentage(): number {
     return this.currentMasteryPercentage - this.baseMasteryPercentage;
+  }
+ *
+ * Clamped at 0: WCL reports catalyst items with the secondary stats of the original tier drop,
+ * so combatantinfo can report 0 mastery rating for a character that has it. That makes the
+ * rating side of this subtraction go negative. Remove the clamp once WCL is fixed.
+ * https://www.warcraftlogs.com/reports/bRVvBpZNyJ4LmFGr/?fight=55&type=summary&source=3
+ */
+  get gearMasteryPercentage(): number {
+    return Math.max(0, this.currentMasteryPercentage - this.baseMasteryPercentage);
   }
 }
 

--- a/src/analysis/retail/shaman/restoration/modules/core/DeepHealing.ts
+++ b/src/analysis/retail/shaman/restoration/modules/core/DeepHealing.ts
@@ -59,19 +59,17 @@ class StatTracker extends CoreStatTracker {
   }
 
   /**
- * Mastery percentage coming from mastery *rating* — gear, gems, enchants, food, flask, procs.
- *
+   * Mastery percentage coming from mastery *rating* — gear, gems, enchants, food, flask, procs.
+   *
+   * Clamped at 0: WCL reports catalyst items with the secondary stats of the original tier drop,
+   * so combatantinfo can report 0 mastery rating for a character that has it. That makes the
+   * rating side of this subtraction go negative with mastery procs from venomcursed cantrip items.
+   * Observed at -144 rating on the log below.
+   * https://www.warcraftlogs.com/reports/bRVvBpZNyJ4LmFGr/?fight=55&type=summary&source=3
+   * Remove the clamp once WCL is fixed or wowA has modules to account for the buffs.
+   */
   get gearMasteryPercentage(): number {
-    return this.currentMasteryPercentage - this.baseMasteryPercentage;
-  }
- *
- * Clamped at 0: WCL reports catalyst items with the secondary stats of the original tier drop,
- * so combatantinfo can report 0 mastery rating for a character that has it. That makes the
- * rating side of this subtraction go negative. Remove the clamp once WCL is fixed.
- * https://www.warcraftlogs.com/reports/bRVvBpZNyJ4LmFGr/?fight=55&type=summary&source=3
- */
-  get gearMasteryPercentage(): number {
-    return Math.max(0, this.currentMasteryPercentage - this.baseMasteryPercentage);
+    return Math.max(0, this.currentMasteryPercentage - this.innateMasteryPercentage);
   }
 }
 

--- a/src/analysis/retail/shaman/restoration/modules/core/DeepHealing.ts
+++ b/src/analysis/retail/shaman/restoration/modules/core/DeepHealing.ts
@@ -13,12 +13,12 @@ import { DEEP_HEALING_BONUS_SPELLPOINTS } from '../../constants';
  * mastery *rating*, but its buff system is expressed purely in rating, so it has no way to
  * represent auras that grant flat spellpoints.
  *
- * # Nominal values on the ingame tooltip
+ * Nominal values on the ingame tooltip:
  * Class TALENT: Spiritual Awakening +3%
  * Hero TALENT (Totemic): Elemental Attunement +2%
  * Skyfury BUFF: +2%
  *
- * # Translates to ingame reality
+ * Translates to ingame reality:
  * BASE:                  (8) * 3     = 24%
  * Spiritual Awakening:   (8 + 3) * 3 = 33%
  * Elemental Attunement:  (8 + 2) * 3 = 30%

--- a/src/analysis/retail/shaman/restoration/modules/features/MasteryEffectiveness.jsx
+++ b/src/analysis/retail/shaman/restoration/modules/features/MasteryEffectiveness.jsx
@@ -49,7 +49,9 @@ class MasteryEffectiveness extends Analyzer {
     // Proportional split: if 40% of the mastery percentage came from rating, 40% of this heal's
     // mastery healing is credited to gear. Read per event so trinket procs are attributed to gear.
     const gearShare =
-      masteryPercent > 0 ? this.statTracker.gearMasteryPercentage / masteryPercent : 0;
+      masteryPercent > 0
+        ? Math.min(1, Math.max(0, this.statTracker.gearMasteryPercentage / masteryPercent))
+        : 0;
     const effectiveMasteryHealing = Math.max(0, masteryHealingDone - (event.overheal || 0));
 
     this.totalMasteryHealing += effectiveMasteryHealing;

--- a/src/analysis/retail/shaman/restoration/modules/features/MasteryEffectiveness.jsx
+++ b/src/analysis/retail/shaman/restoration/modules/features/MasteryEffectiveness.jsx
@@ -117,7 +117,8 @@ class MasteryEffectiveness extends Analyzer {
             <div>
               <strong>{formatPercentage(this.gearMasteryHealingPercent)}%</strong> — Of that
               increase, the share coming from mastery rating on your gear and consumables. The rest
-              comes from your base spellpoints, talents and Skyfury.
+              comes from your base spellpoints, talents and Skyfury. But not accounting recudtion
+              below 0% from venomcursed cantrip items.
             </div>
           </>
         }


### PR DESCRIPTION
### Description

Clamping mastery from gear to account for cantrip items that are not yet accounted for in statTracker.
https://www.wowhead.com/spell=1317582/venomcursed-ascendance

wcl discord: https://discord.com/channels/180033360939319296/687319213127237663/1543931927931781255
wowA discord: https://discord.com/channels/316864121536512000/316864385052049420/1543933355119083562

### Testing

- Test report URL: `/report/bRVvBpZNyJ4LmFGr/55-Mythic++Kings'+Rest+-+Kill+(31:55)/3-Driptinus/standard/statistics`
- Screenshot(s):

Before: 
<img width="608" height="158" alt="image" src="https://github.com/user-attachments/assets/3dcd8a21-65bb-4cfb-9668-7bef0fd40e1d" />

After: 
<img width="588" height="164" alt="image" src="https://github.com/user-attachments/assets/024beeb3-5060-43c7-9bfe-1f8b97b25fcf" />

--- 
<img width="1345" height="877" alt="image" src="https://github.com/user-attachments/assets/2a962cac-1be6-4186-8b50-095854710d5c" />
<img width="672" height="794" alt="image" src="https://github.com/user-attachments/assets/a69f3932-99c2-4b35-b2d9-d2314aff48fb" />
<img width="730" height="85" alt="image" src="https://github.com/user-attachments/assets/59bac0c2-d33e-465a-9922-0f9bf3c440c4" />
<img width="654" height="819" alt="image" src="https://github.com/user-attachments/assets/36d615bd-9073-4a63-8a8b-55f048f364a6" />
<img width="515" height="863" alt="image" src="https://github.com/user-attachments/assets/4c7434ed-9b39-45f4-95a4-cab2a88cb1b7" />
