### PR TITLE
[Mistweaver] 12.1 APL fixes

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2764,36 +2764,42 @@ export const swirl: Contributor = {
     {
       name: 'Swirl',
       spec: SPECS.MISTWEAVER_MONK,
-      link: 'https://worldofwarcraft.com/en-us/character/us/area-52/Swirl',
-    },
-    {
-      name: 'Devotion',
-      spec: SPECS.HOLY_PALADIN,
-      link: 'https://worldofwarcraft.com/en-us/character/us/area-52/Devotion',
+      link: 'https://worldofwarcraft.blizzard.com/en-us/worldsoul/us/armory/character/illidan/Swirl',
     },
   ],
   alts: [
     {
-      name: 'Schizo',
-      spec: SPECS.DISCIPLINE_PRIEST,
-      link: 'https://worldofwarcraft.com/en-us/character/us/area-52/Schizo',
-    },
-    {
-      name: 'Niceorbs',
-      spec: SPECS.PRESERVATION_EVOKER,
-      link: 'https://worldofwarcraft.com/en-us/character/us/area-52/Niceorbs',
-    },
-    {
-      name: 'Efflo',
+      name: 'Cowinpasture',
       spec: SPECS.RESTORATION_DRUID,
-      link: 'https://worldofwarcraft.com/en-us/character/us/area-52/Efflo',
+      link: 'https://worldofwarcraft.blizzard.com/en-us/worldsoul/us/armory/character/zuljin/Cowinpasture',
     },
     {
-      name: 'Tend',
+      name: 'Bunkyunker',
       spec: SPECS.RESTORATION_SHAMAN,
-      link: 'https://worldofwarcraft.com/en-us/character/us/area-52/Tend',
+      link: 'https://worldofwarcraft.blizzard.com/en-us/worldsoul/us/armory/character/zuljin/Bunkyunker',
+    },
+    {
+      name: 'Yeaitspink',
+      spec: SPECS.HOLY_PALADIN,
+      link: 'https://worldofwarcraft.blizzard.com/en-us/worldsoul/us/armory/character/zuljin/Y',
+    },
+    {
+      name: 'Toadbucket',
+      spec: SPECS.PRESERVATION_EVOKER,
+      link: 'https://worldofwarcraft.blizzard.com/en-us/worldsoul/us/armory/character/zuljin/Toadbucket',
+    },
+    {
+      name: 'Squidpilled',
+      spec: SPECS.DISCIPLINE_PRIEST,
+      link: 'https://worldofwarcraft.blizzard.com/en-us/worldsoul/us/armory/character/zuljin/Squidpilled',
     },
   ],
+  links: {
+    'Wowhead Guide': 'https://www.wowhead.com/guide/classes/monk/mistweaver/overview-pve-healer',
+    Website: 'https://waitimramping.com',
+    Twitch: 'https://www.twitch.tv/lolswirl',
+    YouTube: 'https://www.youtube.com/@lolswirl',
+  },
 };
 
 export const Leftyxiv: Contributor = {

--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 9, 5), <>Adjusted APL conditions for 12.1.</>, swirl),
   change(date(2026, 9, 5), <>Added important buffs/procs to Timeline tab, adjusted <ItemSetLink id={MONK_MID2_ID}>12.1 4pc</ItemSetLink> proc rate, added % of total healing to <SpellLink spell={TALENTS_MONK.JADEFIRE_TEACHINGS_TALENT}/> tooltips.</>, swirl),
   change(date(2026, 8, 28), <>Added <SpellLink spell={TALENTS_MONK.DANCE_OF_CHI_JI_MISTWEAVER_TALENT}/> module.</>, swirl),
   change(date(2026, 8, 13), <>Added <ItemSetLink id={MONK_MID2_ID}>12.1 Tier Set</ItemSetLink>, <SpellLink spell={TALENTS_MONK.VITAL_EXPENDITURE_TALENT}/>, and <SpellLink spell={TALENTS_MONK.MISTLINE_TALENT}/> modules, updated various <SpellLink spell={SPELLS.GUSTS_OF_MISTS}/> sources/coefficients.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -27,9 +27,9 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
     <>
       <Section title="Core Spells and Buffs">
         {modules.renewingMist.guideSubsection}
-        {info.combatant.hasTalent(TALENTS_MONK.RUSHING_WIND_KICK_MISTWEAVER_TALENT) ||
-          (info.combatant.hasTalent(TALENTS_MONK.JADEFIRE_TEACHINGS_TALENT) &&
-            modules.risingSunKick.guideSubsection)}
+        {(info.combatant.hasTalent(TALENTS_MONK.RUSHING_WIND_KICK_MISTWEAVER_TALENT) ||
+          info.combatant.hasTalent(TALENTS_MONK.JADEFIRE_TEACHINGS_TALENT)) &&
+          modules.risingSunKick.guideSubsection}
         {modules.thunderFocusTea.guideSubsection}
         {!info.combatant.hasTalent(TALENTS_MONK.SHEILUNS_GIFT_TALENT) &&
           modules.vivify.guideSubsection}

--- a/src/analysis/retail/monk/mistweaver/Guide.tsx
+++ b/src/analysis/retail/monk/mistweaver/Guide.tsx
@@ -11,6 +11,7 @@ import { RoundedPanel } from 'interface/guide/components/GuideDivs';
 import * as AplCheck from './modules/core/apl/AplCheck';
 import AplChoiceDescription from './modules/core/apl/AplChoiceDescription';
 import { AplSectionData } from 'interface/guide/components/Apl';
+import { TipBox } from 'interface/guide/components';
 import { defaultExplainers } from 'interface/guide/components/Apl/violations/claims';
 import { filterCelestial } from './modules/core/apl/ExplainCelestial';
 import { getCurrentCelestialTalent, getCurrentRSKTalent } from './constants';
@@ -58,13 +59,11 @@ export default function Guide({ modules, events, info }: GuideProps<typeof Comba
           use the abilities that are highest on the list.
         </p>
         <AplChoiceDescription aplChoice={AplCheck.chooseApl(info)} />
-        <p>
-          <strong>
-            It is important to note that using abilites like{' '}
-            <SpellLink spell={getCurrentCelestialTalent(info.combatant)} /> have their own priority
-            that supercedes the priority list below. This section omits all casts in those windows.
-          </strong>
-        </p>
+        <TipBox type="info">
+          It is important to note that using abilites like{' '}
+          <SpellLink spell={getCurrentCelestialTalent(info.combatant)} /> have their own priority
+          that supercedes the priority list below. This section omits all casts in those windows.
+        </TipBox>
         <SubSection>
           <AplSectionData
             checker={AplCheck.check}

--- a/src/analysis/retail/monk/mistweaver/modules/core/apl/AplCheck.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/apl/AplCheck.tsx
@@ -84,7 +84,103 @@ const SPIRITFONT_PROC = {
 
 const MANA_TEA_20_STACKS = {
   spell: SPELLS.MANA_TEA_CAST,
-  condition: cnd.buffStacks(SPELLS.MANA_TEA_STACK, { atLeast: 20, atMost: 20 }),
+  condition: cnd.and(
+    cnd.buffStacks(SPELLS.MANA_TEA_STACK, { atLeast: 20, atMost: 20 }),
+    mwCnd.manaPercent({ atMost: 99 }),
+  ),
+};
+
+const MANA_TEA_ANY_STACKS = {
+  spell: SPELLS.MANA_TEA_CAST,
+  condition: cnd.optionalRule(
+    cnd.and(
+      cnd.buffStacks(SPELLS.MANA_TEA_STACK, { atLeast: 1 }),
+      mwCnd.manaPercent({ atMost: 99 }),
+    ),
+  ),
+};
+
+const REM_AFTER_THUNDER_FOCUS_TEA = {
+  spell: SPELLS.RENEWING_MIST_CAST,
+  condition: cnd.describe(cnd.lastSpellCast(talents.THUNDER_FOCUS_TEA_TALENT), (tense) => (
+    <>
+      {' '}
+      you cast <SpellLink spell={talents.THUNDER_FOCUS_TEA_TALENT} />
+    </>
+  )),
+};
+
+const SPIRITFONT_OVERCAP = {
+  spell: talents.ENVELOPING_MIST_TALENT,
+  condition: cnd.optionalRule(
+    cnd.buffStacks(SPELLS.SPIRITFONT_BUFF, { atLeast: 2, atMost: 2 }),
+    <>
+      <div>
+        <b>This does not mean you should only spend at 2 stacks.</b>{' '}
+      </div>
+      <div>
+        <SpellLink spell={talents.THUNDER_FOCUS_TEA_TALENT} /> grants you a{' '}
+        <SpellLink spell={SPELLS.SPIRITFONT_BUFF} /> stack on cast, so if you're already sitting at
+        2, spend at least one beforehand to avoid overcapping. Continue to use this regularly (later
+        in the priority list) with damage on your group.
+      </div>
+    </>,
+    'to avoid overcapping',
+  ),
+};
+
+// "injured" is harder to quantify here, but we
+// model this elsewhere on the analyzer
+const VIVIFY_INJURED_RAID = {
+  spell: SPELLS.VIVIFY,
+  condition: cnd.optionalRule(
+    cnd.describe(
+      mwCnd.targetsHealed(
+        { atLeast: 8 },
+        {
+          lookahead: 750,
+          targetSpell: SPELLS.INVIGORATING_MISTS_HEAL,
+          targetType: EventType.Heal,
+        },
+      ),
+      (tense) => (
+        <>
+          you {tenseAlt(tense, 'have', 'had')} at least 8 active{' '}
+          <SpellLink spell={SPELLS.RENEWING_MIST_CAST} />s
+        </>
+      ),
+    ),
+    undefined,
+    'with an injured raid',
+  ),
+};
+
+// this will always be true, since spiritfont
+// has a "won't activate unless injured" component
+const SPIRITFONT_PROC_INJURED_RAID = {
+  spell: talents.ENVELOPING_MIST_TALENT,
+  condition: cnd.optionalRule(
+    cnd.buffStacks(SPELLS.SPIRITFONT_BUFF, { atLeast: 1, atMost: 1 }),
+    undefined,
+    'with an injured raid',
+  ),
+};
+
+const BLACKOUT_KICK_FILLER = {
+  spell: SPELLS.BLACKOUT_KICK,
+  condition: cnd.optionalRule(cnd.spellAvailable(SPELLS.BLACKOUT_KICK)),
+};
+
+const TOTM_NOT_CAPPED = cnd.buffStacks(SPELLS.TEACHINGS_OF_THE_MONASTERY, {
+  atLeast: 0,
+  atMost: 3,
+});
+
+const TIGER_PALM_FILLER = {
+  spell: SPELLS.TIGER_PALM,
+  condition: cnd.optionalRule(
+    cnd.and(cnd.spellAvailable(SPELLS.BLACKOUT_KICK, { inverse: true }), TOTM_NOT_CAPPED),
+  ),
 };
 
 const commonTop = [
@@ -131,9 +227,9 @@ const commonTop = [
   MANA_TEA_20_STACKS,
 ];
 
-const RM_AT_CORE = [ZP_VIVIFY_5_REMS, VIVIFY_8_REMS];
+const RM_JFT_CORE = [ZP_VIVIFY_5_REMS, VIVIFY_8_REMS];
 
-const rotation_rm_at_sg = build([
+const rotation_rm_jft = build([
   {
     spell: [SPELLS.RENEWING_MIST_CAST, talents.RISING_SUN_KICK_TALENT],
     condition: cnd.describe(cnd.lastSpellCast(talents.THUNDER_FOCUS_TEA_TALENT), (tense) => (
@@ -144,38 +240,31 @@ const rotation_rm_at_sg = build([
     )),
   },
   ...commonTop,
-  ...RM_AT_CORE,
+  ...RM_JFT_CORE,
   BLACKOUT_KICK,
   REM_REMAINING,
   {
     spell: SPELLS.TIGER_PALM,
-    condition: cnd.optionalRule(
-      cnd.buffStacks(SPELLS.TEACHINGS_OF_THE_MONASTERY, { atLeast: 0, atMost: 4 }),
-    ),
+    condition: cnd.optionalRule(TOTM_NOT_CAPPED),
   },
 ]);
 
-const rotation_rm_rwk_sg = build([
+const rotation_rm_rwk = build([
+  talents.RUSHING_WIND_KICK_MISTWEAVER_TALENT,
   {
     spell: SPELLS.RENEWING_MIST_CAST,
-    condition: cnd.describe(cnd.lastSpellCast(talents.THUNDER_FOCUS_TEA_TALENT), (tense) => (
-      <>
-        {' '}
-        you cast <SpellLink spell={talents.THUNDER_FOCUS_TEA_TALENT} />
-      </>
-    )),
+    condition: cnd.spellCharges(SPELLS.RENEWING_MIST_CAST, { atLeast: 3 }),
   },
-  ...commonTop,
-  ZP_VIVIFY_5_REMS,
-  VIVIFY_8_REMS,
+  MANA_TEA_20_STACKS,
+  SPIRITFONT_OVERCAP,
+  REM_AFTER_THUNDER_FOCUS_TEA,
   REM_REMAINING,
-  BLACKOUT_KICK,
-  {
-    spell: SPELLS.TIGER_PALM,
-    condition: cnd.optionalRule(
-      cnd.buffStacks(SPELLS.TEACHINGS_OF_THE_MONASTERY, { atLeast: 0, atMost: 4 }),
-    ),
-  },
+  VIVIFY_INJURED_RAID,
+  SPIRITFONT_PROC_INJURED_RAID,
+  BLACK_OX_PROC,
+  MANA_TEA_ANY_STACKS,
+  BLACKOUT_KICK_FILLER,
+  TIGER_PALM_FILLER,
 ]);
 
 const rotation_fallback = build([...commonTop]);
@@ -208,8 +297,8 @@ export const chooseApl = (info: PlayerInfo): MistweaverApl => {
 };
 
 const apls: Record<MistweaverApl, Apl> = {
-  [MistweaverApl.RisingMistJadefireTeachings]: rotation_rm_at_sg,
-  [MistweaverApl.RisingMistRushingWindKick]: rotation_rm_rwk_sg,
+  [MistweaverApl.RisingMistJadefireTeachings]: rotation_rm_jft,
+  [MistweaverApl.RisingMistRushingWindKick]: rotation_rm_rwk,
   [MistweaverApl.WayOfTheCrane]: rotation_fallback,
   [MistweaverApl.TearOfMorning]: rotation_fallback,
   [MistweaverApl.Fallback]: rotation_fallback,

--- a/src/analysis/retail/monk/mistweaver/modules/core/apl/AplCheck.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/apl/AplCheck.tsx
@@ -74,18 +74,12 @@ const REM_REMAINING = {
 
 const BLACK_OX_PROC = {
   spell: talents.ENVELOPING_MIST_TALENT,
-  condition: cnd.and(
-    cnd.buffPresent(SPELLS.STRENGTH_OF_THE_BLACK_OX_BUFF),
-    cnd.hasTalent(talents.STRENGTH_OF_THE_BLACK_OX_TALENT),
-  ),
+  condition: cnd.buffPresent(SPELLS.STRENGTH_OF_THE_BLACK_OX_BUFF),
 };
 
 const SPIRITFONT_PROC = {
   spell: talents.ENVELOPING_MIST_TALENT,
-  condition: cnd.and(
-    cnd.buffStacks(SPELLS.SPIRITFONT_BUFF, { atLeast: 2, atMost: 2 }),
-    cnd.hasTalent(talents.SPIRITFONT_1_MISTWEAVER_TALENT),
-  ),
+  condition: cnd.buffStacks(SPELLS.SPIRITFONT_BUFF, { atLeast: 2, atMost: 2 }),
 };
 
 const MANA_TEA_20_STACKS = {

--- a/src/analysis/retail/monk/mistweaver/modules/core/apl/AplChoiceDescription.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/apl/AplChoiceDescription.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react';
 import SPELLS from 'common/SPELLS';
 import talents from 'common/TALENTS/monk';
 import { SpellLink } from 'interface';
+import { TipBox } from 'interface/guide/components';
 import { MistweaverApl } from './AplCheck';
 
 const aplTitle = (choice: MistweaverApl) => {
@@ -40,7 +41,7 @@ const aplTitle = (choice: MistweaverApl) => {
 const JadefireTeachingsDescription = () => {
   return (
     <>
-      <SpellLink spell={talents.RISING_SUN_KICK_TALENT} /> to extend hots and convert damage to
+      <SpellLink spell={talents.RISING_SUN_KICK_TALENT} /> to extend HoTs and convert damage to
       healing through <SpellLink spell={talents.RISING_SUN_KICK_TALENT} />,{' '}
       <SpellLink spell={SPELLS.BLACKOUT_KICK} />, <SpellLink spell={SPELLS.TIGER_PALM} />, and{' '}
       <SpellLink spell={SPELLS.CRACKLING_JADE_LIGHTNING} />.
@@ -51,8 +52,11 @@ const JadefireTeachingsDescription = () => {
 const RushingWindKickDescription = () => {
   return (
     <>
-      <SpellLink spell={talents.RUSHING_WIND_KICK_MISTWEAVER_TALENT} /> to extend hots to accrue
-      high counts of <SpellLink spell={SPELLS.RENEWING_MIST_CAST} /> and amplify their healing.
+      <SpellLink spell={talents.RUSHING_WIND_KICK_MISTWEAVER_TALENT} /> to extend your active HoTs,
+      building up high counts of <SpellLink spell={SPELLS.RENEWING_MIST_CAST} />. This sets up{' '}
+      <SpellLink spell={SPELLS.VIVIFY} /> to deal increasingly stronger{' '}
+      <SpellLink spell={talents.INVIGORATING_MISTS_TALENT} /> healing the more{' '}
+      <SpellLink spell={SPELLS.RENEWING_MIST_CAST} />s you have active.
     </>
   );
 };
@@ -76,12 +80,11 @@ const ThunderFocusTeaRemRsk = () => {
   );
 };
 
-const RisingMistJadefireTeachingsShaohaosDescription = () => {
+const RisingMistJadefireTeachingsDescription = () => {
   return (
     <>
       <p>
-        The {aplTitle(MistweaverApl.RisingMistJadefireTeachings)} rotation uses{' '}
-        <JadefireTeachingsDescription />
+        This rotation uses <JadefireTeachingsDescription />
       </p>
       <p>
         When playing <SpellLink spell={talents.RISING_MIST_TALENT} /> and{' '}
@@ -96,45 +99,36 @@ const RisingMistJadefireTeachingsShaohaosDescription = () => {
   );
 };
 
-const RisingMistRushingWindKickShaohaosDescription = () => {
+const RisingMistRushingWindKickDescription = () => {
   return (
     <>
       <p>
-        The {aplTitle(MistweaverApl.RisingMistRushingWindKick)} rotation uses{' '}
-        <RushingWindKickDescription />
+        This rotation uses <RushingWindKickDescription />
       </p>
-      When playing <SpellLink spell={talents.RISING_MIST_TALENT} /> with{' '}
-      <SpellLink spell={talents.RUSHING_WIND_KICK_MISTWEAVER_TALENT} />, keep{' '}
-      <SpellLink spell={SPELLS.RENEWING_MIST_CAST} /> on cooldown and cast{' '}
-      <SpellLink spell={talents.RUSHING_WIND_KICK_MISTWEAVER_TALENT} /> as often as possible.{' '}
-      <ThunderFocusTeaRem />
+      <p>
+        When playing <SpellLink spell={talents.RISING_MIST_TALENT} /> with{' '}
+        <SpellLink spell={talents.RUSHING_WIND_KICK_MISTWEAVER_TALENT} />, keep{' '}
+        <SpellLink spell={SPELLS.RENEWING_MIST_CAST} /> on cooldown and cast{' '}
+        <SpellLink spell={talents.RUSHING_WIND_KICK_MISTWEAVER_TALENT} /> as often as possible.{' '}
+        <ThunderFocusTeaRem />
+      </p>
     </>
   );
 };
 
 const CleaveBuildNotYetSupportedDescription = () => {
   return (
-    <>
-      <p>
-        <strong>
-          The <SpellLink spell={talents.WAY_OF_THE_CRANE_TALENT} /> rotation is not currently
-          supported.
-        </strong>
-      </p>
-    </>
+    <TipBox type="warning">
+      The <SpellLink spell={talents.WAY_OF_THE_CRANE_TALENT} /> rotation is not currently supported.
+    </TipBox>
   );
 };
 
 const TomDescription = () => {
   return (
-    <>
-      <p>
-        <strong>
-          The <SpellLink spell={talents.TEAR_OF_MORNING_TALENT} /> rotation is not currently
-          supported.
-        </strong>
-      </p>
-    </>
+    <TipBox type="warning">
+      The <SpellLink spell={talents.TEAR_OF_MORNING_TALENT} /> rotation is not currently supported.
+    </TipBox>
   );
 };
 
@@ -155,9 +149,9 @@ const FallbackDescription = () => {
 const Description = ({ aplChoice }: { aplChoice: MistweaverApl }) => {
   switch (aplChoice) {
     case MistweaverApl.RisingMistJadefireTeachings:
-      return <RisingMistJadefireTeachingsShaohaosDescription />;
+      return <RisingMistJadefireTeachingsDescription />;
     case MistweaverApl.RisingMistRushingWindKick:
-      return <RisingMistRushingWindKickShaohaosDescription />;
+      return <RisingMistRushingWindKickDescription />;
     case MistweaverApl.WayOfTheCrane:
       return <CleaveBuildNotYetSupportedDescription />;
     case MistweaverApl.TearOfMorning:
@@ -183,6 +177,7 @@ export default function AplChoiceDescription({
         <SpellLink spell={talents.THUNDER_FOCUS_TEA_TALENT} /> always being the top priority
         abilities.
       </p>
+      <hr />
       <p>
         <strong>Selected Build:</strong> {aplTitle(aplChoice)}
       </p>

--- a/src/analysis/retail/monk/mistweaver/modules/core/apl/AplChoiceDescription.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/apl/AplChoiceDescription.tsx
@@ -104,7 +104,7 @@ const RisingMistRushingWindKickShaohaosDescription = () => {
         <RushingWindKickDescription />
       </p>
       When playing <SpellLink spell={talents.RISING_MIST_TALENT} /> with{' '}
-      <SpellLink spell={talents.RUSHING_WIND_KICK_MISTWEAVER_TALENT} /> and{' '}
+      <SpellLink spell={talents.RUSHING_WIND_KICK_MISTWEAVER_TALENT} />, keep{' '}
       <SpellLink spell={SPELLS.RENEWING_MIST_CAST} /> on cooldown and cast{' '}
       <SpellLink spell={talents.RUSHING_WIND_KICK_MISTWEAVER_TALENT} /> as often as possible.{' '}
       <ThunderFocusTeaRem />

--- a/src/analysis/retail/monk/mistweaver/modules/core/apl/conditions/index.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/apl/conditions/index.tsx
@@ -1,2 +1,3 @@
 export { default as targetsHealed } from './targetsHealed';
+export { default as manaPercent } from './manaPercent';
 export * from 'parser/shared/metrics/apl/conditions/util';

--- a/src/analysis/retail/monk/mistweaver/modules/core/apl/conditions/manaPercent.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/core/apl/conditions/manaPercent.tsx
@@ -1,0 +1,59 @@
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
+import { ClassResources, EventType } from 'parser/core/Events';
+import { AplTriggerEvent, Condition, tenseAlt } from 'parser/shared/metrics/apl';
+import { Range, formatRange } from 'parser/shared/metrics/apl/conditions';
+
+interface ManaState {
+  current: number;
+  max: number;
+}
+
+const castManaResource = (event: AplTriggerEvent): ClassResources | undefined =>
+  event.classResources?.find(({ type }) => type === RESOURCE_TYPES.MANA.id);
+
+const percentSatisfied = (state: ManaState, range: Range): boolean => {
+  if (state.max === 0) {
+    return false;
+  }
+  const percent = (state.current / state.max) * 100;
+  return percent >= (range.atLeast || 0) && (range.atMost === undefined || percent <= range.atMost);
+};
+
+/**
+ * Condition that is valid when the player's mana, as a percentage of max, falls within `range`.
+ */
+export default function manaPercent(range: Range): Condition<ManaState> {
+  return {
+    key: `manaPercent-${range.atLeast}-${range.atMost}`,
+    init: () => ({ current: 0, max: 0 }),
+    update: (state, event) => {
+      if (
+        event.type === EventType.ResourceChange &&
+        event.resourceChangeType === RESOURCE_TYPES.MANA.id
+      ) {
+        return { current: event.resourceChange - event.waste + state.current, max: state.max };
+      } else if (event.type === EventType.Cast) {
+        const res = castManaResource(event);
+        if (res) {
+          return { current: res.amount - (res.cost || 0), max: res.max };
+        }
+      }
+      return state;
+    },
+    validate: (state, event) => {
+      const res = castManaResource(event);
+      if (res) {
+        return percentSatisfied({ current: res.amount, max: res.max }, range);
+      }
+      return percentSatisfied(state, range);
+    },
+    describe: (tense) =>
+      range.atMost !== undefined && range.atLeast === undefined ? (
+        <>you {tenseAlt(tense, "aren't", "weren't")} at full mana</>
+      ) : (
+        <>
+          you {tenseAlt(tense, 'have', 'had')} {formatRange(range)}% mana
+        </>
+      ),
+  };
+}

--- a/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
+++ b/src/analysis/retail/monk/mistweaver/modules/spells/RisingSunKick.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import { Fragment, type JSX, type ReactNode } from 'react';
 import SPELLS from 'common/SPELLS';
 import { TALENTS_MONK } from 'common/TALENTS';
 import { SpellLink } from 'interface';
@@ -14,6 +14,17 @@ import { getCurrentRSKTalent } from '../../constants';
 import { Talent } from 'common/TALENTS/types';
 
 const CAST_BUFFER_MS = 250;
+
+/** Renders a list of talents as SpellLinks joined by commas, with 'and' before the last one. */
+function spellLinkList(talents: Talent[]): ReactNode {
+  return talents.map((talent, index) => (
+    <Fragment key={talent.id}>
+      {index > 0 &&
+        (index === talents.length - 1 ? (talents.length > 2 ? ', and ' : ' and ') : ', ')}
+      <SpellLink spell={talent} />
+    </Fragment>
+  ));
+}
 
 class RisingSunKick extends Analyzer {
   static dependencies = {
@@ -74,21 +85,24 @@ class RisingSunKick extends Analyzer {
 
   /** Guide subsection describing the proper usage of RSK */
   get guideSubsection(): JSX.Element {
+    const synergyTalents = [
+      TALENTS_MONK.RISING_MIST_TALENT,
+      TALENTS_MONK.POOL_OF_MISTS_TALENT,
+      TALENTS_MONK.RAPID_DIFFUSION_TALENT,
+    ].filter((talent) => this.selectedCombatant.hasTalent(talent));
+
     const explanation = (
       <p>
         <b>
           <SpellLink spell={this.currentRskTalent} />
         </b>{' '}
         is one of your primary damaging spells but is also your highest priority healing spell
-        (alongside <SpellLink spell={SPELLS.RENEWING_MIST_CAST} />) due to its synergy with{' '}
-        <SpellLink spell={TALENTS_MONK.RISING_MIST_TALENT} />
-        {this.selectedCombatant.hasTalent(TALENTS_MONK.POOL_OF_MISTS_TALENT) && (
-          <>
-            , <SpellLink spell={TALENTS_MONK.POOL_OF_MISTS_TALENT} />
-          </>
+        (alongside <SpellLink spell={SPELLS.RENEWING_MIST_CAST} />
+        ), both through its own healing
+        {synergyTalents.length > 0 && (
+          <> and its synergy with talents such as {spellLinkList(synergyTalents)}</>
         )}
-        , and <SpellLink spell={TALENTS_MONK.RAPID_DIFFUSION_TALENT} />. Using it as much as
-        possible is essential for maintaining high counts of{' '}
+        . Using it as much as possible is essential for maintaining high counts of{' '}
         <SpellLink spell={SPELLS.RENEWING_MIST_CAST} />.
       </p>
     );

--- a/src/common/SPELLS/monk.ts
+++ b/src/common/SPELLS/monk.ts
@@ -123,7 +123,7 @@ const spells = {
   STRENGTH_OF_THE_BLACK_OX_BUFF: {
     id: 443112,
     name: 'Strength of the Black Ox',
-    icon: 'ability_monk_chargingoxwave',
+    icon: 'ability_monk_leeroftheox',
   },
   STRENGTH_OF_THE_BLACK_OX_SHIELD: {
     id: 443113,

--- a/src/parser/shared/metrics/apl/conditions/buffStacks.tsx
+++ b/src/parser/shared/metrics/apl/conditions/buffStacks.tsx
@@ -2,7 +2,7 @@ import type Spell from 'common/SPELLS/Spell';
 import { SpellLink } from 'interface';
 import { EventType } from 'parser/core/Events';
 
-import { Condition, tenseAlt } from '../index';
+import { Condition, pluralAlt, tenseAlt } from '../index';
 import { Range, formatRange } from './index';
 
 export default function buffStacks(spell: Spell, range: Range): Condition<number> {
@@ -39,7 +39,8 @@ export default function buffStacks(spell: Spell, range: Range): Condition<number
     describe: (tense) => (
       <>
         you {tenseAlt(tense, 'have', 'had')} {formatRange(range)}{' '}
-        <SpellLink spell={spell.id} icon /> stacks
+        <SpellLink spell={spell.id} icon />{' '}
+        {pluralAlt(range.atMost ?? range.atLeast ?? 0, 'stack', 'stacks')}
       </>
     ),
   };

--- a/src/parser/shared/metrics/apl/index.ts
+++ b/src/parser/shared/metrics/apl/index.ts
@@ -273,6 +273,13 @@ function updateState(apl: Apl, oldState: ConditionState, event: AnyEvent): Condi
 export function tenseAlt<T>(tense: Tense | undefined, a: T, b: T): T {
   return tense === Tense.Present ? a : b;
 }
+
+/**
+ * Returns `singular` if `count` is exactly 1, otherwise `plural`.
+ **/
+export function pluralAlt<T>(count: number, singular: T, plural: T): T {
+  return count === 1 ? singular : plural;
+}
 export const spells = (rule: InternalRule): Spell[] =>
   rule.spell.type === TargetType.SpellList ? rule.spell.target : [rule.spell.target];
 


### PR DESCRIPTION
### Description

- Adjusted APL in several places
  - Matched meta build APL to [Wowhead's APL](https://www.wowhead.com/guide/classes/monk/mistweaver/rotation-cooldowns-pve-healer#rotations-raid-priority)
  - Removed .hasTalent calls for visual clarity on Strength of the Black Ox and Spiritfont
  - Added a manaPercent condition for Mana Tea to capture usage below full mana
- Adjusted grammar + visuals of Core Rotation section for hierarchy
- Tear of Morning caused some issues displaying talents and didn't have gating on other synergy areas.
- Fixed Strength of the Black Ox consume buff icon
- Added a pluralAlt function to return singular or plural versions of the input strings based on count for metrics
- Modified my CONTRIBUTOR entry for main/alts + links

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

`/report/bRMgGLqF1zBmfAYn/49-Heroic+Ula'tek+-+Kill+(9:51)/18-Sharkfish/standard/overview`
<img width="1418" height="945" alt="image" src="https://github.com/user-attachments/assets/d413790a-a24d-4b0e-ad2e-aa2788097465" />

`/report/PTZGWXnpJVNYwQdL/33-Normal+Sszorak+-+Kill+(7:36)/11-Aütobot/standard/overview`
<img width="1412" height="965" alt="image" src="https://github.com/user-attachments/assets/de5eb0a6-5f2f-4a54-9edb-b987891cde82" />

`/report/y96Q4qxrPHMJ2gaA/29-Mythic++Ruby+Life+Pools+-+Kill+(25:36)/1159-Burrmutt/standard`
Tear of Morning
<img width="1373" height="163" alt="image" src="https://github.com/user-attachments/assets/7afe112f-deff-4b05-b12d-9eea7d3e5265" />
<img width="1388" height="202" alt="image" src="https://github.com/user-attachments/assets/0d7c1d07-2d9a-4b6f-80b8-5f8d64294d73" />

`/report/92GnWp1Mczfjv7LA/1-Mythic++Altar+of+Fangs+-+Kill+(28:35)/8-双马尾张俊杰/standard`
Way of the Crane
<img width="1377" height="212" alt="image" src="https://github.com/user-attachments/assets/4f7a85a2-523e-4dc2-891d-051b45763873" />
No Rising Mist
<img width="1377" height="162" alt="image" src="https://github.com/user-attachments/assets/3fb77b5a-6a8d-48b6-89b6-c0574fb41cfd" />


