### PR TITLE
[Monk][Windwalker][Shadopan] Only consider Zenith Stomp if talented into it

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -71,6 +71,10 @@ export const Dummy: Contributor = {
   twitter: '@Dummy',
   avatar: avatar('zerotorescue-avatar.jpg'),
 };
+export const TastyArsenic: Contributor = {
+  nickname: 'TastyArsenic',
+  github: 'francozanini',
+};
 export const Zerotorescue: Contributor = {
   nickname: 'Zerotorescue',
   github: 'MartijnHols',

--- a/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/windwalker/CHANGELOG.tsx
@@ -1,10 +1,18 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/monk';
-import { Durpn, swirl } from 'CONTRIBUTORS';
+import { Durpn, swirl, TastyArsenic } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(
+    date(2026, 9, 3),
+    <>
+      <SpellLink spell={TALENTS.ZENITH_STOMP_TALENT} /> is no longer suggested in the Shado-Pan APL
+      unless <SpellLink spell={TALENTS.TIGEREYE_BREW_3_WINDWALKER_TALENT} /> is talented.
+    </>,
+    TastyArsenic,
+  ),
   change(
     date(2026, 7, 22),
     <>

--- a/src/analysis/retail/monk/windwalker/modules/apl/ShadoPanApl.tsx
+++ b/src/analysis/retail/monk/windwalker/modules/apl/ShadoPanApl.tsx
@@ -39,11 +39,16 @@ export default function shadoPanApl(combatant: Combatant): Apl {
     {
       spell: TALENTS.ZENITH_STOMP_TALENT,
       condition: describe(
-        or(
-          hasResource(RESOURCE_TYPES.CHI, { atMost: 2 }),
-          and(
-            buffPresent(TALENTS.ZENITH_TALENT),
-            buffRemaining(TALENTS.ZENITH_TALENT, getZenithDurationMs(combatant), { atMost: 3000 }),
+        and(
+          hasTalent(TALENTS.TIGEREYE_BREW_3_WINDWALKER_TALENT),
+          or(
+            hasResource(RESOURCE_TYPES.CHI, { atMost: 2 }),
+            and(
+              buffPresent(TALENTS.ZENITH_TALENT),
+              buffRemaining(TALENTS.ZENITH_TALENT, getZenithDurationMs(combatant), {
+                atMost: 3000,
+              }),
+            ),
           ),
         ),
         () => (


### PR DESCRIPTION
### Description

Access to `Zenith Stomp` requires 3 points in Windwalker's apex talent `Tigereyes Brew`.  I added a condition to check that the character has that many points in the talent before running the combo strikes APL. 
### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

You can see the problem live if you go to this analysis of my character and scroll down to the `Most Common Problems` section.

<img width="1113" height="498" alt="Screenshot 2026-09-03 at 01 04 31" src="https://github.com/user-attachments/assets/4d331bf4-c66f-4c6a-9763-150f764dc410" />

And this is how it looks on this branch:

<img width="1250" height="495" alt="Screenshot 2026-09-03 at 01 06 07" src="https://github.com/user-attachments/assets/da473843-0dc3-4771-95f8-3e9b1a914add" />

