### PR TITLE
Fixed cooldown of Raise Dead

### DIFF
--- a/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
+++ b/src/analysis/retail/deathknight/blood/CHANGELOG.tsx
@@ -6,6 +6,8 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 9, 3), <>Fixed <SpellLink spell={talents.RAISE_DEAD_TALENT} /> cooldown</>, Badkad),
+
   change(date(2026, 8, 29), <>Added <SpellLink spell={talents.VISCERAL_STRENGTH_TALENT} /> tracking</>, Gazh),
   change(date(2026, 8, 28), <>Added <SpellLink spell={SPELLS.ESSENCE_OF_THE_BLOOD_QUEEN_BUFF} /> tracking</>, Gazh),
   change(date(2026, 8, 27), <>Added basic 12.1 support and <SpellLink spell={talents.ABOMINATION_LIMB_TALENT}></SpellLink> tracking</>, Badkad),

--- a/src/analysis/retail/deathknight/blood/modules/Abilities.ts
+++ b/src/analysis/retail/deathknight/blood/modules/Abilities.ts
@@ -184,7 +184,7 @@ class Abilities extends CoreAbilities {
         spell: TALENTS.RAISE_DEAD_TALENT.id,
         enabled: combatant.hasTalent(TALENTS.RAISE_DEAD_TALENT),
         category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 90,
+        cooldown: 120 - combatant.getTalentRank(TALENTS.DEATHS_MESSENGER_TALENT) * 30,
       },
       {
         spell: TALENTS.REAPERS_MARK_TALENT.id,


### PR DESCRIPTION
### Description

Cooldown for Raise dead was hard coded to 90 seconds. 
Correct behaivor is that it is 120 seconds and only 90 seconds when Death's Messanger Talent is taken for Deathbringer.
This fixes it

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->Observe number of casts

- Test report URL: `/report/xXLGt1zZ8vK3TWAJ?fight=last)`



