### PR TITLE
[General] Tighten section margins

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -45,6 +45,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 9, 5), "Adjusted margins for sections in the Overview tab.", swirl),
   change(date(2026, 9, 2), 'Add item and spell definitions for the Midnight Season 2 trinkets (Venomous Abyss raid, Mythic+ dungeon pool, and PvP badge).', Baloop),
   change(date(2026, 8, 31), "Fix a rare issue where negative stat ratings would result in negative stat percentages", Putro),
   change(date(2026, 8, 28), "Fix tooltips & donut chart rendering non-numerical values.", swirl),

--- a/src/interface/guide/index.module.scss
+++ b/src/interface/guide/index.module.scss
@@ -24,7 +24,7 @@
   padding: 0 design.$gaps_large 0 design.$gaps_large;
 
   &:global(.expanded) {
-    padding-bottom: design.$gaps_small;
+    padding-bottom: design.$gaps_large;
   }
 
   & :global(.details) > div {
@@ -44,10 +44,6 @@
   /* including .guide-container here is a specificity hack */
   :global(.guide-container) &:not(:first-child) {
     margin-top: design.$gaps_large;
-  }
-
-  &:last-child {
-    margin-bottom: design.$gaps_large;
   }
 
   & > header {

--- a/src/interface/guide/index.module.scss
+++ b/src/interface/guide/index.module.scss
@@ -21,7 +21,11 @@
 
 .SectionExpandable {
   @include design.level(1);
-  padding: 0 design.$gaps_large design.$gaps_small design.$gaps_large;
+  padding: 0 design.$gaps_large 0 design.$gaps_large;
+
+  &:global(.expanded) {
+    padding-bottom: design.$gaps_small;
+  }
 
   & :global(.details) > div {
     background: unset;
@@ -38,8 +42,12 @@
 
 .SubSectionContainer {
   /* including .guide-container here is a specificity hack */
-  :global(.guide-container) & {
+  :global(.guide-container) &:not(:first-child) {
     margin-top: design.$gaps_large;
+  }
+
+  &:last-child {
+    margin-bottom: design.$gaps_large;
   }
 
   & > header {


### PR DESCRIPTION
### Description

Tightening margins for Sections in the Overview tab

#### Collapsed headers:
<img width="1612" height="197" alt="image" src="https://github.com/user-attachments/assets/4f9d14b9-de8b-40f0-bd28-d33e4c4bfeab" />

Fixed, matching top margin:
<img width="1422" height="177" alt="image" src="https://github.com/user-attachments/assets/b17d661d-f7b7-474a-a2ef-946b5973ef72" />

#### 1st item margin
<img width="1620" height="310" alt="image" src="https://github.com/user-attachments/assets/35d9b74d-f02c-4731-9bee-d7279abb3de9" />
<img width="1637" height="315" alt="image" src="https://github.com/user-attachments/assets/98db1837-9235-46d3-b4b3-7e8435a40c54" />

Fixed, removing first child's margin-top:
<img width="1630" height="287" alt="image" src="https://github.com/user-attachments/assets/0bbcef26-8cf1-44a1-9f51-580f7eb4db4b" />
<img width="1630" height="288" alt="image" src="https://github.com/user-attachments/assets/0ae286c5-ab8e-4976-ac4e-b9f496b0acd9" />

#### Bottom margin
<img width="1646" height="342" alt="image" src="https://github.com/user-attachments/assets/e4a5cd47-fbf0-41d7-ac93-b8753b53aa67" />
<img width="1647" height="802" alt="image" src="https://github.com/user-attachments/assets/a3858af2-1fa5-433b-bc71-f0ab4e56544b" />


Fixed, added last child bottom margin:
<img width="1646" height="366" alt="image" src="https://github.com/user-attachments/assets/7fb30bf1-d68e-4c52-afbf-0dea514b7480" />
<img width="1637" height="821" alt="image" src="https://github.com/user-attachments/assets/756d39ae-a0ac-4223-bc70-ef22707b7fc6" />
