### PR TITLE
[Mistweaver] Mana Tea fix for fightend during channel

### DIFF
--- a/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
+++ b/src/analysis/retail/monk/mistweaver/CHANGELOG.tsx
@@ -8,6 +8,7 @@ import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2026, 9, 8), <>Fixed <SpellLink spell={TALENTS_MONK.MANA_TEA_TALENT}/> not being recognized as completed when a fight ends during a channel.</>, swirl),
   change(date(2026, 9, 5), <>Added Defensive and Active Time tracking to Overview tab.</>, swirl),
   change(date(2026, 9, 5), <>Adjusted APL conditions for 12.1.</>, swirl),
   change(date(2026, 9, 5), <>Added important buffs/procs to Timeline tab, adjusted <ItemSetLink id={MONK_MID2_ID}>12.1 4pc</ItemSetLink> proc rate, added % of total healing to <SpellLink spell={TALENTS_MONK.JADEFIRE_TEACHINGS_TALENT}/> tooltips.</>, swirl),

--- a/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/ManaTeaEventLinks.ts
+++ b/src/analysis/retail/monk/mistweaver/normalizers/EventLinks/ManaTeaEventLinks.ts
@@ -27,6 +27,24 @@ export const MANA_TEA_EVENT_LINKS: EventLink[] = [
     },
   },
   {
+    // fallback for a channel still running when the log ends, so there is no removebuff to link to
+    linkRelation: MANA_TEA_CHANNEL,
+    linkingEventId: SPELLS.MANA_TEA_CAST.id,
+    linkingEventType: EventType.Cast,
+    referencedEventId: null,
+    referencedEventType: EventType.FightEnd,
+    forwardBufferMs: MAX_MT_CHANNEL,
+    maximumLinks: 1,
+    anySource: true,
+    anyTarget: true,
+    additionalCondition(linkingEvent) {
+      return !HasRelatedEvent(linkingEvent, MANA_TEA_CHANNEL);
+    },
+    isActive(c) {
+      return c.hasTalent(TALENTS_MONK.MANA_TEA_TALENT);
+    },
+  },
+  {
     linkRelation: MANA_TEA_CAST_LINK,
     reverseLinkRelation: MANA_TEA_CAST_LINK,
     linkingEventId: SPELLS.MANA_TEA_CAST.id,


### PR DESCRIPTION
### Description

A player was channeling Mana Tea as a fight completed, and broke EventLinks that depended on Mana Tea buff removal to depict a completed channel (which didn't happen, as the fight ended already)
Added an EventLink to add completed time to Mana Tea channels, if they happen to be channeling during fightend. 

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/kPvKfpzWaJdghVG1/15-Heroic+The+Lost+Explorers+-+Kill+(4:33)/7-Tamo/standard/statistics`
