### PR TITLE
[Warlock] Add a ranked "What to Focus On" section to the Demonology and Affliction guides

### DIFF
--- a/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/affliction/CHANGELOG.tsx
@@ -1,10 +1,11 @@
 import { change, date } from 'common/changelog';
-import {Katorri} from 'CONTRIBUTORS';
+import {Katorri, Zea} from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 
 export default [
+  change(date(2026, 9, 9), <>Add a "What to Focus On" section at the top of the guide. It ranks up to four changes by impact: uptime, DoT uptime, <SpellLink spell={TALENTS.SUMMON_DARKGLARE_TALENT} /> and <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> usage, and Soul Shard waste.</>, Zea),
   change(date(2026, 8, 15), <>Create <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> guide section tracking per-cast DoT coverage across every target it hits and <SpellLink spell={TALENTS.CULL_THE_WEAK_TALENT} /> CDR efficiency.</>, Katorri),
   change(date(2026, 8, 15), "Update Haunt baseline percent increase, update Compatibility for 12.1.0", Katorri),
   change(date(2026, 5, 31), "Add Always Be Casting guide section; adjust DoT Uptimes guide section; add contextual tip to UA uptime section for cleave/AoE fights; register SiphonLife analyzer and correct damage bonus from 20% to 30%; remove outdated Darkglare dot extension tracking.", Katorri),

--- a/src/analysis/retail/warlock/affliction/Guide.tsx
+++ b/src/analysis/retail/warlock/affliction/Guide.tsx
@@ -7,10 +7,13 @@ import DefensivesGuide from '../shared/Defensives';
 import UnstableAfflictionGuide from './modules/guide/UnstableAfflictionGuide';
 import { DemonicHealthstoneGuide } from '../shared/DHSGuide';
 import DarkHarvestGuide from './modules/guide/DarkHarvestGuide';
+import ImprovementPrioritiesSection from './modules/guide/ImprovementPrioritiesSection';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
     <>
+      <ImprovementPrioritiesSection />
+
       {/* Always Be Casting Section */}
       <Section title="Always Be Casting">{modules.alwaysBeCasting.guideSubsection}</Section>
 

--- a/src/analysis/retail/warlock/affliction/modules/guide/DarkHarvestGuide.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/guide/DarkHarvestGuide.tsx
@@ -51,7 +51,7 @@ function missingToPerformance(missing: number): QualitativePerformance {
   return QualitativePerformance.Fail;
 }
 
-function castPerformance(cast: DarkHarvestCastData): QualitativePerformance {
+export function castPerformance(cast: DarkHarvestCastData): QualitativePerformance {
   if (cast.hits.length === 0) return QualitativePerformance.Fail;
   const scoreUA = cast.hits.length === 1;
   const worstMissing = Math.max(...cast.hits.map((hit) => missingDotCount(hit, scoreUA)));

--- a/src/analysis/retail/warlock/affliction/modules/guide/ImprovementPrioritiesSection.test.ts
+++ b/src/analysis/retail/warlock/affliction/modules/guide/ImprovementPrioritiesSection.test.ts
@@ -1,0 +1,131 @@
+import TALENTS from 'common/TALENTS/warlock';
+import type { Talent } from 'common/TALENTS/types';
+import type { Info } from 'parser/core/metric';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { rankImprovementPriorities } from 'interface/guide/components/ImprovementPriorities';
+import {
+  buildAfflictionPriorities,
+  type AfflictionPriorityInputs,
+} from './ImprovementPrioritiesSection';
+
+const MINUTE = 60000;
+
+const ALL_TALENTS = [
+  TALENTS.UNSTABLE_AFFLICTION_TALENT,
+  TALENTS.HAUNT_TALENT,
+  TALENTS.SUMMON_DARKGLARE_TALENT,
+  TALENTS.DARK_HARVEST_TALENT,
+  TALENTS.NIGHTFALL_TALENT,
+];
+
+const infoWith = (talents: Talent[]): Info =>
+  ({
+    fightDuration: 5 * MINUTE,
+    fightStart: 0,
+    combatant: { hasTalent: (talent: Talent) => talents.includes(talent) },
+  }) as unknown as Info;
+
+const uptime = (value: number, performance: QualitativePerformance, active = true) =>
+  ({ active, uptime: value, DowntimePerformance: performance }) as never;
+
+const castEfficiencyWith = (efficiencyBySpellId: Record<number, number>) =>
+  ({
+    getCastEfficiencyForSpell: (spell: { id: number }) => ({
+      casts: 2,
+      maxCasts: 3,
+      efficiency: efficiencyBySpellId[spell.id],
+      recommendedEfficiency: 0.9,
+      averageIssueEfficiency: 0.85,
+      majorIssueEfficiency: 0.75,
+      gotMaxCasts: false,
+    }),
+  }) as never;
+
+/** A player with room to improve on most checks. Analyzers are active only with their talent. */
+const inputs = (talents = ALL_TALENTS): AfflictionPriorityInputs => {
+  const has = (talent: Talent) => talents.includes(talent);
+  return {
+    info: infoWith(talents),
+    castEfficiency: castEfficiencyWith({
+      [TALENTS.SUMMON_DARKGLARE_TALENT.id]: 0.8,
+      [TALENTS.DARK_HARVEST_TALENT.id]: 0.95,
+    }),
+    alwaysBeCasting: { downtimePercentage: 0.18, activeTimePercentage: 0.82 } as never,
+    cancelledCasts: {
+      castsCancelled: 12,
+      totalCasts: 200,
+      canceled: 0.06,
+      cancelledPerformance: QualitativePerformance.Ok,
+    } as never,
+    agony: uptime(0.88, QualitativePerformance.Ok),
+    corruption: uptime(0.97, QualitativePerformance.Good),
+    unstableAffliction: uptime(0.62, QualitativePerformance.Fail),
+    haunt: uptime(0.8, QualitativePerformance.Fail, has(TALENTS.HAUNT_TALENT)),
+    darkglare: {
+      active: has(TALENTS.SUMMON_DARKGLARE_TALENT),
+      casts: [
+        { timestamp: 0, dotCount: 2 },
+        { timestamp: 1, dotCount: 3 },
+      ],
+    } as never,
+    darkHarvest: {
+      active: has(TALENTS.DARK_HARVEST_TALENT),
+      casts: [
+        { hits: [] },
+        { hits: [{ hadAgony: true, hadCorruption: true, hadUA: true }] },
+        { hits: [{ hadAgony: false, hadCorruption: false, hadUA: true }] },
+      ],
+    } as never,
+    nightfall: { active: has(TALENTS.NIGHTFALL_TALENT), wastedProcs: 4 } as never,
+    soulShards: { wasted: 3 } as never,
+  };
+};
+
+describe('buildAfflictionPriorities', () => {
+  it('builds one priority for each check that applies to the talents', () => {
+    const ids = buildAfflictionPriorities(inputs()).map((p) => p.id);
+    expect(ids).toEqual([
+      'active-time',
+      'cancelled-casts',
+      'agony-uptime',
+      'corruption-uptime',
+      'unstable-affliction-uptime',
+      'haunt-uptime',
+      `cast-efficiency-${TALENTS.SUMMON_DARKGLARE_TALENT.id}`,
+      'darkglare-dots',
+      `cast-efficiency-${TALENTS.DARK_HARVEST_TALENT.id}`,
+      'dark-harvest-coverage',
+      'soul-shard-waste',
+      'nightfall',
+    ]);
+  });
+
+  it('skips the checks for talents the player does not have', () => {
+    const ids = buildAfflictionPriorities(inputs([])).map((p) => p.id);
+    expect(ids).toEqual([
+      'active-time',
+      'cancelled-casts',
+      'agony-uptime',
+      'corruption-uptime',
+      'soul-shard-waste',
+    ]);
+  });
+
+  it('ranks downtime, then the weak DoTs, then Dark Harvest coverage', () => {
+    const ranked = rankImprovementPriorities(buildAfflictionPriorities(inputs()));
+    expect(ranked.map((p) => p.id)).toEqual([
+      'active-time',
+      'unstable-affliction-uptime',
+      'agony-uptime',
+      'dark-harvest-coverage',
+    ]);
+  });
+
+  it('rates Dark Harvest coverage from the per-cast ratings', () => {
+    const coverage = buildAfflictionPriorities(inputs()).find(
+      (p) => p.id === 'dark-harvest-coverage',
+    );
+    expect(coverage?.score).toBeCloseTo(1 / 3);
+    expect(coverage?.performance).toBe(QualitativePerformance.Fail);
+  });
+});

--- a/src/analysis/retail/warlock/affliction/modules/guide/ImprovementPrioritiesSection.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/guide/ImprovementPrioritiesSection.tsx
@@ -5,22 +5,20 @@ import type Spell from 'common/SPELLS/Spell';
 import { formatPercentage } from 'common/format';
 import { SpellLink } from 'interface';
 import { useAnalyzer, useInfo } from 'interface/guide';
-import ImprovementPriorities, {
-  type ImprovementPriority,
-} from 'interface/guide/components/ImprovementPriorities';
 import type { Info } from 'parser/core/metric';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import SoulShardTracker from 'analysis/retail/warlock/shared/resources/SoulShardTracker';
-import {
+import ImprovementPriorities, {
   activeTimePriority,
   castEfficiencyPriority,
   linearScore,
   performanceForHigherIsBetter,
   performanceForLowerIsBetter,
   plural,
-  soulShardWastePriority,
-} from 'analysis/retail/warlock/shared/guide/priorities';
+  type ImprovementPriority,
+} from 'interface/guide/components/ImprovementPriorities';
+import { soulShardWastePriority } from 'analysis/retail/warlock/shared/guide/priorities';
 import AlwaysBeCasting from '../core/AlwaysBeCasting';
 import CancelledCasts from '../core/CancelledCasts';
 import Agony from '../analyzers/Agony';

--- a/src/analysis/retail/warlock/affliction/modules/guide/ImprovementPrioritiesSection.tsx
+++ b/src/analysis/retail/warlock/affliction/modules/guide/ImprovementPrioritiesSection.tsx
@@ -1,0 +1,406 @@
+import type { JSX, ReactNode } from 'react';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
+import type Spell from 'common/SPELLS/Spell';
+import { formatPercentage } from 'common/format';
+import { SpellLink } from 'interface';
+import { useAnalyzer, useInfo } from 'interface/guide';
+import ImprovementPriorities, {
+  type ImprovementPriority,
+} from 'interface/guide/components/ImprovementPriorities';
+import type { Info } from 'parser/core/metric';
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import SoulShardTracker from 'analysis/retail/warlock/shared/resources/SoulShardTracker';
+import {
+  activeTimePriority,
+  castEfficiencyPriority,
+  linearScore,
+  performanceForHigherIsBetter,
+  performanceForLowerIsBetter,
+  plural,
+  soulShardWastePriority,
+} from 'analysis/retail/warlock/shared/guide/priorities';
+import AlwaysBeCasting from '../core/AlwaysBeCasting';
+import CancelledCasts from '../core/CancelledCasts';
+import Agony from '../analyzers/Agony';
+import Corruption from '../analyzers/Corruption';
+import UnstableAffliction from '../analyzers/UnstableAffliction';
+import Haunt from '../analyzers/Haunt';
+import Darkglare from '../analyzers/Darkglare';
+import DarkHarvest from '../analyzers/DarkHarvest';
+import Nightfall from '../analyzers/Nightfall';
+import { castPerformance as darkHarvestCastPerformance } from './DarkHarvestGuide';
+
+/**
+ * How much each check matters to Affliction damage, relative to the other checks. Only the
+ * ratios matter. A weight 10 check at a 50% score outranks a weight 5 check at a 0% score.
+ */
+const WEIGHTS = {
+  activeTime: 10,
+  agony: 9,
+  darkglareCastEfficiency: 8,
+  corruption: 7,
+  unstableAffliction: 6,
+  darkHarvestCastEfficiency: 6,
+  haunt: 5,
+  soulShards: 5,
+  darkglareDots: 4,
+  darkHarvestCoverage: 4,
+  cancelledCasts: 4,
+  nightfall: 3,
+} as const;
+
+interface DotUptimeOptions {
+  id: string;
+  spell: Spell;
+  uptime: number;
+  performance: QualitativePerformance;
+  weight: number;
+  /** The uptime at which the score reaches 0. */
+  worst: number;
+  tip: ReactNode;
+}
+
+/** Priority for a DoT the player must keep active. The analyzer of the DoT supplies the rating. */
+function dotUptimePriority({
+  id,
+  spell,
+  uptime,
+  performance,
+  weight,
+  worst,
+  tip,
+}: DotUptimeOptions): ImprovementPriority {
+  return {
+    id,
+    title: (
+      <>
+        Keep <SpellLink spell={spell} /> active
+      </>
+    ),
+    description: (
+      <>
+        <SpellLink spell={spell} /> was active for {formatPercentage(uptime, 1)}% of the fight.{' '}
+        {tip}
+      </>
+    ),
+    score: linearScore(uptime, 1, worst),
+    weight,
+    performance,
+  };
+}
+
+function cancelledCastsPriority(
+  cancelledCasts: CancelledCasts | undefined,
+): ImprovementPriority | null {
+  if (!cancelledCasts || cancelledCasts.totalCasts === 0) {
+    return null;
+  }
+  const { castsCancelled, totalCasts, canceled } = cancelledCasts;
+  return {
+    id: 'cancelled-casts',
+    title: 'Cancel fewer casts',
+    description: (
+      <>
+        You cancelled {castsCancelled} of {totalCasts} casts ({formatPercentage(canceled, 1)}%). A
+        cancelled cast is a lost global. When you must move, start an instant spell instead of a
+        cast that you cannot finish.
+      </>
+    ),
+    score: linearScore(canceled, 0, 0.2),
+    weight: WEIGHTS.cancelledCasts,
+    performance: cancelledCasts.cancelledPerformance,
+  };
+}
+
+function darkglareDotsPriority(
+  darkglare: Darkglare | undefined,
+  maxDots: number,
+): ImprovementPriority | null {
+  if (!darkglare?.active || darkglare.casts.length === 0) {
+    return null;
+  }
+  const casts = darkglare.casts.length;
+  const average = darkglare.casts.reduce((sum, cast) => sum + cast.dotCount, 0) / casts;
+  const ratio = Math.min(1, average / maxDots);
+  return {
+    id: 'darkglare-dots',
+    title: (
+      <>
+        Apply every DoT before <SpellLink spell={TALENTS.SUMMON_DARKGLARE_TALENT} />
+      </>
+    ),
+    description: (
+      <>
+        Your {casts} Darkglare {plural(casts, 'cast')} found {average.toFixed(1)} DoTs on average,
+        out of {maxDots}. Darkglare deals 10% more damage for each DoT it finds. Refresh{' '}
+        <SpellLink spell={SPELLS.AGONY} />, <SpellLink spell={SPELLS.CORRUPTION_DEBUFF} /> and{' '}
+        <SpellLink spell={SPELLS.UNSTABLE_AFFLICTION} />, then cast it.
+      </>
+    ),
+    score: ratio,
+    weight: WEIGHTS.darkglareDots,
+    performance: performanceForHigherIsBetter(ratio, { perfect: 1, good: 0.85, ok: 0.65 }),
+  };
+}
+
+function darkHarvestCoveragePriority(
+  darkHarvest: DarkHarvest | undefined,
+): ImprovementPriority | null {
+  if (!darkHarvest?.active || darkHarvest.casts.length === 0) {
+    return null;
+  }
+  const casts = darkHarvest.casts.length;
+  const ratings = darkHarvest.casts.map(darkHarvestCastPerformance);
+  const good = ratings.filter(
+    (rating) => rating === QualitativePerformance.Good || rating === QualitativePerformance.Perfect,
+  ).length;
+  const missedEverything = darkHarvest.casts.filter((cast) => cast.hits.length === 0).length;
+  const ratio = good / casts;
+  return {
+    id: 'dark-harvest-coverage',
+    title: (
+      <>
+        Channel <SpellLink spell={TALENTS.DARK_HARVEST_TALENT} /> into targets with every DoT
+      </>
+    ),
+    description: (
+      <>
+        {casts - good} of {casts} Dark Harvest {plural(casts, 'cast')} hit a target that lacked 2 or
+        more DoTs
+        {missedEverything > 0 && <>, and {missedEverything} hit no afflicted target at all</>}.
+        Refresh <SpellLink spell={SPELLS.AGONY} />, <SpellLink spell={SPELLS.CORRUPTION_DEBUFF} />{' '}
+        and <SpellLink spell={SPELLS.UNSTABLE_AFFLICTION} /> before you channel it.
+      </>
+    ),
+    score: ratio,
+    weight: WEIGHTS.darkHarvestCoverage,
+    performance: performanceForHigherIsBetter(ratio, { perfect: 1, good: 0.8, ok: 0.5 }),
+  };
+}
+
+function nightfallPriority(
+  nightfall: Nightfall | undefined,
+  fightDuration: number,
+): ImprovementPriority | null {
+  if (!nightfall?.active) {
+    return null;
+  }
+  const wasted = nightfall.wastedProcs;
+  const perMinute = wasted / (fightDuration / 60000);
+  return {
+    id: 'nightfall',
+    title: (
+      <>
+        Use <SpellLink spell={TALENTS.NIGHTFALL_TALENT} /> procs before they expire
+      </>
+    ),
+    description: (
+      <>
+        You wasted {wasted} {plural(wasted, 'proc')} ({perMinute.toFixed(1)} per minute). A proc
+        expired, or a new proc replaced one while you already had two. Cast the instant{' '}
+        <SpellLink spell={SPELLS.SHADOW_BOLT_AFFLI} /> before you refresh a DoT that has time left.
+      </>
+    ),
+    score: linearScore(perMinute, 0, 3),
+    weight: WEIGHTS.nightfall,
+    performance:
+      wasted === 0
+        ? QualitativePerformance.Perfect
+        : performanceForLowerIsBetter(perMinute, { good: 0.5, ok: 1.5 }),
+  };
+}
+
+export interface AfflictionPriorityInputs {
+  info: Info;
+  castEfficiency?: CastEfficiency;
+  alwaysBeCasting?: AlwaysBeCasting;
+  cancelledCasts?: CancelledCasts;
+  agony?: Agony;
+  corruption?: Corruption;
+  unstableAffliction?: UnstableAffliction;
+  haunt?: Haunt;
+  darkglare?: Darkglare;
+  darkHarvest?: DarkHarvest;
+  nightfall?: Nightfall;
+  soulShards?: SoulShardTracker;
+}
+
+/** Builds one priority for each check that applies to the talents of this player. */
+export function buildAfflictionPriorities({
+  info,
+  castEfficiency,
+  alwaysBeCasting,
+  cancelledCasts,
+  agony,
+  corruption,
+  unstableAffliction,
+  haunt,
+  darkglare,
+  darkHarvest,
+  nightfall,
+  soulShards,
+}: AfflictionPriorityInputs): ImprovementPriority[] {
+  const { combatant, fightDuration } = info;
+  const hasUnstableAffliction = combatant.hasTalent(TALENTS.UNSTABLE_AFFLICTION_TALENT);
+  const corruptionSpell = combatant.hasTalent(TALENTS.WITHER_TALENT)
+    ? SPELLS.WITHER_DEBUFF
+    : SPELLS.CORRUPTION_DEBUFF;
+
+  const candidates: (ImprovementPriority | null)[] = [
+    activeTimePriority({
+      alwaysBeCasting,
+      fightDuration,
+      weight: WEIGHTS.activeTime,
+      thresholds: { perfect: 0.02, good: 0.1, ok: 0.15 },
+      worst: 0.25,
+      movementTips: (
+        <>
+          While you move, refresh DoTs with the instant <SpellLink spell={SPELLS.AGONY} /> and{' '}
+          <SpellLink spell={SPELLS.CORRUPTION_CAST} />, and use{' '}
+          <SpellLink spell={TALENTS.NIGHTFALL_TALENT} /> Shadow Bolts. Place{' '}
+          <SpellLink spell={SPELLS.DEMONIC_CIRCLE} /> before you need it.
+        </>
+      ),
+    }),
+    cancelledCastsPriority(cancelledCasts),
+    agony
+      ? dotUptimePriority({
+          id: 'agony-uptime',
+          spell: SPELLS.AGONY,
+          uptime: agony.uptime,
+          performance: agony.DowntimePerformance,
+          weight: WEIGHTS.agony,
+          worst: 0.6,
+          tip: 'It is your primary Soul Shard generator. Refresh it in its last 5 seconds, before it expires.',
+        })
+      : null,
+    corruption
+      ? dotUptimePriority({
+          id: 'corruption-uptime',
+          spell: corruptionSpell,
+          uptime: corruption.uptime,
+          performance: corruption.DowntimePerformance,
+          weight: WEIGHTS.corruption,
+          worst: 0.6,
+          tip: (
+            <>
+              Refresh it in its last 4 seconds, before it expires.{' '}
+              <SpellLink spell={TALENTS.NIGHTFALL_TALENT} /> procs come from it.
+            </>
+          ),
+        })
+      : null,
+    hasUnstableAffliction && unstableAffliction
+      ? dotUptimePriority({
+          id: 'unstable-affliction-uptime',
+          spell: SPELLS.UNSTABLE_AFFLICTION,
+          uptime: unstableAffliction.uptime,
+          performance: unstableAffliction.DowntimePerformance,
+          weight: WEIGHTS.unstableAffliction,
+          worst: 0.4,
+          tip: (
+            <>
+              Cast it whenever it is not on your target and you have a Soul Shard. On fights with 2
+              or more targets, <SpellLink spell={SPELLS.SEED_OF_CORRUPTION_DEBUFF} /> replaces it,
+              and low uptime is correct play.
+            </>
+          ),
+        })
+      : null,
+    haunt?.active
+      ? dotUptimePriority({
+          id: 'haunt-uptime',
+          spell: TALENTS.HAUNT_TALENT,
+          uptime: haunt.uptime,
+          performance: haunt.DowntimePerformance,
+          weight: WEIGHTS.haunt,
+          worst: 0.5,
+          tip: `It increases all your damage to the target by ${formatPercentage(haunt.hauntDamageBonus, 0)}%. Cast it when its cooldown ends.`,
+        })
+      : null,
+    combatant.hasTalent(TALENTS.SUMMON_DARKGLARE_TALENT)
+      ? castEfficiencyPriority({
+          castEfficiency,
+          spell: TALENTS.SUMMON_DARKGLARE_TALENT,
+          weight: WEIGHTS.darkglareCastEfficiency,
+          why: 'It is your largest cooldown. Hold it only for a burn phase that you know will come.',
+        })
+      : null,
+    darkglareDotsPriority(darkglare, hasUnstableAffliction ? 3 : 2),
+    combatant.hasTalent(TALENTS.DARK_HARVEST_TALENT)
+      ? castEfficiencyPriority({
+          castEfficiency,
+          spell: TALENTS.DARK_HARVEST_TALENT,
+          weight: WEIGHTS.darkHarvestCastEfficiency,
+          why: (
+            <>
+              Each <SpellLink spell={SPELLS.UNSTABLE_AFFLICTION} /> cast reduces its cooldown, so it
+              returns faster than the tooltip says.
+            </>
+          ),
+        })
+      : null,
+    darkHarvestCoveragePriority(darkHarvest),
+    soulShardWastePriority({
+      tracker: soulShards,
+      fightDuration,
+      weight: WEIGHTS.soulShards,
+      spender: SPELLS.UNSTABLE_AFFLICTION,
+      shardsPerCast: 1,
+    }),
+    nightfallPriority(nightfall, fightDuration),
+  ];
+  return candidates.filter((p): p is ImprovementPriority => p !== null);
+}
+
+/** The "What to Focus On" section for Affliction. */
+function ImprovementPrioritiesSection(): JSX.Element | null {
+  const info = useInfo();
+  const castEfficiency = useAnalyzer(CastEfficiency);
+  const alwaysBeCasting = useAnalyzer(AlwaysBeCasting);
+  const cancelledCasts = useAnalyzer(CancelledCasts);
+  const agony = useAnalyzer(Agony);
+  const corruption = useAnalyzer(Corruption);
+  const unstableAffliction = useAnalyzer(UnstableAffliction);
+  const haunt = useAnalyzer(Haunt);
+  const darkglare = useAnalyzer(Darkglare);
+  const darkHarvest = useAnalyzer(DarkHarvest);
+  const nightfall = useAnalyzer(Nightfall);
+  const soulShards = useAnalyzer(SoulShardTracker);
+
+  if (!info) {
+    return null;
+  }
+
+  const priorities = buildAfflictionPriorities({
+    info,
+    castEfficiency,
+    alwaysBeCasting,
+    cancelledCasts,
+    agony,
+    corruption,
+    unstableAffliction,
+    haunt,
+    darkglare,
+    darkHarvest,
+    nightfall,
+    soulShards,
+  });
+
+  return (
+    <ImprovementPriorities
+      priorities={priorities}
+      intro={
+        <>
+          The changes most likely to raise your damage on this pull, ranked by value. Each one is
+          something you control: DoT uptime, cooldown timing, resources, and casting. Gear and fight
+          length are not included. The sections below give the details.
+        </>
+      }
+    />
+  );
+}
+
+export default ImprovementPrioritiesSection;

--- a/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/demonology/CHANGELOG.tsx
@@ -1,10 +1,12 @@
 import { change, date } from 'common/changelog';
 import SPELLS from 'common/SPELLS';
 // import { TALENTS_WARLOCK } from 'common/TALENTS';
-import { Katorri } from 'CONTRIBUTORS';
+import { Katorri, Zea } from 'CONTRIBUTORS';
 import SpellLink from 'interface/SpellLink';
 
 export default [
+  change(date(2026, 9, 9), <>Add a "What to Focus On" section at the top of the guide. It ranks up to four changes by impact: uptime, <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT} /> window quality, cooldown timing, Soul Shard waste, and more.</>, Zea),
+  change(date(2026, 9, 9), "Remove Charhound and Gloomhound from the cast efficiency list. Call Dreadstalkers summons them in 12.1, so they are not casts.", Zea),
   change(date(2026, 8, 18), "Update compatibility for 12.1", Katorri),
   change(date(2026, 4, 23), "Update spec Compatibility for 12.0.5", Katorri),
   change(date(2026, 4, 3), "Overhaul Demonic Tyrant guide with weighted scoring, add Diabolist support, and improved resource/cooldown tracking in Tyrant windows.", Katorri),

--- a/src/analysis/retail/warlock/demonology/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/demonology/CombatLogParser.ts
@@ -8,6 +8,7 @@ import LegionStrike from './modules/features/LegionStrike';
 import DemoPets from './modules/pets/DemoPets';
 import DemonicTyrant from './modules/features/DemonicTyrant';
 import SummonDoomguard from './modules/features/SummonDoomguard';
+import DemonboltHardcasts from './modules/features/DemonboltHardcasts';
 import PetDamageHandler from './modules/pets/DemoPets/PetDamageHandler';
 import PetSummonHandler from './modules/pets/DemoPets/PetSummonHandler';
 import PowerSiphonHandler from './modules/pets/DemoPets/PowerSiphonHandler';
@@ -41,6 +42,7 @@ class CombatLogParser extends CoreCombatLogParser {
     legionStrike: LegionStrike,
     DemonicTyrant: DemonicTyrant,
     summonDoomguard: SummonDoomguard,
+    demonboltHardcasts: DemonboltHardcasts,
 
     // Core
     soulShardTracker: SoulShardTracker,

--- a/src/analysis/retail/warlock/demonology/Guide.tsx
+++ b/src/analysis/retail/warlock/demonology/Guide.tsx
@@ -6,10 +6,12 @@ import ResourceUsage from './modules/guide/ResourceUsage';
 import DefensivesGuide from '../shared/Defensives';
 import DemonicTyrantGuide from './modules/guide/DemonicTyrantGuide';
 import { DemonicHealthstoneGuide } from '../shared/DHSGuide';
+import ImprovementPrioritiesSection from './modules/guide/ImprovementPrioritiesSection';
 
 export default function Guide({ modules, events, info }: GuideProps<typeof CombatLogParser>) {
   return (
     <>
+      <ImprovementPrioritiesSection />
       <CoreSection modules={modules} events={events} info={info} />
       <CooldownSection modules={modules} events={events} info={info} />
       <DefensivesSection modules={modules} events={events} info={info} />

--- a/src/analysis/retail/warlock/demonology/modules/features/Abilities.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/Abilities.ts
@@ -74,32 +74,6 @@ class Abilities extends SharedAbilities {
         },
       },
       {
-        spell: SPELLS.CHARHOUND_SUMMON.id,
-        category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 30,
-        enabled: combatant.hasTalent(TALENTS.MARK_OF_FHARG_TALENT),
-        gcd: {
-          base: 1500,
-        },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.9,
-        },
-      },
-      {
-        spell: SPELLS.GLOOMHOUND_SUMMON.id,
-        category: SPELL_CATEGORY.ROTATIONAL,
-        cooldown: 30,
-        enabled: combatant.hasTalent(TALENTS.MARK_OF_SHATUG_TALENT),
-        gcd: {
-          base: 1500,
-        },
-        castEfficiency: {
-          suggestion: true,
-          recommendedEfficiency: 0.9,
-        },
-      },
-      {
         spell: SPELLS.SHADOW_BOLT_DEMO.id,
         category: SPELL_CATEGORY.ROTATIONAL,
         gcd: {

--- a/src/analysis/retail/warlock/demonology/modules/features/DemonboltHardcasts.ts
+++ b/src/analysis/retail/warlock/demonology/modules/features/DemonboltHardcasts.ts
@@ -1,0 +1,46 @@
+import SPELLS from 'common/SPELLS';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import Events, { BeginCastEvent, CastEvent } from 'parser/core/Events';
+
+/**
+ * A Demonic Core Demonbolt logs a `begincast` at the same timestamp as its `cast`.
+ * A hard cast logs the `begincast` seconds earlier. Anything above this gap is a hard cast.
+ */
+const HARDCAST_MIN_DURATION_MS = 1000;
+
+/** Counts Demonbolts that were hard cast instead of made instant by Demonic Core. */
+class DemonboltHardcasts extends Analyzer {
+  casts = 0;
+  hardcasts = 0;
+  private lastBeginCast: number | null = null;
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(
+      Events.begincast.by(SELECTED_PLAYER).spell(SPELLS.DEMONBOLT),
+      this.onBeginCast,
+    );
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.DEMONBOLT), this.onCast);
+  }
+
+  onBeginCast(event: BeginCastEvent) {
+    this.lastBeginCast = event.timestamp;
+  }
+
+  onCast(event: CastEvent) {
+    this.casts += 1;
+    if (
+      this.lastBeginCast !== null &&
+      event.timestamp - this.lastBeginCast >= HARDCAST_MIN_DURATION_MS
+    ) {
+      this.hardcasts += 1;
+    }
+    this.lastBeginCast = null;
+  }
+
+  get hardcastsPerMinute() {
+    return this.hardcasts / (this.owner.fightDuration / 60000);
+  }
+}
+
+export default DemonboltHardcasts;

--- a/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/DemonicTyrantGuide.tsx
@@ -19,7 +19,7 @@ import { useAnalyzer, useInfo } from 'interface/guide';
 const TYRANT_PRE_WINDOW = 7000;
 const TYRANT_POST_BUFFER = 3000;
 
-interface ScoreBreakdown {
+export interface ScoreBreakdown {
   total: number;
   totalSpenderCasts: number;
   maxExpectedCasts: number;
@@ -33,7 +33,7 @@ interface ScoreBreakdown {
 }
 
 // Computes a weighted 0–100 score for a single Tyrant window across spender casts, cooldown usage, and resource management.
-function scoreTyrantWindow(cast: TyrantCastData, isDialobist: boolean): ScoreBreakdown {
+export function scoreTyrantWindow(cast: TyrantCastData, isDialobist: boolean): ScoreBreakdown {
   const totalSpenderCasts = cast.handOfGuldanCasts;
 
   // Pro-rate the max HoG cast expectation based on how much of the window actually occurred.
@@ -132,7 +132,7 @@ function scoreTyrantWindow(cast: TyrantCastData, isDialobist: boolean): ScoreBre
 
 // Maps a numeric window score to a performance rating.
 // Perfect requires ≥ maxExpectedCasts spender casts; Good requires ≥ 6.
-function scoreToPerf(
+export function scoreToPerf(
   score: number,
   totalSpenderCasts?: number,
   maxExpectedCasts = 8,

--- a/src/analysis/retail/warlock/demonology/modules/guide/ImprovementPrioritiesSection.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/ImprovementPrioritiesSection.tsx
@@ -1,0 +1,498 @@
+import type { JSX, ReactNode } from 'react';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
+import { formatDuration, formatPercentage } from 'common/format';
+import { SpellLink } from 'interface';
+import { useAnalyzer, useInfo } from 'interface/guide';
+import ImprovementPriorities, {
+  type ImprovementPriority,
+} from 'interface/guide/components/ImprovementPriorities';
+import type { Info } from 'parser/core/metric';
+import CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import SoulShardTracker from 'analysis/retail/warlock/shared/resources/SoulShardTracker';
+import {
+  activeTimePriority,
+  castEfficiencyPriority,
+  linearScore,
+  performanceForHigherIsBetter,
+  performanceForLowerIsBetter,
+  plural,
+  soulShardWastePriority,
+} from 'analysis/retail/warlock/shared/guide/priorities';
+import AlwaysBeCasting from '../features/AlwaysBeCasting';
+import DemonicTyrant, { type TyrantCastData } from '../features/DemonicTyrant';
+import DemonboltHardcasts from '../features/DemonboltHardcasts';
+import DemonicCalling from '../talents/DemonicCalling';
+import Doom from '../talents/Doom';
+import PowerSiphon from '../talents/PowerSiphon';
+import { scoreToPerf, scoreTyrantWindow } from './DemonicTyrantGuide';
+
+/**
+ * How much each check matters to Demonology damage, relative to the other checks. Only the
+ * ratios matter. A weight 10 check at a 50% score outranks a weight 5 check at a 0% score.
+ */
+const WEIGHTS = {
+  activeTime: 10,
+  tyrantWindows: 12,
+  tyrantCastEfficiency: 9,
+  dreadstalkers: 7,
+  grimoire: 5,
+  doomguard: 5,
+  soulShards: 5,
+  powerSiphon: 4,
+  demonboltHardcasts: 4,
+  doomUptime: 3,
+  demonicCalling: 3,
+  powerSiphonImps: 2,
+} as const;
+
+interface ScoredWindow {
+  window: TyrantCastData;
+  index: number;
+  score: number;
+  maxSpenderCasts: number;
+  performance: QualitativePerformance;
+}
+
+/**
+ * Turns the scores of all Tyrant windows into one priority. It uses the same scoring as the
+ * Demonic Tyrant section. The weak windows set the rating. The problems that repeat across all
+ * windows set the advice, because a habit that also shows in a Good window is still worth a fix.
+ */
+function tyrantWindowsPriority(
+  tyrant: DemonicTyrant | undefined,
+  isDiabolist: boolean,
+  fightStart: number,
+): ImprovementPriority | null {
+  if (!tyrant || tyrant.tyrantData.length === 0) {
+    // The cast efficiency check covers a Tyrant that was never cast.
+    return null;
+  }
+
+  const windows: ScoredWindow[] = tyrant.tyrantData.map((window, index) => {
+    const breakdown = scoreTyrantWindow(window, isDiabolist);
+    return {
+      window,
+      index,
+      score: breakdown.total,
+      maxSpenderCasts: breakdown.maxExpectedCasts,
+      performance: scoreToPerf(
+        breakdown.total,
+        breakdown.totalSpenderCasts,
+        breakdown.maxExpectedCasts,
+      ),
+    };
+  });
+  const total = windows.length;
+  const average = windows.reduce((sum, w) => sum + w.score, 0) / total / 100;
+  const weak = windows.filter(
+    (w) =>
+      w.performance === QualitativePerformance.Ok || w.performance === QualitativePerformance.Fail,
+  );
+  const failed = windows.filter((w) => w.performance === QualitativePerformance.Fail);
+  const goodFraction = 1 - weak.length / total;
+
+  let performance: QualitativePerformance;
+  if (weak.length === 0) {
+    performance = average >= 0.95 ? QualitativePerformance.Perfect : QualitativePerformance.Good;
+  } else if (failed.length * 2 >= total || average < 0.6) {
+    performance = QualitativePerformance.Fail;
+  } else {
+    performance = QualitativePerformance.Ok;
+  }
+
+  const spender = isDiabolist ? (
+    <>
+      <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} /> or{' '}
+      <SpellLink spell={SPELLS.RUINATION_CAST} />
+    </>
+  ) : (
+    <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} />
+  );
+
+  const count = (predicate: (w: ScoredWindow) => boolean) => windows.filter(predicate).length;
+  const issues: { label: ReactNode; count: number }[] = [
+    {
+      label: 'ended with 3 or more unspent Soul Shards',
+      count: count(
+        (w) => !w.window.fightEndedDuringWindow && (w.window.shardsAtWindowEnd ?? 0) >= 3,
+      ),
+    },
+    {
+      label: <>fewer than 6 {spender} casts in the window</>,
+      count: count(
+        (w) => w.window.handOfGuldanCasts < Math.min(6, Math.round(w.maxSpenderCasts * 0.75)),
+      ),
+    },
+    {
+      label: (
+        <>
+          no <SpellLink spell={SPELLS.CALL_DREADSTALKERS} /> active at the cast
+        </>
+      ),
+      count: count((w) => !w.window.dreadstalkersActive),
+    },
+    {
+      label: (
+        <>
+          <SpellLink spell={SPELLS.CALL_DREADSTALKERS} /> cast too early before Tyrant
+        </>
+      ),
+      count: count((w) => w.window.dreadstalkersTooEarly),
+    },
+    {
+      label: (
+        <>
+          1 or fewer <SpellLink spell={SPELLS.DEMONIC_CORE_BUFF} /> at the cast
+        </>
+      ),
+      // The opener cannot have Cores banked, so the first window is skipped.
+      count: count((w) => w.index > 0 && w.window.demonicCoresOnCast <= 1),
+    },
+    {
+      label: 'Grimoire demon available but not used',
+      count: count(
+        (w) =>
+          w.window.grimoireAvailable === true &&
+          !w.window.grimoireCast &&
+          !w.window.grimoireCastDuringWindow,
+      ),
+    },
+    {
+      label: (
+        <>
+          <SpellLink spell={TALENTS.SUMMON_DOOMGUARD_TALENT} /> available but not used
+        </>
+      ),
+      count: count((w) => w.window.doomguardAvailable === true && !w.window.doomguardCast),
+    },
+    isDiabolist
+      ? {
+          label: 'fewer than 5 Soul Shards at the cast',
+          count: count((w) => w.window.shardsOnCast < 5),
+        }
+      : {
+          label: '4 or more Soul Shards at the cast (Tyrant gives 3, so those overcap)',
+          count: count((w) => w.window.shardsOnCast >= 4),
+        },
+  ]
+    .filter((issue) => issue.count > 0)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 3);
+
+  const weakList = weak
+    .map((w) => `${formatDuration(w.window.cast - fightStart)} (${w.score}/100)`)
+    .join(', ');
+
+  return {
+    id: 'tyrant-windows',
+    title: (
+      <>
+        Prepare stronger <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT} /> windows
+      </>
+    ),
+    description: (
+      <>
+        {weak.length === 0 ? (
+          <>All {total} windows rated Good or better.</>
+        ) : (
+          <>
+            {weak.length} of {total} {plural(total, 'window')} rated below Good: {weakList}.
+          </>
+        )}{' '}
+        The average score was {Math.round(average * 100)}/100.
+        {issues.length > 0 && (
+          <>
+            {' '}
+            Recurring problems:{' '}
+            {issues.map((issue, i) => (
+              <span key={i}>
+                {i > 0 && ', '}
+                {issue.label} ({issue.count} of {total})
+              </span>
+            ))}
+            .
+          </>
+        )}{' '}
+        Before each Tyrant, cast <SpellLink spell={SPELLS.CALL_DREADSTALKERS} /> and your Grimoire
+        demon. Bank {isDiabolist ? '5 Soul Shards' : 'about 2 Soul Shards'} and 4{' '}
+        <SpellLink spell={SPELLS.DEMONIC_CORE_BUFF} />. Then spend everything on {spender} inside
+        the window.
+      </>
+    ),
+    score: 0.5 * average + 0.5 * goodFraction,
+    weight: WEIGHTS.tyrantWindows,
+    performance,
+  };
+}
+
+function demonboltHardcastPriority(
+  analyzer: DemonboltHardcasts | undefined,
+): ImprovementPriority | null {
+  if (!analyzer) {
+    return null;
+  }
+  const { hardcasts, casts, hardcastsPerMinute } = analyzer;
+  return {
+    id: 'demonbolt-hardcasts',
+    title: (
+      <>
+        Cast <SpellLink spell={SPELLS.DEMONBOLT} /> only with{' '}
+        <SpellLink spell={SPELLS.DEMONIC_CORE_BUFF} />
+      </>
+    ),
+    description: (
+      <>
+        You hard cast {hardcasts} of your {casts} Demonbolts without a Demonic Core (
+        {hardcastsPerMinute.toFixed(1)} per minute). A hard cast Demonbolt takes much longer than{' '}
+        <SpellLink spell={SPELLS.SHADOW_BOLT_DEMO} /> for the same shard. Use Shadow Bolt as the
+        filler and keep Demonbolt for Core procs.
+      </>
+    ),
+    score: linearScore(hardcastsPerMinute, 0, 2),
+    weight: WEIGHTS.demonboltHardcasts,
+    performance:
+      hardcasts === 0
+        ? QualitativePerformance.Perfect
+        : performanceForLowerIsBetter(hardcastsPerMinute, { good: 0.25, ok: 1 }),
+  };
+}
+
+function doomUptimePriority(doom: Doom | undefined): ImprovementPriority | null {
+  if (!doom?.active) {
+    return null;
+  }
+  const uptime = doom.uptime;
+  return {
+    id: 'doom-uptime',
+    title: (
+      <>
+        Keep <SpellLink spell={SPELLS.DOOM_DEBUFF} /> active
+      </>
+    ),
+    description: (
+      <>
+        Doom was on your target for {formatPercentage(uptime, 1)}% of the fight. Each{' '}
+        <SpellLink spell={SPELLS.DEMONIC_CORE_BUFF} /> Demonbolt applies it. Outside of Tyrant
+        preparation, spend a Core before Doom expires. Do not hold all four.
+      </>
+    ),
+    score: linearScore(uptime, 1, 0.6),
+    weight: WEIGHTS.doomUptime,
+    performance: performanceForHigherIsBetter(uptime, { perfect: 0.98, good: 0.95, ok: 0.85 }),
+  };
+}
+
+function demonicCallingPriority(
+  demonicCalling: DemonicCalling | undefined,
+  fightDuration: number,
+): ImprovementPriority | null {
+  if (!demonicCalling?.active) {
+    return null;
+  }
+  const wasted = demonicCalling.wastedProcs;
+  const perMinute = wasted / (fightDuration / 60000);
+  return {
+    id: 'demonic-calling',
+    title: (
+      <>
+        Use <SpellLink spell={TALENTS.DEMONIC_CALLING_TALENT} /> procs before they expire
+      </>
+    ),
+    description: (
+      <>
+        You wasted {wasted} {plural(wasted, 'proc')} ({perMinute.toFixed(1)} per minute). The buff
+        expired, or a new proc replaced it while <SpellLink spell={SPELLS.CALL_DREADSTALKERS} /> was
+        available. When you have the proc and Dreadstalkers is ready, cast it at once.
+      </>
+    ),
+    score: linearScore(perMinute, 0, 3),
+    weight: WEIGHTS.demonicCalling,
+    performance:
+      wasted === 0
+        ? QualitativePerformance.Perfect
+        : performanceForLowerIsBetter(perMinute, { good: 1, ok: 2 }),
+  };
+}
+
+function powerSiphonImpsPriority(powerSiphon: PowerSiphon | undefined): ImprovementPriority | null {
+  if (!powerSiphon?.active || powerSiphon.numCasts === 0) {
+    return null;
+  }
+  const { numCasts, doubleImpSiphons, singleImpSiphons } = powerSiphon;
+  const ratio = doubleImpSiphons / numCasts;
+  return {
+    id: 'power-siphon-imps',
+    title: (
+      <>
+        Cast <SpellLink spell={TALENTS.POWER_SIPHON_TALENT} /> with 2 Wild Imps out
+      </>
+    ),
+    description: (
+      <>
+        {singleImpSiphons} of {numCasts} Power Siphon {plural(numCasts, 'cast')} had only one Wild
+        Imp to sacrifice. Each of those gave one <SpellLink spell={SPELLS.DEMONIC_CORE_BUFF} />{' '}
+        instead of two. Cast it after a <SpellLink spell={SPELLS.HAND_OF_GULDAN_CAST} /> lands.
+      </>
+    ),
+    score: ratio,
+    weight: WEIGHTS.powerSiphonImps,
+    performance: performanceForHigherIsBetter(ratio, { perfect: 1, good: 0.8, ok: 0.5 }),
+  };
+}
+
+export interface DemonologyPriorityInputs {
+  info: Info;
+  castEfficiency?: CastEfficiency;
+  alwaysBeCasting?: AlwaysBeCasting;
+  tyrant?: DemonicTyrant;
+  soulShards?: SoulShardTracker;
+  demonboltHardcasts?: DemonboltHardcasts;
+  demonicCalling?: DemonicCalling;
+  doom?: Doom;
+  powerSiphon?: PowerSiphon;
+}
+
+/** Builds one priority for each check that applies to the talents of this player. */
+export function buildDemonologyPriorities({
+  info,
+  castEfficiency,
+  alwaysBeCasting,
+  tyrant,
+  soulShards,
+  demonboltHardcasts,
+  demonicCalling,
+  doom,
+  powerSiphon,
+}: DemonologyPriorityInputs): ImprovementPriority[] {
+  const { combatant, fightDuration, fightStart } = info;
+  const isDiabolist = combatant.hasTalent(TALENTS.RUINATION_TALENT);
+  const grimoire = combatant.hasTalent(TALENTS.GRIMOIRE_IMP_LORD_TALENT)
+    ? TALENTS.GRIMOIRE_IMP_LORD_TALENT
+    : combatant.hasTalent(TALENTS.GRIMOIRE_FEL_RAVAGER_TALENT)
+      ? TALENTS.GRIMOIRE_FEL_RAVAGER_TALENT
+      : null;
+
+  const candidates: (ImprovementPriority | null)[] = [
+    activeTimePriority({
+      alwaysBeCasting,
+      fightDuration,
+      weight: WEIGHTS.activeTime,
+      thresholds: { perfect: 0.02, good: 0.1, ok: 0.2 },
+      worst: 0.3,
+      movementTips: (
+        <>
+          While you move, use instant <SpellLink spell={SPELLS.DEMONBOLT} />s from{' '}
+          <SpellLink spell={SPELLS.DEMONIC_CORE_BUFF} /> and{' '}
+          <SpellLink spell={SPELLS.IMPLOSION_CAST} />. Place{' '}
+          <SpellLink spell={SPELLS.DEMONIC_CIRCLE} /> before you need it, so that each move costs
+          fewer globals.
+        </>
+      ),
+    }),
+    tyrantWindowsPriority(tyrant, isDiabolist, fightStart),
+    castEfficiencyPriority({
+      castEfficiency,
+      spell: SPELLS.SUMMON_DEMONIC_TYRANT,
+      weight: WEIGHTS.tyrantCastEfficiency,
+      why: 'Each delay pushes a full Tyrant window later into the fight. The last window can then not happen at all.',
+    }),
+    castEfficiencyPriority({
+      castEfficiency,
+      spell: SPELLS.CALL_DREADSTALKERS,
+      weight: WEIGHTS.dreadstalkers,
+      why: (
+        <>
+          Dreadstalkers are your main source of <SpellLink spell={SPELLS.DEMONIC_CORE_BUFF} />. A
+          late cast also delays your Demonbolts.
+        </>
+      ),
+    }),
+    grimoire
+      ? castEfficiencyPriority({
+          castEfficiency,
+          spell: grimoire,
+          weight: WEIGHTS.grimoire,
+          why: 'It aligns with every second Tyrant. Hold it only for a burn phase that you know will come.',
+        })
+      : null,
+    combatant.hasTalent(TALENTS.SUMMON_DOOMGUARD_TALENT)
+      ? castEfficiencyPriority({
+          castEfficiency,
+          spell: TALENTS.SUMMON_DOOMGUARD_TALENT,
+          weight: WEIGHTS.doomguard,
+          why: (
+            <>
+              Demonic Core Demonbolts reduce its cooldown. Cast it before{' '}
+              <SpellLink spell={SPELLS.SUMMON_DEMONIC_TYRANT} />.
+            </>
+          ),
+        })
+      : null,
+    combatant.hasTalent(TALENTS.POWER_SIPHON_TALENT)
+      ? castEfficiencyPriority({
+          castEfficiency,
+          spell: TALENTS.POWER_SIPHON_TALENT,
+          weight: WEIGHTS.powerSiphon,
+          why: 'Two free Demonic Cores every 30 seconds is a lot of Demonbolts.',
+        })
+      : null,
+    powerSiphonImpsPriority(powerSiphon),
+    soulShardWastePriority({
+      tracker: soulShards,
+      fightDuration,
+      weight: WEIGHTS.soulShards,
+      spender: SPELLS.HAND_OF_GULDAN_CAST,
+      shardsPerCast: 3,
+    }),
+    demonboltHardcastPriority(demonboltHardcasts),
+    doomUptimePriority(doom),
+    demonicCallingPriority(demonicCalling, fightDuration),
+  ];
+  return candidates.filter((p): p is ImprovementPriority => p !== null);
+}
+
+/** The "What to Focus On" section for Demonology. */
+function ImprovementPrioritiesSection(): JSX.Element | null {
+  const info = useInfo();
+  const castEfficiency = useAnalyzer(CastEfficiency);
+  const alwaysBeCasting = useAnalyzer(AlwaysBeCasting);
+  const tyrant = useAnalyzer(DemonicTyrant);
+  const soulShards = useAnalyzer(SoulShardTracker);
+  const demonboltHardcasts = useAnalyzer(DemonboltHardcasts);
+  const demonicCalling = useAnalyzer(DemonicCalling);
+  const doom = useAnalyzer(Doom);
+  const powerSiphon = useAnalyzer(PowerSiphon);
+
+  if (!info) {
+    return null;
+  }
+
+  const priorities = buildDemonologyPriorities({
+    info,
+    castEfficiency,
+    alwaysBeCasting,
+    tyrant,
+    soulShards,
+    demonboltHardcasts,
+    demonicCalling,
+    doom,
+    powerSiphon,
+  });
+
+  return (
+    <ImprovementPriorities
+      priorities={priorities}
+      intro={
+        <>
+          The changes most likely to raise your damage on this pull, ranked by value. Each one is
+          something you control: cooldown timing, Tyrant preparation, resources, and uptime. Gear
+          and fight length are not included. The sections below give the details.
+        </>
+      }
+    />
+  );
+}
+
+export default ImprovementPrioritiesSection;

--- a/src/analysis/retail/warlock/demonology/modules/guide/ImprovementPrioritiesSection.tsx
+++ b/src/analysis/retail/warlock/demonology/modules/guide/ImprovementPrioritiesSection.tsx
@@ -4,22 +4,20 @@ import TALENTS from 'common/TALENTS/warlock';
 import { formatDuration, formatPercentage } from 'common/format';
 import { SpellLink } from 'interface';
 import { useAnalyzer, useInfo } from 'interface/guide';
-import ImprovementPriorities, {
-  type ImprovementPriority,
-} from 'interface/guide/components/ImprovementPriorities';
 import type { Info } from 'parser/core/metric';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import SoulShardTracker from 'analysis/retail/warlock/shared/resources/SoulShardTracker';
-import {
+import ImprovementPriorities, {
   activeTimePriority,
   castEfficiencyPriority,
   linearScore,
   performanceForHigherIsBetter,
   performanceForLowerIsBetter,
   plural,
-  soulShardWastePriority,
-} from 'analysis/retail/warlock/shared/guide/priorities';
+  type ImprovementPriority,
+} from 'interface/guide/components/ImprovementPriorities';
+import { soulShardWastePriority } from 'analysis/retail/warlock/shared/guide/priorities';
 import AlwaysBeCasting from '../features/AlwaysBeCasting';
 import DemonicTyrant, { type TyrantCastData } from '../features/DemonicTyrant';
 import DemonboltHardcasts from '../features/DemonboltHardcasts';

--- a/src/analysis/retail/warlock/shared/guide/priorities.test.ts
+++ b/src/analysis/retail/warlock/shared/guide/priorities.test.ts
@@ -1,0 +1,173 @@
+import SPELLS from 'common/SPELLS';
+import type CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import type AlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
+import type ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import {
+  activeTimePriority,
+  castEfficiencyPriority,
+  linearScore,
+  performanceForHigherIsBetter,
+  performanceForLowerIsBetter,
+  soulShardWastePriority,
+} from './priorities';
+
+const MINUTE = 60000;
+
+const castEfficiencyWith = (data: Record<string, unknown> | null) =>
+  ({ getCastEfficiencyForSpell: () => data }) as unknown as CastEfficiency;
+
+const efficiencyData = (efficiency: number | null, casts = 7, maxCasts = 8) => ({
+  casts,
+  maxCasts,
+  efficiency,
+  recommendedEfficiency: 0.9,
+  averageIssueEfficiency: 0.85,
+  majorIssueEfficiency: 0.75,
+  gotMaxCasts: casts === maxCasts,
+});
+
+describe('linearScore', () => {
+  it('is 1 at best and 0 at worst, in either direction', () => {
+    expect(linearScore(0, 0, 0.3)).toBe(1);
+    expect(linearScore(0.3, 0, 0.3)).toBe(0);
+    expect(linearScore(0.15, 0, 0.3)).toBeCloseTo(0.5);
+    expect(linearScore(1, 1, 0.6)).toBe(1);
+    expect(linearScore(0.8, 1, 0.6)).toBeCloseTo(0.5);
+  });
+
+  it('clamps outside the range', () => {
+    expect(linearScore(0.9, 0, 0.3)).toBe(0);
+    expect(linearScore(-1, 0, 0.3)).toBe(1);
+  });
+
+  it('handles best equal to worst', () => {
+    expect(linearScore(2, 2, 2)).toBe(1);
+    expect(linearScore(3, 2, 2)).toBe(0);
+  });
+});
+
+describe('performance thresholds', () => {
+  it('rates lower-is-better values', () => {
+    const thresholds = { perfect: 0.02, good: 0.1, ok: 0.2 };
+    expect(performanceForLowerIsBetter(0.01, thresholds)).toBe(QualitativePerformance.Perfect);
+    expect(performanceForLowerIsBetter(0.1, thresholds)).toBe(QualitativePerformance.Good);
+    expect(performanceForLowerIsBetter(0.15, thresholds)).toBe(QualitativePerformance.Ok);
+    expect(performanceForLowerIsBetter(0.21, thresholds)).toBe(QualitativePerformance.Fail);
+  });
+
+  it('rates higher-is-better values and skips Perfect without a threshold', () => {
+    const thresholds = { good: 0.95, ok: 0.85 };
+    expect(performanceForHigherIsBetter(1, thresholds)).toBe(QualitativePerformance.Good);
+    expect(performanceForHigherIsBetter(0.9, thresholds)).toBe(QualitativePerformance.Ok);
+    expect(performanceForHigherIsBetter(0.5, thresholds)).toBe(QualitativePerformance.Fail);
+  });
+});
+
+describe('castEfficiencyPriority', () => {
+  const build = (data: Record<string, unknown> | null) =>
+    castEfficiencyPriority({
+      castEfficiency: castEfficiencyWith(data),
+      spell: SPELLS.SUMMON_DEMONIC_TYRANT,
+      weight: 9,
+    });
+
+  it('returns null without cast efficiency data', () => {
+    expect(build(null)).toBeNull();
+    expect(build(efficiencyData(null))).toBeNull();
+    expect(
+      castEfficiencyPriority({
+        castEfficiency: undefined,
+        spell: SPELLS.SUMMON_DEMONIC_TYRANT,
+        weight: 9,
+      }),
+    ).toBeNull();
+  });
+
+  it('maps efficiency onto the spell thresholds', () => {
+    expect(build(efficiencyData(0.7, 8, 8))?.performance).toBe(QualitativePerformance.Perfect);
+    expect(build(efficiencyData(0.99))?.performance).toBe(QualitativePerformance.Perfect);
+    expect(build(efficiencyData(0.92))?.performance).toBe(QualitativePerformance.Good);
+    expect(build(efficiencyData(0.8))?.performance).toBe(QualitativePerformance.Ok);
+    expect(build(efficiencyData(0.7))?.performance).toBe(QualitativePerformance.Fail);
+  });
+
+  it('uses the efficiency as the score and the spell id in the key', () => {
+    const priority = build(efficiencyData(0.8));
+    expect(priority?.score).toBe(0.8);
+    expect(priority?.weight).toBe(9);
+    expect(priority?.id).toBe(`cast-efficiency-${SPELLS.SUMMON_DEMONIC_TYRANT.id}`);
+  });
+});
+
+describe('activeTimePriority', () => {
+  const build = (downtime: number) =>
+    activeTimePriority({
+      alwaysBeCasting: {
+        downtimePercentage: downtime,
+        activeTimePercentage: 1 - downtime,
+      } as unknown as AlwaysBeCasting,
+      fightDuration: 5 * MINUTE,
+      weight: 10,
+      thresholds: { perfect: 0.02, good: 0.1, ok: 0.2 },
+      worst: 0.3,
+      movementTips: 'tips',
+    });
+
+  it('returns null without the analyzer', () => {
+    expect(
+      activeTimePriority({
+        alwaysBeCasting: undefined,
+        fightDuration: MINUTE,
+        weight: 10,
+        thresholds: { good: 0.1, ok: 0.2 },
+        worst: 0.3,
+        movementTips: 'tips',
+      }),
+    ).toBeNull();
+  });
+
+  it('rates downtime against the thresholds and scores it linearly', () => {
+    expect(build(0.05)?.performance).toBe(QualitativePerformance.Good);
+    expect(build(0.188)?.performance).toBe(QualitativePerformance.Ok);
+    expect(build(0.25)?.performance).toBe(QualitativePerformance.Fail);
+    expect(build(0.15)?.score).toBeCloseTo(0.5);
+  });
+});
+
+describe('soulShardWastePriority', () => {
+  const build = (wasted: number, minutes: number) =>
+    soulShardWastePriority({
+      tracker: { wasted } as unknown as ResourceTracker,
+      fightDuration: minutes * MINUTE,
+      weight: 5,
+      spender: SPELLS.HAND_OF_GULDAN_CAST,
+      shardsPerCast: 3,
+    });
+
+  it('returns null without a tracker or a fight', () => {
+    expect(
+      soulShardWastePriority({
+        tracker: undefined,
+        fightDuration: MINUTE,
+        weight: 5,
+        spender: SPELLS.HAND_OF_GULDAN_CAST,
+        shardsPerCast: 3,
+      }),
+    ).toBeNull();
+    expect(build(3, 0)).toBeNull();
+  });
+
+  it('is Perfect with no waste and rates waste per minute', () => {
+    expect(build(0, 5)?.performance).toBe(QualitativePerformance.Perfect);
+    expect(build(2, 5)?.performance).toBe(QualitativePerformance.Good);
+    expect(build(9, 7)?.performance).toBe(QualitativePerformance.Ok);
+    expect(build(20, 5)?.performance).toBe(QualitativePerformance.Fail);
+  });
+
+  it('scores waste per minute linearly down to 0 at 10 shards per 3 minutes', () => {
+    expect(build(0, 5)?.score).toBe(1);
+    expect(build(10, 3)?.score).toBe(0);
+    expect(build(5, 3)?.score).toBeCloseTo(0.5);
+  });
+});

--- a/src/analysis/retail/warlock/shared/guide/priorities.test.ts
+++ b/src/analysis/retail/warlock/shared/guide/priorities.test.ts
@@ -1,151 +1,21 @@
 import SPELLS from 'common/SPELLS';
-import type CastEfficiency from 'parser/shared/modules/CastEfficiency';
-import type AlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
 import type ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import {
-  activeTimePriority,
-  castEfficiencyPriority,
-  linearScore,
-  performanceForHigherIsBetter,
-  performanceForLowerIsBetter,
-  soulShardWastePriority,
-} from './priorities';
+import { soulShardWastePriority } from './priorities';
 
 const MINUTE = 60000;
 
-const castEfficiencyWith = (data: Record<string, unknown> | null) =>
-  ({ getCastEfficiencyForSpell: () => data }) as unknown as CastEfficiency;
-
-const efficiencyData = (efficiency: number | null, casts = 7, maxCasts = 8) => ({
-  casts,
-  maxCasts,
-  efficiency,
-  recommendedEfficiency: 0.9,
-  averageIssueEfficiency: 0.85,
-  majorIssueEfficiency: 0.75,
-  gotMaxCasts: casts === maxCasts,
-});
-
-describe('linearScore', () => {
-  it('is 1 at best and 0 at worst, in either direction', () => {
-    expect(linearScore(0, 0, 0.3)).toBe(1);
-    expect(linearScore(0.3, 0, 0.3)).toBe(0);
-    expect(linearScore(0.15, 0, 0.3)).toBeCloseTo(0.5);
-    expect(linearScore(1, 1, 0.6)).toBe(1);
-    expect(linearScore(0.8, 1, 0.6)).toBeCloseTo(0.5);
+const build = (wasted: number, minutes: number) =>
+  soulShardWastePriority({
+    tracker: { wasted } as unknown as ResourceTracker,
+    fightDuration: minutes * MINUTE,
+    weight: 5,
+    spender: SPELLS.HAND_OF_GULDAN_CAST,
+    shardsPerCast: 3,
   });
-
-  it('clamps outside the range', () => {
-    expect(linearScore(0.9, 0, 0.3)).toBe(0);
-    expect(linearScore(-1, 0, 0.3)).toBe(1);
-  });
-
-  it('handles best equal to worst', () => {
-    expect(linearScore(2, 2, 2)).toBe(1);
-    expect(linearScore(3, 2, 2)).toBe(0);
-  });
-});
-
-describe('performance thresholds', () => {
-  it('rates lower-is-better values', () => {
-    const thresholds = { perfect: 0.02, good: 0.1, ok: 0.2 };
-    expect(performanceForLowerIsBetter(0.01, thresholds)).toBe(QualitativePerformance.Perfect);
-    expect(performanceForLowerIsBetter(0.1, thresholds)).toBe(QualitativePerformance.Good);
-    expect(performanceForLowerIsBetter(0.15, thresholds)).toBe(QualitativePerformance.Ok);
-    expect(performanceForLowerIsBetter(0.21, thresholds)).toBe(QualitativePerformance.Fail);
-  });
-
-  it('rates higher-is-better values and skips Perfect without a threshold', () => {
-    const thresholds = { good: 0.95, ok: 0.85 };
-    expect(performanceForHigherIsBetter(1, thresholds)).toBe(QualitativePerformance.Good);
-    expect(performanceForHigherIsBetter(0.9, thresholds)).toBe(QualitativePerformance.Ok);
-    expect(performanceForHigherIsBetter(0.5, thresholds)).toBe(QualitativePerformance.Fail);
-  });
-});
-
-describe('castEfficiencyPriority', () => {
-  const build = (data: Record<string, unknown> | null) =>
-    castEfficiencyPriority({
-      castEfficiency: castEfficiencyWith(data),
-      spell: SPELLS.SUMMON_DEMONIC_TYRANT,
-      weight: 9,
-    });
-
-  it('returns null without cast efficiency data', () => {
-    expect(build(null)).toBeNull();
-    expect(build(efficiencyData(null))).toBeNull();
-    expect(
-      castEfficiencyPriority({
-        castEfficiency: undefined,
-        spell: SPELLS.SUMMON_DEMONIC_TYRANT,
-        weight: 9,
-      }),
-    ).toBeNull();
-  });
-
-  it('maps efficiency onto the spell thresholds', () => {
-    expect(build(efficiencyData(0.7, 8, 8))?.performance).toBe(QualitativePerformance.Perfect);
-    expect(build(efficiencyData(0.99))?.performance).toBe(QualitativePerformance.Perfect);
-    expect(build(efficiencyData(0.92))?.performance).toBe(QualitativePerformance.Good);
-    expect(build(efficiencyData(0.8))?.performance).toBe(QualitativePerformance.Ok);
-    expect(build(efficiencyData(0.7))?.performance).toBe(QualitativePerformance.Fail);
-  });
-
-  it('uses the efficiency as the score and the spell id in the key', () => {
-    const priority = build(efficiencyData(0.8));
-    expect(priority?.score).toBe(0.8);
-    expect(priority?.weight).toBe(9);
-    expect(priority?.id).toBe(`cast-efficiency-${SPELLS.SUMMON_DEMONIC_TYRANT.id}`);
-  });
-});
-
-describe('activeTimePriority', () => {
-  const build = (downtime: number) =>
-    activeTimePriority({
-      alwaysBeCasting: {
-        downtimePercentage: downtime,
-        activeTimePercentage: 1 - downtime,
-      } as unknown as AlwaysBeCasting,
-      fightDuration: 5 * MINUTE,
-      weight: 10,
-      thresholds: { perfect: 0.02, good: 0.1, ok: 0.2 },
-      worst: 0.3,
-      movementTips: 'tips',
-    });
-
-  it('returns null without the analyzer', () => {
-    expect(
-      activeTimePriority({
-        alwaysBeCasting: undefined,
-        fightDuration: MINUTE,
-        weight: 10,
-        thresholds: { good: 0.1, ok: 0.2 },
-        worst: 0.3,
-        movementTips: 'tips',
-      }),
-    ).toBeNull();
-  });
-
-  it('rates downtime against the thresholds and scores it linearly', () => {
-    expect(build(0.05)?.performance).toBe(QualitativePerformance.Good);
-    expect(build(0.188)?.performance).toBe(QualitativePerformance.Ok);
-    expect(build(0.25)?.performance).toBe(QualitativePerformance.Fail);
-    expect(build(0.15)?.score).toBeCloseTo(0.5);
-  });
-});
 
 describe('soulShardWastePriority', () => {
-  const build = (wasted: number, minutes: number) =>
-    soulShardWastePriority({
-      tracker: { wasted } as unknown as ResourceTracker,
-      fightDuration: minutes * MINUTE,
-      weight: 5,
-      spender: SPELLS.HAND_OF_GULDAN_CAST,
-      shardsPerCast: 3,
-    });
-
-  it('returns null without a tracker or a fight', () => {
+  it('returns null without a tracker', () => {
     expect(
       soulShardWastePriority({
         tracker: undefined,
@@ -155,19 +25,19 @@ describe('soulShardWastePriority', () => {
         shardsPerCast: 3,
       }),
     ).toBeNull();
-    expect(build(3, 0)).toBeNull();
   });
 
-  it('is Perfect with no waste and rates waste per minute', () => {
+  it('uses the Soul Shard thresholds of the shared suggestion', () => {
     expect(build(0, 5)?.performance).toBe(QualitativePerformance.Perfect);
     expect(build(2, 5)?.performance).toBe(QualitativePerformance.Good);
     expect(build(9, 7)?.performance).toBe(QualitativePerformance.Ok);
     expect(build(20, 5)?.performance).toBe(QualitativePerformance.Fail);
   });
 
-  it('scores waste per minute linearly down to 0 at 10 shards per 3 minutes', () => {
-    expect(build(0, 5)?.score).toBe(1);
-    expect(build(10, 3)?.score).toBe(0);
-    expect(build(5, 3)?.score).toBeCloseTo(0.5);
+  it('keeps a stable id and a countable title', () => {
+    const priority = build(3, 5);
+    expect(priority?.id).toBe('soul-shard-waste');
+    expect(priority?.title).toBe('Waste fewer Soul Shards');
+    expect(priority?.score).toBeCloseTo(1 - 0.6 / (10 / 3));
   });
 });

--- a/src/analysis/retail/warlock/shared/guide/priorities.tsx
+++ b/src/analysis/retail/warlock/shared/guide/priorities.tsx
@@ -1,193 +1,9 @@
-import type { ReactNode } from 'react';
 import type Spell from 'common/SPELLS/Spell';
-import { formatDuration, formatPercentage } from 'common/format';
-import { SpellLink } from 'interface';
-import type { ImprovementPriority } from 'interface/guide/components/ImprovementPriorities';
-import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import type CastEfficiency from 'parser/shared/modules/CastEfficiency';
-import type AlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
+import {
+  resourceWastePriority,
+  type ImprovementPriority,
+} from 'interface/guide/components/ImprovementPriorities';
 import type ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
-
-/**
- * Building blocks for the "What to Focus On" section of the Warlock specs.
- * Each helper turns the data of one analyzer into an {@link ImprovementPriority}. It returns
- * null when the check does not apply. The spec decides the weight and the wording.
- */
-
-const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
-
-/** Linear score from 0 to 1. It is 1 at `best` and 0 at `worst`, in either direction. */
-export function linearScore(actual: number, best: number, worst: number): number {
-  if (best === worst) {
-    return actual === best ? 1 : 0;
-  }
-  return clamp01((actual - worst) / (best - worst));
-}
-
-export interface PerformanceThresholds {
-  /** Values on the good side of this value (inclusive) are Perfect. Optional. */
-  perfect?: number;
-  /** Values on the good side of this value (inclusive) are Good. */
-  good: number;
-  /** Values on the good side of this value (inclusive) are Ok. All other values are Fail. */
-  ok: number;
-}
-
-/** Rates a value where lower is better, such as downtime or waste per minute. */
-export function performanceForLowerIsBetter(
-  actual: number,
-  { perfect, good, ok }: PerformanceThresholds,
-): QualitativePerformance {
-  if (perfect !== undefined && actual <= perfect) {
-    return QualitativePerformance.Perfect;
-  }
-  if (actual <= good) {
-    return QualitativePerformance.Good;
-  }
-  if (actual <= ok) {
-    return QualitativePerformance.Ok;
-  }
-  return QualitativePerformance.Fail;
-}
-
-/** Rates a value where higher is better, such as uptime or efficiency. */
-export function performanceForHigherIsBetter(
-  actual: number,
-  { perfect, good, ok }: PerformanceThresholds,
-): QualitativePerformance {
-  if (perfect !== undefined && actual >= perfect) {
-    return QualitativePerformance.Perfect;
-  }
-  if (actual >= good) {
-    return QualitativePerformance.Good;
-  }
-  if (actual >= ok) {
-    return QualitativePerformance.Ok;
-  }
-  return QualitativePerformance.Fail;
-}
-
-export const plural = (count: number, singular: string, pluralForm = `${singular}s`) =>
-  count === 1 ? singular : pluralForm;
-
-interface CastEfficiencyPriorityOptions {
-  castEfficiency: CastEfficiency | undefined;
-  spell: Spell;
-  weight: number;
-  /** One or two short sentences on why the cooldown matters, or when it is fine to hold it. */
-  why?: ReactNode;
-  id?: string;
-}
-
-/**
- * Priority for a cooldown that the player must use close to on-cooldown. It uses the
- * thresholds the spec set for the spell in its `Abilities` list, so it agrees with the
- * Cast Efficiency panel.
- */
-export function castEfficiencyPriority({
-  castEfficiency,
-  spell,
-  weight,
-  why,
-  id,
-}: CastEfficiencyPriorityOptions): ImprovementPriority | null {
-  const data = castEfficiency?.getCastEfficiencyForSpell(spell);
-  if (!data || data.efficiency === null) {
-    return null;
-  }
-  const { casts, maxCasts, recommendedEfficiency, majorIssueEfficiency, gotMaxCasts } = data;
-  const efficiency = clamp01(data.efficiency);
-
-  let performance: QualitativePerformance;
-  if (gotMaxCasts || efficiency >= 0.98) {
-    performance = QualitativePerformance.Perfect;
-  } else if (efficiency >= recommendedEfficiency) {
-    performance = QualitativePerformance.Good;
-  } else if (efficiency >= majorIssueEfficiency) {
-    performance = QualitativePerformance.Ok;
-  } else {
-    performance = QualitativePerformance.Fail;
-  }
-
-  const missed = Math.max(0, maxCasts - casts);
-  const title =
-    casts === 0 ? (
-      <>
-        Use <SpellLink spell={spell} />
-      </>
-    ) : (
-      <>
-        Cast <SpellLink spell={spell} /> closer to cooldown
-      </>
-    );
-
-  return {
-    id: id ?? `cast-efficiency-${spell.id}`,
-    title,
-    description: (
-      <>
-        {casts === 0 ? (
-          <>
-            You never cast it. This fight had time for {maxCasts} {plural(maxCasts, 'cast')}.
-          </>
-        ) : (
-          <>
-            You cast it {casts} {plural(casts, 'time')}. This fight had time for {maxCasts}{' '}
-            {plural(maxCasts, 'cast')} ({formatPercentage(efficiency, 0)}% efficiency). That is{' '}
-            {missed} missed {plural(missed, 'cast')}.
-          </>
-        )}
-        {why && <> {why}</>}
-      </>
-    ),
-    score: efficiency,
-    weight,
-    performance,
-  };
-}
-
-interface ActiveTimePriorityOptions {
-  alwaysBeCasting: AlwaysBeCasting | undefined;
-  fightDuration: number;
-  weight: number;
-  /** Downtime fractions. At or below `good` is fine. At or below `ok` is a small issue. */
-  thresholds: PerformanceThresholds;
-  /** The downtime fraction at which the score reaches 0. */
-  worst: number;
-  /** Spec-specific advice on what to cast while moving. */
-  movementTips: ReactNode;
-}
-
-/** Priority for time spent not casting. */
-export function activeTimePriority({
-  alwaysBeCasting,
-  fightDuration,
-  weight,
-  thresholds,
-  worst,
-  movementTips,
-}: ActiveTimePriorityOptions): ImprovementPriority | null {
-  if (!alwaysBeCasting) {
-    return null;
-  }
-  const downtime = clamp01(alwaysBeCasting.downtimePercentage);
-  const active = clamp01(alwaysBeCasting.activeTimePercentage);
-
-  return {
-    id: 'active-time',
-    title: 'Reduce your downtime',
-    description: (
-      <>
-        You cast spells for {formatPercentage(active, 1)}% of the fight. That is{' '}
-        {formatDuration(fightDuration * downtime)} of downtime. Damage lost while the GCD is idle
-        does not come back. {movementTips}
-      </>
-    ),
-    score: linearScore(downtime, 0, worst),
-    weight,
-    performance: performanceForLowerIsBetter(downtime, thresholds),
-  };
-}
 
 interface SoulShardWastePriorityOptions {
   tracker: ResourceTracker | undefined;
@@ -199,8 +15,8 @@ interface SoulShardWastePriorityOptions {
 }
 
 /**
- * Priority for Soul Shards generated at the cap. The thresholds are the same as the ones
- * the shared `SoulShardDetails` module uses for its suggestion.
+ * Soul Shard waste for the Warlock specs. The thresholds are the same as the ones the shared
+ * `SoulShardDetails` module uses for its suggestion.
  */
 export function soulShardWastePriority({
   tracker,
@@ -209,35 +25,17 @@ export function soulShardWastePriority({
   spender,
   shardsPerCast,
 }: SoulShardWastePriorityOptions): ImprovementPriority | null {
-  if (!tracker || fightDuration <= 0) {
-    return null;
-  }
-  const wasted = tracker.wasted;
-  const perMinute = wasted / (fightDuration / 60000);
-  const missedCasts = Math.floor(wasted / shardsPerCast);
-
-  return {
-    id: 'soul-shard-waste',
-    title: 'Waste fewer Soul Shards',
-    description: (
-      <>
-        You generated {wasted} Soul {plural(wasted, 'Shard')} while you were already at 5 (
-        {perMinute.toFixed(1)} per minute).
-        {missedCasts > 0 && (
-          <>
-            {' '}
-            That is enough for {missedCasts} more <SpellLink spell={spender} />{' '}
-            {plural(missedCasts, 'cast')}.
-          </>
-        )}{' '}
-        At 4 or 5 shards, spend before you cast a generator.
-      </>
-    ),
-    score: linearScore(perMinute, 0, 10 / 3),
+  return resourceWastePriority({
+    tracker,
+    fightDuration,
     weight,
-    performance:
-      wasted === 0
-        ? QualitativePerformance.Perfect
-        : performanceForLowerIsBetter(perMinute, { good: 5 / 10, ok: 5 / 3 }),
-  };
+    spender,
+    unitsPerCast: shardsPerCast,
+    id: 'soul-shard-waste',
+    resourceName: { one: 'Soul Shard', many: 'Soul Shards' },
+    title: 'Waste fewer Soul Shards',
+    advice: 'At 4 or 5 shards, spend before you cast a generator.',
+    thresholds: { good: 5 / 10, ok: 5 / 3 },
+    worst: 10 / 3,
+  });
 }

--- a/src/analysis/retail/warlock/shared/guide/priorities.tsx
+++ b/src/analysis/retail/warlock/shared/guide/priorities.tsx
@@ -1,0 +1,243 @@
+import type { ReactNode } from 'react';
+import type Spell from 'common/SPELLS/Spell';
+import { formatDuration, formatPercentage } from 'common/format';
+import { SpellLink } from 'interface';
+import type { ImprovementPriority } from 'interface/guide/components/ImprovementPriorities';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import type CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import type AlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
+import type ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
+
+/**
+ * Building blocks for the "What to Focus On" section of the Warlock specs.
+ * Each helper turns the data of one analyzer into an {@link ImprovementPriority}. It returns
+ * null when the check does not apply. The spec decides the weight and the wording.
+ */
+
+const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
+
+/** Linear score from 0 to 1. It is 1 at `best` and 0 at `worst`, in either direction. */
+export function linearScore(actual: number, best: number, worst: number): number {
+  if (best === worst) {
+    return actual === best ? 1 : 0;
+  }
+  return clamp01((actual - worst) / (best - worst));
+}
+
+export interface PerformanceThresholds {
+  /** Values on the good side of this value (inclusive) are Perfect. Optional. */
+  perfect?: number;
+  /** Values on the good side of this value (inclusive) are Good. */
+  good: number;
+  /** Values on the good side of this value (inclusive) are Ok. All other values are Fail. */
+  ok: number;
+}
+
+/** Rates a value where lower is better, such as downtime or waste per minute. */
+export function performanceForLowerIsBetter(
+  actual: number,
+  { perfect, good, ok }: PerformanceThresholds,
+): QualitativePerformance {
+  if (perfect !== undefined && actual <= perfect) {
+    return QualitativePerformance.Perfect;
+  }
+  if (actual <= good) {
+    return QualitativePerformance.Good;
+  }
+  if (actual <= ok) {
+    return QualitativePerformance.Ok;
+  }
+  return QualitativePerformance.Fail;
+}
+
+/** Rates a value where higher is better, such as uptime or efficiency. */
+export function performanceForHigherIsBetter(
+  actual: number,
+  { perfect, good, ok }: PerformanceThresholds,
+): QualitativePerformance {
+  if (perfect !== undefined && actual >= perfect) {
+    return QualitativePerformance.Perfect;
+  }
+  if (actual >= good) {
+    return QualitativePerformance.Good;
+  }
+  if (actual >= ok) {
+    return QualitativePerformance.Ok;
+  }
+  return QualitativePerformance.Fail;
+}
+
+export const plural = (count: number, singular: string, pluralForm = `${singular}s`) =>
+  count === 1 ? singular : pluralForm;
+
+interface CastEfficiencyPriorityOptions {
+  castEfficiency: CastEfficiency | undefined;
+  spell: Spell;
+  weight: number;
+  /** One or two short sentences on why the cooldown matters, or when it is fine to hold it. */
+  why?: ReactNode;
+  id?: string;
+}
+
+/**
+ * Priority for a cooldown that the player must use close to on-cooldown. It uses the
+ * thresholds the spec set for the spell in its `Abilities` list, so it agrees with the
+ * Cast Efficiency panel.
+ */
+export function castEfficiencyPriority({
+  castEfficiency,
+  spell,
+  weight,
+  why,
+  id,
+}: CastEfficiencyPriorityOptions): ImprovementPriority | null {
+  const data = castEfficiency?.getCastEfficiencyForSpell(spell);
+  if (!data || data.efficiency === null) {
+    return null;
+  }
+  const { casts, maxCasts, recommendedEfficiency, majorIssueEfficiency, gotMaxCasts } = data;
+  const efficiency = clamp01(data.efficiency);
+
+  let performance: QualitativePerformance;
+  if (gotMaxCasts || efficiency >= 0.98) {
+    performance = QualitativePerformance.Perfect;
+  } else if (efficiency >= recommendedEfficiency) {
+    performance = QualitativePerformance.Good;
+  } else if (efficiency >= majorIssueEfficiency) {
+    performance = QualitativePerformance.Ok;
+  } else {
+    performance = QualitativePerformance.Fail;
+  }
+
+  const missed = Math.max(0, maxCasts - casts);
+  const title =
+    casts === 0 ? (
+      <>
+        Use <SpellLink spell={spell} />
+      </>
+    ) : (
+      <>
+        Cast <SpellLink spell={spell} /> closer to cooldown
+      </>
+    );
+
+  return {
+    id: id ?? `cast-efficiency-${spell.id}`,
+    title,
+    description: (
+      <>
+        {casts === 0 ? (
+          <>
+            You never cast it. This fight had time for {maxCasts} {plural(maxCasts, 'cast')}.
+          </>
+        ) : (
+          <>
+            You cast it {casts} {plural(casts, 'time')}. This fight had time for {maxCasts}{' '}
+            {plural(maxCasts, 'cast')} ({formatPercentage(efficiency, 0)}% efficiency). That is{' '}
+            {missed} missed {plural(missed, 'cast')}.
+          </>
+        )}
+        {why && <> {why}</>}
+      </>
+    ),
+    score: efficiency,
+    weight,
+    performance,
+  };
+}
+
+interface ActiveTimePriorityOptions {
+  alwaysBeCasting: AlwaysBeCasting | undefined;
+  fightDuration: number;
+  weight: number;
+  /** Downtime fractions. At or below `good` is fine. At or below `ok` is a small issue. */
+  thresholds: PerformanceThresholds;
+  /** The downtime fraction at which the score reaches 0. */
+  worst: number;
+  /** Spec-specific advice on what to cast while moving. */
+  movementTips: ReactNode;
+}
+
+/** Priority for time spent not casting. */
+export function activeTimePriority({
+  alwaysBeCasting,
+  fightDuration,
+  weight,
+  thresholds,
+  worst,
+  movementTips,
+}: ActiveTimePriorityOptions): ImprovementPriority | null {
+  if (!alwaysBeCasting) {
+    return null;
+  }
+  const downtime = clamp01(alwaysBeCasting.downtimePercentage);
+  const active = clamp01(alwaysBeCasting.activeTimePercentage);
+
+  return {
+    id: 'active-time',
+    title: 'Reduce your downtime',
+    description: (
+      <>
+        You cast spells for {formatPercentage(active, 1)}% of the fight. That is{' '}
+        {formatDuration(fightDuration * downtime)} of downtime. Damage lost while the GCD is idle
+        does not come back. {movementTips}
+      </>
+    ),
+    score: linearScore(downtime, 0, worst),
+    weight,
+    performance: performanceForLowerIsBetter(downtime, thresholds),
+  };
+}
+
+interface SoulShardWastePriorityOptions {
+  tracker: ResourceTracker | undefined;
+  fightDuration: number;
+  weight: number;
+  /** The spender used to express the waste: "enough for N more casts of X". */
+  spender: Spell;
+  shardsPerCast: number;
+}
+
+/**
+ * Priority for Soul Shards generated at the cap. The thresholds are the same as the ones
+ * the shared `SoulShardDetails` module uses for its suggestion.
+ */
+export function soulShardWastePriority({
+  tracker,
+  fightDuration,
+  weight,
+  spender,
+  shardsPerCast,
+}: SoulShardWastePriorityOptions): ImprovementPriority | null {
+  if (!tracker || fightDuration <= 0) {
+    return null;
+  }
+  const wasted = tracker.wasted;
+  const perMinute = wasted / (fightDuration / 60000);
+  const missedCasts = Math.floor(wasted / shardsPerCast);
+
+  return {
+    id: 'soul-shard-waste',
+    title: 'Waste fewer Soul Shards',
+    description: (
+      <>
+        You generated {wasted} Soul {plural(wasted, 'Shard')} while you were already at 5 (
+        {perMinute.toFixed(1)} per minute).
+        {missedCasts > 0 && (
+          <>
+            {' '}
+            That is enough for {missedCasts} more <SpellLink spell={spender} />{' '}
+            {plural(missedCasts, 'cast')}.
+          </>
+        )}{' '}
+        At 4 or 5 shards, spend before you cast a generator.
+      </>
+    ),
+    score: linearScore(perMinute, 0, 10 / 3),
+    weight,
+    performance:
+      wasted === 0
+        ? QualitativePerformance.Perfect
+        : performanceForLowerIsBetter(perMinute, { good: 5 / 10, ok: 5 / 3 }),
+  };
+}

--- a/src/interface/guide/components/ImprovementPriorities.test.ts
+++ b/src/interface/guide/components/ImprovementPriorities.test.ts
@@ -1,0 +1,78 @@
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import {
+  priorityImpact,
+  rankImprovementPriorities,
+  type ImprovementPriority,
+} from './ImprovementPriorities';
+
+const priority = (
+  id: string,
+  score: number,
+  weight: number,
+  performance: QualitativePerformance,
+): ImprovementPriority => ({
+  id,
+  title: id,
+  description: id,
+  score,
+  weight,
+  performance,
+});
+
+describe('priorityImpact', () => {
+  it('is the weight scaled by the distance from a perfect score', () => {
+    expect(priorityImpact(priority('a', 0.75, 8, QualitativePerformance.Ok))).toBeCloseTo(2);
+  });
+
+  it('clamps the score to the 0 to 1 range', () => {
+    expect(priorityImpact(priority('a', -1, 5, QualitativePerformance.Fail))).toBe(5);
+    expect(priorityImpact(priority('a', 2, 5, QualitativePerformance.Fail))).toBe(0);
+  });
+});
+
+describe('rankImprovementPriorities', () => {
+  it('drops Good and Perfect priorities', () => {
+    const ranked = rankImprovementPriorities([
+      priority('good', 0.5, 10, QualitativePerformance.Good),
+      priority('perfect', 0, 10, QualitativePerformance.Perfect),
+      priority('ok', 0.9, 1, QualitativePerformance.Ok),
+    ]);
+    expect(ranked.map((p) => p.id)).toEqual(['ok']);
+  });
+
+  it('sorts by impact, highest first', () => {
+    const ranked = rankImprovementPriorities([
+      priority('light', 0, 2, QualitativePerformance.Fail),
+      priority('heavy', 0.5, 10, QualitativePerformance.Ok),
+      priority('medium', 0.2, 4, QualitativePerformance.Ok),
+    ]);
+    expect(ranked.map((p) => p.id)).toEqual(['heavy', 'medium', 'light']);
+  });
+
+  it('puts the worse rating first when the impact is equal', () => {
+    const ranked = rankImprovementPriorities([
+      priority('ok', 0.5, 4, QualitativePerformance.Ok),
+      priority('fail', 0.5, 4, QualitativePerformance.Fail),
+    ]);
+    expect(ranked.map((p) => p.id)).toEqual(['fail', 'ok']);
+  });
+
+  it('cuts the list at the limit', () => {
+    const priorities = Array.from({ length: 7 }, (_, i) =>
+      priority(`p${i}`, 0, 7 - i, QualitativePerformance.Fail),
+    );
+    expect(rankImprovementPriorities(priorities).map((p) => p.id)).toEqual([
+      'p0',
+      'p1',
+      'p2',
+      'p3',
+    ]);
+    expect(rankImprovementPriorities(priorities, 2)).toHaveLength(2);
+  });
+
+  it('returns an empty list when nothing needs a fix', () => {
+    expect(
+      rankImprovementPriorities([priority('a', 1, 10, QualitativePerformance.Perfect)]),
+    ).toEqual([]);
+  });
+});

--- a/src/interface/guide/components/ImprovementPriorities.tsx
+++ b/src/interface/guide/components/ImprovementPriorities.tsx
@@ -1,0 +1,140 @@
+import { ReactNode } from 'react';
+import { Section } from 'interface/guide';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import { qualitativePerformanceToNumber } from 'common/combineQualitativePerformances';
+import { TipBox, PerformanceTipBox } from './TipBox';
+
+/**
+ * One thing a player can change to improve their throughput.
+ *
+ * A spec builds one of these for each check it runs and gives the list to
+ * {@link ImprovementPriorities}. The component then shows the few that matter most.
+ */
+export interface ImprovementPriority {
+  /** Stable identifier, used as the React key. */
+  id: string;
+  /** Short imperative heading. Example: "Cast Call Dreadstalkers closer to cooldown". */
+  title: ReactNode;
+  /** What happened in this fight, with numbers, and what to do instead. */
+  description: ReactNode;
+  /**
+   * How well the player did on this check, from 0 to 1. A score of 1 means there is
+   * nothing left to gain. The rank uses `score` together with `weight`.
+   */
+  score: number;
+  /**
+   * How much this check matters to damage, relative to the other checks.
+   * Only the ratio between weights matters.
+   */
+  weight: number;
+  /**
+   * The rating for this check. The component shows only `Ok` and `Fail` priorities.
+   * `Good` and `Perfect` count as "nothing to fix".
+   */
+  performance: QualitativePerformance;
+}
+
+export const DEFAULT_PRIORITY_LIMIT = 4;
+
+const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
+
+/** The damage on the table for one priority: its weight, scaled by how far from perfect it was. */
+export function priorityImpact(priority: ImprovementPriority): number {
+  return priority.weight * (1 - clamp01(priority.score));
+}
+
+export function isActionable(priority: ImprovementPriority): boolean {
+  return (
+    priority.performance === QualitativePerformance.Ok ||
+    priority.performance === QualitativePerformance.Fail
+  );
+}
+
+/**
+ * Keeps the priorities with room to improve, sorts them by impact, and cuts the list at
+ * `limit`. Highest impact goes first. When two impacts are equal, the worse rating goes first.
+ */
+export function rankImprovementPriorities(
+  priorities: ImprovementPriority[],
+  limit: number = DEFAULT_PRIORITY_LIMIT,
+): ImprovementPriority[] {
+  return priorities
+    .filter(isActionable)
+    .sort(
+      (a, b) =>
+        priorityImpact(b) - priorityImpact(a) ||
+        qualitativePerformanceToNumber(a.performance) -
+          qualitativePerformanceToNumber(b.performance),
+    )
+    .slice(0, limit);
+}
+
+interface ImprovementPrioritiesProps {
+  /** Every check the spec ran, with or without a problem found. */
+  priorities: ImprovementPriority[];
+  /** Maximum number of priorities to show. Defaults to 4. */
+  limit?: number;
+  /** Section title. */
+  title?: ReactNode;
+  /** Optional lead-in paragraph shown above the list. */
+  intro?: ReactNode;
+}
+
+/**
+ * A guide section that shows the few changes most likely to improve a player's throughput,
+ * ranked by weighted impact. It shows at most `limit` items. It says so when it found fewer
+ * than `limit`, and it says so when it found nothing to fix.
+ */
+export default function ImprovementPriorities({
+  priorities,
+  limit = DEFAULT_PRIORITY_LIMIT,
+  title = 'What to Focus On',
+  intro,
+}: ImprovementPrioritiesProps) {
+  const shown = rankImprovementPriorities(priorities, limit);
+  const checked = priorities.length;
+  const remaining = checked - shown.length;
+
+  return (
+    <Section title={title}>
+      <p>
+        {intro ?? (
+          <>
+            These are the changes that we estimate will improve your damage the most, ranked by
+            impact. Each one is something you control during the fight. The sections below have the
+            details.
+          </>
+        )}
+      </p>
+      {checked === 0 && (
+        <TipBox type="info" title="No checks available">
+          We did not have enough data to evaluate this fight.
+        </TipBox>
+      )}
+      {checked > 0 && shown.length === 0 && (
+        <TipBox type="success" title="Nothing major to fix">
+          All {checked} of the things we check were in good shape this fight. The sections below
+          have the details if you want more.
+        </TipBox>
+      )}
+      {shown.map((priority, index) => (
+        <PerformanceTipBox
+          key={priority.id}
+          performance={priority.performance}
+          title={`Priority ${index + 1}`}
+        >
+          <strong>{priority.title}</strong>
+          <div>{priority.description}</div>
+        </PerformanceTipBox>
+      ))}
+      {shown.length > 0 && shown.length < limit && (
+        <p style={{ opacity: 0.75, marginTop: 8 }}>
+          <small>
+            Only {shown.length} {shown.length === 1 ? 'thing' : 'things'} to improve. The other{' '}
+            {remaining} {remaining === 1 ? 'check' : 'checks'} looked good.
+          </small>
+        </p>
+      )}
+    </Section>
+  );
+}

--- a/src/interface/guide/components/ImprovementPriorities/README.md
+++ b/src/interface/guide/components/ImprovementPriorities/README.md
@@ -1,0 +1,176 @@
+# What to Focus On
+
+A guide section that shows the few changes most likely to raise the throughput of a player,
+ranked by weighted impact. It shows at most four items. It says so when it finds fewer than
+four, and it says so when it finds none.
+
+The Demonology and Affliction Warlock guides use it. The full examples are in
+`src/analysis/retail/warlock/demonology/modules/guide/ImprovementPrioritiesSection.tsx` and
+`src/analysis/retail/warlock/affliction/modules/guide/ImprovementPrioritiesSection.tsx`.
+
+## How it ranks
+
+Each check produces one `ImprovementPriority`:
+
+| Field         | Meaning                                                                                         |
+| ------------- | ----------------------------------------------------------------------------------------------- |
+| `score`       | 0 to 1. How well the player did. 1 means there is nothing left to gain.                         |
+| `weight`      | How much the check matters to throughput, relative to the other checks. Only the ratio matters. |
+| `performance` | The rating. Only `Ok` and `Fail` are shown. `Good` and `Perfect` count as "nothing to fix".     |
+| `title`       | An imperative heading. Example: "Cast Call Dreadstalkers closer to cooldown".                   |
+| `description` | What happened in this fight, with numbers, and what to do instead.                              |
+
+Impact is `weight × (1 − score)`. The component keeps the `Ok` and `Fail` checks, sorts them
+by impact, and cuts the list at four. A weight 10 check at a 50% score outranks a weight 5
+check at a 0% score.
+
+## Add it to a spec
+
+Time: about half a day for a spec with existing analyzers. Most of that is calibration.
+
+1. Create `modules/guide/ImprovementPrioritiesSection.tsx` in the spec folder. Export a pure
+   `build<Spec>Priorities(inputs)` function, and a thin component that reads the analyzers
+   with hooks and calls it:
+
+   ```tsx
+   export interface MySpecPriorityInputs {
+     info: Info;
+     castEfficiency?: CastEfficiency;
+     alwaysBeCasting?: AlwaysBeCasting;
+   }
+
+   export function buildMySpecPriorities({
+     info,
+     castEfficiency,
+     alwaysBeCasting,
+   }: MySpecPriorityInputs): ImprovementPriority[] {
+     const candidates: (ImprovementPriority | null)[] = [
+       activeTimePriority({
+         alwaysBeCasting,
+         fightDuration: info.fightDuration,
+         weight: 10,
+         thresholds: { perfect: 0.02, good: 0.1, ok: 0.2 },
+         worst: 0.3,
+         movementTips: <>While you move, use ...</>,
+       }),
+       castEfficiencyPriority({ castEfficiency, spell: TALENTS.BIG_COOLDOWN_TALENT, weight: 9 }),
+     ];
+     return candidates.filter((p): p is ImprovementPriority => p !== null);
+   }
+
+   function ImprovementPrioritiesSection() {
+     const info = useInfo();
+     const castEfficiency = useAnalyzer(CastEfficiency);
+     const alwaysBeCasting = useAnalyzer(AlwaysBeCasting);
+     if (!info) {
+       return null;
+     }
+     const priorities = buildMySpecPriorities({ info, castEfficiency, alwaysBeCasting });
+     return <ImprovementPriorities priorities={priorities} />;
+   }
+
+   export default ImprovementPrioritiesSection;
+   ```
+
+2. Render `<ImprovementPrioritiesSection />` as the first child of the spec `Guide`.
+3. Add a test for the builder with stub analyzers. The Affliction test shows the pattern:
+   `src/analysis/retail/warlock/affliction/modules/guide/ImprovementPrioritiesSection.test.ts`.
+
+## Write a check
+
+Use a helper when one fits. All of them are exported from
+`interface/guide/components/ImprovementPriorities`.
+
+| Helper                         | Data source           | Use for                                                                                              |
+| ------------------------------ | --------------------- | ---------------------------------------------------------------------------------------------------- |
+| `castEfficiencyPriority`       | `CastEfficiency`      | A cooldown the player must use close to on-cooldown. Uses the thresholds from the spec `Abilities`.  |
+| `activeTimePriority`           | `AlwaysBeCasting`     | Downtime. The spec gives the thresholds and the movement advice.                                     |
+| `resourceWastePriority`        | any `ResourceTracker` | A resource generated at its cap. A class can wrap it with its own wording (see the Warlock wrapper). |
+| `linearScore`                  | any number            | A 0 to 1 score that is 1 at `best` and 0 at `worst`.                                                 |
+| `performanceForLowerIsBetter`  | any number            | A rating for downtime, waste, or misses.                                                             |
+| `performanceForHigherIsBetter` | any number            | A rating for uptime, efficiency, or coverage.                                                        |
+
+For anything else, build the object by hand. Example, a DoT uptime check:
+
+```tsx
+function agonyPriority(agony: Agony | undefined): ImprovementPriority | null {
+  if (!agony?.active) {
+    return null;
+  }
+  return {
+    id: 'agony-uptime',
+    title: (
+      <>
+        Keep <SpellLink spell={SPELLS.AGONY} /> active
+      </>
+    ),
+    description: (
+      <>
+        <SpellLink spell={SPELLS.AGONY} /> was active for {formatPercentage(agony.uptime, 1)}% of
+        the fight. Refresh it in its last 5 seconds, before it expires.
+      </>
+    ),
+    score: linearScore(agony.uptime, 1, 0.6),
+    weight: 9,
+    performance: agony.DowntimePerformance,
+  };
+}
+```
+
+Return `null` when the check does not apply: the talent is missing, the analyzer is inactive,
+or there were no casts. An absent check does not count against the player.
+
+## Pick weights and thresholds
+
+- Weight 10 to 12: the biggest lever of the spec. Downtime, or the main burst window.
+- Weight 6 to 9: a core cooldown, or a primary DoT.
+- Weight 3 to 5: resource waste, a secondary cooldown, or proc usage.
+- Weight 2: a minor habit.
+- Reuse the thresholds an analyzer already has (`suggestionThresholds`, `DowntimePerformance`),
+  so this section agrees with the rest of the guide.
+- Only `Ok` and `Fail` show. Set the `good` threshold where a top player lands.
+
+## Calibrate with two logs
+
+Get a top parse and an average parse of the same boss. Replay each through the spec parser and
+print the ranked list. Then apply three rules:
+
+1. The top parse must show "Nothing major to fix", or at most one item.
+2. The average parse must show three or four items.
+3. Remove a check that rates the top parse worse than the average parse. It does not measure
+   skill.
+
+Replay recipe. This is temporary work. Do not commit the harness or the logs.
+
+1. Fetch `https://wowanalyzer.com/i/v1/report/fights/<code>?translate=true`. Note the
+   `start_time` and `end_time` of the fight and the `id` of the player.
+2. Fetch `https://wowanalyzer.com/i/v1/report/events/<code>?start=<start>&end=<end>&actorid=<player>&translate=true`.
+   Page with `nextPageTimestamp` until it is absent. Fetch the same URL with
+   `filter=type="combatantinfo"` instead of `actorid` for the combatant info.
+3. In a temporary vitest file under `src/`, construct the spec `CombatLogParser` with the
+   report (add `code` and `isAnonymous`), the player, the fight (add `offset_time: 0` and
+   `filtered: false`), the combatant info event of the player, and `DEFAULT_CHARACTER_PROFILE`
+   from `parser/core/tests/constants`.
+4. Call `parser.normalize(events)`, sort by timestamp, set `parser.normalizedEvents`, trigger
+   each event through `parser.getModule(EventEmitter).triggerEvent`, then call `parser.finish()`.
+5. Read the analyzers with `parser.getModule(...)`, call your builder, then
+   `rankImprovementPriorities`. Print the ids, scores, and ratings.
+6. Delete the file before you commit.
+
+## Write the copy
+
+The section is advice. Keep it plain, in the style of ASD-STE100 Simplified Technical English:
+
+- One instruction per sentence. Max 20 words for an instruction, 25 for a description.
+- Active voice and simple tenses. No contractions. No semicolons.
+- Numbers first: what happened in this fight. Then what to do instead.
+- Say what to press. "Use Shadow Bolt as the filler" beats "improve your rotation".
+- Nothing the player cannot change during the fight: no gear, no fight length, no group.
+
+## Checklist before a PR
+
+- The section is the first child of the guide.
+- Every check returns `null` when it does not apply.
+- Top parse: nothing to fix. Average parse: three or four items.
+- The builder test with stub analyzers passes.
+- The spec changelog has an entry.

--- a/src/interface/guide/components/ImprovementPriorities/helpers.test.ts
+++ b/src/interface/guide/components/ImprovementPriorities/helpers.test.ts
@@ -1,0 +1,184 @@
+import SPELLS from 'common/SPELLS';
+import type CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import type AlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
+import type ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import {
+  activeTimePriority,
+  castEfficiencyPriority,
+  linearScore,
+  performanceForHigherIsBetter,
+  performanceForLowerIsBetter,
+  resourceWastePriority,
+} from './helpers';
+
+const MINUTE = 60000;
+
+const castEfficiencyWith = (data: Record<string, unknown> | null) =>
+  ({ getCastEfficiencyForSpell: () => data }) as unknown as CastEfficiency;
+
+const efficiencyData = (efficiency: number | null, casts = 7, maxCasts = 8) => ({
+  casts,
+  maxCasts,
+  efficiency,
+  recommendedEfficiency: 0.9,
+  averageIssueEfficiency: 0.85,
+  majorIssueEfficiency: 0.75,
+  gotMaxCasts: casts === maxCasts,
+});
+
+describe('linearScore', () => {
+  it('is 1 at best and 0 at worst, in either direction', () => {
+    expect(linearScore(0, 0, 0.3)).toBe(1);
+    expect(linearScore(0.3, 0, 0.3)).toBe(0);
+    expect(linearScore(0.15, 0, 0.3)).toBeCloseTo(0.5);
+    expect(linearScore(1, 1, 0.6)).toBe(1);
+    expect(linearScore(0.8, 1, 0.6)).toBeCloseTo(0.5);
+  });
+
+  it('clamps outside the range', () => {
+    expect(linearScore(0.9, 0, 0.3)).toBe(0);
+    expect(linearScore(-1, 0, 0.3)).toBe(1);
+  });
+
+  it('handles best equal to worst', () => {
+    expect(linearScore(2, 2, 2)).toBe(1);
+    expect(linearScore(3, 2, 2)).toBe(0);
+  });
+});
+
+describe('performance thresholds', () => {
+  it('rates lower-is-better values', () => {
+    const thresholds = { perfect: 0.02, good: 0.1, ok: 0.2 };
+    expect(performanceForLowerIsBetter(0.01, thresholds)).toBe(QualitativePerformance.Perfect);
+    expect(performanceForLowerIsBetter(0.1, thresholds)).toBe(QualitativePerformance.Good);
+    expect(performanceForLowerIsBetter(0.15, thresholds)).toBe(QualitativePerformance.Ok);
+    expect(performanceForLowerIsBetter(0.21, thresholds)).toBe(QualitativePerformance.Fail);
+  });
+
+  it('rates higher-is-better values and skips Perfect without a threshold', () => {
+    const thresholds = { good: 0.95, ok: 0.85 };
+    expect(performanceForHigherIsBetter(1, thresholds)).toBe(QualitativePerformance.Good);
+    expect(performanceForHigherIsBetter(0.9, thresholds)).toBe(QualitativePerformance.Ok);
+    expect(performanceForHigherIsBetter(0.5, thresholds)).toBe(QualitativePerformance.Fail);
+  });
+});
+
+describe('castEfficiencyPriority', () => {
+  const build = (data: Record<string, unknown> | null) =>
+    castEfficiencyPriority({
+      castEfficiency: castEfficiencyWith(data),
+      spell: SPELLS.SUMMON_DEMONIC_TYRANT,
+      weight: 9,
+    });
+
+  it('returns null without cast efficiency data', () => {
+    expect(build(null)).toBeNull();
+    expect(build(efficiencyData(null))).toBeNull();
+    expect(
+      castEfficiencyPriority({
+        castEfficiency: undefined,
+        spell: SPELLS.SUMMON_DEMONIC_TYRANT,
+        weight: 9,
+      }),
+    ).toBeNull();
+  });
+
+  it('maps efficiency onto the spell thresholds', () => {
+    expect(build(efficiencyData(0.7, 8, 8))?.performance).toBe(QualitativePerformance.Perfect);
+    expect(build(efficiencyData(0.99))?.performance).toBe(QualitativePerformance.Perfect);
+    expect(build(efficiencyData(0.92))?.performance).toBe(QualitativePerformance.Good);
+    expect(build(efficiencyData(0.8))?.performance).toBe(QualitativePerformance.Ok);
+    expect(build(efficiencyData(0.7))?.performance).toBe(QualitativePerformance.Fail);
+  });
+
+  it('uses the efficiency as the score and the spell id in the key', () => {
+    const priority = build(efficiencyData(0.8));
+    expect(priority?.score).toBe(0.8);
+    expect(priority?.weight).toBe(9);
+    expect(priority?.id).toBe(`cast-efficiency-${SPELLS.SUMMON_DEMONIC_TYRANT.id}`);
+  });
+});
+
+describe('activeTimePriority', () => {
+  const build = (downtime: number) =>
+    activeTimePriority({
+      alwaysBeCasting: {
+        downtimePercentage: downtime,
+        activeTimePercentage: 1 - downtime,
+      } as unknown as AlwaysBeCasting,
+      fightDuration: 5 * MINUTE,
+      weight: 10,
+      thresholds: { perfect: 0.02, good: 0.1, ok: 0.2 },
+      worst: 0.3,
+      movementTips: 'tips',
+    });
+
+  it('returns null without the analyzer', () => {
+    expect(
+      activeTimePriority({
+        alwaysBeCasting: undefined,
+        fightDuration: MINUTE,
+        weight: 10,
+        thresholds: { good: 0.1, ok: 0.2 },
+        worst: 0.3,
+        movementTips: 'tips',
+      }),
+    ).toBeNull();
+  });
+
+  it('rates downtime against the thresholds and scores it linearly', () => {
+    expect(build(0.05)?.performance).toBe(QualitativePerformance.Good);
+    expect(build(0.188)?.performance).toBe(QualitativePerformance.Ok);
+    expect(build(0.25)?.performance).toBe(QualitativePerformance.Fail);
+    expect(build(0.15)?.score).toBeCloseTo(0.5);
+  });
+});
+
+describe('resourceWastePriority', () => {
+  const build = (wasted: number, minutes: number) =>
+    resourceWastePriority({
+      tracker: { wasted } as unknown as ResourceTracker,
+      fightDuration: minutes * MINUTE,
+      weight: 5,
+      resourceName: { one: 'Soul Shard', many: 'Soul Shards' },
+      spender: SPELLS.HAND_OF_GULDAN_CAST,
+      unitsPerCast: 3,
+      thresholds: { good: 0.5, ok: 5 / 3 },
+      worst: 10 / 3,
+    });
+
+  it('returns null without a tracker or a fight', () => {
+    expect(
+      resourceWastePriority({
+        tracker: undefined,
+        fightDuration: MINUTE,
+        weight: 5,
+        resourceName: { one: 'Rune', many: 'Runes' },
+        spender: SPELLS.HAND_OF_GULDAN_CAST,
+        unitsPerCast: 1,
+        thresholds: { good: 1, ok: 2 },
+        worst: 4,
+      }),
+    ).toBeNull();
+    expect(build(3, 0)).toBeNull();
+  });
+
+  it('is Perfect with no waste and rates waste per minute', () => {
+    expect(build(0, 5)?.performance).toBe(QualitativePerformance.Perfect);
+    expect(build(2, 5)?.performance).toBe(QualitativePerformance.Good);
+    expect(build(9, 7)?.performance).toBe(QualitativePerformance.Ok);
+    expect(build(20, 5)?.performance).toBe(QualitativePerformance.Fail);
+  });
+
+  it('scores waste per minute linearly down to 0 at worst', () => {
+    expect(build(0, 5)?.score).toBe(1);
+    expect(build(10, 3)?.score).toBe(0);
+    expect(build(5, 3)?.score).toBeCloseTo(0.5);
+  });
+
+  it('uses a generic title and id unless the caller gives one', () => {
+    expect(build(1, 5)?.title).toBe('Waste less Soul Shards');
+    expect(build(1, 5)?.id).toBe('resource-waste');
+  });
+});

--- a/src/interface/guide/components/ImprovementPriorities/helpers.tsx
+++ b/src/interface/guide/components/ImprovementPriorities/helpers.tsx
@@ -1,0 +1,257 @@
+import type { ReactNode } from 'react';
+import type Spell from 'common/SPELLS/Spell';
+import { formatDuration, formatPercentage } from 'common/format';
+import { SpellLink } from 'interface';
+import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
+import type CastEfficiency from 'parser/shared/modules/CastEfficiency';
+import type AlwaysBeCasting from 'parser/shared/modules/AlwaysBeCasting';
+import type ResourceTracker from 'parser/shared/modules/resources/resourcetracker/ResourceTracker';
+import type { ImprovementPriority } from './index';
+
+/**
+ * Building blocks for the "What to Focus On" section. Each helper turns the data of one
+ * core analyzer into an {@link ImprovementPriority}. It returns null when the check does not
+ * apply. The spec decides the weight and the wording. README.md in this folder has the guide.
+ */
+
+const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
+
+/** Linear score from 0 to 1. It is 1 at `best` and 0 at `worst`, in either direction. */
+export function linearScore(actual: number, best: number, worst: number): number {
+  if (best === worst) {
+    return actual === best ? 1 : 0;
+  }
+  return clamp01((actual - worst) / (best - worst));
+}
+
+export interface PerformanceThresholds {
+  /** Values on the good side of this value (inclusive) are Perfect. Optional. */
+  perfect?: number;
+  /** Values on the good side of this value (inclusive) are Good. */
+  good: number;
+  /** Values on the good side of this value (inclusive) are Ok. All other values are Fail. */
+  ok: number;
+}
+
+/** Rates a value where lower is better, such as downtime or waste per minute. */
+export function performanceForLowerIsBetter(
+  actual: number,
+  { perfect, good, ok }: PerformanceThresholds,
+): QualitativePerformance {
+  if (perfect !== undefined && actual <= perfect) {
+    return QualitativePerformance.Perfect;
+  }
+  if (actual <= good) {
+    return QualitativePerformance.Good;
+  }
+  if (actual <= ok) {
+    return QualitativePerformance.Ok;
+  }
+  return QualitativePerformance.Fail;
+}
+
+/** Rates a value where higher is better, such as uptime or efficiency. */
+export function performanceForHigherIsBetter(
+  actual: number,
+  { perfect, good, ok }: PerformanceThresholds,
+): QualitativePerformance {
+  if (perfect !== undefined && actual >= perfect) {
+    return QualitativePerformance.Perfect;
+  }
+  if (actual >= good) {
+    return QualitativePerformance.Good;
+  }
+  if (actual >= ok) {
+    return QualitativePerformance.Ok;
+  }
+  return QualitativePerformance.Fail;
+}
+
+export const plural = (count: number, singular: string, pluralForm = `${singular}s`) =>
+  count === 1 ? singular : pluralForm;
+
+interface CastEfficiencyPriorityOptions {
+  castEfficiency: CastEfficiency | undefined;
+  spell: Spell;
+  weight: number;
+  /** One or two short sentences on why the cooldown matters, or when it is fine to hold it. */
+  why?: ReactNode;
+  id?: string;
+}
+
+/**
+ * Priority for a cooldown that the player must use close to on-cooldown. It uses the
+ * thresholds the spec set for the spell in its `Abilities` list, so it agrees with the
+ * Cast Efficiency panel.
+ */
+export function castEfficiencyPriority({
+  castEfficiency,
+  spell,
+  weight,
+  why,
+  id,
+}: CastEfficiencyPriorityOptions): ImprovementPriority | null {
+  const data = castEfficiency?.getCastEfficiencyForSpell(spell);
+  if (!data || data.efficiency === null) {
+    return null;
+  }
+  const { casts, maxCasts, recommendedEfficiency, majorIssueEfficiency, gotMaxCasts } = data;
+  const efficiency = clamp01(data.efficiency);
+
+  let performance: QualitativePerformance;
+  if (gotMaxCasts || efficiency >= 0.98) {
+    performance = QualitativePerformance.Perfect;
+  } else if (efficiency >= recommendedEfficiency) {
+    performance = QualitativePerformance.Good;
+  } else if (efficiency >= majorIssueEfficiency) {
+    performance = QualitativePerformance.Ok;
+  } else {
+    performance = QualitativePerformance.Fail;
+  }
+
+  const missed = Math.max(0, maxCasts - casts);
+  const title =
+    casts === 0 ? (
+      <>
+        Use <SpellLink spell={spell} />
+      </>
+    ) : (
+      <>
+        Cast <SpellLink spell={spell} /> closer to cooldown
+      </>
+    );
+
+  return {
+    id: id ?? `cast-efficiency-${spell.id}`,
+    title,
+    description: (
+      <>
+        {casts === 0 ? (
+          <>
+            You never cast it. This fight had time for {maxCasts} {plural(maxCasts, 'cast')}.
+          </>
+        ) : (
+          <>
+            You cast it {casts} {plural(casts, 'time')}. This fight had time for {maxCasts}{' '}
+            {plural(maxCasts, 'cast')} ({formatPercentage(efficiency, 0)}% efficiency). That is{' '}
+            {missed} missed {plural(missed, 'cast')}.
+          </>
+        )}
+        {why && <> {why}</>}
+      </>
+    ),
+    score: efficiency,
+    weight,
+    performance,
+  };
+}
+
+interface ActiveTimePriorityOptions {
+  alwaysBeCasting: AlwaysBeCasting | undefined;
+  fightDuration: number;
+  weight: number;
+  /** Downtime fractions. At or below `good` is fine. At or below `ok` is a small issue. */
+  thresholds: PerformanceThresholds;
+  /** The downtime fraction at which the score reaches 0. */
+  worst: number;
+  /** Spec-specific advice on what to cast while moving. */
+  movementTips: ReactNode;
+}
+
+/** Priority for time spent not casting. */
+export function activeTimePriority({
+  alwaysBeCasting,
+  fightDuration,
+  weight,
+  thresholds,
+  worst,
+  movementTips,
+}: ActiveTimePriorityOptions): ImprovementPriority | null {
+  if (!alwaysBeCasting) {
+    return null;
+  }
+  const downtime = clamp01(alwaysBeCasting.downtimePercentage);
+  const active = clamp01(alwaysBeCasting.activeTimePercentage);
+
+  return {
+    id: 'active-time',
+    title: 'Reduce your downtime',
+    description: (
+      <>
+        You cast spells for {formatPercentage(active, 1)}% of the fight. That is{' '}
+        {formatDuration(fightDuration * downtime)} of downtime. Damage lost while the GCD is idle
+        does not come back. {movementTips}
+      </>
+    ),
+    score: linearScore(downtime, 0, worst),
+    weight,
+    performance: performanceForLowerIsBetter(downtime, thresholds),
+  };
+}
+
+interface ResourceWastePriorityOptions {
+  tracker: ResourceTracker | undefined;
+  fightDuration: number;
+  weight: number;
+  /** The resource name as shown to the player, in the singular and the plural. */
+  resourceName: { one: string; many: string };
+  /** The spender used to express the waste: "enough for N more casts of X". */
+  spender: Spell;
+  unitsPerCast: number;
+  /** Waste per minute. At or below `good` is fine. At or below `ok` is a small issue. */
+  thresholds: PerformanceThresholds;
+  /** The waste per minute at which the score reaches 0. */
+  worst: number;
+  /** Defaults to "Waste less <resource>". Pass one for a countable resource ("Waste fewer ..."). */
+  title?: ReactNode;
+  /** One sentence on how to prevent the waste. */
+  advice?: ReactNode;
+  id?: string;
+}
+
+/** Priority for a resource generated at its cap. Works with any `ResourceTracker`. */
+export function resourceWastePriority({
+  tracker,
+  fightDuration,
+  weight,
+  resourceName,
+  spender,
+  unitsPerCast,
+  thresholds,
+  worst,
+  title,
+  advice,
+  id,
+}: ResourceWastePriorityOptions): ImprovementPriority | null {
+  if (!tracker || fightDuration <= 0) {
+    return null;
+  }
+  const wasted = tracker.wasted;
+  const perMinute = wasted / (fightDuration / 60000);
+  const missedCasts = Math.floor(wasted / unitsPerCast);
+
+  return {
+    id: id ?? 'resource-waste',
+    title: title ?? `Waste less ${resourceName.many}`,
+    description: (
+      <>
+        You generated {wasted} {wasted === 1 ? resourceName.one : resourceName.many} while you were
+        already at the cap ({perMinute.toFixed(1)} per minute).
+        {missedCasts > 0 && (
+          <>
+            {' '}
+            That is enough for {missedCasts} more <SpellLink spell={spender} />{' '}
+            {plural(missedCasts, 'cast')}.
+          </>
+        )}{' '}
+        {advice ?? 'When you are close to the cap, spend before you cast a generator.'}
+      </>
+    ),
+    score: linearScore(perMinute, 0, worst),
+    weight,
+    performance:
+      wasted === 0
+        ? QualitativePerformance.Perfect
+        : performanceForLowerIsBetter(perMinute, thresholds),
+  };
+}

--- a/src/interface/guide/components/ImprovementPriorities/index.test.ts
+++ b/src/interface/guide/components/ImprovementPriorities/index.test.ts
@@ -1,9 +1,5 @@
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
-import {
-  priorityImpact,
-  rankImprovementPriorities,
-  type ImprovementPriority,
-} from './ImprovementPriorities';
+import { priorityImpact, rankImprovementPriorities, type ImprovementPriority } from './index';
 
 const priority = (
   id: string,

--- a/src/interface/guide/components/ImprovementPriorities/index.tsx
+++ b/src/interface/guide/components/ImprovementPriorities/index.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { Section } from 'interface/guide';
 import { QualitativePerformance } from 'parser/ui/QualitativePerformance';
 import { qualitativePerformanceToNumber } from 'common/combineQualitativePerformances';
-import { TipBox, PerformanceTipBox } from './TipBox';
+import { TipBox, PerformanceTipBox } from '../TipBox';
 
 /**
  * One thing a player can change to improve their throughput.
@@ -138,3 +138,14 @@ export default function ImprovementPriorities({
     </Section>
   );
 }
+
+export {
+  activeTimePriority,
+  castEfficiencyPriority,
+  linearScore,
+  performanceForHigherIsBetter,
+  performanceForLowerIsBetter,
+  plural,
+  resourceWastePriority,
+  type PerformanceThresholds,
+} from './helpers';

--- a/src/interface/guide/components/index.ts
+++ b/src/interface/guide/components/index.ts
@@ -31,3 +31,10 @@ export {
   FilterBadge,
 } from './GuideDataWrapper';
 export { HelperTextRow } from './GuideDataWrapper';
+export {
+  default as ImprovementPriorities,
+  rankImprovementPriorities,
+  priorityImpact,
+  DEFAULT_PRIORITY_LIMIT,
+  type ImprovementPriority,
+} from './ImprovementPriorities';

--- a/src/interface/guide/components/index.ts
+++ b/src/interface/guide/components/index.ts
@@ -36,5 +36,13 @@ export {
   rankImprovementPriorities,
   priorityImpact,
   DEFAULT_PRIORITY_LIMIT,
+  activeTimePriority,
+  castEfficiencyPriority,
+  resourceWastePriority,
+  linearScore,
+  performanceForHigherIsBetter,
+  performanceForLowerIsBetter,
+  plural,
   type ImprovementPriority,
+  type PerformanceThresholds,
 } from './ImprovementPriorities';


### PR DESCRIPTION
## Summary

Sharing this in case it helps. Feel free to not pull it if it is not useful, or to ask for any change.

This adds a "What to Focus On" section at the top of the Demonology and Affliction guides. It lists up to four changes the player can make, ranked by weighted impact. It shows only the checks rated Ok or Fail. When it finds fewer than four, it says so. When it finds none, it says so.

The component and its helpers are generic. They live in `src/interface/guide/components/ImprovementPriorities/`. A README in that folder explains how another spec can add the section, and how to calibrate it. Happy to move or rename any of it if there is a better home.

## What it checks

- Demonology, 12 checks: downtime, Demonic Tyrant window quality (reuses the existing window scoring), Tyrant and Call Dreadstalkers cast timing, Grimoire, Doomguard, Power Siphon timing and 2-imp casts, Soul Shard waste, hard cast Demonbolts, Doom uptime, and Demonic Calling procs.
- Affliction, 12 checks: downtime, cancelled casts, Agony, Corruption, Unstable Affliction and Haunt uptime, Darkglare timing and DoTs at the cast, Dark Harvest timing and DoT coverage, Soul Shard waste, and Nightfall procs.

Each check returns nothing when it does not apply, so a missing talent never counts against the player.

## Calibration

I replayed two Heroic Twin Fangs logs through the parser:

- [Top-ranked Demonology parse](https://wowanalyzer.com/report/Q4q3bKxDCwGRvNTJ/31-Heroic+The+Twin+Fangs+-+Kill+(4:49)/26-Frendz/standard): all checks rate Good or Perfect. The section shows "Nothing major to fix".
- [An average parse](https://wowanalyzer.com/report/HCV8dKDyhJtGkRNc/32-Heroic+The+Twin+Fangs+-+Kill+(7:16)/104-Zeawarlock/standard): four items. Downtime, Tyrant windows, Soul Shard waste, and Tyrant cast timing.

Implosion cast efficiency and Demonic Core overcap did not separate the two players, so they are not checks.

## Also in this PR

- Removes Charhound and Gloomhound from the Demonology cast efficiency list. In 12.1, Call Dreadstalkers summons them, so the list flagged "0 of 15 casts, can be improved". If you would rather have this in a separate PR, say so and I will split it.
- Exports the Tyrant window scoring and the Dark Harvest cast rating, so the new section reuses them instead of a copy.

## Tests

- Unit tests for the ranking, the helpers, the Soul Shard wrapper, and the Affliction builder.
- `pnpm typecheck`, `pnpm lint`, `pnpm format --check`, and `pnpm test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
