### PR TITLE
Add M+ Pull List

### DIFF
--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -52,9 +52,15 @@ export function formatDuration(duration: number, precision = 0): string {
 /**
  * Like `formatDuration`, but formats it as "Xm Ys".
  */
-export function formatDurationMinSec(duration: number, omitSeconds = false): string {
+export function formatDurationMinSec(
+  duration: number,
+  omitSeconds = false,
+  secondsPrecision = 1,
+): string {
   const minutes = Math.floor(duration / 60);
-  const seconds = Number.isInteger(duration) ? duration % 60 : (duration % 60).toFixed(1);
+  const seconds = Number.isInteger(duration)
+    ? duration % 60
+    : (duration % 60).toFixed(secondsPrecision);
 
   if (omitSeconds && minutes > 0) {
     return `${minutes}m`;

--- a/src/interface/Icon.tsx
+++ b/src/interface/Icon.tsx
@@ -18,18 +18,19 @@ export type SvgIconProps = Omit<
   'xmlns' | 'version' | 'viewBox' | 'className'
 >;
 
+const ICON_FOLDER_NAMES = ['NPC'];
+
 export function iconUrl(icon: string): string {
   let [folder, name] = icon.split('/');
   if (name === undefined) {
-    name = folder;
-    if (folder.match(/^custom-icon-/)) {
-      folder = 'abilities';
-    } else {
-      folder = 'icons';
-    }
+    [folder, name] = ['abilities', folder];
   }
 
   icon = name.replace('.jpg', '').replace(/^custom-icon-/, '');
+
+  if (ICON_FOLDER_NAMES.includes(icon)) {
+    folder = 'icons';
+  }
 
   if (ICON_RENAME[icon]) {
     icon = ICON_RENAME[icon];

--- a/src/interface/Icon.tsx
+++ b/src/interface/Icon.tsx
@@ -21,7 +21,12 @@ export type SvgIconProps = Omit<
 export function iconUrl(icon: string): string {
   let [folder, name] = icon.split('/');
   if (name === undefined) {
-    [folder, name] = ['abilities', folder];
+    name = folder;
+    if (folder.match(/^custom-icon-/)) {
+      folder = 'abilities';
+    } else {
+      folder = 'icons';
+    }
   }
 
   icon = name.replace('.jpg', '').replace(/^custom-icon-/, '');

--- a/src/interface/LoadingSpinner.module.scss
+++ b/src/interface/LoadingSpinner.module.scss
@@ -1,0 +1,108 @@
+// CSS is MIT licensed from https://github.com/vineethtrv/css-loader
+.loader {
+  --color-1: #ffffff;
+  --color-2: rgba(255, 255, 255, 0.2);
+  --color-3: rgba(255, 255, 255, 0.5);
+  --color-4: rgba(255, 255, 255, 0.7);
+  --size: 0.4px;
+
+  font-size: calc(10 * var(--size));
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  position: relative;
+  text-indent: -9999em;
+  animation: mulShdSpin 1.1s infinite ease;
+  transform: translateZ(0);
+}
+@keyframes mulShdSpin {
+  0%,
+  100% {
+    box-shadow:
+      0em -2.6em 0em 0em var(--color-1),
+      1.8em -1.8em 0 0em var(--color-2),
+      2.5em 0em 0 0em var(--color-2),
+      1.75em 1.75em 0 0em var(--color-2),
+      0em 2.5em 0 0em var(--color-2),
+      -1.8em 1.8em 0 0em var(--color-2),
+      -2.6em 0em 0 0em var(--color-3),
+      -1.8em -1.8em 0 0em var(--color-4);
+  }
+  12.5% {
+    box-shadow:
+      0em -2.6em 0em 0em var(--color-4),
+      1.8em -1.8em 0 0em var(--color-1),
+      2.5em 0em 0 0em var(--color-2),
+      1.75em 1.75em 0 0em var(--color-2),
+      0em 2.5em 0 0em var(--color-2),
+      -1.8em 1.8em 0 0em var(--color-2),
+      -2.6em 0em 0 0em var(--color-2),
+      -1.8em -1.8em 0 0em var(--color-3);
+  }
+  25% {
+    box-shadow:
+      0em -2.6em 0em 0em var(--color-3),
+      1.8em -1.8em 0 0em var(--color-4),
+      2.5em 0em 0 0em var(--color-1),
+      1.75em 1.75em 0 0em var(--color-2),
+      0em 2.5em 0 0em var(--color-2),
+      -1.8em 1.8em 0 0em var(--color-2),
+      -2.6em 0em 0 0em var(--color-2),
+      -1.8em -1.8em 0 0em var(--color-2);
+  }
+  37.5% {
+    box-shadow:
+      0em -2.6em 0em 0em var(--color-2),
+      1.8em -1.8em 0 0em var(--color-3),
+      2.5em 0em 0 0em var(--color-4),
+      1.75em 1.75em 0 0em var(--color-1),
+      0em 2.5em 0 0em var(--color-2),
+      -1.8em 1.8em 0 0em var(--color-2),
+      -2.6em 0em 0 0em var(--color-2),
+      -1.8em -1.8em 0 0em var(--color-2);
+  }
+  50% {
+    box-shadow:
+      0em -2.6em 0em 0em var(--color-2),
+      1.8em -1.8em 0 0em var(--color-2),
+      2.5em 0em 0 0em var(--color-3),
+      1.75em 1.75em 0 0em var(--color-4),
+      0em 2.5em 0 0em var(--color-1),
+      -1.8em 1.8em 0 0em var(--color-2),
+      -2.6em 0em 0 0em var(--color-2),
+      -1.8em -1.8em 0 0em var(--color-2);
+  }
+  62.5% {
+    box-shadow:
+      0em -2.6em 0em 0em var(--color-2),
+      1.8em -1.8em 0 0em var(--color-2),
+      2.5em 0em 0 0em var(--color-2),
+      1.75em 1.75em 0 0em var(--color-3),
+      0em 2.5em 0 0em var(--color-4),
+      -1.8em 1.8em 0 0em var(--color-1),
+      -2.6em 0em 0 0em var(--color-2),
+      -1.8em -1.8em 0 0em var(--color-2);
+  }
+  75% {
+    box-shadow:
+      0em -2.6em 0em 0em var(--color-2),
+      1.8em -1.8em 0 0em var(--color-2),
+      2.5em 0em 0 0em var(--color-2),
+      1.75em 1.75em 0 0em var(--color-2),
+      0em 2.5em 0 0em var(--color-3),
+      -1.8em 1.8em 0 0em var(--color-4),
+      -2.6em 0em 0 0em var(--color-1),
+      -1.8em -1.8em 0 0em var(--color-2);
+  }
+  87.5% {
+    box-shadow:
+      0em -2.6em 0em 0em var(--color-2),
+      1.8em -1.8em 0 0em var(--color-2),
+      2.5em 0em 0 0em var(--color-2),
+      1.75em 1.75em 0 0em var(--color-2),
+      0em 2.5em 0 0em var(--color-2),
+      -1.8em 1.8em 0 0em var(--color-3),
+      -2.6em 0em 0 0em var(--color-4),
+      -1.8em -1.8em 0 0em var(--color-1);
+  }
+}

--- a/src/interface/LoadingSpinner.tsx
+++ b/src/interface/LoadingSpinner.tsx
@@ -1,0 +1,7 @@
+import { JSX } from 'react';
+import styles from './LoadingSpinner.module.scss';
+import clsx from 'clsx';
+
+export default function LoadingSpinner(props: React.ComponentProps<'div'>): JSX.Element {
+  return <div {...props} className={clsx(props.className, styles.loader)} />;
+}

--- a/src/interface/RootErrorBoundary.tsx
+++ b/src/interface/RootErrorBoundary.tsx
@@ -6,6 +6,7 @@ import ApiDownBackground from 'interface/images/api-down-background.gif';
 import { PureComponent, ErrorInfo, ReactNode } from 'react';
 
 import { EventsParseError } from './report/hooks/useEventParser';
+import { UnknownApiError } from 'common/fetchWclApi';
 
 interface HandledError {
   message: string;
@@ -18,6 +19,9 @@ interface HandledError {
 // our error handling. If a plug-in like Google Translate messes with the DOM and that breaks the
 // app, that triggers a different error so those third party issues are still handled.
 const isTriggeredByExternalScript = (error: HandledError) => {
+  if (error instanceof UnknownApiError) {
+    return false;
+  }
   if (!error || error.message === 'Script error.') {
     return true;
   }

--- a/src/interface/controls/Button.module.scss
+++ b/src/interface/controls/Button.module.scss
@@ -7,7 +7,17 @@
   border-radius: 0.5rem;
   padding: 0 1rem;
 
+  cursor: pointer;
+
   &:hover {
     filter: brightness(115%);
+  }
+
+  &:disabled {
+    filter: brightness(70%);
+    cursor: not-allowed;
+    &:hover {
+      filter: brightness(70%);
+    }
   }
 }

--- a/src/interface/guide/foundation/ByRole.tsx
+++ b/src/interface/guide/foundation/ByRole.tsx
@@ -37,7 +37,13 @@ type RoleShorthand = (props: Pick<RoleProps, 'children'>) => JSX.Element | null;
 const Melee: RoleShorthand = ({ children }) => <Role roles={MELEE}>{children}</Role>;
 const Caster: RoleShorthand = ({ children }) => <Role roles={CASTER}>{children}</Role>;
 const Healer: RoleShorthand = ({ children }) => <Role role={ROLES.HEALER}>{children}</Role>;
+const Tank: RoleShorthand = ({ children }) => <Role role={ROLES.TANK}>{children}</Role>;
+const DPS: RoleShorthand = ({ children }) => (
+  <Role roles={[ROLES.DPS.MELEE, ROLES.DPS.RANGED]}>{children}</Role>
+);
 
 Role.Melee = Melee;
 Role.Caster = Caster;
 Role.Healer = Healer;
+Role.Tank = Tank;
+Role.DPS = DPS;

--- a/src/interface/makeAnalyzerUrl.ts
+++ b/src/interface/makeAnalyzerUrl.ts
@@ -38,6 +38,7 @@ export default function makeReportUrl(
   playerId?: number,
   tab?: string,
   build = 'standard',
+  pull?: 'all' | number,
 ) {
   const parts = [];
   if (report) {
@@ -63,7 +64,18 @@ export default function makeReportUrl(
       }
     }
   }
-  return `/${parts.join('/')}`;
+  let url = `/${parts.join('/')}`;
+
+  const search = new URLSearchParams();
+  if (pull) {
+    search.set('pull', pull.toString());
+  }
+
+  if (search.size > 0) {
+    url += `?${search.toString()}`;
+  }
+
+  return url;
 }
 
 export function makeCharacterUrl(player: Combatant) {

--- a/src/interface/reducers/navigation.ts
+++ b/src/interface/reducers/navigation.ts
@@ -9,6 +9,7 @@ interface NavigationState {
     link: string;
     title: string;
   };
+  pull?: 'all' | number;
 }
 
 const initialState: NavigationState = {};
@@ -19,7 +20,7 @@ const navigationSlice = createSlice({
   reducers: {
     reset: () => initialState,
     clearReport: (state) => ({ ...state, report: undefined }),
-    clearFight: (state) => ({ ...state, fight: undefined }),
+    clearFight: (state) => ({ ...state, fight: undefined, pull: undefined }),
     setReport: (state, action: PayloadAction<{ link: string; title: string }>) => ({
       ...state,
       report: { link: action.payload.link, title: action.payload.title },
@@ -28,8 +29,14 @@ const navigationSlice = createSlice({
       ...state,
       fight: { link: action.payload.link, title: action.payload.title },
     }),
+    clearPull: (state) => ({ ...state, pull: undefined }),
+    setPull: (state, action: PayloadAction<{ id: 'all' | number }>) => ({
+      ...state,
+      pull: action.payload.id,
+    }),
   },
 });
 
-export const { clearReport, clearFight, reset, setReport, setFight } = navigationSlice.actions;
+export const { clearReport, clearFight, reset, setReport, setFight, clearPull, setPull } =
+  navigationSlice.actions;
 export const { reducer } = navigationSlice;

--- a/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
+++ b/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
@@ -9,6 +9,7 @@ import Auras from 'parser/core/modules/Auras';
 import Report from 'parser/core/Report';
 import Events, {
   AbilityEvent,
+  ApplyBuffEvent,
   CombatantInfoEvent,
   DeathEvent,
   EventType,
@@ -26,6 +27,7 @@ import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import SpellManaCost from 'parser/shared/modules/SpellManaCost';
 import Enemies from 'parser/shared/modules/Enemies';
 import Combatants from 'parser/shared/modules/Combatants';
+import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
 
 export class RetailDungeonPullListCombatParser extends CombatLogParser {
   static defaultModules: DependenciesDefinition = {
@@ -49,6 +51,9 @@ class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
   cooldowns: Ability[] = [];
   defensives: Ability[] = [];
 
+  // we can't see the actual cast. so if it was used and you were dead, no way to practically tell.
+  #bloodlustUses: ApplyBuffEvent[] = [];
+
   constructor(options: Options) {
     super(options);
 
@@ -70,6 +75,19 @@ class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
         this.defensives.push(ability);
       }
     });
+
+    this.addEventListener(
+      Events.applybuff.spell(
+        Object.keys(BLOODLUST_BUFFS)
+          .map((id) => Number(id))
+          .map((id) => ({ id })),
+      ),
+      this.recordBloodlustUse,
+    );
+  }
+
+  private recordBloodlustUse(event: ApplyBuffEvent) {
+    this.#bloodlustUses.push(event);
   }
 
   private addCooldownUse(event: AbilityEvent<EventType>) {
@@ -90,6 +108,7 @@ class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
   ): DungeonPullDetails[] {
     const cooldownUses = new StateHistory(this.#cooldownUses);
     const defensiveUses = new StateHistory(this.#defensiveUses);
+    const bloodlustUses = new StateHistory(this.#bloodlustUses); // should only be a few but the timestamp api is nicer and with so few the perf is not relevant
     const allDeaths = new StateHistory(allDeathEvents ?? []);
 
     let totalCount = 0;
@@ -148,6 +167,8 @@ class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
             ),
           )
           .data.filter((event) => this.deps.combatants.getEntity(event)),
+        bloodlustUsed:
+          bloodlustUses.slice(pull.target.start_time, pull.target.end_time).data.length > 0,
       };
     });
   }
@@ -164,7 +185,7 @@ export interface DungeonPullDetails {
   countGained: number;
   countAtEnd: number;
   deaths: DeathEvent[];
-  // TODO: bloodlust!
+  bloodlustUsed: boolean;
 }
 
 function usePlayerCombatantInfo(

--- a/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
+++ b/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
@@ -241,10 +241,6 @@ export default function useDungeonPullList({
 }): DungeonPullDetails[] {
   const nextPullIndex = useRef(0);
 
-  useEffect(() => {
-    nextPullIndex.current = 0;
-  }, [fight, report]);
-
   const playerCombatantInfo = usePlayerCombatantInfo(player.id, pulls);
 
   const parserClass = useMemo(
@@ -264,24 +260,33 @@ export default function useDungeonPullList({
     [baseParser],
   );
 
-  const parser = useMemo(
-    () =>
-      parserClass && playerCombatantInfo
-        ? new parserClass(
-            config,
-            report,
-            player,
-            {
-              ...fight,
-              offset_time: 0,
-            },
-            playerCombatantInfo,
-            characterProfile!,
-            allPlayers,
-          )
-        : undefined,
-    [config, report, player, fight, playerCombatantInfo, characterProfile, allPlayers, parserClass],
-  );
+  const parser = useMemo(() => {
+    nextPullIndex.current = 0;
+
+    return parserClass && playerCombatantInfo
+      ? new parserClass(
+          config,
+          report,
+          player,
+          {
+            ...fight,
+            offset_time: 0,
+          },
+          playerCombatantInfo,
+          characterProfile!,
+          allPlayers,
+        )
+      : undefined;
+  }, [
+    config,
+    report,
+    player,
+    fight,
+    playerCombatantInfo,
+    characterProfile,
+    allPlayers,
+    parserClass,
+  ]);
 
   return useMemo(() => {
     if (!parser) {

--- a/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
+++ b/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
@@ -5,7 +5,6 @@ import { PlayerDetails } from 'parser/core/Player';
 import { DungeonPullEvents } from '../hooks/useEvents';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Abilities from 'parser/core/modules/Abilities';
-import Auras from 'parser/core/modules/Auras';
 import Report from 'parser/core/Report';
 import Events, {
   AbilityEvent,
@@ -40,7 +39,6 @@ export class RetailDungeonPullListCombatParser extends CombatLogParser {
 
 class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
   abilities: Abilities,
-  auras: Auras,
   abilityTracker: AbilityTracker,
   enemies: Enemies,
   combatants: Combatants,
@@ -260,7 +258,6 @@ export default function useDungeonPullList({
 
             static specModules: DependenciesDefinition = {
               abilities: CombatLogParser.getModuleClass(baseParser!, Abilities)!,
-              auras: CombatLogParser.getModuleClass(baseParser!, Auras)!,
             };
           }
         : undefined,

--- a/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
+++ b/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
@@ -1,0 +1,232 @@
+import Config from 'parser/Config';
+import CombatLogParser, { DependenciesDefinition } from 'parser/core/CombatLogParser';
+import { WCLDungeonPull, WCLFight } from 'parser/core/Fight';
+import { PlayerDetails } from 'parser/core/Player';
+import { DungeonPullEvents } from '../hooks/useEvents';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Abilities from 'parser/core/modules/Abilities';
+import Auras from 'parser/core/modules/Auras';
+import Report from 'parser/core/Report';
+import Events, {
+  AbilityEvent,
+  CombatantInfoEvent,
+  DeathEvent,
+  EventType,
+} from 'parser/core/Events';
+import CharacterProfile from 'parser/core/CharacterProfile';
+import EventEmitter from 'parser/core/modules/EventEmitter';
+import Spell from 'common/SPELLS/Spell';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+import Ability from 'parser/core/modules/Ability';
+import StateHistory from 'parser/core/StateHistory';
+import Haste from 'parser/shared/modules/Haste';
+import StatTracker from 'parser/shared/modules/StatTracker';
+import AbilityTracker from 'parser/shared/modules/AbilityTracker';
+import SpellManaCost from 'parser/shared/modules/SpellManaCost';
+
+export class RetailDungeonPullListCombatParser extends CombatLogParser {
+  static defaultModules: DependenciesDefinition = {
+    haste: Haste,
+    statTracker: StatTracker,
+    spellManaCost: SpellManaCost,
+    abilityTracker: AbilityTracker,
+  };
+}
+
+class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
+  abilities: Abilities,
+  auras: Auras,
+  abilityTracker: AbilityTracker,
+}) {
+  #cooldownUses: AbilityEvent<EventType>[] = [];
+  #defensiveUses: AbilityEvent<EventType>[] = [];
+
+  cooldowns: Ability[] = [];
+  defensives: Ability[] = [];
+
+  constructor(options: Options) {
+    super(options);
+
+    this.deps.abilities.activeAbilities.forEach((ability) => {
+      const spells = Array.isArray(ability.spell)
+        ? ability.spell.map((id) => ({ id }))
+        : { id: ability.spell };
+      if (ability.category === SPELL_CATEGORY.COOLDOWNS) {
+        this.addEventListener(Events.cast.spell(spells).by(SELECTED_PLAYER), this.addCooldownUse);
+        this.cooldowns.push(ability);
+      }
+
+      if (ability.category === SPELL_CATEGORY.DEFENSIVE && ability.cooldown >= 60) {
+        this.addEventListener(
+          Events.cast.spell(spells).by(SELECTED_PLAYER),
+          this.addDefensiveCooldownUse,
+        );
+
+        this.defensives.push(ability);
+      }
+    });
+  }
+
+  private addCooldownUse(event: AbilityEvent<EventType>) {
+    this.#cooldownUses.push(event);
+  }
+
+  private addDefensiveCooldownUse(event: AbilityEvent<EventType>) {
+    this.#defensiveUses.push(event);
+  }
+
+  private static uniqueAbilityIds(events: AbilityEvent<EventType>[]): number[] {
+    return Array.from(new Set(events.map((event) => event.ability.guid)));
+  }
+
+  getDetails(pulls: Pick<DungeonPullEvents, 'target'>[]): DungeonPullDetails[] {
+    const cooldownUses = new StateHistory(this.#cooldownUses);
+    const defensiveUses = new StateHistory(this.#defensiveUses);
+
+    return pulls.map((pull) => {
+      const durationSec = (pull.target.end_time - pull.target.start_time) / 1000;
+
+      return {
+        pull: pull.target,
+        dps:
+          this.deps.abilityTracker.getTotalDamageInRange(
+            pull.target.start_time,
+            pull.target.end_time,
+          ) / durationSec,
+        hps:
+          this.deps.abilityTracker.getTotalHealingInRange(
+            pull.target.start_time,
+            pull.target.end_time,
+          ) / durationSec,
+
+        cooldownsUsed: DungeonPullDetailsGenerator.uniqueAbilityIds(
+          cooldownUses.slice(pull.target.start_time, pull.target.end_time).data,
+        ),
+        defensivesUsed: DungeonPullDetailsGenerator.uniqueAbilityIds(
+          defensiveUses.slice(pull.target.start_time, pull.target.end_time).data,
+        ),
+        deaths: [],
+      };
+    });
+  }
+}
+
+export interface DungeonPullDetails {
+  pull: WCLDungeonPull;
+  dps: number;
+  hps: number;
+  cooldownsUsed: Spell['id'][];
+  defensivesUsed: Spell['id'][];
+  deaths: DeathEvent[];
+}
+
+function usePlayerCombatantInfo(
+  playerId: number,
+  pulls: DungeonPullEvents[],
+): CombatantInfoEvent | undefined {
+  const [event, setEvent] = useState<CombatantInfoEvent | undefined>();
+
+  useEffect(() => {
+    if (event && playerId !== event.sourceID) {
+      setEvent(undefined);
+    }
+  }, [playerId, event]);
+
+  useEffect(() => {
+    if (event) {
+      return;
+    }
+
+    for (const pull of pulls) {
+      const event = pull.events.find(
+        (event) => event.type === EventType.CombatantInfo && event.sourceID === playerId,
+      );
+
+      if (event) {
+        setEvent(event as CombatantInfoEvent);
+        break;
+      }
+    }
+  }, [event, pulls, playerId, pulls.length]);
+
+  return event;
+}
+
+export default function useDungeonPullList({
+  fight,
+  config,
+  player,
+  pulls,
+  parser: baseParser,
+  report,
+  characterProfile,
+  allPlayers,
+}: {
+  fight: WCLFight;
+  config: Config;
+  player: PlayerDetails;
+  pulls: DungeonPullEvents[];
+  parser: typeof CombatLogParser | undefined;
+  report: Report;
+  characterProfile: CharacterProfile | null;
+  allPlayers: PlayerDetails[];
+}): DungeonPullDetails[] {
+  const nextPullIndex = useRef(0);
+
+  const playerCombatantInfo = usePlayerCombatantInfo(player.id, pulls);
+
+  const parserClass = useMemo(
+    () =>
+      baseParser
+        ? class extends RetailDungeonPullListCombatParser {
+            static internalModules: DependenciesDefinition = {
+              ...baseParser!.internalModules,
+              dungeonPullDetails: DungeonPullDetailsGenerator,
+            };
+
+            static specModules: DependenciesDefinition = {
+              abilities: CombatLogParser.getModuleClass(baseParser!, Abilities)!,
+              auras: CombatLogParser.getModuleClass(baseParser!, Auras)!,
+            };
+          }
+        : undefined,
+    [baseParser],
+  );
+
+  const parser = useMemo(
+    () =>
+      parserClass && playerCombatantInfo
+        ? new parserClass(
+            config,
+            report,
+            player,
+            {
+              ...fight,
+              offset_time: 0,
+            },
+            playerCombatantInfo,
+            characterProfile!,
+            allPlayers,
+          )
+        : undefined,
+    [config, report, player, fight, playerCombatantInfo, characterProfile, allPlayers, parserClass],
+  );
+
+  return useMemo(() => {
+    if (!parser) {
+      return [];
+    }
+    const emitter = parser.getModule(EventEmitter);
+    for (const pull of pulls.slice(nextPullIndex.current)) {
+      const events = parser
+        .normalize(pull.events.map((event) => ({ ...event })))
+        .sort((a, b) => a.timestamp - b.timestamp);
+
+      events.forEach(emitter.triggerEvent.bind(emitter));
+    }
+    nextPullIndex.current = pulls.length;
+
+    return parser.getModule(DungeonPullDetailsGenerator).getDetails(pulls);
+  }, [pulls, parser]);
+}

--- a/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
+++ b/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
@@ -24,6 +24,8 @@ import Haste from 'parser/shared/modules/Haste';
 import StatTracker from 'parser/shared/modules/StatTracker';
 import AbilityTracker from 'parser/shared/modules/AbilityTracker';
 import SpellManaCost from 'parser/shared/modules/SpellManaCost';
+import Enemies from 'parser/shared/modules/Enemies';
+import Combatants from 'parser/shared/modules/Combatants';
 
 export class RetailDungeonPullListCombatParser extends CombatLogParser {
   static defaultModules: DependenciesDefinition = {
@@ -38,6 +40,8 @@ class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
   abilities: Abilities,
   auras: Auras,
   abilityTracker: AbilityTracker,
+  enemies: Enemies,
+  combatants: Combatants,
 }) {
   #cooldownUses: AbilityEvent<EventType>[] = [];
   #defensiveUses: AbilityEvent<EventType>[] = [];
@@ -80,12 +84,29 @@ class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
     return Array.from(new Set(events.map((event) => event.ability.guid)));
   }
 
-  getDetails(pulls: Pick<DungeonPullEvents, 'target'>[]): DungeonPullDetails[] {
+  getDetails(
+    pulls: Pick<DungeonPullEvents, 'target'>[],
+    allDeathEvents: DeathEvent[] | undefined,
+  ): DungeonPullDetails[] {
     const cooldownUses = new StateHistory(this.#cooldownUses);
     const defensiveUses = new StateHistory(this.#defensiveUses);
+    const allDeaths = new StateHistory(allDeathEvents ?? []);
+
+    let totalCount = 0;
 
     return pulls.map((pull) => {
       const durationSec = (pull.target.end_time - pull.target.start_time) / 1000;
+      const countGained = allDeaths
+        .slice(pull.target.start_time, pull.target.end_time)
+        .data.map(
+          (event) =>
+            this.owner.fight.npcCountMap?.[this.deps.enemies.getById(event.targetID)?.guid ?? 0] ??
+            0,
+        )
+        .filter((count) => count > 0)
+        .reduce((a, b) => a + b, 0);
+
+      totalCount += countGained;
 
       return {
         pull: pull.target,
@@ -106,7 +127,11 @@ class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
         defensivesUsed: DungeonPullDetailsGenerator.uniqueAbilityIds(
           defensiveUses.slice(pull.target.start_time, pull.target.end_time).data,
         ),
-        deaths: [],
+        countGained,
+        countAtEnd: totalCount,
+        deaths: allDeaths
+          .slice(pull.target.start_time, pull.target.end_time)
+          .data.filter((event) => this.deps.combatants.getEntity(event)),
       };
     });
   }
@@ -118,6 +143,8 @@ export interface DungeonPullDetails {
   hps: number;
   cooldownsUsed: Spell['id'][];
   defensivesUsed: Spell['id'][];
+  countGained: number;
+  countAtEnd: number;
   deaths: DeathEvent[];
 }
 
@@ -162,6 +189,7 @@ export default function useDungeonPullList({
   report,
   characterProfile,
   allPlayers,
+  allDeaths,
 }: {
   fight: WCLFight;
   config: Config;
@@ -171,6 +199,7 @@ export default function useDungeonPullList({
   report: Report;
   characterProfile: CharacterProfile | null;
   allPlayers: PlayerDetails[];
+  allDeaths: DeathEvent[] | undefined;
 }): DungeonPullDetails[] {
   const nextPullIndex = useRef(0);
 
@@ -227,6 +256,6 @@ export default function useDungeonPullList({
     }
     nextPullIndex.current = pulls.length;
 
-    return parser.getModule(DungeonPullDetailsGenerator).getDetails(pulls);
-  }, [pulls, parser]);
+    return parser.getModule(DungeonPullDetailsGenerator).getDetails(pulls, allDeaths);
+  }, [pulls, parser, allDeaths]);
 }

--- a/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
+++ b/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
@@ -94,7 +94,7 @@ class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
 
     let totalCount = 0;
 
-    return pulls.map((pull) => {
+    return pulls.map((pull, index, allPulls) => {
       const durationSec = (pull.target.end_time - pull.target.start_time) / 1000;
       const countGained = allDeaths
         .slice(pull.target.start_time, pull.target.end_time)
@@ -110,6 +110,8 @@ class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
 
       return {
         pull: pull.target,
+        cooldowns: this.cooldowns.map((cd) => cd.primarySpell),
+        defensives: this.defensives.map((cd) => cd.primarySpell),
         dps:
           this.deps.abilityTracker.getTotalDamageInRange(
             pull.target.start_time,
@@ -130,7 +132,14 @@ class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
         countGained,
         countAtEnd: totalCount,
         deaths: allDeaths
-          .slice(pull.target.start_time, pull.target.end_time)
+          // due to WCL combat end logic, the death may appear shortly after a pull ends on a full wipe
+          .slice(
+            pull.target.start_time,
+            Math.min(
+              pull.target.end_time + 1000,
+              allPulls[index + 1]?.target.start_time ?? Infinity,
+            ),
+          )
           .data.filter((event) => this.deps.combatants.getEntity(event)),
       };
     });
@@ -141,11 +150,14 @@ export interface DungeonPullDetails {
   pull: WCLDungeonPull;
   dps: number;
   hps: number;
+  cooldowns: Spell['id'][];
+  defensives: Spell['id'][];
   cooldownsUsed: Spell['id'][];
   defensivesUsed: Spell['id'][];
   countGained: number;
   countAtEnd: number;
   deaths: DeathEvent[];
+  // TODO: bloodlust!
 }
 
 function usePlayerCombatantInfo(
@@ -202,6 +214,10 @@ export default function useDungeonPullList({
   allDeaths: DeathEvent[] | undefined;
 }): DungeonPullDetails[] {
   const nextPullIndex = useRef(0);
+
+  useEffect(() => {
+    nextPullIndex.current = 0;
+  }, [fight, report]);
 
   const playerCombatantInfo = usePlayerCombatantInfo(player.id, pulls);
 

--- a/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
+++ b/src/interface/report/DungeonPullList/DungeonPullListCombatParser.ts
@@ -98,7 +98,14 @@ class DungeonPullDetailsGenerator extends Analyzer.withDependencies({
       const durationSec = (pull.target.end_time - pull.target.start_time) / 1000;
       const countGained = allDeaths
         .slice(pull.target.start_time, pull.target.end_time)
-        .data.map(
+        // exclude npcs that aren't listed in the pull to keep the UI from looking weird when we can't find them later.
+        // this can happen if the only event for an enemy in a pull is its death (such as last-moment chaining into a boss)
+        .data.filter(
+          (event) =>
+            (pull.target as WCLDungeonPull).enemyNPCs?.some((npc) => npc.id === event.targetID) ??
+            true,
+        )
+        .map(
           (event) =>
             this.owner.fight.npcCountMap?.[this.deps.enemies.getById(event.targetID)?.guid ?? 0] ??
             0,

--- a/src/interface/report/DungeonPullList/index.module.scss
+++ b/src/interface/report/DungeonPullList/index.module.scss
@@ -18,7 +18,7 @@
 
 .PullListGrid {
   display: grid;
-  grid-template-columns: max-content repeat(5, min-content) 1fr;
+  grid-template-columns: max-content repeat(6, min-content) 1fr;
   grid-auto-flow: row;
   gap: design.$gaps_medium;
 }
@@ -30,7 +30,7 @@
 
   display: grid;
   grid-template-columns: subgrid;
-  grid-column: 1 / 8;
+  grid-column: 1 / 9;
 
   align-items: center;
 
@@ -126,7 +126,7 @@
   grid-template-columns: subgrid;
   white-space: nowrap;
   gap: 0;
-  grid-column: 2 / 4;
+  grid-column: 3 / 5;
 
   &.DoubleWide {
     & span:nth-child(1) {
@@ -156,7 +156,13 @@
 .ViewButton {
   justify-self: end;
   height: 100%;
-  grid-column: 7;
+  grid-column: -1;
   display: flex;
   align-items: center;
+}
+
+.BloodlustIcon {
+  margin-top: 0 !important;
+  height: 3.1rem !important;
+  box-shadow: 0 0 2px rgb(102, 153, 255);
 }

--- a/src/interface/report/DungeonPullList/index.module.scss
+++ b/src/interface/report/DungeonPullList/index.module.scss
@@ -42,6 +42,14 @@
   &:hover {
     filter: brightness(110%);
   }
+
+  &Disabled {
+    cursor: progress;
+
+    &:hover {
+      filter: none;
+    }
+  }
 }
 
 .desaturatedIcon {

--- a/src/interface/report/DungeonPullList/index.module.scss
+++ b/src/interface/report/DungeonPullList/index.module.scss
@@ -1,0 +1,20 @@
+@use 'interface/design-system' as design;
+
+.Container {
+  @include design.level(0);
+  padding: design.$gaps_small design.$gaps_medium;
+
+  display: flex;
+  flex-direction: column;
+  gap: design.$gaps_small;
+  margin: 0;
+}
+
+.PullContainer {
+  @include design.level(1);
+  padding: design.$gaps_small;
+}
+
+.desaturatedIcon {
+  filter: grayscale(90%);
+}

--- a/src/interface/report/DungeonPullList/index.module.scss
+++ b/src/interface/report/DungeonPullList/index.module.scss
@@ -13,6 +13,9 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    align-items: baseline;
+
+    margin-bottom: design.$gaps_small;
   }
 }
 

--- a/src/interface/report/DungeonPullList/index.module.scss
+++ b/src/interface/report/DungeonPullList/index.module.scss
@@ -166,3 +166,9 @@
   height: 3.1rem !important;
   box-shadow: 0 0 2px rgb(102, 153, 255);
 }
+
+.LoadingSpinner {
+  margin-right: design.$gaps_large;
+  grid-column: -1;
+  justify-self: end;
+}

--- a/src/interface/report/DungeonPullList/index.module.scss
+++ b/src/interface/report/DungeonPullList/index.module.scss
@@ -8,13 +8,155 @@
   flex-direction: column;
   gap: design.$gaps_small;
   margin: 0;
+
+  & > header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+
+.PullListGrid {
+  display: grid;
+  grid-template-columns: max-content repeat(5, min-content) 1fr;
+  grid-auto-flow: row;
+  gap: design.$gaps_medium;
 }
 
 .PullContainer {
   @include design.level(1);
   padding: design.$gaps_small;
+  min-height: 5rem;
+
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / 8;
+
+  align-items: center;
+
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(110%);
+  }
 }
 
 .desaturatedIcon {
   filter: grayscale(90%);
+}
+
+.activeIcon {
+  border: 1px solid design.$level2_border;
+  box-shadow: 0 0 1px design.$colors_wowaYellow;
+}
+
+.PullDetailsTitleContainer {
+  display: grid;
+  grid-template-areas:
+    'image name'
+    'image subtext';
+
+  gap: 0.1rem design.$gaps_small;
+
+  grid-template-columns: 3.1rem 1fr;
+  grid-template-rows: max-content max-content;
+  height: 3.1rem;
+}
+
+.PullDetailsTitleImage {
+  grid-area: image;
+
+  aspect-ratio: 1 / 1;
+  border: 1px solid design.$level2_border;
+  border-radius: 0.5rem;
+  height: 3rem;
+  max-height: 3rem;
+}
+
+.PullDetailsTitleName {
+  grid-area: name;
+
+  font-weight: bold;
+  font-size: design.$fontSize_subHeading;
+  line-height: 1;
+
+  & :global(.icon) {
+    height: 0.8lh;
+    margin-right: 0.2rem;
+  }
+}
+
+.PullDetailsTitleSubtext {
+  grid-area: subtext;
+
+  font-size: 1rem;
+  color: design.$colors_unfocusedText;
+  white-space: nowrap;
+  overflow-x: hidden;
+  justify-self: start;
+}
+
+.InsetContainer {
+  border: 1px solid design.$level1_border;
+  background: design.$level0_background;
+  box-shadow: inset 1px 3px design.$level1_shadow;
+  padding: design.$gaps_small design.$gaps_medium;
+}
+
+.AbilityList {
+  display: flex;
+  flex-direction: row;
+  gap: design.$gaps_small;
+}
+
+.shieldIcon {
+  height: 1em;
+  margin-top: -0.15em;
+}
+
+.SelectPullLabel {
+  font-size: design.$fontSize_subHeading;
+  font-weight: bold;
+  color: design.$colors_wowaYellow;
+  margin-left: design.$gaps_small;
+}
+
+.PerSecondContainer {
+  display: grid;
+  grid-template-columns: subgrid;
+  white-space: nowrap;
+  gap: 0;
+  grid-column: 2 / 4;
+
+  &.DoubleWide {
+    & span:nth-child(1) {
+      padding-right: design.$gaps_small;
+      text-align: right;
+    }
+
+    & span:nth-child(2) {
+      padding-left: design.$gaps_small;
+      border-left: 1px solid design.$level2_border;
+    }
+  }
+
+  & svg,
+  & img {
+    margin-right: design.$gaps_small;
+  }
+}
+
+.DeathsContainer {
+  display: flex;
+  flex-direction: row;
+  gap: design.$gaps_small;
+  justify-self: start;
+}
+
+.ViewButton {
+  justify-self: end;
+  height: 100%;
+  grid-column: 7;
+  display: flex;
+  align-items: center;
 }

--- a/src/interface/report/DungeonPullList/index.tsx
+++ b/src/interface/report/DungeonPullList/index.tsx
@@ -1,9 +1,3 @@
-/** TODOs
- * - disabled state for the buttons while loading is in progress
- * - bar for trash %
- * - allow viewing an individual pull before the rest have loaded?
- */
-
 import { isMythicPlus } from 'common/isMythicPlus';
 import Fight, { WCLDungeonPull, WCLFight } from 'parser/core/Fight';
 import { JSX, useCallback, useEffect, useMemo } from 'react';

--- a/src/interface/report/DungeonPullList/index.tsx
+++ b/src/interface/report/DungeonPullList/index.tsx
@@ -1,6 +1,6 @@
 import { isMythicPlus } from 'common/isMythicPlus';
 import Fight, { WCLDungeonPull, WCLFight } from 'parser/core/Fight';
-import { JSX, useMemo } from 'react';
+import { JSX, useCallback, useEffect, useMemo } from 'react';
 import { DungeonPullDetails } from './DungeonPullListCombatParser';
 import styles from './index.module.scss';
 import { formatDurationMinSec, formatNumber, formatPercentage } from 'common/format';
@@ -16,8 +16,54 @@ import { Trans } from '@lingui/react/macro';
 import { ByRole, Role } from 'interface/guide/foundation/ByRole';
 import ActorLink from 'interface/ActorLink';
 import SpellLink from 'interface/SpellLink';
+import { useSearchParams } from 'react-router-dom';
+import { useWaDispatch } from 'interface/utils/useWaDispatch';
+import { clearPull, setPull } from 'interface/reducers/navigation';
 
 const MIN_PULL_DURATION_MS = 100;
+
+export type SelectedDungeonPull = 'all' | WCLDungeonPull | undefined;
+
+export function useSelectedPull(
+  fight: Fight,
+): [SelectedDungeonPull, (pull: SelectedDungeonPull) => void] {
+  const [search, setSearch] = useSearchParams();
+
+  const setSelectedPull = useCallback(
+    (pull: SelectedDungeonPull) => {
+      if (pull === undefined) {
+        setSearch((prev) => {
+          prev.delete('pull');
+          return prev;
+        });
+      } else if (pull === 'all') {
+        setSearch({ pull: 'all' });
+      } else {
+        setSearch({
+          pull: String(pull.id),
+        });
+      }
+    },
+    [setSearch],
+  );
+
+  if (search.has('pull')) {
+    const pullId = search.get('pull');
+    if (pullId === 'all') {
+      return ['all', setSelectedPull];
+    } else {
+      const pullNum = Number.parseInt(pullId!);
+      const pull = fight.dungeonPulls?.find((pull) => pull.id === pullNum);
+      if (!pull) {
+        setSelectedPull(undefined);
+      }
+
+      return [pull, setSelectedPull];
+    }
+  } else {
+    return [undefined, setSelectedPull];
+  }
+}
 
 export default function DungeonPullList({
   children,
@@ -28,14 +74,25 @@ export default function DungeonPullList({
   fight: Fight;
   details?: DungeonPullDetails[];
 }): JSX.Element | null {
-  if (shouldShowDungeonPullList(fight, undefined)) {
+  const [selectedPull, setSelectedPull] = useSelectedPull(fight);
+  const dispatch = useWaDispatch();
+
+  useEffect(() => {
+    if (selectedPull) {
+      dispatch(setPull({ id: selectedPull === 'all' ? selectedPull : selectedPull.id }));
+    } else {
+      dispatch(clearPull());
+    }
+  }, [selectedPull, dispatch]);
+
+  if (shouldShowDungeonPullList(fight, selectedPull)) {
     return (
       <section className={styles.Container}>
         <header>
           <div className={styles.SelectPullLabel}>
             <Trans id="interface.report.selectPull">Select a Pull</Trans>
           </div>
-          <Button className={styles.ViewEntireDungeonButton}>
+          <Button className={styles.ViewEntireDungeonButton} onClick={() => setSelectedPull('all')}>
             <Trans id="interface.report.viewEntireDungeon">View Entire Dungeon</Trans>
           </Button>
         </header>
@@ -45,7 +102,15 @@ export default function DungeonPullList({
             .map((pull) => {
               const pullDetails = details?.find((det) => det.pull.id === pull.id);
 
-              return <PullDetails pull={pull} details={pullDetails} fight={fight} />;
+              return (
+                <PullDetails
+                  key={pull.id}
+                  pull={pull}
+                  details={pullDetails}
+                  fight={fight}
+                  onClick={() => setSelectedPull(pull)}
+                />
+              );
             })}
         </div>
       </section>
@@ -59,10 +124,12 @@ function PullDetails({
   pull,
   details,
   fight,
+  onClick,
 }: {
   pull: WCLDungeonPull;
   details?: DungeonPullDetails;
   fight: Fight;
+  onClick: () => void;
 }) {
   const dps = details && (
     <span title="DPS">
@@ -78,7 +145,7 @@ function PullDetails({
     </span>
   );
   return (
-    <div className={styles.PullContainer}>
+    <div className={styles.PullContainer} onClick={onClick}>
       <PullDetailsTitleBlock pull={pull} fight={fight} details={details} />
       {details && (
         <>
@@ -124,6 +191,7 @@ function PullDetails({
               Deaths: {/* FIXME: being the only one with a text label is weird */}
               {details.deaths.map((death) => (
                 <Tooltip
+                  key={`${death.timestamp}-${death.targetID}`}
                   content={
                     <>
                       <ActorLink id={death.targetID} /> died to{' '}
@@ -219,7 +287,7 @@ function PullDetailsTitleBlock({
                       const name = report.enemies.find((enemy) => enemy.id === npc.id)?.name;
 
                       return (
-                        <li>
+                        <li key={npc.id}>
                           {formatPercentage((num * countPer) / fight.countRequired!)}% &mdash; {num}
                           x {name}
                         </li>
@@ -278,6 +346,7 @@ function AbilityList({
       <div>{label}</div>
       {abilities.map((id) => (
         <SpellIcon
+          key={id}
           spell={id}
           className={clsx({
             [styles.activeIcon]: activeAbilities.includes(id),
@@ -289,6 +358,9 @@ function AbilityList({
   );
 }
 
-export function shouldShowDungeonPullList(fight: Fight, selectedPull?: unknown): boolean {
+export function shouldShowDungeonPullList(
+  fight: Fight,
+  selectedPull?: SelectedDungeonPull,
+): boolean {
   return isMythicPlus(fight) && !selectedPull;
 }

--- a/src/interface/report/DungeonPullList/index.tsx
+++ b/src/interface/report/DungeonPullList/index.tsx
@@ -1,0 +1,9 @@
+import { JSX } from 'react';
+
+export default function DungeonPullList({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element | null {
+  return <>{children}</>;
+}

--- a/src/interface/report/DungeonPullList/index.tsx
+++ b/src/interface/report/DungeonPullList/index.tsx
@@ -1,9 +1,119 @@
+import { isMythicPlus } from 'common/isMythicPlus';
+import Fight, { WCLDungeonPull } from 'parser/core/Fight';
 import { JSX } from 'react';
+import { DungeonPullDetails } from './DungeonPullListCombatParser';
+import styles from './index.module.scss';
+import { formatDurationMinSec, formatNumber, formatPercentage } from 'common/format';
+import ActorLink from 'interface/ActorLink';
+import SpellIcon from 'interface/SpellIcon';
+import clsx from 'clsx';
 
 export default function DungeonPullList({
   children,
+  fight,
+  details,
 }: {
   children: React.ReactNode;
+  fight: Fight;
+  details?: DungeonPullDetails[];
 }): JSX.Element | null {
+  if (shouldShowDungeonPullList(fight, undefined)) {
+    return (
+      <section className={styles.Container}>
+        {fight.dungeonPulls
+          ?.filter((pull) => pull.end_time - pull.start_time > 100)
+          .map((pull) => {
+            const pullDetails = details?.find((det) => det.pull.id === pull.id);
+
+            return <PullDetails pull={pull} details={pullDetails} fight={fight} />;
+          })}
+      </section>
+    );
+  }
+
   return <>{children}</>;
+}
+
+function PullDetails({
+  pull,
+  details,
+  fight,
+}: {
+  pull: WCLDungeonPull;
+  details?: DungeonPullDetails;
+  fight: Fight;
+}) {
+  const countPct = (count: number) => `${formatPercentage(count / fight.countRequired!, 1)}%`;
+  const time = (timestamp: number) =>
+    `${formatDurationMinSec((timestamp - fight.start_time) / 1000)}`;
+  return (
+    <div className={styles.PullContainer}>
+      <header>
+        <span>
+          Pull {pull.id} &mdash; {pull.name}
+        </span>
+
+        <span>
+          {time(pull.start_time)} &mdash; {time(pull.end_time)}
+        </span>
+
+        {details && (
+          <span>
+            +{countPct(details.countGained)} ({countPct(details.countAtEnd - details.countGained)}{' '}
+            &rarr; {countPct(details.countAtEnd)})
+          </span>
+        )}
+      </header>
+
+      {details && (
+        <>
+          <div>
+            <strong>Cooldowns</strong>{' '}
+            {details.cooldowns.map((id) => (
+              <SpellIcon
+                spell={id}
+                className={clsx({
+                  [styles.desaturatedIcon]: !details.cooldownsUsed.includes(id),
+                })}
+              />
+            ))}
+          </div>
+          <div>
+            <strong>Defensives</strong>
+            {details.defensives.map((id) => (
+              <SpellIcon
+                spell={id}
+                className={clsx({
+                  [styles.desaturatedIcon]: !details.defensivesUsed.includes(id),
+                })}
+              />
+            ))}
+          </div>
+          <div>
+            <strong>DPS</strong>
+            {formatNumber(details.dps)}
+          </div>
+          <div>
+            <strong>HPS</strong>
+            {formatNumber(details.hps)}
+          </div>
+          {details.deaths.length > 0 && (
+            <div>
+              <strong>Deaths</strong>
+              {details.deaths.map((death) => (
+                <span>
+                  <ActorLink id={death.targetID} /> (at{' '}
+                  {formatDurationMinSec((death.timestamp - pull.start_time) / 1000)} into the pull)
+                </span>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export function shouldShowDungeonPullList(fight: Fight, selectedPull?: unknown): boolean {
+  return isMythicPlus(fight) && !selectedPull;
 }

--- a/src/interface/report/DungeonPullList/index.tsx
+++ b/src/interface/report/DungeonPullList/index.tsx
@@ -20,6 +20,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useWaDispatch } from 'interface/utils/useWaDispatch';
 import { clearPull, setPull } from 'interface/reducers/navigation';
 import SPELLS from 'common/SPELLS';
+import LoadingSpinner from 'interface/LoadingSpinner';
 
 const MIN_PULL_DURATION_MS = 100;
 
@@ -87,6 +88,8 @@ export default function DungeonPullList({
   }, [selectedPull, dispatch]);
 
   if (shouldShowDungeonPullList(fight, selectedPull)) {
+    let isFirstWithoutDetails = true;
+
     return (
       <section className={styles.Container}>
         <header>
@@ -102,6 +105,10 @@ export default function DungeonPullList({
             ?.filter((pull) => pull.end_time - pull.start_time > MIN_PULL_DURATION_MS)
             .map((pull) => {
               const pullDetails = details?.find((det) => det.pull.id === pull.id);
+              const showSpinner = isFirstWithoutDetails && !pullDetails;
+              if (showSpinner) {
+                isFirstWithoutDetails = false;
+              }
 
               return (
                 <PullDetails
@@ -109,6 +116,7 @@ export default function DungeonPullList({
                   pull={pull}
                   details={pullDetails}
                   fight={fight}
+                  showSpinner={showSpinner}
                   onClick={() => setSelectedPull(pull)}
                 />
               );
@@ -126,11 +134,13 @@ function PullDetails({
   details,
   fight,
   onClick,
+  showSpinner,
 }: {
   pull: WCLDungeonPull;
   details?: DungeonPullDetails;
   fight: Fight;
   onClick: () => void;
+  showSpinner: boolean;
 }) {
   const dps = details && (
     <span title="DPS">
@@ -148,9 +158,14 @@ function PullDetails({
   return (
     <div className={styles.PullContainer} onClick={onClick}>
       <PullDetailsTitleBlock pull={pull} fight={fight} details={details} />
-      {details && (
+      {showSpinner && <LoadingSpinner className={styles.LoadingSpinner} />}
+      {!showSpinner && details && (
         <>
-          {details.bloodlustUsed ? <SpellIcon className={styles.BloodlustIcon} spell={SPELLS.BLOODLUST} /> : <div />}
+          {details.bloodlustUsed ? (
+            <SpellIcon className={styles.BloodlustIcon} spell={SPELLS.BLOODLUST} />
+          ) : (
+            <div />
+          )}
           <ByRole>
             <Role.Tank>
               <InsetContainer className={clsx(styles.PerSecondContainer, styles.DoubleWide)}>
@@ -210,14 +225,14 @@ function PullDetails({
           ) : (
             <div />
           )}
+          <div className={styles.ViewButton}>
+            <span>
+              View
+              <span className="glyphicon glyphicon-chevron-right" aria-hidden />
+            </span>
+          </div>
         </>
       )}
-      <div className={styles.ViewButton}>
-        <span>
-          View
-          <span className="glyphicon glyphicon-chevron-right" aria-hidden />
-        </span>
-      </div>
     </div>
   );
 }

--- a/src/interface/report/DungeonPullList/index.tsx
+++ b/src/interface/report/DungeonPullList/index.tsx
@@ -20,7 +20,9 @@ import { useSearchParams } from 'react-router-dom';
 import SPELLS from 'common/SPELLS';
 import LoadingSpinner from 'interface/LoadingSpinner';
 
-const MIN_PULL_DURATION_MS = 100;
+// don't show very short pulls. these are often combat drop weirdness
+// note: `useEvents` will still load these for completeness
+const MIN_PULL_DURATION_MS = 2500;
 
 export type SelectedDungeonPull = 'all' | WCLDungeonPull | undefined;
 

--- a/src/interface/report/DungeonPullList/index.tsx
+++ b/src/interface/report/DungeonPullList/index.tsx
@@ -1,12 +1,23 @@
 import { isMythicPlus } from 'common/isMythicPlus';
-import Fight, { WCLDungeonPull } from 'parser/core/Fight';
-import { JSX } from 'react';
+import Fight, { WCLDungeonPull, WCLFight } from 'parser/core/Fight';
+import { JSX, useMemo } from 'react';
 import { DungeonPullDetails } from './DungeonPullListCombatParser';
 import styles from './index.module.scss';
 import { formatDurationMinSec, formatNumber, formatPercentage } from 'common/format';
-import ActorLink from 'interface/ActorLink';
 import SpellIcon from 'interface/SpellIcon';
 import clsx from 'clsx';
+import { useReport } from '../context/ReportContext';
+import Report from 'parser/core/Report';
+import { CooldownIcon, DamageIcon, SkullIcon } from 'interface/icons';
+import { iconUrl } from 'interface/Icon';
+import Tooltip from 'interface/Tooltip';
+import Button from 'interface/controls/Button';
+import { Trans } from '@lingui/react/macro';
+import { ByRole, Role } from 'interface/guide/foundation/ByRole';
+import ActorLink from 'interface/ActorLink';
+import SpellLink from 'interface/SpellLink';
+
+const MIN_PULL_DURATION_MS = 100;
 
 export default function DungeonPullList({
   children,
@@ -20,13 +31,23 @@ export default function DungeonPullList({
   if (shouldShowDungeonPullList(fight, undefined)) {
     return (
       <section className={styles.Container}>
-        {fight.dungeonPulls
-          ?.filter((pull) => pull.end_time - pull.start_time > 100)
-          .map((pull) => {
-            const pullDetails = details?.find((det) => det.pull.id === pull.id);
+        <header>
+          <div className={styles.SelectPullLabel}>
+            <Trans id="interface.report.selectPull">Select a Pull</Trans>
+          </div>
+          <Button className={styles.ViewEntireDungeonButton}>
+            <Trans id="interface.report.viewEntireDungeon">View Entire Dungeon</Trans>
+          </Button>
+        </header>
+        <div className={styles.PullListGrid}>
+          {fight.dungeonPulls
+            ?.filter((pull) => pull.end_time - pull.start_time > MIN_PULL_DURATION_MS)
+            .map((pull) => {
+              const pullDetails = details?.find((det) => det.pull.id === pull.id);
 
-            return <PullDetails pull={pull} details={pullDetails} fight={fight} />;
-          })}
+              return <PullDetails pull={pull} details={pullDetails} fight={fight} />;
+            })}
+        </div>
       </section>
     );
   }
@@ -43,74 +64,228 @@ function PullDetails({
   details?: DungeonPullDetails;
   fight: Fight;
 }) {
-  const countPct = (count: number) => `${formatPercentage(count / fight.countRequired!, 1)}%`;
-  const time = (timestamp: number) =>
-    `${formatDurationMinSec((timestamp - fight.start_time) / 1000)}`;
+  const dps = details && (
+    <span title="DPS">
+      <DamageIcon />
+      {formatNumber(details.dps)}
+    </span>
+  );
+
+  const hps = details && (
+    <span title="HPS">
+      <img src="/img/healing.png" alt="HPS" className="icon" />
+      {formatNumber(details.hps)}
+    </span>
+  );
   return (
     <div className={styles.PullContainer}>
-      <header>
-        <span>
-          Pull {pull.id} &mdash; {pull.name}
-        </span>
-
-        <span>
-          {time(pull.start_time)} &mdash; {time(pull.end_time)}
-        </span>
-
-        {details && (
-          <span>
-            +{countPct(details.countGained)} ({countPct(details.countAtEnd - details.countGained)}{' '}
-            &rarr; {countPct(details.countAtEnd)})
-          </span>
-        )}
-      </header>
-
+      <PullDetailsTitleBlock pull={pull} fight={fight} details={details} />
       {details && (
         <>
-          <div>
-            <strong>Cooldowns</strong>{' '}
-            {details.cooldowns.map((id) => (
-              <SpellIcon
-                spell={id}
-                className={clsx({
-                  [styles.desaturatedIcon]: !details.cooldownsUsed.includes(id),
-                })}
-              />
-            ))}
-          </div>
-          <div>
-            <strong>Defensives</strong>
-            {details.defensives.map((id) => (
-              <SpellIcon
-                spell={id}
-                className={clsx({
-                  [styles.desaturatedIcon]: !details.defensivesUsed.includes(id),
-                })}
-              />
-            ))}
-          </div>
-          <div>
-            <strong>DPS</strong>
-            {formatNumber(details.dps)}
-          </div>
-          <div>
-            <strong>HPS</strong>
-            {formatNumber(details.hps)}
-          </div>
-          {details.deaths.length > 0 && (
-            <div>
-              <strong>Deaths</strong>
+          <ByRole>
+            <Role.Tank>
+              <InsetContainer className={clsx(styles.PerSecondContainer, styles.DoubleWide)}>
+                {dps} {hps}
+              </InsetContainer>
+            </Role.Tank>
+            <Role.Healer>
+              <InsetContainer className={clsx(styles.PerSecondContainer, styles.DoubleWide)}>
+                {hps} {dps}
+              </InsetContainer>
+            </Role.Healer>
+            <Role.DPS>
+              <InsetContainer className={styles.PerSecondContainer}>{dps}</InsetContainer>
+            </Role.DPS>
+          </ByRole>
+          <AbilityList
+            abilities={details.cooldowns}
+            activeAbilities={details.cooldownsUsed}
+            label={
+              <Tooltip content="Cooldowns">
+                <div>
+                  <CooldownIcon />
+                </div>
+              </Tooltip>
+            }
+          />
+          <AbilityList
+            abilities={details.defensives}
+            activeAbilities={details.defensivesUsed}
+            label={
+              <Tooltip content="Defensive Cooldowns">
+                <div>
+                  <img className={styles.shieldIcon} src="/img/shield.png" />
+                </div>
+              </Tooltip>
+            }
+          />
+          {details.deaths.length > 0 ? (
+            <InsetContainer className={styles.DeathsContainer}>
+              Deaths: {/* FIXME: being the only one with a text label is weird */}
               {details.deaths.map((death) => (
-                <span>
-                  <ActorLink id={death.targetID} /> (at{' '}
-                  {formatDurationMinSec((death.timestamp - pull.start_time) / 1000)} into the pull)
-                </span>
+                <Tooltip
+                  content={
+                    <>
+                      <ActorLink id={death.targetID} /> died to{' '}
+                      <SpellLink spell={death.killingAbility?.guid ?? 0} />
+                    </>
+                  }
+                >
+                  <div>
+                    <ActorLink id={death.targetID}>{''}</ActorLink>
+                  </div>
+                </Tooltip>
               ))}
-            </div>
+            </InsetContainer>
+          ) : (
+            <div />
           )}
         </>
       )}
+      <div className={styles.ViewButton}>
+        <span>
+          View
+          <span className="glyphicon glyphicon-chevron-right" aria-hidden />
+        </span>
+      </div>
     </div>
+  );
+}
+
+function pullIcon(pull: WCLDungeonPull, report: Report): string | undefined {
+  let matchingEnemy = report.enemies.find(
+    (enemy) => enemy.name === pull.name && pull.enemyNPCs?.some((npc) => npc.id === enemy.id),
+  );
+
+  if (!matchingEnemy) {
+    matchingEnemy = pull.enemyNPCs
+      ?.map((npc) => report.enemies.find((enemy) => enemy.id === npc.id))
+      .filter(Boolean)
+      .at(0);
+  }
+
+  return matchingEnemy?.icon ? iconUrl(matchingEnemy.icon) : undefined;
+}
+
+function PullDetailsTitleBlock({
+  pull,
+  fight,
+  details,
+}: {
+  pull: WCLDungeonPull;
+  fight: Fight;
+  details?: DungeonPullDetails;
+}) {
+  const { report } = useReport();
+
+  const iconUrl = useMemo(() => pullIcon(pull, report), [pull, report]);
+
+  const npcCount = useMemo(() => moreNpcsCount(pull, fight, report), [pull, fight, report]);
+
+  return (
+    <div className={styles.PullDetailsTitleContainer}>
+      <img className={styles.PullDetailsTitleImage} src={iconUrl} />
+      <div className={styles.PullDetailsTitleName}>
+        {pull.boss > 0 && <SkullIcon />}
+        {pull.name} {npcCount > 1 && <small>(+{npcCount} more)</small>}
+      </div>
+      <div className={styles.PullDetailsTitleSubtext}>
+        <Tooltip
+          content={
+            <>
+              {formatDurationMinSec((pull.start_time - fight.start_time) / 1000, false, 0)} &mdash;{' '}
+              {formatDurationMinSec((pull.end_time - fight.start_time) / 1000, false, 0)}
+            </>
+          }
+        >
+          <span>{formatDurationMinSec((pull.end_time - pull.start_time) / 1000, false, 0)}</span>
+        </Tooltip>
+        {details && details.countGained > 0 && fight.countRequired && (
+          <>
+            {' '}
+            &middot;
+            <Tooltip
+              content={
+                <ul style={{ listStyle: 'none', paddingLeft: 0 }}>
+                  {pull.enemyNPCs
+                    ?.filter((npc) => fight.npcCountMap?.[npc.gameID])
+                    .sort(
+                      (a, b) =>
+                        (fight.npcCountMap?.[b.gameID] ?? 0) - (fight.npcCountMap?.[a.gameID] ?? 0),
+                    )
+                    .map((npc) => {
+                      const num = npc.maximumInstanceID - npc.minimumInstanceID + 1;
+                      const countPer = fight.npcCountMap?.[npc.gameID] ?? 0;
+                      const name = report.enemies.find((enemy) => enemy.id === npc.id)?.name;
+
+                      return (
+                        <li>
+                          {formatPercentage((num * countPer) / fight.countRequired!)}% &mdash; {num}
+                          x {name}
+                        </li>
+                      );
+                    })}
+                </ul>
+              }
+            >
+              <span> +{formatPercentage(details.countGained / fight.countRequired, 1)}%</span>
+            </Tooltip>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function moreNpcsCount(pull: WCLDungeonPull, fight: WCLFight, report: Report) {
+  return (
+    pull.enemyNPCs
+      ?.filter((npc) => fight.npcCountMap?.[npc.gameID])
+      .map((npc) => {
+        const enemy = report.enemies.find((enemy) => enemy.id === npc.id);
+        const count = npc.maximumInstanceID - npc.minimumInstanceID;
+        if (enemy?.name === pull.name) {
+          return count;
+        }
+
+        return count + 1;
+      })
+      .reduce((a, b) => a + b, 0) ?? 0
+  );
+}
+
+function InsetContainer({
+  children,
+  className,
+}: {
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  return <div className={clsx(styles.InsetContainer, className)}>{children}</div>;
+}
+
+function AbilityList({
+  abilities,
+  activeAbilities,
+  label,
+}: {
+  abilities: number[];
+  activeAbilities: number[];
+  label: React.ReactNode;
+}) {
+  return (
+    <InsetContainer className={styles.AbilityList}>
+      <div>{label}</div>
+      {abilities.map((id) => (
+        <SpellIcon
+          spell={id}
+          className={clsx({
+            [styles.activeIcon]: activeAbilities.includes(id),
+            [styles.desaturatedIcon]: !activeAbilities.includes(id),
+          })}
+        />
+      ))}
+    </InsetContainer>
   );
 }
 

--- a/src/interface/report/DungeonPullList/index.tsx
+++ b/src/interface/report/DungeonPullList/index.tsx
@@ -19,6 +19,7 @@ import SpellLink from 'interface/SpellLink';
 import { useSearchParams } from 'react-router-dom';
 import { useWaDispatch } from 'interface/utils/useWaDispatch';
 import { clearPull, setPull } from 'interface/reducers/navigation';
+import SPELLS from 'common/SPELLS';
 
 const MIN_PULL_DURATION_MS = 100;
 
@@ -149,6 +150,7 @@ function PullDetails({
       <PullDetailsTitleBlock pull={pull} fight={fight} details={details} />
       {details && (
         <>
+          {details.bloodlustUsed ? <SpellIcon className={styles.BloodlustIcon} spell={SPELLS.BLOODLUST} /> : <div />}
           <ByRole>
             <Role.Tank>
               <InsetContainer className={clsx(styles.PerSecondContainer, styles.DoubleWide)}>

--- a/src/interface/report/DungeonPullList/index.tsx
+++ b/src/interface/report/DungeonPullList/index.tsx
@@ -1,3 +1,9 @@
+/** TODOs
+ * - disabled state for the buttons while loading is in progress
+ * - bar for trash %
+ * - allow viewing an individual pull before the rest have loaded?
+ */
+
 import { isMythicPlus } from 'common/isMythicPlus';
 import Fight, { WCLDungeonPull, WCLFight } from 'parser/core/Fight';
 import { JSX, useCallback, useEffect, useMemo } from 'react';
@@ -87,6 +93,22 @@ export default function DungeonPullList({
     }
   }, [selectedPull, dispatch]);
 
+  const missingAnyDetails = useMemo(() => {
+    if (!details) {
+      return true;
+    }
+
+    if (!fight.dungeonPulls) {
+      return true;
+    }
+
+    return fight.dungeonPulls!.some(
+      (pull) =>
+        details.find((det) => det.pull.id === pull.id) === undefined &&
+        pull.end_time - pull.start_time > MIN_PULL_DURATION_MS,
+    );
+  }, [fight.dungeonPulls, details]);
+
   if (shouldShowDungeonPullList(fight, selectedPull)) {
     let isFirstWithoutDetails = true;
 
@@ -96,7 +118,11 @@ export default function DungeonPullList({
           <div className={styles.SelectPullLabel}>
             <Trans id="interface.report.selectPull">Select a Pull</Trans>
           </div>
-          <Button className={styles.ViewEntireDungeonButton} onClick={() => setSelectedPull('all')}>
+          <Button
+            className={styles.ViewEntireDungeonButton}
+            onClick={() => setSelectedPull('all')}
+            disabled={missingAnyDetails}
+          >
             <Trans id="interface.report.viewEntireDungeon">View Entire Dungeon</Trans>
           </Button>
         </header>
@@ -156,7 +182,12 @@ function PullDetails({
     </span>
   );
   return (
-    <div className={styles.PullContainer} onClick={onClick}>
+    <div
+      className={clsx(styles.PullContainer, !details && styles.PullContainerDisabled)}
+      onClick={details ? onClick : undefined}
+      aria-role="button"
+      aria-disabled={!details}
+    >
       <PullDetailsTitleBlock pull={pull} fight={fight} details={details} />
       {showSpinner && <LoadingSpinner className={styles.LoadingSpinner} />}
       {!showSpinner && details && (

--- a/src/interface/report/DungeonPullList/index.tsx
+++ b/src/interface/report/DungeonPullList/index.tsx
@@ -1,6 +1,6 @@
 import { isMythicPlus } from 'common/isMythicPlus';
 import Fight, { WCLDungeonPull, WCLFight } from 'parser/core/Fight';
-import { JSX, useCallback, useEffect, useMemo } from 'react';
+import { JSX, useCallback, useMemo } from 'react';
 import { DungeonPullDetails } from './DungeonPullListCombatParser';
 import styles from './index.module.scss';
 import { formatDurationMinSec, formatNumber, formatPercentage } from 'common/format';
@@ -17,8 +17,6 @@ import { ByRole, Role } from 'interface/guide/foundation/ByRole';
 import ActorLink from 'interface/ActorLink';
 import SpellLink from 'interface/SpellLink';
 import { useSearchParams } from 'react-router-dom';
-import { useWaDispatch } from 'interface/utils/useWaDispatch';
-import { clearPull, setPull } from 'interface/reducers/navigation';
 import SPELLS from 'common/SPELLS';
 import LoadingSpinner from 'interface/LoadingSpinner';
 
@@ -27,7 +25,7 @@ const MIN_PULL_DURATION_MS = 100;
 export type SelectedDungeonPull = 'all' | WCLDungeonPull | undefined;
 
 export function useSelectedPull(
-  fight: Fight,
+  fight: WCLFight,
 ): [SelectedDungeonPull, (pull: SelectedDungeonPull) => void] {
   const [search, setSearch] = useSearchParams();
 
@@ -68,25 +66,13 @@ export function useSelectedPull(
 }
 
 export default function DungeonPullList({
-  children,
   fight,
   details,
 }: {
-  children: React.ReactNode;
   fight: Fight;
   details?: DungeonPullDetails[];
 }): JSX.Element | null {
-  const [selectedPull, setSelectedPull] = useSelectedPull(fight);
-  const dispatch = useWaDispatch();
-
-  useEffect(() => {
-    if (selectedPull) {
-      dispatch(setPull({ id: selectedPull === 'all' ? selectedPull : selectedPull.id }));
-    } else {
-      dispatch(clearPull());
-    }
-  }, [selectedPull, dispatch]);
-
+  const [, setSelectedPull] = useSelectedPull(fight);
   const missingAnyDetails = useMemo(() => {
     if (!details) {
       return true;
@@ -103,50 +89,46 @@ export default function DungeonPullList({
     );
   }, [fight.dungeonPulls, details]);
 
-  if (shouldShowDungeonPullList(fight, selectedPull)) {
-    let isFirstWithoutDetails = true;
+  let isFirstWithoutDetails = true;
 
-    return (
-      <section className={styles.Container}>
-        <header>
-          <div className={styles.SelectPullLabel}>
-            <Trans id="interface.report.selectPull">Select a Pull</Trans>
-          </div>
-          <Button
-            className={styles.ViewEntireDungeonButton}
-            onClick={() => setSelectedPull('all')}
-            disabled={missingAnyDetails}
-          >
-            <Trans id="interface.report.viewEntireDungeon">View Entire Dungeon</Trans>
-          </Button>
-        </header>
-        <div className={styles.PullListGrid}>
-          {fight.dungeonPulls
-            ?.filter((pull) => pull.end_time - pull.start_time > MIN_PULL_DURATION_MS)
-            .map((pull) => {
-              const pullDetails = details?.find((det) => det.pull.id === pull.id);
-              const showSpinner = isFirstWithoutDetails && !pullDetails;
-              if (showSpinner) {
-                isFirstWithoutDetails = false;
-              }
-
-              return (
-                <PullDetails
-                  key={pull.id}
-                  pull={pull}
-                  details={pullDetails}
-                  fight={fight}
-                  showSpinner={showSpinner}
-                  onClick={() => setSelectedPull(pull)}
-                />
-              );
-            })}
+  return (
+    <section className={styles.Container}>
+      <header>
+        <div className={styles.SelectPullLabel}>
+          <Trans id="interface.report.selectPull">Select a Pull</Trans>
         </div>
-      </section>
-    );
-  }
+        <Button
+          className={styles.ViewEntireDungeonButton}
+          onClick={() => setSelectedPull('all')}
+          disabled={missingAnyDetails}
+        >
+          <Trans id="interface.report.viewEntireDungeon">View Entire Dungeon</Trans>
+        </Button>
+      </header>
+      <div className={styles.PullListGrid}>
+        {fight.dungeonPulls
+          ?.filter((pull) => pull.end_time - pull.start_time > MIN_PULL_DURATION_MS)
+          .map((pull) => {
+            const pullDetails = details?.find((det) => det.pull.id === pull.id);
+            const showSpinner = isFirstWithoutDetails && !pullDetails;
+            if (showSpinner) {
+              isFirstWithoutDetails = false;
+            }
 
-  return <>{children}</>;
+            return (
+              <PullDetails
+                key={pull.id}
+                pull={pull}
+                details={pullDetails}
+                fight={fight}
+                showSpinner={showSpinner}
+                onClick={() => setSelectedPull(pull)}
+              />
+            );
+          })}
+      </div>
+    </section>
+  );
 }
 
 function PullDetails({
@@ -179,7 +161,6 @@ function PullDetails({
     <div
       className={clsx(styles.PullContainer, !details && styles.PullContainerDisabled)}
       onClick={details ? onClick : undefined}
-      aria-role="button"
       aria-disabled={!details}
     >
       <PullDetailsTitleBlock pull={pull} fight={fight} details={details} />

--- a/src/interface/report/Results/Header/FilterButton.tsx
+++ b/src/interface/report/Results/Header/FilterButton.tsx
@@ -13,6 +13,7 @@ import { useFight } from 'interface/report/context/FightContext';
 import Select from 'interface/controls/Select';
 import useClickOutsideHandler from 'interface/hooks/useClickOutsideHandler';
 import Button from 'interface/controls/Button';
+import { useSelectedPull } from 'interface/report/DungeonPullList';
 
 const FilterContainer = cssComponent('div', styles.FilterContainer, [] as const);
 
@@ -33,10 +34,19 @@ export default function FilterButton(props: Props): JSX.Element | null {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   const [showMenu, setShowMenu] = useState(false);
   const [position, setPosition] = useState<FilterMenuProps['position']>({});
+  const [, setSelectedPull] = useSelectedPull(props.fight);
+
   const closeMenu = useCallback(() => {
     setShowMenu(false);
   }, []);
+  const { hasDungeonPulls, canGoPrev, canGoNext, goToPrevPull, goToNextPull } =
+    usePullNavigation(props);
   const toggleMenu = useCallback(() => {
+    if (hasDungeonPulls) {
+      setSelectedPull(undefined);
+      return;
+    }
+
     setShowMenu((v) => !v);
     setPosition(
       ref.current
@@ -46,7 +56,7 @@ export default function FilterButton(props: Props): JSX.Element | null {
           }
         : {},
     );
-  }, []);
+  }, [hasDungeonPulls, setSelectedPull]);
 
   useClickOutsideHandler([ref, dialogRef], closeMenu);
   const phases = usePhases();
@@ -64,9 +74,6 @@ export default function FilterButton(props: Props): JSX.Element | null {
 
     return 'Filter';
   }, [props.selectedPhaseIndex, props.timeFilter, phases, props.fight]);
-
-  const { hasDungeonPulls, canGoPrev, canGoNext, goToPrevPull, goToNextPull } =
-    usePullNavigation(props);
 
   return (
     <>
@@ -241,7 +248,8 @@ function NextPullButton({ disabled, onClick }: PullNavBtnProps): JSX.Element {
   );
 }
 
-function usePullNavigation({ fight, selectedPhaseIndex, handlePhaseSelection }: Props) {
+function usePullNavigation({ fight, selectedPhaseIndex }: Props) {
+  const [, setSelectedPull] = useSelectedPull(fight);
   const pullCount = fight.dungeonPulls?.length ?? 0;
   const hasDungeonPulls = pullCount > 0;
 
@@ -252,17 +260,20 @@ function usePullNavigation({ fight, selectedPhaseIndex, handlePhaseSelection }: 
 
   const goToPrevPull = useCallback(() => {
     if (canGoPrev) {
-      handlePhaseSelection(selectedPhaseIndex - 1);
+      const targetPullId = selectedPhaseIndex;
+      setSelectedPull(fight.dungeonPulls!.find((pull) => pull.id === targetPullId));
     }
-  }, [canGoPrev, handlePhaseSelection, selectedPhaseIndex]);
+  }, [canGoPrev, setSelectedPull, selectedPhaseIndex, fight]);
 
   const goToNextPull = useCallback(() => {
     if (canGoNext) {
       const isAllPhases = selectedPhaseIndex === SELECTION_ALL_PHASES;
       const isCustomPhase = selectedPhaseIndex === SELECTION_CUSTOM_PHASE;
-      handlePhaseSelection(isAllPhases || isCustomPhase ? 0 : selectedPhaseIndex + 1);
+      // +2 because of the shift from 0-index to 1-index
+      const targetPullId = isAllPhases || isCustomPhase ? 1 : selectedPhaseIndex + 2;
+      setSelectedPull(fight.dungeonPulls!.find((pull) => pull.id === targetPullId));
     }
-  }, [canGoNext, handlePhaseSelection, selectedPhaseIndex]);
+  }, [canGoNext, setSelectedPull, selectedPhaseIndex, fight]);
 
   return { hasDungeonPulls, canGoPrev, canGoNext, goToPrevPull, goToNextPull };
 }

--- a/src/interface/report/Results/Header/index.module.scss
+++ b/src/interface/report/Results/Header/index.module.scss
@@ -4,6 +4,12 @@
   @include design.level(1);
   padding: 1rem;
   margin-bottom: 2.5rem;
+
+  padding-bottom: 0;
+
+  &.MiniHeader {
+    padding-bottom: design.$gaps_small;
+  }
 }
 
 .TabStrip {

--- a/src/interface/report/Results/Header/index.tsx
+++ b/src/interface/report/Results/Header/index.tsx
@@ -32,6 +32,7 @@ import Select from 'interface/controls/Select';
 import useMediaQueryMatch from 'interface/hooks/useMediaQueryMatch';
 import { specIconPath } from 'interface/SpecIcon';
 import { shouldShowDungeonPullList, useSelectedPull } from 'interface/report/DungeonPullList';
+import clsx from 'clsx';
 
 const Section = cssComponent('section', styles.Section, [] as const);
 
@@ -161,7 +162,9 @@ export default function Header({
     <>
       <HeaderBackground boss={boss} raid={raid} expansion={expansion} />
       <div>
-        <Section style={{ paddingBottom: 0 }}>
+        <Section
+          className={clsx(shouldShowDungeonPullList(fight, selectedPull) && styles.MiniHeader)}
+        >
           <HeaderContainer>
             <BossMiniBox boss={boss} fight={fight} />
             {!shouldShowDungeonPullList(fight, selectedPull) && (
@@ -230,7 +233,10 @@ function CharacterMiniBox({
   // intentionally smaller than the layout switch
   const showClassName = useMediaQueryMatch('(min-width: 600px)');
   return (
-    <MiniBoxContainer className={styles.flipped} style={{ gridArea: 'character' }}>
+    <MiniBoxContainer
+      className={styles.flipped}
+      style={{ gridArea: 'character', justifySelf: 'end' }}
+    >
       <MiniBoxImage
         src={characterProfile?.thumbnail ?? specIconPath(config.spec)}
         alt={`${player.name} (${config.spec.specName ? i18n._(config.spec.specName) : ''} ${i18n._(config.spec.className)})`}

--- a/src/interface/report/Results/Header/index.tsx
+++ b/src/interface/report/Results/Header/index.tsx
@@ -31,6 +31,7 @@ import { Filter } from 'interface/report/hooks/useTimeEventFilter';
 import Select from 'interface/controls/Select';
 import useMediaQueryMatch from 'interface/hooks/useMediaQueryMatch';
 import { specIconPath } from 'interface/SpecIcon';
+import { shouldShowDungeonPullList, useSelectedPull } from 'interface/report/DungeonPullList';
 
 const Section = cssComponent('section', styles.Section, [] as const);
 
@@ -151,6 +152,7 @@ export default function Header({
     [tabs],
   );
   const navigate = useNavigate();
+  const [selectedPull] = useSelectedPull(fight);
 
   const expansion = currentExpansion(config.branch);
   const raid = boss ? findZoneByBossId(boss.id) : undefined;
@@ -162,41 +164,47 @@ export default function Header({
         <Section style={{ paddingBottom: 0 }}>
           <HeaderContainer>
             <BossMiniBox boss={boss} fight={fight} />
-            <FilterButton
-              fight={fight}
-              handlePhaseSelection={handlePhaseSelection}
-              handleTimeSelection={handleTimeSelection}
-              selectedPhaseIndex={selectedPhaseIndex}
-              timeFilter={timeFilter}
-            />
+            {!shouldShowDungeonPullList(fight, selectedPull) && (
+              <FilterButton
+                fight={fight}
+                handlePhaseSelection={handlePhaseSelection}
+                handleTimeSelection={handleTimeSelection}
+                selectedPhaseIndex={selectedPhaseIndex}
+                timeFilter={timeFilter}
+              />
+            )}
             <CharacterMiniBox player={player} characterProfile={characterProfile} config={config} />
-            <TabStrip>
-              {tabList
-                .filter((tab: InternalTab) => !tab.hidden || tab.url === selectedTab)
-                .map(({ icon: Icon, ...tab }) => (
-                  <TabButton
-                    key={tab.url}
-                    to={makeTabUrl(tab.url)}
-                    className={selectedTab === tab.url ? styles.active : ''}
-                  >
-                    <Icon />
-                    {isMessageDescriptor(tab.title) ? i18n._(tab.title) : tab.title}
-                  </TabButton>
-                ))}
-            </TabStrip>
-            <TabSelect
-              onChange={(event) => navigate(makeTabUrl(event.target.value))}
-              value={selectedTab}
-            >
-              {tabList
-                .filter((tab: InternalTab) => !tab.hidden || tab.url === selectedTab)
-                .map((tab) => (
-                  <option key={tab.url} value={tab.url}>
-                    {isMessageDescriptor(tab.title) ? i18n._(tab.title) : tab.title}
-                  </option>
-                ))}
-            </TabSelect>
-            {!isLoading && <HeaderStatBox className={styles.StatBoxContainer} />}
+            {!shouldShowDungeonPullList(fight, selectedPull) ? (
+              <>
+                <TabStrip>
+                  {tabList
+                    .filter((tab: InternalTab) => !tab.hidden || tab.url === selectedTab)
+                    .map(({ icon: Icon, ...tab }) => (
+                      <TabButton
+                        key={tab.url}
+                        to={makeTabUrl(tab.url)}
+                        className={selectedTab === tab.url ? styles.active : ''}
+                      >
+                        <Icon />
+                        {isMessageDescriptor(tab.title) ? i18n._(tab.title) : tab.title}
+                      </TabButton>
+                    ))}
+                </TabStrip>
+                <TabSelect
+                  onChange={(event) => navigate(makeTabUrl(event.target.value))}
+                  value={selectedTab}
+                >
+                  {tabList
+                    .filter((tab: InternalTab) => !tab.hidden || tab.url === selectedTab)
+                    .map((tab) => (
+                      <option key={tab.url} value={tab.url}>
+                        {isMessageDescriptor(tab.title) ? i18n._(tab.title) : tab.title}
+                      </option>
+                    ))}
+                </TabSelect>
+                {!isLoading && <HeaderStatBox className={styles.StatBoxContainer} />}
+              </>
+            ) : null}
           </HeaderContainer>
         </Section>
       </div>

--- a/src/interface/report/Results/index.tsx
+++ b/src/interface/report/Results/index.tsx
@@ -44,6 +44,8 @@ import Ad, { Location } from 'interface/Ad';
 
 import usePremium from 'interface/usePremium';
 import useMediaQueryMatch from 'interface/hooks/useMediaQueryMatch';
+import { DungeonPullDetails } from '../DungeonPullList/DungeonPullListCombatParser';
+import DungeonPullList from '../DungeonPullList';
 
 interface PassedProps {
   parser: CombatLogParser;
@@ -60,6 +62,7 @@ interface PassedProps {
   loadingStatus: LoadingStatus;
   premium?: boolean;
   config: Config;
+  dungeonPullDetails?: DungeonPullDetails[];
 }
 
 const Results = (props: PassedProps) => {
@@ -251,7 +254,9 @@ const Results = (props: PassedProps) => {
                 </AlertWarning>
               </div>
             )}
-            <Outlet />
+            <DungeonPullList details={props.dungeonPullDetails} fight={props.fight}>
+              <Outlet />
+            </DungeonPullList>
 
             <div style={{ marginTop: 40 }}>
               <div className="row">

--- a/src/interface/report/Results/index.tsx
+++ b/src/interface/report/Results/index.tsx
@@ -45,7 +45,7 @@ import Ad, { Location } from 'interface/Ad';
 import usePremium from 'interface/usePremium';
 import useMediaQueryMatch from 'interface/hooks/useMediaQueryMatch';
 import { DungeonPullDetails } from '../DungeonPullList/DungeonPullListCombatParser';
-import DungeonPullList from '../DungeonPullList';
+import DungeonPullList, { shouldShowDungeonPullList, useSelectedPull } from '../DungeonPullList';
 
 interface PassedProps {
   parser: CombatLogParser;
@@ -71,6 +71,7 @@ const Results = (props: PassedProps) => {
   const dispatch = useDispatch();
   const [adjustForDowntime, setAdjustForDowntime] = useState(false);
   const [results, setResults] = useState<ParseResults | null>(null);
+  const [selectedPull] = useSelectedPull(props.fight);
 
   const generateResults = useCallback(() => {
     if (props.parser == null) {
@@ -254,9 +255,11 @@ const Results = (props: PassedProps) => {
                 </AlertWarning>
               </div>
             )}
-            <DungeonPullList details={props.dungeonPullDetails} fight={props.fight}>
+            {shouldShowDungeonPullList(props.fight, selectedPull) ? (
+              <DungeonPullList details={props.dungeonPullDetails} fight={props.fight} />
+            ) : (
               <Outlet />
-            </DungeonPullList>
+            )}
 
             <div style={{ marginTop: 40 }}>
               <div className="row">

--- a/src/interface/report/hooks/useEvents.ts
+++ b/src/interface/report/hooks/useEvents.ts
@@ -2,11 +2,55 @@ import { WCLEventsResponse } from 'common/WCL_TYPES';
 import { captureException } from 'common/errorLogger';
 import fetchWcl from 'common/fetchWclApi';
 import { AnyEvent } from 'parser/core/Events';
-import { WCLFight } from 'parser/core/Fight';
+import { WCLDungeonPull, WCLFight } from 'parser/core/Fight';
 import { PlayerInfo } from 'parser/core/Player';
 import Report from 'parser/core/Report';
 import { useEffect, useState } from 'react';
 import { isCommonError } from '../handleApiError';
+
+interface EventRange {
+  target: WCLFight | WCLDungeonPull;
+  start_time: number;
+  end_time: number;
+}
+
+async function* fetchEvents(
+  report: Report,
+  fight: WCLFight,
+  player: Pick<PlayerInfo, 'id'>,
+): AsyncGenerator<{ target: EventRange['target']; events: AnyEvent[] }> {
+  const timeRanges = fightTimeRanges(fight);
+
+  for (const { target, start_time, end_time } of timeRanges) {
+    let events: AnyEvent[] = [];
+    let nextStartTime: number | undefined = start_time;
+    do {
+      const page: WCLEventsResponse = await fetchWcl(`report/events/${report.code}`, {
+        start: nextStartTime,
+        end: end_time,
+        actorid: player.id,
+        translate: true,
+      });
+
+      events = events.concat(page.events);
+
+      nextStartTime = page.nextPageTimestamp;
+    } while (Number.isFinite(nextStartTime));
+
+    yield { target, events };
+  }
+}
+
+function fightTimeRanges(fight: WCLFight): EventRange[] {
+  if (!fight.dungeonPulls) {
+    return [{ ...fight, target: fight }];
+  }
+
+  return fight.dungeonPulls.map((pull, index, pulls) => {
+    const previousEndTime = pulls[index - 1]?.end_time ?? fight.start_time;
+    return { target: pull, start_time: previousEndTime, end_time: pull.end_time };
+  });
+}
 
 const useEvents = ({
   report,
@@ -18,60 +62,42 @@ const useEvents = ({
   player: Pick<PlayerInfo, 'id'>;
 }) => {
   const [events, setEvents] = useState<AnyEvent[] | null>(null);
+  const [pulls, setPulls] = useState<{ target: EventRange['target']; events: AnyEvent[] }[]>([]);
   const [currentTime, setCurrentTime] = useState<number>(fight.start_time);
-  const [error, setError] = useState<Error | null>(null);
-
-  const updateState = (error: Error | null, events: AnyEvent[] | null) => {
-    setError(error);
-    setEvents(events);
-  };
+  const [error, setError] = useState<Error | undefined>();
 
   useEffect(() => {
     let cancelled = false;
-    // we are using the raw `fetchWcl` here for greater control
-    const loadPage = (startTime: number) =>
-      fetchWcl<WCLEventsResponse>(`report/events/${report.code}`, {
-        start: startTime,
-        end: fight.end_time,
-        actorid: player.id,
-        translate: true,
-      });
-
-    const load = async (startTime: number): Promise<AnyEvent[]> => {
-      if (cancelled) {
-        return [];
-      }
-
-      const { events, nextPageTimestamp } = await loadPage(startTime);
-
-      if (!nextPageTimestamp) {
-        setCurrentTime(fight.end_time);
-        return events;
-      } else {
-        setCurrentTime(nextPageTimestamp);
-
-        return events.concat(await load(nextPageTimestamp));
-      }
-    };
-
     (async () => {
+      let events: AnyEvent[] = [];
       try {
-        const events = await load(fight.start_time);
-        updateState(null, events);
+        for await (const range of fetchEvents(report, fight, player)) {
+          if (cancelled) {
+            break;
+          }
+
+          setPulls((pulls) => {
+            pulls.push(range);
+            return pulls;
+          });
+          setCurrentTime(range.target.end_time);
+          events = events.concat(range.events);
+        }
       } catch (err) {
         if (!isCommonError(err)) {
           captureException(err as Error);
         }
-        updateState(err as Error, null);
+        setError(err as Error);
       }
+
+      setEvents(events);
     })();
 
     return () => {
       cancelled = true;
     };
   }, [report, fight, player]);
-
-  return { events, currentTime, error };
+  return { events, currentTime, error, pulls };
 };
 
 export default useEvents;

--- a/src/interface/report/hooks/useEvents.ts
+++ b/src/interface/report/hooks/useEvents.ts
@@ -52,6 +52,11 @@ function fightTimeRanges(fight: WCLFight): EventRange[] {
   });
 }
 
+export interface DungeonPullEvents {
+  target: EventRange['target'];
+  events: AnyEvent[];
+}
+
 const useEvents = ({
   report,
   fight,
@@ -62,7 +67,7 @@ const useEvents = ({
   player: Pick<PlayerInfo, 'id'>;
 }) => {
   const [events, setEvents] = useState<AnyEvent[] | null>(null);
-  const [pulls, setPulls] = useState<{ target: EventRange['target']; events: AnyEvent[] }[]>([]);
+  const [pulls, setPulls] = useState<DungeonPullEvents[]>([]);
   const [currentTime, setCurrentTime] = useState<number>(fight.start_time);
   const [error, setError] = useState<Error | undefined>();
 
@@ -76,10 +81,7 @@ const useEvents = ({
             break;
           }
 
-          setPulls((pulls) => {
-            pulls.push(range);
-            return pulls;
-          });
+          setPulls((pulls) => [...pulls, range]);
           setCurrentTime(range.target.end_time);
           events = events.concat(range.events);
         }

--- a/src/interface/report/hooks/useEvents.ts
+++ b/src/interface/report/hooks/useEvents.ts
@@ -1,7 +1,7 @@
 import { WCLEventsResponse } from 'common/WCL_TYPES';
 import { captureException } from 'common/errorLogger';
-import fetchWcl from 'common/fetchWclApi';
-import { AnyEvent } from 'parser/core/Events';
+import fetchWcl, { fetchEvents } from 'common/fetchWclApi';
+import { AnyEvent, DeathEvent } from 'parser/core/Events';
 import { WCLDungeonPull, WCLFight } from 'parser/core/Fight';
 import { PlayerInfo } from 'parser/core/Player';
 import Report from 'parser/core/Report';
@@ -14,7 +14,7 @@ interface EventRange {
   end_time: number;
 }
 
-async function* fetchEvents(
+async function* fetchPlayerEvents(
   report: Report,
   fight: WCLFight,
   player: Pick<PlayerInfo, 'id'>,
@@ -46,7 +46,14 @@ function fightTimeRanges(fight: WCLFight): EventRange[] {
     return [{ ...fight, target: fight }];
   }
 
-  return fight.dungeonPulls.map((pull, index, pulls) => {
+  // sometimes there is an extra junk "pull" at the end when combat drops on completion
+  const lastPull = fight.dungeonPulls.at(-1);
+  let pulls = fight.dungeonPulls;
+  if (lastPull && lastPull.end_time - lastPull.start_time < 100) {
+    pulls = fight.dungeonPulls.slice(0, -1);
+  }
+
+  return pulls.map((pull, index, pulls) => {
     const previousEndTime = pulls[index - 1]?.end_time ?? fight.start_time;
     return { target: pull, start_time: previousEndTime, end_time: pull.end_time };
   });
@@ -70,13 +77,42 @@ const useEvents = ({
   const [pulls, setPulls] = useState<DungeonPullEvents[]>([]);
   const [currentTime, setCurrentTime] = useState<number>(fight.start_time);
   const [error, setError] = useState<Error | undefined>();
+  const [allDeaths, setAllDeaths] = useState<DeathEvent[] | undefined>();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const events = await fetchEvents(
+          report.code,
+          fight.start_time,
+          fight.end_time,
+          undefined,
+          'type = "death" and (target.disposition = "enemy" or target.type != "Pet") and feign = false',
+        );
+        if (!cancelled) {
+          setAllDeaths(events as DeathEvent[]);
+        }
+      } catch (err) {
+        if (!isCommonError(err)) {
+          captureException(err as Error);
+        }
+        setError(err as Error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [report, fight]);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       let events: AnyEvent[] = [];
       try {
-        for await (const range of fetchEvents(report, fight, player)) {
+        for await (const range of fetchPlayerEvents(report, fight, player)) {
           if (cancelled) {
             break;
           }
@@ -99,7 +135,8 @@ const useEvents = ({
       cancelled = true;
     };
   }, [report, fight, player]);
-  return { events, currentTime, error, pulls };
+
+  return { events, currentTime, error, pulls, allDeaths };
 };
 
 export default useEvents;

--- a/src/interface/report/hooks/useTimeEventFilter.ts
+++ b/src/interface/report/hooks/useTimeEventFilter.ts
@@ -24,13 +24,6 @@ import { EventsParseError } from './useEventParser';
 const bench = (id: string) => console.time(id);
 const benchEnd = (id: string) => console.timeEnd(id);
 
-//returns whether e2 follows e and the events are associated
-const eventFollows = (e: BuffEvent | StackEvent, e2: BuffEvent | StackEvent) =>
-  e2.timestamp > e.timestamp &&
-  (e2.ability && e.ability ? e2.ability.guid === e.ability.guid : !e2.ability && !e.ability) && //if both have an ability, its ID needs to match, otherwise neither can have an ability
-  e2.sourceID === e.sourceID &&
-  e2.targetID === e.targetID;
-
 function findRelevantPostFilterEvents(events: AnyEvent[]) {
   return events
     .filter(
@@ -46,94 +39,102 @@ function findRelevantPostFilterEvents(events: AnyEvent[]) {
     );
 }
 
+/**
+ * Simple helper to track buffs that have been seen in the event list.
+ *
+ * Note that we do not distinguish between buffs and debuffs. Each ability is only ever a buff or a debuff, so we don't need to care about both.
+ */
+class BuffSet {
+  private buffs: Map<string, Set<number>> = new Map();
+
+  private static eventKey(event: BuffEvent): string {
+    return `${event.sourceID}-${event.sourceInstance ?? 0}-${event.targetID}-${event.targetInstance ?? 0}`;
+  }
+
+  private abilitySet(event: BuffEvent): Set<number> {
+    const key = BuffSet.eventKey(event);
+    if (!this.buffs.has(key)) {
+      this.buffs.set(key, new Set());
+    }
+
+    return this.buffs.get(key)!;
+  }
+
+  public add(event: BuffEvent) {
+    this.abilitySet(event).add(event.ability.guid);
+  }
+
+  public has(event: BuffEvent): boolean {
+    return this.abilitySet(event).has(event.ability.guid);
+  }
+}
+
 //filter prephase events to just the events outside the time period that "matter" to make statistics more accurate (e.g. buffs and cooldowns)
 type StackEvent =
   | ApplyBuffStackEvent
   | ApplyDebuffStackEvent
   | RemoveBuffStackEvent
   | RemoveDebuffStackEvent;
-type BuffEvent = ApplyBuffEvent | ApplyDebuffEvent | RemoveBuffEvent | RemoveDebuffEvent;
+type BuffEvent =
+  | ApplyBuffEvent
+  | ApplyDebuffEvent
+  | RemoveBuffEvent
+  | RemoveDebuffEvent
+  | ApplyBuffStackEvent
+  | RemoveBuffStackEvent
+  | ApplyDebuffStackEvent
+  | RemoveDebuffStackEvent;
 type CastRelevantEvent = CastEvent | FilterCooldownInfoEvent;
 function findRelevantPreFilterEvents(events: AnyEvent[]) {
   const buffEvents: BuffEvent[] = []; //(de)buff apply events for (de)buffs that stay active going into the time period
   const stackEvents: StackEvent[] = []; //stack events related to the above buff events that happen after the buff is applied
   const castEvents: CastRelevantEvent[] = []; //latest cast event of each cast by player for cooldown tracking
 
-  const buffIsMarkedActive = (e: BuffEvent) =>
-    buffEvents.find(
-      (e2) =>
-        e.ability.guid === e2.ability.guid &&
-        e.targetID === e2.targetID &&
-        e.sourceID === e2.targetID,
-    ) !== undefined;
-  const buffIsRemoved = (e: BuffEvent, buffRelevantEvents: AnyEvent[]) =>
-    buffRelevantEvents.find(
-      (e2) => e2.type === e.type.replace('apply', 'remove') && eventFollows(e, e2 as BuffEvent),
-    ) !== undefined;
-  const castHappenedLater = (e: CastEvent) =>
-    castEvents.find((e2) => e.ability.guid === e2.ability.guid && e.sourceID === e2.sourceID) !==
-    undefined;
+  const seenAuras = new BuffSet();
+  const seenCasts = new Set();
 
-  events.forEach((e, index) => {
-    switch (e.type) {
-      case EventType.ApplyBuff:
-      case EventType.ApplyDebuff:
-        //if buff isn't already confirmed as "staying active"
-        if (!buffIsMarkedActive(e as BuffEvent)) {
-          //look only at buffs that happen after the apply event (since we traverse in reverse order)
-          const buffRelevantEvents = events.slice(0, index);
-          //if no remove is found following the apply event, mark the buff as "staying active"
-          if (!buffIsRemoved(e as BuffEvent, buffRelevantEvents)) {
-            buffEvents.push(e as BuffEvent);
-            //find relevant stack information for active buff / debuff
-            stackEvents.push(
-              ...buffRelevantEvents.reverse().reduce((arr: StackEvent[], e2: AnyEvent) => {
-                //traverse through all following stack events in chronological order
-                if (eventFollows(e as BuffEvent, e2 as StackEvent)) {
-                  //if stack is added, add the event to the end of the array
-                  if (
-                    e2.type === EventType.ApplyBuffStack ||
-                    e2.type === EventType.ApplyDebuffStack
-                  ) {
-                    return [...arr, e2 as StackEvent];
-                    //if stack is removed, remove first event from array
-                  } else if (
-                    e2.type === EventType.RemoveBuffStack ||
-                    e2.type === EventType.RemoveDebuffStack
-                  ) {
-                    return arr.slice(0, 1);
-                  }
-                }
-                return arr;
-              }, []),
-            );
-          }
-        }
-        break;
+  // events are processed in reverse order
+  for (const event of events) {
+    switch (event.type) {
       case EventType.RemoveBuff:
       case EventType.RemoveDebuff:
-        if (COMBAT_POTIONS.includes((e as BuffEvent).ability.guid)) {
-          buffEvents.push(e as BuffEvent);
+        if (COMBAT_POTIONS.includes(event.ability.guid)) {
+          buffEvents.push(event);
         }
+        seenAuras.add(event);
+        break;
+      case EventType.ApplyBuff:
+      case EventType.ApplyDebuff:
+        // note: intentionally omitting refreshes. they often immediately follow a stack change and add no info that is relevant for pre-pull events.
+        if (seenAuras.has(event)) {
+          continue;
+        }
+        seenAuras.add(event);
+        buffEvents.push(event);
+        break;
+      case EventType.ApplyBuffStack:
+      case EventType.RemoveBuffStack:
+      case EventType.ApplyDebuffStack:
+      case EventType.RemoveDebuffStack:
+        if (seenAuras.has(event)) {
+          continue;
+        }
+        // note: stack events don't add to seenAuras
+        stackEvents.push(event);
         break;
       case EventType.Cast:
-        //only keep "latest" cast, override type to prevent > 100% uptime / efficiency
-        //whitelist certain casts (like potions) to keep suggestions working
-        if (
-          COMBAT_POTIONS.includes((e as CastEvent).ability.guid) ||
-          !castHappenedLater(e as CastEvent)
-        ) {
-          castEvents.push({
-            ...(e as CastEvent),
-            type: EventType.FilterCooldownInfo,
-            trigger: e.type,
-          });
+        if (!COMBAT_POTIONS.includes(event.ability.guid) && seenCasts.has(event.ability.guid)) {
+          continue;
         }
-        break;
-      default:
+        seenCasts.add(event.ability.guid);
+        castEvents.push({
+          ...event,
+          type: EventType.FilterCooldownInfo,
+          trigger: event.type,
+        });
         break;
     }
-  });
+  }
 
   return [...castEvents, ...buffEvents, ...stackEvents];
 }

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -35,6 +35,7 @@ import { wclGameVersionToBranch } from 'game/VERSIONS';
 import GameBranch from 'game/GameBranch';
 import { fetchCombatants } from 'common/fetchWclApi';
 import { normalizedEncounterId } from 'game/raids';
+import useDungeonPullList from './DungeonPullList/DungeonPullListCombatParser';
 
 const UnsupportedSpecBouncer = ({ report, fight }: { report: Report; fight: WCLFight }) => (
   <main className="container offset">
@@ -104,7 +105,7 @@ const ResultsLoader = () => {
   const parserClass = useParser(config);
   const isLoadingParser = !parserClass;
 
-  const { events, currentTime, error } = useEvents({ report, fight, player });
+  const { events, currentTime, error, pulls } = useEvents({ report, fight, player });
   const isLoadingEvents = events == null;
 
   const { loadingState: bossPhaseEventsLoadingState, events: bossPhaseEvents } = useBossPhaseEvents(
@@ -239,6 +240,19 @@ const ResultsLoader = () => {
     dependenciesLoading: isLoadingParser || isLoadingCharacterProfile || isFilteringEvents,
     playerCombatantInfo,
   });
+
+  const dungeonPullDetails = useDungeonPullList({
+    report,
+    fight,
+    config,
+    player,
+    allPlayers,
+    parser: parserClass,
+    characterProfile,
+    pulls,
+  });
+  console.log(pulls, dungeonPullDetails);
+
   const parsingState = isParsingEvents ? EVENT_PARSING_STATE.PARSING : EVENT_PARSING_STATE.DONE;
 
   const pageProgress = (currentTime - fight.start_time) / (fight.end_time - fight.start_time);

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -36,6 +36,7 @@ import GameBranch from 'game/GameBranch';
 import { fetchCombatants } from 'common/fetchWclApi';
 import { normalizedEncounterId } from 'game/raids';
 import useDungeonPullList from './DungeonPullList/DungeonPullListCombatParser';
+import { useWaSelector } from 'interface/utils/useWaSelector';
 
 const UnsupportedSpecBouncer = ({ report, fight }: { report: Report; fight: WCLFight }) => (
   <main className="container offset">
@@ -101,6 +102,25 @@ const ResultsLoader = () => {
   const { fight } = useFight();
   const [timeFilter, setTimeFilter] = useState<Filter | null>(null);
   const [selectedPhase, setSelectedPhase] = useState<number>(SELECTION_ALL_PHASES);
+  const pull = useWaSelector((state) => state.navigation.pull);
+  useEffect(() => {
+    if (typeof pull === 'number') {
+      setSelectedPhase(pull - 1); // wcl is 1-indexed
+      const pullObj = fight.dungeonPulls?.find((pullObj) => pullObj.id === pull);
+
+      if (pullObj) {
+        setTimeFilter({
+          start: pullObj.start_time,
+          end: pullObj.end_time,
+        });
+      }
+
+      // DungeonPullList handles redux state updates when the pull is not present
+    } else if (isMythicPlus(fight)) {
+      setSelectedPhase(SELECTION_ALL_PHASES);
+      setTimeFilter(null);
+    }
+  }, [fight, pull]);
 
   const parserClass = useParser(config);
   const isLoadingParser = !parserClass;
@@ -303,7 +323,9 @@ const ResultsLoader = () => {
       handlePhaseSelection={applyPhaseFilter}
       applyFilter={applyTimeFilter}
       timeFilter={timeFilter ?? undefined}
-      makeTabUrl={(tab: string) => makeAnalyzerUrl(report, fight.id, player.id, tab)}
+      makeTabUrl={(tab: string) =>
+        makeAnalyzerUrl(report, fight.id, player.id, tab, undefined, pull)
+      }
       dungeonPullDetails={dungeonPullDetails}
     />
   );

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -1,7 +1,7 @@
 import ErrorBoundary from 'interface/ErrorBoundary';
 import makeAnalyzerUrl from 'interface/makeAnalyzerUrl';
 import NavigationBar from 'interface/NavigationBar';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import BOSS_PHASES_STATE from './BOSS_PHASES_STATE';
 import { useConfig } from './ConfigContext';
@@ -30,7 +30,7 @@ import Report from 'parser/core/Report';
 import { Link, useNavigate } from 'react-router-dom';
 import { WCLFight } from 'parser/core/Fight';
 import handleApiError from './handleApiError';
-import { EventType, type CombatantInfoEvent } from 'parser/core/Events';
+import { AnyEvent, EventType, type CombatantInfoEvent } from 'parser/core/Events';
 import { wclGameVersionToBranch } from 'game/VERSIONS';
 import GameBranch from 'game/GameBranch';
 import { fetchCombatants } from 'common/fetchWclApi';
@@ -136,7 +136,36 @@ const ResultsLoader = () => {
     pulls,
     allDeaths,
   } = useEvents({ report, fight, player });
-  const events = isWaitingOnPullSelection ? null : rawEvents;
+
+  const partialEvents = useRef<{ pull: number; events: AnyEvent[] } | null>(null);
+
+  useEffect(() => {
+    partialEvents.current = null;
+  }, [fight, report]);
+
+  // beware: turning off `events` here is performant, toggling `dependenciesLoading` in the `useEventsParser` call is NOT.
+  const events = useMemo(() => {
+    if (isWaitingOnPullSelection) {
+      partialEvents.current = null;
+      return null;
+    }
+
+    if (typeof pull === 'number' && partialEvents.current?.pull === pull) {
+      return partialEvents.current.events;
+    }
+
+    if (!rawEvents && typeof pull === 'number' && pulls) {
+      const index = pulls.findIndex((chunk) => chunk.target.id === pull + 1);
+      const partial = pulls
+        .slice(0, index + 1)
+        .reduce((a, b) => a.concat(b.events), [] as AnyEvent[]);
+      partialEvents.current = { pull, events: partial };
+      return partial;
+    }
+
+    return rawEvents;
+  }, [rawEvents, isWaitingOnPullSelection, pull, pulls]);
+
   const isLoadingEvents = events == null;
 
   const { loadingState: bossPhaseEventsLoadingState, events: bossPhaseEvents } = useBossPhaseEvents(
@@ -203,7 +232,8 @@ const ResultsLoader = () => {
   const [playerCombatantInfo, setPlayerCombatantInfo] = useState<CombatantInfoEvent | undefined>();
 
   useEffect(() => {
-    const existing = rawEvents?.find(
+    // we optimistically check both the rawEvent list and the first pull from a dungeon to avoid the "missing combatantinfo" intermediate state
+    const existing = (rawEvents ?? pulls[0]?.events)?.find(
       (event): event is CombatantInfoEvent =>
         event.type === EventType.CombatantInfo && event.sourceID === player.id,
     );
@@ -244,7 +274,7 @@ const ResultsLoader = () => {
     return () => {
       cancelled = true;
     };
-  }, [rawEvents, player.id, report, fight]);
+  }, [rawEvents, player.id, report, fight, pulls]);
 
   // Original code only rendered EventParser if
   // > !this.state.isLoadingParser &&

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -156,6 +156,10 @@ const ResultsLoader = () => {
 
     if (!rawEvents && typeof pull === 'number' && pulls) {
       const index = pulls.findIndex((chunk) => chunk.target.id === pull + 1);
+      if (index < 0) {
+        return null;
+      }
+
       const partial = pulls
         .slice(0, index + 1)
         .reduce((a, b) => a.concat(b.events), [] as AnyEvent[]);

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -105,7 +105,7 @@ const ResultsLoader = () => {
   const parserClass = useParser(config);
   const isLoadingParser = !parserClass;
 
-  const { events, currentTime, error, pulls } = useEvents({ report, fight, player });
+  const { events, currentTime, error, pulls, allDeaths } = useEvents({ report, fight, player });
   const isLoadingEvents = events == null;
 
   const { loadingState: bossPhaseEventsLoadingState, events: bossPhaseEvents } = useBossPhaseEvents(
@@ -250,6 +250,7 @@ const ResultsLoader = () => {
     parser: parserClass,
     characterProfile,
     pulls,
+    allDeaths,
   });
   console.log(pulls, dungeonPullDetails);
 

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -38,6 +38,9 @@ import { normalizedEncounterId } from 'game/raids';
 import useDungeonPullList from './DungeonPullList/DungeonPullListCombatParser';
 import { useWaSelector } from 'interface/utils/useWaSelector';
 import { isMythicPlus } from 'common/isMythicPlus';
+import { useSelectedPull } from './DungeonPullList';
+import { useWaDispatch } from 'interface/utils/useWaDispatch';
+import { setPull, clearPull } from 'interface/reducers/navigation';
 
 const UnsupportedSpecBouncer = ({ report, fight }: { report: Report; fight: WCLFight }) => (
   <main className="container offset">
@@ -104,8 +107,18 @@ const ResultsLoader = () => {
   const [timeFilter, setTimeFilter] = useState<Filter | null>(null);
   const [selectedPhase, setSelectedPhase] = useState<number>(SELECTION_ALL_PHASES);
   const pull = useWaSelector((state) => state.navigation.pull);
+  const dispatch = useWaDispatch();
+  const [selectedPull] = useSelectedPull(fight);
 
   const isWaitingOnPullSelection = isMythicPlus(fight) && pull === undefined;
+
+  useEffect(() => {
+    if (selectedPull) {
+      dispatch(setPull({ id: selectedPull === 'all' ? selectedPull : selectedPull.id }));
+    } else {
+      dispatch(clearPull());
+    }
+  }, [selectedPull, dispatch]);
 
   useEffect(() => {
     if (typeof pull === 'number') {
@@ -318,6 +331,11 @@ const ResultsLoader = () => {
     allDeaths,
   });
 
+  const makeTabUrl = useCallback(
+    (tab: string) => makeAnalyzerUrl(report, fight.id, player.id, tab, undefined, pull),
+    [report, fight, player, pull],
+  );
+
   const parsingState = isParsingEvents ? EVENT_PARSING_STATE.PARSING : EVENT_PARSING_STATE.DONE;
 
   const pageProgress = (currentTime - fight.start_time) / (fight.end_time - fight.start_time);
@@ -330,16 +348,27 @@ const ResultsLoader = () => {
     (!isFilteringEvents ? 0.05 : 0) +
     parsingEventsProgress! * 0.75;
 
-  const loadingStatus: LoadingStatus = {
-    progress: progress,
-    isLoadingParser: isLoadingParser,
-    isLoadingEvents: isLoadingEvents,
-    bossPhaseEventsLoadingState: bossPhaseEventsLoadingState,
-    isLoadingCharacterProfile: isLoadingCharacterProfile,
-    isLoadingPhases: false,
-    isFilteringEvents: isFilteringEvents,
-    parsingState: parsingState,
-  };
+  const loadingStatus: LoadingStatus = useMemo(
+    () => ({
+      progress: progress,
+      isLoadingParser: isLoadingParser,
+      isLoadingEvents: isLoadingEvents,
+      bossPhaseEventsLoadingState: bossPhaseEventsLoadingState,
+      isLoadingCharacterProfile: isLoadingCharacterProfile,
+      isLoadingPhases: false,
+      isFilteringEvents: isFilteringEvents,
+      parsingState: parsingState,
+    }),
+    [
+      progress,
+      isLoadingParser,
+      isLoadingEvents,
+      bossPhaseEventsLoadingState,
+      isLoadingCharacterProfile,
+      isFilteringEvents,
+      parsingState,
+    ],
+  );
 
   if (events && !playerCombatantInfo) {
     // display error instead of crashing. this can happen in rare cases where `combatantinfo` is not a part of the fight
@@ -368,9 +397,7 @@ const ResultsLoader = () => {
       handlePhaseSelection={applyPhaseFilter}
       applyFilter={applyTimeFilter}
       timeFilter={timeFilter ?? undefined}
-      makeTabUrl={(tab: string) =>
-        makeAnalyzerUrl(report, fight.id, player.id, tab, undefined, pull)
-      }
+      makeTabUrl={makeTabUrl}
       dungeonPullDetails={dungeonPullDetails}
     />
   );

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -37,6 +37,7 @@ import { fetchCombatants } from 'common/fetchWclApi';
 import { normalizedEncounterId } from 'game/raids';
 import useDungeonPullList from './DungeonPullList/DungeonPullListCombatParser';
 import { useWaSelector } from 'interface/utils/useWaSelector';
+import { isMythicPlus } from 'common/isMythicPlus';
 
 const UnsupportedSpecBouncer = ({ report, fight }: { report: Report; fight: WCLFight }) => (
   <main className="container offset">
@@ -103,6 +104,9 @@ const ResultsLoader = () => {
   const [timeFilter, setTimeFilter] = useState<Filter | null>(null);
   const [selectedPhase, setSelectedPhase] = useState<number>(SELECTION_ALL_PHASES);
   const pull = useWaSelector((state) => state.navigation.pull);
+
+  const isWaitingOnPullSelection = isMythicPlus(fight) && pull === undefined;
+
   useEffect(() => {
     if (typeof pull === 'number') {
       setSelectedPhase(pull - 1); // wcl is 1-indexed
@@ -125,7 +129,14 @@ const ResultsLoader = () => {
   const parserClass = useParser(config);
   const isLoadingParser = !parserClass;
 
-  const { events, currentTime, error, pulls, allDeaths } = useEvents({ report, fight, player });
+  const {
+    events: rawEvents,
+    currentTime,
+    error,
+    pulls,
+    allDeaths,
+  } = useEvents({ report, fight, player });
+  const events = isWaitingOnPullSelection ? null : rawEvents;
   const isLoadingEvents = events == null;
 
   const { loadingState: bossPhaseEventsLoadingState, events: bossPhaseEvents } = useBossPhaseEvents(
@@ -192,7 +203,7 @@ const ResultsLoader = () => {
   const [playerCombatantInfo, setPlayerCombatantInfo] = useState<CombatantInfoEvent | undefined>();
 
   useEffect(() => {
-    const existing = events?.find(
+    const existing = rawEvents?.find(
       (event): event is CombatantInfoEvent =>
         event.type === EventType.CombatantInfo && event.sourceID === player.id,
     );
@@ -233,7 +244,7 @@ const ResultsLoader = () => {
     return () => {
       cancelled = true;
     };
-  }, [events, player.id, report, fight]);
+  }, [rawEvents, player.id, report, fight]);
 
   // Original code only rendered EventParser if
   // > !this.state.isLoadingParser &&

--- a/src/interface/report/index.tsx
+++ b/src/interface/report/index.tsx
@@ -252,7 +252,6 @@ const ResultsLoader = () => {
     pulls,
     allDeaths,
   });
-  console.log(pulls, dungeonPullDetails);
 
   const parsingState = isParsingEvents ? EVENT_PARSING_STATE.PARSING : EVENT_PARSING_STATE.DONE;
 
@@ -305,6 +304,7 @@ const ResultsLoader = () => {
       applyFilter={applyTimeFilter}
       timeFilter={timeFilter ?? undefined}
       makeTabUrl={(tab: string) => makeAnalyzerUrl(report, fight.id, player.id, tab)}
+      dungeonPullDetails={dungeonPullDetails}
     />
   );
 };

--- a/src/parser/core/CombatLogParser.tsx
+++ b/src/parser/core/CombatLogParser.tsx
@@ -357,7 +357,29 @@ class CombatLogParser {
     console.log('server metrics', this.serverMetrics);
   }
 
-  _getModuleClass(config: DependencyDefinition): [typeof Module, Record<string, unknown>] {
+  static getModuleClass(
+    parser: typeof CombatLogParser,
+    baseModule: typeof Module,
+  ): DependencyDefinition | undefined {
+    const modules = {
+      ...parser.internalModules,
+      ...parser.defaultModules,
+      ...parser.specModules,
+    };
+
+    for (const mod of Object.values(modules)) {
+      const [modClass] = CombatLogParser._getModuleClass(mod);
+      if (modClass.prototype instanceof baseModule) {
+        return mod;
+      }
+    }
+
+    return undefined;
+  }
+
+  protected static _getModuleClass(
+    config: DependencyDefinition,
+  ): [typeof Module, Record<string, unknown>] {
     let moduleClass;
     let options;
     if (config instanceof Array) {
@@ -415,7 +437,7 @@ class CombatLogParser {
       if (!moduleConfig) {
         return;
       }
-      const [moduleClass, options] = this._getModuleClass(moduleConfig);
+      const [moduleClass, options] = CombatLogParser._getModuleClass(moduleConfig);
       const [availableDependencies, missingDependencies] = this._resolveDependencies(
         moduleClass.dependencies,
       );

--- a/src/parser/core/Fight.ts
+++ b/src/parser/core/Fight.ts
@@ -6,7 +6,14 @@ export interface WCLDungeonPull {
   end_time: number;
   name: string;
   kill?: boolean;
-  enemies?: number[][];
+  enemyNPCs?: WCLDungeonPullEnemy[];
+}
+
+export interface WCLDungeonPullEnemy {
+  id: number;
+  gameID: number;
+  minimumInstanceID: number;
+  maximumInstanceID: number;
 }
 
 export interface WCLFight {

--- a/src/parser/core/Fight.ts
+++ b/src/parser/core/Fight.ts
@@ -28,6 +28,19 @@ export interface WCLFight {
   hardModeLevel?: number;
   dungeonPulls?: WCLDungeonPull[];
   phases?: WCLPhaseTransition[];
+
+  /**
+   * The actual amount of enemy forces count reached by killing non-boss enemies in a Mythic+ dungeon.
+   */
+  countReached?: number | null;
+  /**
+   * The required amount of enemy forces count to reach 100%.
+   */
+  countRequired?: number | null;
+  /**
+   * The amount of count provided for different NPCs by game ID. Because JSON, the actual keys after parse are strings.
+   */
+  npcCountMap?: Record<number | string, number>;
 }
 
 interface WCLPhaseTransition {

--- a/src/parser/core/Fight.ts
+++ b/src/parser/core/Fight.ts
@@ -1,5 +1,5 @@
 // WCL properties
-interface WCLDungeonPull {
+export interface WCLDungeonPull {
   id: number;
   boss: number;
   start_time: number;

--- a/src/parser/core/StateHistory.ts
+++ b/src/parser/core/StateHistory.ts
@@ -106,7 +106,7 @@ export default class StateHistory<State extends { timestamp: number }> {
   slice(start: number, end: number, expand = false): StateHistory<State> {
     this.ensureSort();
 
-    // handle the pathological cases: start > end of data and end < start of data
+    // handle the pathological cases: start > end of data or end < start of data
     if (
       (this._data.at(-1) && start > this._data.at(-1)!.timestamp) ||
       (this._data[0] && end < this._data[0].timestamp)

--- a/src/parser/core/StateHistory.ts
+++ b/src/parser/core/StateHistory.ts
@@ -105,6 +105,15 @@ export default class StateHistory<State extends { timestamp: number }> {
    */
   slice(start: number, end: number, expand = false): StateHistory<State> {
     this.ensureSort();
+
+    // handle the pathological cases: start > end of data and end < start of data
+    if (
+      (this._data.at(-1) && start > this._data.at(-1)!.timestamp) ||
+      (this._data[0] && end < this._data[0].timestamp)
+    ) {
+      return new StateHistory([]);
+    }
+
     let left = 0;
     let right = this._data.length - 1;
 

--- a/src/parser/shared/modules/AbilityTracker.ts
+++ b/src/parser/shared/modules/AbilityTracker.ts
@@ -173,6 +173,9 @@ class DamageTracker extends HealingTracker {
   }
 
   onDamage(event: DamageEvent) {
+    if (event.targetIsFriendly) {
+      return; // don't track friendly-fire (Stagger, SLT)
+    }
     const spellId = event.ability.guid;
     const cast = this.getAbility(spellId, event.ability);
 

--- a/src/parser/shared/modules/AbilityTracker.ts
+++ b/src/parser/shared/modules/AbilityTracker.ts
@@ -11,8 +11,9 @@ import Events, {
 } from 'parser/core/Events';
 
 import SpellManaCost from './SpellManaCost';
-import HealingValue from 'parser/shared/modules/HealingValue';
-import DamageValue from 'parser/shared/modules/DamageValue';
+import HealingValue, { effectiveHealing } from 'parser/shared/modules/HealingValue';
+import DamageValue, { effectiveDamage } from 'parser/shared/modules/DamageValue';
+import StateHistory from 'parser/core/StateHistory';
 
 export interface TrackedAbility {
   ability: Ability | null;
@@ -28,6 +29,11 @@ export interface TrackedAbility {
   healingCriticalVal: HealingValue;
 }
 
+interface TotalPoint {
+  timestamp: number;
+  total: number;
+}
+
 class AbilityTracker extends Analyzer {
   static dependencies = {
     // Needed for the `resourceCost` prop of events
@@ -36,6 +42,9 @@ class AbilityTracker extends Analyzer {
   protected spellManaCost!: SpellManaCost;
 
   abilities = new Map<number, TrackedAbility>();
+
+  protected totalDamagePoints: TotalPoint[] = [];
+  protected totalHealingPoints: TotalPoint[] = [];
 
   constructor(options: Options) {
     super(options);
@@ -103,8 +112,35 @@ class AbilityTracker extends Analyzer {
     const ability = this.getAbility(spellId, abilityInfo);
     return ability.healingVal.effective / ability.casts || 0;
   }
+
+  protected addTotal(points: TotalPoint[], timestamp: number, amount: number) {
+    const current = points.at(-1);
+    if (current && current.timestamp === timestamp) {
+      current.total += amount;
+    } else {
+      points.push({ timestamp, total: (current?.total ?? 0) + amount });
+    }
+  }
+
+  private getTotalInRange(points: TotalPoint[], startTime: number, endTime: number) {
+    const history = new StateHistory(points);
+
+    const before = history.getBefore(startTime, true);
+    const after = history.getBefore(endTime);
+
+    return (after?.total ?? 0) - (before?.total ?? 0);
+  }
+
+  getTotalDamageInRange(startTime: number, endTime: number) {
+    return this.getTotalInRange(this.totalDamagePoints, startTime, endTime);
+  }
+
+  getTotalHealingInRange(startTime: number, endTime: number) {
+    return this.getTotalInRange(this.totalHealingPoints, startTime, endTime);
+  }
 }
 
+// FIXME: this class structure is not good
 class HealingTracker extends AbilityTracker {
   constructor(options: Options) {
     super(options);
@@ -124,6 +160,8 @@ class HealingTracker extends AbilityTracker {
       cast.healingCriticalHits += 1;
       cast.healingCriticalVal = cast.healingCriticalVal.addEvent(event);
     }
+
+    this.addTotal(this.totalHealingPoints, event.timestamp, effectiveHealing(event));
   }
 }
 
@@ -131,6 +169,7 @@ class DamageTracker extends HealingTracker {
   constructor(options: Options) {
     super(options);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER_PET), this.onDamage);
   }
 
   onDamage(event: DamageEvent) {
@@ -143,6 +182,8 @@ class DamageTracker extends HealingTracker {
       cast.damageCriticalHits += 1;
       cast.damageCriticalVal = cast.damageCriticalVal.addEvent(event);
     }
+
+    this.addTotal(this.totalDamagePoints, event.timestamp, effectiveDamage(event));
   }
 }
 

--- a/src/parser/shared/modules/Entities.ts
+++ b/src/parser/shared/modules/Entities.ts
@@ -131,6 +131,7 @@ abstract class Entities<T extends Entity> extends Analyzer {
     } else {
       console.error(
         "Buff stack updated while active buff wasn't known. Was this buff applied pre-combat? Maybe we should register the buff with start time as fight start when this happens, but it might also be a basic case of erroneous combatlog ordering.",
+        event,
       );
     }
   }


### PR DESCRIPTION
### Description

<!-- A brief description of the changes made with this pull request.-->
<img width="1308" height="765" alt="image" src="https://github.com/user-attachments/assets/3d92011e-03c9-43f6-a559-ea334bba859d" />

https://github.com/user-attachments/assets/93e18853-7540-46a9-9fa6-c31c8a452e17

The bulk of the code in this PR is UI code. However, there are a couple of pretty significant internal changes:

1. `useEvents` got a significant refactor to load the pulls independently and provide them early
2. `ResultsLoader` got a significant refactor to process those pulls early and allow that to be provided to the analyzer
3. `useTimeEventFilter` got a significant refactor to fix a performance issue which is highly visible if you are clicking around pulls in M+ (calling `.find` on an event list inside a loop)

### Structure

This PR works by changing `useEvents` to download event chunks pull-by-pull instead of in 20k event chunks. (This does mean more WCL requests, which I'll deal with on the WCL side if it causes problems)

These pulls are provided to the downstream code early, before all events are loaded. The early events are used in two main ways:

1. `DungeonPullListCombatLogParser` uses them to do *light* processing to produce cooldowns used, bloodlust timing, dps/hps, and deaths
2. If you select a pull, we can now show you that pull before the rest of the dungeon has finished downloading (this is done in `report/index.tsx` with some hook magic)

There is some 🍝 going on here. After doing the refactoring for this, I'm tempted to refactor the whole `report/index.tsx` / `useEvents` loading process but I'll leave it for future 🙃 

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

These changes are up on https://next.wowanalyzer.com. you should be able to load both raid and m+ logs. M+ logs should load events pull-by-pull and should work if you try to click a pull before the entire dungeon is loaded.

(There is also an ongoing issue with 429s from WCL that I'm working on so if you see 429 errors it is not (directly) related to this PR)

### Known Issue List

- [ ] Empower spells do not have cooldowns tracked properly unless `pulls=all` is viewed first
- [ ] proc bloodlusts (Aug Evoker has one rn) incorrectly trigger the bloodlust display (should just use sated/exhausted debuffs instead)