### PR TITLE
[Mistweaver] Timeline markers, tuning, minor adjustments

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 9, 5), <>Added important buffs/procs to Timeline tab, adjusted <ItemSetLink id={MONK_MID2_ID}>12.1 4pc</ItemSetLink> proc rate, added % of total healing to <SpellLink spell={TALENTS_MONK.JADEFIRE_TEACHINGS_TALENT}/> tooltips.</>, swirl),
   change(date(2026, 8, 28), <>Added <SpellLink spell={TALENTS_MONK.DANCE_OF_CHI_JI_MISTWEAVER_TALENT}/> module.</>, swirl),
   change(date(2026, 8, 13), <>Added <ItemSetLink id={MONK_MID2_ID}>12.1 Tier Set</ItemSetLink>, <SpellLink spell={TALENTS_MONK.VITAL_EXPENDITURE_TALENT}/>, and <SpellLink spell={TALENTS_MONK.MISTLINE_TALENT}/> modules, updated various <SpellLink spell={SPELLS.GUSTS_OF_MISTS}/> sources/coefficients.</>, swirl),
   change(date(2026, 6, 29), <>Fixed abilities affected by healing increases across several modules.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
+++ b/src/analysis/retail/monk/mistweaver/CombatLogParser.ts
@@ -95,6 +95,7 @@ import CastingWhileMoving from './modules/features/CastingWhileMoving';
 import WayOfTheCrane from './modules/spells/WayOfTheCrane';
 import AncientTeachingsLinkNormalizer from './normalizers/AncientTeachingsLinkNormalizer';
 import SoothingMistLinkNormalizer from './normalizers/SoothingMistLinkNormalizer';
+import CelestialBuffNormalizer from './normalizers/CelestialBuffNormalizer';
 import PeacefulMending from './modules/spells/PeacefulMending';
 import Spiritfont from './modules/spells/Spiritfont';
 import InvigoratingMists from './modules/spells/InvigoratingMists';
@@ -111,6 +112,7 @@ class CombatLogParser extends CoreCombatLogParser {
     castLinkNormalizer: CastLinkNormalizer,
     ancientTeachingsLinkNormalizer: AncientTeachingsLinkNormalizer,
     soothingMistLinkNormalizer: SoothingMistLinkNormalizer,
+    celestialBuffNormalizer: CelestialBuffNormalizer,
     celestialConduitNormalizer: CelestialConduitNormalizer,
     conduitOfTheCelestialsEventLinks: ConduitOfTheCelestialsEventLinks,
     hotApplicationNormalizer: HotApplicationNormalizer,

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -86,6 +86,9 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           modules.strengthOfTheBlackOx.guideSubsection}
         {info.combatant.hasTalent(TALENTS_MONK.DANCE_OF_CHI_JI_MISTWEAVER_TALENT) &&
           modules.danceOfChiJi.guideSubsection}
+
+        {/* last item in the column for padding */}
+        <div style={{ marginBottom: '1rem' }} />
       </Section>
       <PreparationSection />
     </>

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -27,8 +27,9 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
     <>
       <Section title="Core Spells and Buffs">
         {modules.renewingMist.guideSubsection}
-        {info.combatant.hasTalent(TALENTS_MONK.RISING_MIST_TALENT) &&
-          modules.risingSunKick.guideSubsection}
+        {info.combatant.hasTalent(TALENTS_MONK.RUSHING_WIND_KICK_MISTWEAVER_TALENT) ||
+          (info.combatant.hasTalent(TALENTS_MONK.JADEFIRE_TEACHINGS_TALENT) &&
+            modules.risingSunKick.guideSubsection)}
         {modules.thunderFocusTea.guideSubsection}
         {!info.combatant.hasTalent(TALENTS_MONK.SHEILUNS_GIFT_TALENT) &&
           modules.vivify.guideSubsection}

--- a/src/analysis/retail/monk/mistweaver/modules/features/Buffs.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/features/Buffs.tsx
@@ -1,6 +1,7 @@
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import BLOODLUST_BUFFS from 'game/BLOODLUST_BUFFS';
+import { TIERS } from 'game/TIERS';
 import CoreAuras from 'parser/core/modules/Auras';
 
 class Buffs extends CoreAuras {
@@ -24,30 +25,56 @@ class Buffs extends CoreAuras {
         spellId: SPELLS.SECRET_INFUSION_HASTE_BUFF.id,
         enabled: combatant.hasTalent(TALENTS_MONK.SECRET_INFUSION_TALENT),
       },
+
+      // Procs
       {
-        spellId: SPELLS.INVOKE_CHIJI_THE_RED_CRANE_BUFF.id,
-        enabled: combatant.hasTalent(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT),
-        triggeredBySpellId: TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id,
+        spellId: SPELLS.STRENGTH_OF_THE_BLACK_OX_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS_MONK.STRENGTH_OF_THE_BLACK_OX_TALENT),
+        timelineHighlight: true,
       },
       {
-        spellId: SPELLS.INVOKE_YULON_BUFF.id,
-        enabled: combatant.hasTalent(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT),
-        triggeredBySpellId: TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id,
+        spellId: SPELLS.SPIRITFONT_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS_MONK.SPIRITFONT_1_MISTWEAVER_TALENT),
+        timelineHighlight: true,
       },
+      {
+        spellId: SPELLS.ZEN_PULSE_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS_MONK.ZEN_PULSE_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: SPELLS.DANCE_OF_CHI_JI_MW_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS_MONK.DANCE_OF_CHI_JI_MISTWEAVER_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: SPELLS.MW_S2_4PC_BUFF.id,
+        enabled: combatant.has4PieceByTier(TIERS.MID2),
+        timelineHighlight: true,
+      },
+
       // Throughput Cooldown
       {
         spellId: SPELLS.MANA_TEA_CAST.id,
         enabled: combatant.hasTalent(TALENTS_MONK.MANA_TEA_TALENT),
         timelineHighlight: true,
       },
+      {
+        spellId: TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id,
+        enabled: combatant.hasTalent(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT),
+        timelineHighlight: true,
+      },
+      {
+        spellId: SPELLS.INVOKE_YULON_BUFF.id,
+        enabled: combatant.hasTalent(TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT),
+        triggeredBySpellId: TALENTS_MONK.INVOKE_YULON_THE_JADE_SERPENT_TALENT.id,
+        timelineHighlight: true,
+      },
+
       // Utility
       {
         spellId: TALENTS_MONK.TIGERS_LUST_TALENT.id,
         enabled: combatant.hasTalent(TALENTS_MONK.TIGERS_LUST_TALENT),
-      },
-      {
-        spellId: TALENTS_MONK.DIFFUSE_MAGIC_TALENT.id,
-        enabled: combatant.hasTalent(TALENTS_MONK.DIFFUSE_MAGIC_TALENT),
       },
       {
         spellId: TALENTS_MONK.FORTIFYING_BREW_TALENT.id,

--- a/src/analysis/retail/monk/mistweaver/modules/heroTalents/StrengthOfTheBlackOx.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/heroTalents/StrengthOfTheBlackOx.tsx
@@ -3,7 +3,7 @@ import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Events, { RefreshBuffEvent, RemoveBuffEvent } from 'parser/core/Events';
-import { isStrengthOfTheBlackOxConsumed } from '../../normalizers/CastLinkNormalizer';
+import { getStrengthOfTheBlackOxConsumingCast } from '../../normalizers/CastLinkNormalizer';
 import SpellLink from 'interface/SpellLink';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
 import {
@@ -15,6 +15,7 @@ import CastDetail, { type PerCastData } from 'interface/guide/components/CastDet
 import CastOverview from 'interface/guide/components/CastOverview';
 import { CelestialHooks } from 'analysis/retail/monk/shared';
 import { getCurrentCelestialTalent } from '../../constants';
+import { addEnhancedCastReason } from 'parser/core/EventMetaLib';
 
 class StrengthOfTheBlackOx extends Analyzer {
   static dependencies = {
@@ -55,7 +56,8 @@ class StrengthOfTheBlackOx extends Analyzer {
   }
 
   private onRemoveBuff(event: RemoveBuffEvent) {
-    const isConsumed = isStrengthOfTheBlackOxConsumed(event);
+    const consumingCast = getStrengthOfTheBlackOxConsumingCast(event);
+    const isConsumed = consumingCast !== undefined;
     if (!isConsumed) {
       this.expiredBuffs += 1;
     }
@@ -79,6 +81,15 @@ class StrengthOfTheBlackOx extends Analyzer {
         'Buff expired before being consumed'
       ),
     });
+
+    if (consumingCast) {
+      addEnhancedCastReason(
+        consumingCast,
+        <>
+          This cast consumed <SpellLink spell={SPELLS.STRENGTH_OF_THE_BLACK_OX_BUFF} />.
+        </>,
+      );
+    }
   }
 
   get guideSubsection(): JSX.Element {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/DanceOfChiJi.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/DanceOfChiJi.tsx
@@ -6,7 +6,6 @@ import { calculateEffectiveDamage, calculateEffectiveHealing } from 'parser/core
 import Events, {
   CastEvent,
   DamageEvent,
-  HasRelatedEvent,
   HealEvent,
   RefreshBuffEvent,
   RemoveBuffEvent,
@@ -27,8 +26,8 @@ import {
 import CastOverview from 'interface/guide/components/CastOverview';
 import CastSummary, { type CastEvaluation } from 'interface/guide/components/CastSummary';
 import { DANCE_OF_CHI_JI_INCREASE } from '../../constants';
-import { DANCE_OF_CHI_JI_CONSUME } from '../../normalizers/EventLinks/EventLinkConstants';
-import { isDanceOfChiJi } from '../../normalizers/CastLinkNormalizer';
+import { getDanceOfChiJiConsumingCast, isDanceOfChiJi } from '../../normalizers/CastLinkNormalizer';
+import { addEnhancedCastReason } from 'parser/core/EventMetaLib';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 import GuideSection from 'interface/guide/components/GuideSection';
 
@@ -85,7 +84,14 @@ class DanceOfChiJi extends Analyzer {
   }
 
   private onRemoveBuff(event: RemoveBuffEvent) {
-    if (HasRelatedEvent(event, DANCE_OF_CHI_JI_CONSUME)) {
+    const consumingCast = getDanceOfChiJiConsumingCast(event);
+    if (consumingCast) {
+      addEnhancedCastReason(
+        consumingCast,
+        <>
+          This cast consumed <SpellLink spell={SPELLS.DANCE_OF_CHI_JI_MW_BUFF} />.
+        </>,
+      );
       this.casts.push({
         timestamp: event.timestamp,
         performance: QualitativePerformance.Good,

--- a/src/analysis/retail/monk/mistweaver/modules/spells/JadefireTeachings.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/JadefireTeachings.tsx
@@ -165,13 +165,14 @@ class JadefireTeachings extends Analyzer {
   }
 
   getTooltip(spellId: number, secondarySourceId?: number) {
+    const healing = this.damageSpellToHealing.get(spellId) || 0;
     return (
       <ul>
         <li>
           {secondarySourceId && <SpellLink spell={secondarySourceId} />}{' '}
           <SpellLink spell={spellId} /> converted to healing{' '}
-          {this.damageSpellsCount.get(spellId) || 0} times for a total of{' '}
-          {formatNumber(this.damageSpellToHealing.get(spellId) || 0)} healing
+          {this.damageSpellsCount.get(spellId) || 0} times for a total of {formatNumber(healing)}{' '}
+          healing ({formatPercentage(this.owner.getPercentageOfTotalHealingDone(healing))}%)
         </li>
       </ul>
     );

--- a/src/analysis/retail/monk/mistweaver/modules/spells/Spiritfont.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/Spiritfont.tsx
@@ -34,9 +34,11 @@ import {
   SPIRITFONT_TFT,
 } from '../../normalizers/EventLinks/EventLinkConstants';
 import {
-  isSpiritfontConsumed,
+  getSpiritfontConsumingCast,
+  getSpiritfontOvercapCast,
   isSpiritfontFalseRefresh,
 } from '../../normalizers/CastLinkNormalizer';
+import { addEnhancedCastReason, addInefficientCastReason } from 'parser/core/EventMetaLib';
 import StatisticListBoxItem from 'parser/ui/StatisticListBoxItem';
 import ItemDamageDone from 'parser/ui/ItemDamageDone';
 import { GUIDE_CORE_EXPLANATION_PERCENT } from '../../Guide';
@@ -136,10 +138,22 @@ class Spiritfont extends Analyzer {
       performance: QualitativePerformance.Fail,
       reason: `Refreshed at ${SPIRITFONT_MAX_STACKS} stacks`,
     });
+
+    const overcapCast = getSpiritfontOvercapCast(event);
+    if (overcapCast) {
+      addInefficientCastReason(
+        overcapCast,
+        <>
+          This cast procced <SpellLink spell={TALENTS_MONK.SPIRITFONT_1_MISTWEAVER_TALENT} /> while
+          already at {SPIRITFONT_MAX_STACKS} stacks, wasting the proc.
+        </>,
+      );
+    }
   }
 
   private onRemoveBuff(event: RemoveBuffEvent | RemoveBuffStackEvent) {
-    const isConsumed = isSpiritfontConsumed(event);
+    const consumingCast = getSpiritfontConsumingCast(event);
+    const isConsumed = consumingCast !== undefined;
     if (!isConsumed) {
       this.expiredBuffs += 1;
     }
@@ -148,6 +162,15 @@ class Spiritfont extends Analyzer {
       performance: isConsumed ? QualitativePerformance.Good : QualitativePerformance.Fail,
       reason: isConsumed ? 'Consumed' : 'Expired',
     });
+
+    if (consumingCast) {
+      addEnhancedCastReason(
+        consumingCast,
+        <>
+          This cast consumed <SpellLink spell={SPELLS.SPIRITFONT_BUFF} />.
+        </>,
+      );
+    }
   }
 
   handleSpiritfontHeal(event: HealEvent) {

--- a/src/analysis/retail/monk/mistweaver/modules/spells/ZenPulse.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/ZenPulse.tsx
@@ -10,7 +10,12 @@ import Events, {
   RemoveBuffEvent,
   RemoveBuffStackEvent,
 } from 'parser/core/Events';
-import { getZenPulseHitsPerCast, isZenPulseConsumed } from '../../normalizers/CastLinkNormalizer';
+import {
+  getZenPulseConsumingCast,
+  getZenPulseHitsPerCast,
+  getZenPulseOvercapCast,
+} from '../../normalizers/CastLinkNormalizer';
+import { addEnhancedCastReason, addInefficientCastReason } from 'parser/core/EventMetaLib';
 import Statistic from 'parser/ui/Statistic';
 import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
 import TalentSpellText from 'parser/ui/TalentSpellText';
@@ -131,14 +136,31 @@ class ZenPulse extends Analyzer {
         stats: [],
         details: `Buff refreshed at ${MAX_STACKS} stacks`,
       });
+
+      const overcapCast = getZenPulseOvercapCast(event);
+      if (overcapCast) {
+        addInefficientCastReason(
+          overcapCast,
+          <>
+            This cast procced <SpellLink spell={TALENTS_MONK.ZEN_PULSE_TALENT} /> while already at{' '}
+            {MAX_STACKS} stacks, wasting the proc.
+          </>,
+        );
+      }
     }
   }
 
   private onRemoveBuff(event: RemoveBuffEvent | RemoveBuffStackEvent) {
-    const isConsumed = isZenPulseConsumed(event);
-    if (isConsumed) {
+    const consumingCast = getZenPulseConsumingCast(event);
+    if (consumingCast) {
       this.consumedBuffs += 1;
       this.currentBuffs -= 1;
+      addEnhancedCastReason(
+        consumingCast,
+        <>
+          This cast consumed <SpellLink spell={SPELLS.ZEN_PULSE_BUFF} />.
+        </>,
+      );
     } else {
       this.expiredBuffs += 1;
       this.currentBuffs = 0;

--- a/src/analysis/retail/monk/mistweaver/modules/tier/S2TierSet.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/tier/S2TierSet.tsx
@@ -35,6 +35,7 @@ import { Talent } from 'common/TALENTS/types';
 import Spell from 'common/SPELLS/Spell';
 import HotTrackerMW from '../core/HotTrackerMW';
 import { plotOneVariableBinomChart } from 'parser/shared/modules/helpers/Probability';
+import { addEnhancedCastReason } from 'parser/core/EventMetaLib';
 
 // tier specific constants
 const TWO_PIECE_RSK_DAMAGE_INCREASE = 0.3;
@@ -235,6 +236,12 @@ class S2TierSet extends TierSetAnalyzer.withDependencies({
       return;
     }
 
+    addEnhancedCastReason(
+      consumingCast,
+      <>
+        This cast was made free by the <SpellLink spell={SPELLS.MW_S2_4PC_BUFF} /> 4-piece.
+      </>,
+    );
     this.attributeFreeCast(consumingCast);
   }
 

--- a/src/analysis/retail/monk/mistweaver/modules/tier/S2TierSet.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/tier/S2TierSet.tsx
@@ -40,8 +40,8 @@ import { addEnhancedCastReason } from 'parser/core/EventMetaLib';
 // tier specific constants
 const TWO_PIECE_RSK_DAMAGE_INCREASE = 0.3;
 const TWO_PIECE_RWK_HEAL_INCREASE = 1.0;
-// actually 20% ingame but it cannot proc off of its self, rendering 15%
-const FOUR_PIECE_PROC_CHANCE = 0.15;
+// actually 25% ingame but it cannot proc off of its self, rendering 20%
+const FOUR_PIECE_PROC_CHANCE = 0.2;
 
 interface FourPieceSource {
   spell: Spell | Talent;

--- a/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CastLinkNormalizer.ts
@@ -41,10 +41,12 @@ import {
   CRANE_STYLE_SCK,
   VIVACIOUS_VIVIFICATION,
   ZEN_PULSE_CONSUME,
+  ZEN_PULSE_OVERCAP,
   ZEN_PULSE_CAST,
   STRENGTH_OF_THE_BLACK_OX,
   SPIRITFONT_CONSUMED,
   SPIRITFONT_FALSE_REFRESH,
+  SPIRITFONT_OVERCAP,
   JADE_BOND_ENVM,
   INSURANCE_FROM_REM,
   INSURANCE,
@@ -282,8 +284,14 @@ export function getZenPulseHitsPerCast(event: HealEvent): HealEvent[] {
   return GetRelatedEvents<HealEvent>(event, ZEN_PULSE_CAST);
 }
 
-export function isZenPulseConsumed(event: RemoveBuffEvent | RemoveBuffStackEvent) {
-  return GetRelatedEvent(event, ZEN_PULSE_CONSUME);
+export function getZenPulseConsumingCast(
+  event: RemoveBuffEvent | RemoveBuffStackEvent,
+): CastEvent | undefined {
+  return GetRelatedEvent<CastEvent>(event, ZEN_PULSE_CONSUME);
+}
+
+export function getZenPulseOvercapCast(event: RefreshBuffEvent): CastEvent | undefined {
+  return GetRelatedEvent<CastEvent>(event, ZEN_PULSE_OVERCAP);
 }
 
 export function getManaTeaChannelDuration(event: ApplyBuffEvent) {
@@ -306,8 +314,14 @@ export function HasStackChange(event: RefreshBuffEvent): boolean {
 }
 
 // apex talent (spiritfont)
-export function isSpiritfontConsumed(event: RemoveBuffEvent | RemoveBuffStackEvent): boolean {
-  return HasRelatedEvent(event, SPIRITFONT_CONSUMED);
+export function getSpiritfontConsumingCast(
+  event: RemoveBuffEvent | RemoveBuffStackEvent,
+): CastEvent | undefined {
+  return GetRelatedEvent<CastEvent>(event, SPIRITFONT_CONSUMED);
+}
+
+export function getSpiritfontOvercapCast(event: RefreshBuffEvent): CastEvent | undefined {
+  return GetRelatedEvent<CastEvent>(event, SPIRITFONT_OVERCAP);
 }
 
 export function isSpiritfontFalseRefresh(event: RefreshBuffEvent): boolean {
@@ -315,8 +329,10 @@ export function isSpiritfontFalseRefresh(event: RefreshBuffEvent): boolean {
 }
 
 // hero talents
-export function isStrengthOfTheBlackOxConsumed(event: RemoveBuffEvent): boolean {
-  return HasRelatedEvent(event, STRENGTH_OF_THE_BLACK_OX);
+export function getStrengthOfTheBlackOxConsumingCast(
+  event: RemoveBuffEvent,
+): CastEvent | undefined {
+  return GetRelatedEvent<CastEvent>(event, STRENGTH_OF_THE_BLACK_OX);
 }
 
 // tier
@@ -335,6 +351,10 @@ export function isInsuranceFromHardcast(event: HealEvent) {
 // damage -> heal
 export function isDanceOfChiJi(event: CastEvent): boolean {
   return HasRelatedEvent(event, DANCE_OF_CHI_JI_CONSUME);
+}
+
+export function getDanceOfChiJiConsumingCast(event: RemoveBuffEvent): CastEvent | undefined {
+  return GetRelatedEvent<CastEvent>(event, DANCE_OF_CHI_JI_CONSUME);
 }
 
 export default CastLinkNormalizer;

--- a/src/analysis/retail/monk/mistweaver/normalizers/CelestialBuffNormalizer.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/CelestialBuffNormalizer.ts
@@ -1,0 +1,104 @@
+import { TALENTS_MONK } from 'common/TALENTS';
+import Spell from 'common/SPELLS/Spell';
+import MAGIC_SCHOOLS from 'game/MAGIC_SCHOOLS';
+import {
+  AnyEvent,
+  ApplyBuffEvent,
+  EventType,
+  HasTarget,
+  RemoveBuffEvent,
+} from 'parser/core/Events';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+// fabricates invoke chi-ji buff events since we can only
+// signal from the pet's (chi-ji) summon to its death (rip bird)
+class CelestialBuffNormalizer extends EventsNormalizer {
+  normalize(events: AnyEvent[]): AnyEvent[] {
+    if (!this.selectedCombatant.hasTalent(TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT)) {
+      return events;
+    }
+
+    const buffSpell = TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT;
+    const fabricated: { index: number; event: AnyEvent }[] = [];
+    let open = false;
+
+    events.forEach((event, index) => {
+      if (
+        event.type === EventType.Cast &&
+        event.ability.guid === TALENTS_MONK.INVOKE_CHI_JI_THE_RED_CRANE_TALENT.id &&
+        event.sourceID === this.owner.playerId
+      ) {
+        if (open) {
+          fabricated.push({ index, event: this.removeBuff(buffSpell, event.timestamp) });
+        }
+        open = true;
+        fabricated.push({ index, event: this.applyBuff(buffSpell, event.timestamp) });
+        return;
+      }
+
+      if (open && this.isPetDeath(event)) {
+        fabricated.push({ index, event: this.removeBuff(buffSpell, event.timestamp) });
+        open = false;
+      }
+    });
+
+    if (open) {
+      fabricated.push({
+        index: events.length,
+        event: this.removeBuff(buffSpell, this.owner.fight.end_time),
+      });
+    }
+
+    if (fabricated.length === 0) {
+      return events;
+    }
+
+    fabricated.reverse().forEach(({ index, event }) => {
+      events.splice(index, 0, event);
+    });
+    return events;
+  }
+
+  private isPetDeath(event: AnyEvent): boolean {
+    if (event.type !== EventType.Death || !HasTarget(event)) {
+      return false;
+    }
+    return (
+      event.targetID === this.owner.playerId ||
+      this.owner.playerPets.some((pet) => pet.id === event.targetID)
+    );
+  }
+
+  private applyBuff(spell: Spell, timestamp: number): ApplyBuffEvent {
+    return {
+      ...this.buffEvent(spell, timestamp),
+      type: EventType.ApplyBuff,
+    };
+  }
+
+  private removeBuff(spell: Spell, timestamp: number): RemoveBuffEvent {
+    return {
+      ...this.buffEvent(spell, timestamp),
+      type: EventType.RemoveBuff,
+    };
+  }
+
+  private buffEvent(spell: Spell, timestamp: number) {
+    return {
+      ability: {
+        guid: spell.id,
+        name: spell.name,
+        abilityIcon: spell.icon,
+        type: MAGIC_SCHOOLS.ids.NATURE,
+      },
+      timestamp,
+      sourceID: this.owner.playerId,
+      sourceIsFriendly: true as const,
+      targetID: this.owner.playerId,
+      targetIsFriendly: true as const,
+      __fabricated: true as const,
+    };
+  }
+}
+
+export default CelestialBuffNormalizer;

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/ApexEventLinks.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/ApexEventLinks.ts
@@ -8,6 +8,7 @@ import {
   SPIRITFONT_TFT,
   SPIRITFONT_CONSUMED,
   SPIRITFONT_FALSE_REFRESH,
+  SPIRITFONT_OVERCAP,
 } from './EventLinkConstants';
 
 export const APEX_EVENT_LINKS: EventLink[] = [
@@ -44,6 +45,7 @@ export const APEX_EVENT_LINKS: EventLink[] = [
   },
   {
     linkRelation: SPIRITFONT_CONSUMED,
+    reverseLinkRelation: SPIRITFONT_CONSUMED,
     linkingEventId: SPELLS.SPIRITFONT_BUFF.id,
     linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
     referencedEventId: TALENTS_MONK.ENVELOPING_MIST_TALENT.id,
@@ -53,6 +55,21 @@ export const APEX_EVENT_LINKS: EventLink[] = [
     anyTarget: true,
     isActive(c) {
       return c.hasTalent(TALENTS_MONK.SPIRITFONT_1_MISTWEAVER_TALENT);
+    },
+  },
+  {
+    linkRelation: SPIRITFONT_OVERCAP,
+    reverseLinkRelation: SPIRITFONT_OVERCAP,
+    linkingEventId: SPELLS.SPIRITFONT_BUFF.id,
+    linkingEventType: EventType.RefreshBuff,
+    referencedEventId: TALENTS_MONK.THUNDER_FOCUS_TEA_TALENT.id,
+    referencedEventType: EventType.Cast,
+    backwardBufferMs: CAST_BUFFER_MS,
+    forwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
+    anyTarget: true,
+    isActive(c) {
+      return c.hasTalent(TALENTS_MONK.SPIRITFONT_3_MISTWEAVER_TALENT);
     },
   },
   {

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/EventLinkConstants.ts
@@ -33,6 +33,7 @@ export const VIVIFY = 'Vivify';
 export const VIVACIOUS_VIVIFICATION = 'VivaciousVivification';
 export const ZEN_PULSE_CAST = 'ZenPulseCast';
 export const ZEN_PULSE_CONSUME = 'ZenPulseConsume';
+export const ZEN_PULSE_OVERCAP = 'ZenPulseOvercap';
 export const CHI_WAVE_VIVIFY = 'ChiWaveVivify';
 export const SHEILUNS_GIFT = 'SheilunsGift';
 export const SHEILUNS_GIFT_MAIN_TARGET = 'SheilunsGiftMainTarget';
@@ -85,6 +86,7 @@ export const SPIRITFONT_PROC = 'SpiritfontProc';
 export const SPIRITFONT_TFT = 'SpiritfontTFT';
 export const SPIRITFONT_CONSUMED = 'SpiritfontConsumed';
 export const SPIRITFONT_FALSE_REFRESH = 'SpiritfontFalseRefresh';
+export const SPIRITFONT_OVERCAP = 'SpiritfontOvercap';
 
 // Soothing Mist Channel
 export const SOOTHING_MIST_CHANNEL_START = 'SoothingMistChannelStart';

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/HeroTalentEventLinks.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/HeroTalentEventLinks.ts
@@ -7,6 +7,7 @@ import { CAST_BUFFER_MS, STRENGTH_OF_THE_BLACK_OX } from './EventLinkConstants';
 export const HERO_TALENT_EVENT_LINKS: EventLink[] = [
   {
     linkRelation: STRENGTH_OF_THE_BLACK_OX,
+    reverseLinkRelation: STRENGTH_OF_THE_BLACK_OX,
     linkingEventId: SPELLS.STRENGTH_OF_THE_BLACK_OX_BUFF.id,
     linkingEventType: EventType.RemoveBuff,
     referencedEventId: [SPELLS.ENVELOPING_MIST_TFT.id, TALENTS_MONK.ENVELOPING_MIST_TALENT.id],

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/VivifyEventLinks.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/VivifyEventLinks.ts
@@ -7,10 +7,12 @@ import {
   ZEN_PULSE_CAST,
   VIVACIOUS_VIVIFICATION,
   ZEN_PULSE_CONSUME,
+  ZEN_PULSE_OVERCAP,
   SHEILUNS_GIFT_MAIN_TARGET,
   SHEILUNS_GIFT,
 } from './EventLinkConstants';
 import { TALENTS_MONK } from 'common/TALENTS';
+import { THUNDER_FOCUS_TEA_SPELLS } from '../../constants';
 
 export const VIVIFY_EVENT_LINKS: EventLink[] = [
   {
@@ -37,9 +39,25 @@ export const VIVIFY_EVENT_LINKS: EventLink[] = [
   },
   {
     linkRelation: ZEN_PULSE_CONSUME,
+    reverseLinkRelation: ZEN_PULSE_CONSUME,
     linkingEventId: SPELLS.ZEN_PULSE_BUFF.id,
     linkingEventType: [EventType.RemoveBuff, EventType.RemoveBuffStack],
     referencedEventId: SPELLS.VIVIFY.id,
+    referencedEventType: [EventType.Cast],
+    anyTarget: true,
+    forwardBufferMs: CAST_BUFFER_MS,
+    backwardBufferMs: CAST_BUFFER_MS,
+    maximumLinks: 1,
+    isActive(c) {
+      return c.hasTalent(TALENTS_MONK.ZEN_PULSE_TALENT);
+    },
+  },
+  {
+    linkRelation: ZEN_PULSE_OVERCAP,
+    reverseLinkRelation: ZEN_PULSE_OVERCAP,
+    linkingEventId: SPELLS.ZEN_PULSE_BUFF.id,
+    linkingEventType: EventType.RefreshBuff,
+    referencedEventId: THUNDER_FOCUS_TEA_SPELLS.map((spell) => spell.id),
     referencedEventType: [EventType.Cast],
     anyTarget: true,
     forwardBufferMs: CAST_BUFFER_MS,


### PR DESCRIPTION
### Description

- Added enhancedCastReasons for several procs (Zen Pulse, Spiritfont, Dance of Chi-Ji, Strength of the Black Ox, S2 Tier Set) alongside their inefficientCastReasons.
- Fabricated buff event for Invoke Chi-Ji to pick up based on pet summon/death when invoking. This is added to timeline to display the current active state of both Yu'lon and Chi-Ji's cooldowns.
- Adjusted for Sept 1 tuning, namely the S2 Tier Set proc chance
- Added % of total to JFS tooltip entries since the TalentAggregateBars don't display numerics when they're too small
- Removed the requirement to display RSK on the Overview screen to have Rising Mist - this was necessary before Jadefire Teachings and Rushing Wind Kick where RSK was only giving HPS through Rising Mist. Added those two as checks instead.
- Small padding div below the procs section

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/92GnWp1Mczfjv7LA/1-Mythic++Altar+of+Fangs+-+Kill+(28:35)/8-双马尾张俊杰/standard/timeline`
- Screenshot(s):
<img width="1278" height="348" alt="image" src="https://github.com/user-attachments/assets/87759437-2b9e-4196-9a47-ecfe8b79285a" />
<img width="512" height="302" alt="image" src="https://github.com/user-attachments/assets/acfd266c-e398-4479-9656-a4bedf08149c" />
<img width="391" height="177" alt="image" src="https://github.com/user-attachments/assets/a47c5515-2549-40c6-bb34-107e40930b95" />
<img width="515" height="198" alt="image" src="https://github.com/user-attachments/assets/7e02e1e3-d6e7-4115-a1dc-9549435235ab" />

`report/bRMgGLqF1zBmfAYn/49-Heroic+Ula'tek+-+Kill+(9:51)/18-Sharkfish/standard`
(yu'lon is 25s here, too long to display the whole thing)
<img width="1565" height="175" alt="image" src="https://github.com/user-attachments/assets/814dc2a2-89ce-458d-b9dd-afb0a55531f0" />

`/report/PTZGWXnpJVNYwQdL/33-Normal+Sszorak+-+Kill+(7:36)/11-Aütobot/standard/timeline`
<img width="675" height="152" alt="image" src="https://github.com/user-attachments/assets/b1b264b2-1dfb-4105-8bf6-038558fdd984" />
<img width="422" height="165" alt="image" src="https://github.com/user-attachments/assets/2d48c047-12da-4587-89d4-850f80b83a42" />
