### PR TITLE
[Warlock][Destruction] Havoc Guide Update

### DIFF
--- a/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
+++ b/src/analysis/retail/warlock/destruction/CHANGELOG.tsx
@@ -1,8 +1,13 @@
 import { change, date } from 'common/changelog';
 import {Katorri} from 'CONTRIBUTORS';
+import SpellLink from 'interface/SpellLink';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/warlock';
 
 // prettier-ignore
 export default [
+  change(date(2026, 9, 10), <><SpellLink spell={SPELLS.HAVOC} /> Guide Update: now accounts for <SpellLink spell={TALENTS.SHADOWBURN_TALENT} /> usage in execute range and free <SpellLink spell={TALENTS.FIENDISH_CRUELTY_TALENT} /> usage, rates windows
+by shard-weighted spend instead of flat cast count, tracks Soul Shards banked at cast time, and recovers windows cast before the pull. Update example report and about description.</>, Katorri),
   change(date(2026, 8, 26), "Fix typo in Dot Uptimes", Katorri),
   change(date(2026, 8, 18), "Update compatibility for 12.1", Katorri),
   change(date(2026, 4, 21), "Spec compatibility updated for 12.0.5", Katorri),

--- a/src/analysis/retail/warlock/destruction/CONFIG.tsx
+++ b/src/analysis/retail/warlock/destruction/CONFIG.tsx
@@ -16,7 +16,17 @@ export default {
   // If this spec's analysis does not show a complete picture please mention this in the `<Warning>` component.
   description: (
     <>
-      If you have any questions about Warlocks, feel free to pay a visit to{' '}
+      Hello! Thanks for checking out the Destruction Analyzer. If you have any feedback or
+      suggestions, feel free to reach out to me via Discord (you can reach me @Katorri on either the{' '}
+      <a href="https://discord.com/invite/AxphPxU" target="_blank" rel="noopener noreferrer">
+        WoWAnalyzer
+      </a>{' '}
+      or the{' '}
+      <a href="https://discord.gg/BlackHarvest" target="_blank" rel="noopener noreferrer">
+        Warlock
+      </a>{' '}
+      discords) or drop an issue in the GitHub repo. If you have any questions about Warlocks, feel
+      free to pay a visit to{' '}
       <a href="https://discord.gg/BlackHarvest" target="_blank" rel="noopener noreferrer">
         Council of the Black Harvest Discord
       </a>
@@ -41,7 +51,7 @@ export default {
   ),
   // A recent example report to see interesting parts of the spec. Will be shown on the homepage.
   exampleReport:
-    '/report/CQgrp23KT4kBFDAq/11-Heroic+Vaelgor+&+Ezzorak+-+Kill+(6:40)/73-Speakntongue/standard',
+    '/report/yCzXLNfpcQTBJD6V/27-Heroic+Entombed+Sentinels+-+Kill+(5:15)/1-Katorrí/standard/overview',
 
   // Don't change anything below this line;
   // The current spec identifier. This is the only place (in code) that specifies which spec this parser is about.

--- a/src/analysis/retail/warlock/destruction/CombatLogParser.ts
+++ b/src/analysis/retail/warlock/destruction/CombatLogParser.ts
@@ -24,6 +24,7 @@ import FlashPoint from './modules/analyzers/FlashPoint';
 import { UnendingResolve, DarkPact, DemonicCircle, DemonicHealthstone } from '../shared';
 import Immolate from './modules/analyzers/Immolate';
 import HavocAnalyzer from './modules/analyzers/HavocAnalyzer';
+import HavocPrepullNormalizer from './modules/normalizers/HavocPrepullNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -47,6 +48,7 @@ class CombatLogParser extends CoreCombatLogParser {
     spellUsable: SpellUsable,
 
     grimoireOfSacrificeNormalizer: GrimoireOfSacrificeNormalizer,
+    havocPrepullNormalizer: HavocPrepullNormalizer,
 
     // Talents
     soulFire: SoulFire,

--- a/src/analysis/retail/warlock/destruction/modules/analyzers/HavocAnalyzer.ts
+++ b/src/analysis/retail/warlock/destruction/modules/analyzers/HavocAnalyzer.ts
@@ -7,24 +7,32 @@ import Events, {
   ApplyDebuffEvent,
   RemoveDebuffEvent,
   DamageEvent,
+  ResourceChangeEvent,
 } from 'parser/core/Events';
 import Abilities from '../core/Abilities';
 import { encodeTargetString } from 'parser/shared/modules/Enemies';
+import SoulShardTracker from 'analysis/retail/warlock/shared/resources/SoulShardTracker';
+import RESOURCE_TYPES from 'game/RESOURCE_TYPES';
 
 const EXECUTE_RANGE_THRESHOLD = 0.2;
 
 export default class HavocAnalyzer extends Analyzer {
   static dependencies = {
     abilities: Abilities,
+    soulShardTracker: SoulShardTracker,
   };
 
   protected abilities!: Abilities;
+  protected soulShardTracker!: SoulShardTracker;
 
   havocData: HavocWindowData[] = [];
   currentHavoc: HavocWindowData | null = null;
   executeRangeMap: Map<string, boolean> = new Map();
 
   havocDuration = 15000;
+
+  private gainsBeforeFirstWindowSpend = 0;
+  private pendingRetroactiveShardsOnCast = false;
 
   constructor(options: Options) {
     super(options);
@@ -52,6 +60,7 @@ export default class HavocAnalyzer extends Analyzer {
     // Spell casts during window
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
     this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
+    this.addEventListener(Events.resourcechange.to(SELECTED_PLAYER), this.onShardGain);
   }
 
   onDamage(event: DamageEvent): void {
@@ -62,7 +71,20 @@ export default class HavocAnalyzer extends Analyzer {
     this.executeRangeMap.set(targetString, isExecute);
   }
 
+  onShardGain(event: ResourceChangeEvent): void {
+    if (event.resourceChangeType !== RESOURCE_TYPES.SOUL_SHARDS.id) return;
+    if (!this.currentHavoc) return;
+
+    if (this.pendingRetroactiveShardsOnCast) {
+      const lastUpdate = this.soulShardTracker.resourceUpdates.at(-1);
+      if (lastUpdate?.type === 'gain') {
+        this.gainsBeforeFirstWindowSpend += (lastUpdate.change ?? 0) / 10;
+      }
+    }
+  }
+
   onHavocApplied(event: ApplyDebuffEvent): void {
+    const isFabricatedStart = event.__fabricated === true;
     const havoc: HavocWindowData = {
       start: event.timestamp,
       end: event.timestamp + this.havocDuration,
@@ -70,7 +92,11 @@ export default class HavocAnalyzer extends Analyzer {
       shadowburns: 0,
       shadowburnsInExecute: 0,
       casts: [], // store havocable casts
+      shardsOnCast: isFabricatedStart ? 3 : this.soulShardTracker.current,
+      startWasFabricated: isFabricatedStart,
     };
+    this.pendingRetroactiveShardsOnCast = !isFabricatedStart;
+    this.gainsBeforeFirstWindowSpend = 0;
 
     this.havocData.push(havoc);
     this.currentHavoc = havoc;
@@ -82,7 +108,7 @@ export default class HavocAnalyzer extends Analyzer {
     const window = this.currentHavoc;
 
     // Detect early removal (target likely died)
-    if (event.timestamp < window.start + this.havocDuration) {
+    if (!window.startWasFabricated && event.timestamp < window.start + this.havocDuration) {
       window.targetDied = true;
     }
 
@@ -98,6 +124,18 @@ export default class HavocAnalyzer extends Analyzer {
     // Only count it if the ability is Havoc-able
     if (this.abilities.isHavocable(spellId)) {
       this.currentHavoc.casts.push(event);
+    }
+
+    const isSpender = spellId === SPELLS.CHAOS_BOLT.id || spellId === TALENTS.SHADOWBURN_TALENT.id;
+    if (isSpender && this.pendingRetroactiveShardsOnCast) {
+      const resource = this.soulShardTracker.getResource(event);
+      if (resource !== undefined) {
+        this.currentHavoc.shardsOnCast = Math.max(
+          0,
+          Math.round((resource.amount - this.gainsBeforeFirstWindowSpend) * 10) / 10,
+        );
+      }
+      this.pendingRetroactiveShardsOnCast = false;
     }
 
     if (spellId === SPELLS.CHAOS_BOLT.id) {
@@ -129,4 +167,6 @@ export interface HavocWindowData {
   casts: CastEvent[]; // only tracks Havocable spells
   targetDied?: boolean;
   shadowburnsInExecute: number;
+  shardsOnCast: number;
+  startWasFabricated?: boolean;
 }

--- a/src/analysis/retail/warlock/destruction/modules/analyzers/HavocAnalyzer.ts
+++ b/src/analysis/retail/warlock/destruction/modules/analyzers/HavocAnalyzer.ts
@@ -2,8 +2,16 @@ import SPELLS from 'common/SPELLS';
 import TALENTS from 'common/TALENTS/warlock';
 import { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
 import Analyzer from 'parser/core/Analyzer';
-import Events, { CastEvent, ApplyDebuffEvent, RemoveDebuffEvent } from 'parser/core/Events';
+import Events, {
+  CastEvent,
+  ApplyDebuffEvent,
+  RemoveDebuffEvent,
+  DamageEvent,
+} from 'parser/core/Events';
 import Abilities from '../core/Abilities';
+import { encodeTargetString } from 'parser/shared/modules/Enemies';
+
+const EXECUTE_RANGE_THRESHOLD = 0.2;
 
 export default class HavocAnalyzer extends Analyzer {
   static dependencies = {
@@ -14,6 +22,7 @@ export default class HavocAnalyzer extends Analyzer {
 
   havocData: HavocWindowData[] = [];
   currentHavoc: HavocWindowData | null = null;
+  executeRangeMap: Map<string, boolean> = new Map();
 
   havocDuration = 15000;
 
@@ -42,6 +51,15 @@ export default class HavocAnalyzer extends Analyzer {
 
     // Spell casts during window
     this.addEventListener(Events.cast.by(SELECTED_PLAYER), this.onCast);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER), this.onDamage);
+  }
+
+  onDamage(event: DamageEvent): void {
+    if (event.targetIsFriendly) return;
+
+    const targetString = encodeTargetString(event.targetID, event.targetInstance);
+    const isExecute = (event.hitPoints ?? 1) / (event.maxHitPoints ?? 1) <= EXECUTE_RANGE_THRESHOLD;
+    this.executeRangeMap.set(targetString, isExecute);
   }
 
   onHavocApplied(event: ApplyDebuffEvent): void {
@@ -50,6 +68,7 @@ export default class HavocAnalyzer extends Analyzer {
       end: event.timestamp + this.havocDuration,
       chaosBolts: 0,
       shadowburns: 0,
+      shadowburnsInExecute: 0,
       casts: [], // store havocable casts
     };
 
@@ -87,6 +106,13 @@ export default class HavocAnalyzer extends Analyzer {
 
     if (spellId === TALENTS.SHADOWBURN_TALENT.id) {
       this.currentHavoc.shadowburns += 1;
+
+      if (event.targetID !== undefined) {
+        const targetString = encodeTargetString(event.targetID, event.targetInstance);
+        if (this.executeRangeMap.get(targetString)) {
+          this.currentHavoc.shadowburnsInExecute += 1;
+        }
+      }
     }
   }
 
@@ -102,4 +128,5 @@ export interface HavocWindowData {
   shadowburns: number;
   casts: CastEvent[]; // only tracks Havocable spells
   targetDied?: boolean;
+  shadowburnsInExecute: number;
 }

--- a/src/analysis/retail/warlock/destruction/modules/guide/HavocGuide.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/guide/HavocGuide.tsx
@@ -187,10 +187,12 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
       );
     }
 
-    if (targetDied)
+    if (targetDied) {
+      const proRatedBar = executeBurnBars ? executeBurnBars.perfect : maxExpectedSpenders;
       feedback.push(
-        `The target died before the debuff expired, shortening your Havoc window -- expectation was pro-rated to ${maxExpectedSpenders} shard${maxExpectedSpenders !== 1 ? 's' : ''} worth of spending.`,
+        `The target died before the debuff expired, shortening your Havoc window -- expectation was pro-rated to ${proRatedBar}${executeBurnBars ? ' Shadowburn' : ' shard'}${proRatedBar !== 1 ? 's' : ''}${executeBurnBars ? '' : ' worth of spending'}.`,
       );
+    }
 
     return (
       <ul style={{ paddingLeft: 20, margin: 0 }}>

--- a/src/analysis/retail/warlock/destruction/modules/guide/HavocGuide.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/guide/HavocGuide.tsx
@@ -21,6 +21,9 @@ interface HavocGuideProps {
 
 export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps): JSX.Element {
   const havoc = <SpellLink spell={SPELLS.HAVOC} />;
+  const hasFiendishCruelty = havocAnalyzer.selectedCombatant.hasTalent(
+    TALENTS_WARLOCK.FIENDISH_CRUELTY_TALENT,
+  );
 
   const explanation = (
     <>
@@ -33,6 +36,22 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
         Ideally, you should enter Havoc with Soul Shards already pooled so you can immediately begin
         casting <SpellLink spell={SPELLS.CHAOS_BOLT} />.
       </p>
+      <p>
+        Once the target drops below 20% health,{' '}
+        <SpellLink spell={TALENTS_WARLOCK.SHADOWBURN_TALENT} />
+        becomes the priority Havoc spender instead of <SpellLink spell={SPELLS.CHAOS_BOLT} />.
+        You'll want to generate as many shards as possible to then just spam cast Shadowburn.
+      </p>
+      {hasFiendishCruelty && (
+        <p>
+          With <SpellLink spell={TALENTS_WARLOCK.FIENDISH_CRUELTY_TALENT} /> talented, critical
+          strikes from <SpellLink spell={SPELLS.CHAOS_BOLT} />,{' '}
+          <SpellLink spell={SPELLS.CONFLAGRATE} />, or <SpellLink spell={SPELLS.INCINERATE} /> have
+          a chance to make your next <SpellLink spell={TALENTS_WARLOCK.SHADOWBURN_TALENT} /> free
+          and usable on any target regardless of health. Use these procs during Havoc as soon as
+          they're available.
+        </p>
+      )}
     </>
   );
 
@@ -59,23 +78,20 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
     [havocAnalyzer.havocData, havocAnalyzer.havocDuration],
   );
 
-  function rateHavocWindow(chaosBolts: number, duration: number): QualitativePerformance {
-    if (duration === 20000) {
-      if (chaosBolts >= 6) return QualitativePerformance.Perfect;
-      if (chaosBolts === 5) return QualitativePerformance.Good;
-      if (chaosBolts === 4) return QualitativePerformance.Ok;
-      return QualitativePerformance.Fail;
-    }
-
-    if (chaosBolts >= 5) return QualitativePerformance.Perfect;
-    if (chaosBolts === 4) return QualitativePerformance.Good;
-    if (chaosBolts === 3) return QualitativePerformance.Ok;
+  function rateHavocWindow(spenders: number, maxExpectedSpenders: number): QualitativePerformance {
+    if (spenders >= maxExpectedSpenders) return QualitativePerformance.Perfect;
+    if (spenders >= Math.round(maxExpectedSpenders * 0.75)) return QualitativePerformance.Good;
+    if (spenders >= Math.round(maxExpectedSpenders * 0.625)) return QualitativePerformance.Ok;
     return QualitativePerformance.Fail;
   }
 
   function getHavocFeedback(
-    spenders: number,
+    shardsSpent: number,
     shadowburns: number,
+    shadowburnsInExecute: number,
+    hasFiendishCruelty: boolean,
+    maxExpectedSpenders: number,
+    executeBurnBars: { perfect: number; good: number; ok: number } | null,
     casts: CastEvent[],
     duration: number,
     targetDied?: boolean,
@@ -83,32 +99,64 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
     const feedback: string[] = [];
     const isImproved = duration === 20000;
 
-    if (isImproved) {
-      if (spenders >= 6)
-        feedback.push('Excellent Havoc usage. You maximized Chaos Bolt casts during the window.');
-      else if (spenders === 5)
-        feedback.push('Good Havoc window. One additional Chaos Bolt would make this perfect.');
-      else if (spenders === 4)
+    if (executeBurnBars) {
+      if (shadowburns >= executeBurnBars.perfect)
         feedback.push(
-          'Decent Havoc window, but you could likely fit another Chaos Bolt by pooling more Soul Shards beforehand.',
+          'Excellent Havoc usage. You maximized your Shadowburn casts during the execute window.',
+        );
+      else if (shadowburns >= executeBurnBars.good)
+        feedback.push('Good execute window. A few more Shadowburns would make this perfect.');
+      else if (shadowburns >= executeBurnBars.ok)
+        feedback.push(
+          'Decent execute window, but you could likely fit more Shadowburns with better Soul Shard availability.',
         );
       else
         feedback.push(
-          'Low Chaos Bolt count during Havoc. Try pooling Soul Shards before casting Havoc.',
+          'Low Shadowburn count for a pure execute window. Try entering execute with more Soul Shards banked.',
+        );
+    } else if (isImproved) {
+      if (shardsSpent >= 14)
+        feedback.push(
+          'Excellent Havoc usage. You maximized your shard spending during the window.',
+        );
+      else if (shardsSpent >= 11)
+        feedback.push('Good Havoc window. A bit more shard spending would make this perfect.');
+      else if (shardsSpent >= 9)
+        feedback.push(
+          'Decent Havoc window, but you could likely spend more shards by pooling Soul Shards beforehand.',
+        );
+      else
+        feedback.push(
+          'Low shard spending during Havoc. Try pooling Soul Shards before casting Havoc.',
         );
     } else {
-      if (spenders >= 5)
-        feedback.push('Excellent Havoc usage. You maximized Chaos Bolt casts during the window.');
-      else if (spenders === 4)
-        feedback.push('Good Havoc window. One additional Chaos Bolt would make this perfect.');
-      else if (spenders === 3)
+      if (shardsSpent >= 10)
         feedback.push(
-          'Decent Havoc window, but you could likely fit another Chaos Bolt by pooling more Soul Shards beforehand.',
+          'Excellent Havoc usage. You maximized your shard spending during the window.',
+        );
+      else if (shardsSpent >= 8)
+        feedback.push('Good Havoc window. A bit more shard spending would make this perfect.');
+      else if (shardsSpent >= 6)
+        feedback.push(
+          'Decent Havoc window, but you could likely spend more shards by pooling Soul Shards beforehand.',
         );
       else
         feedback.push(
-          'Low Chaos Bolt count during Havoc. Try pooling Soul Shards before casting Havoc.',
+          'Low shard spending during Havoc. Try pooling Soul Shards before casting Havoc.',
         );
+    }
+
+    if (shadowburnsInExecute > 0) {
+      feedback.push(
+        `${shadowburnsInExecute} Shadowburn${shadowburnsInExecute !== 1 ? 's' : ''} landed while the target was in execute range -- good use of Havoc during execute.`,
+      );
+    }
+
+    const nonExecuteShadowburns = shadowburns - shadowburnsInExecute;
+    if (nonExecuteShadowburns > 0 && hasFiendishCruelty) {
+      feedback.push(
+        `${nonExecuteShadowburns} Shadowburn${nonExecuteShadowburns !== 1 ? 's' : ''} cast via a Fiendish Cruelty proc (free, no shard cost) outside of execute range - good use of the free cast.`,
+      );
     }
 
     if (casts.length < 6) {
@@ -118,7 +166,9 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
     }
 
     if (targetDied)
-      feedback.push('The target died before the debuff expired, shortening your Havoc window.');
+      feedback.push(
+        `The target died before the debuff expired, shortening your Havoc window -- expectation was pro-rated to ${maxExpectedSpenders} shard${maxExpectedSpenders !== 1 ? 's' : ''} worth of spending.`,
+      );
 
     return (
       <>
@@ -131,11 +181,45 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
 
   const perCastData: PerCastData[] = havocAnalyzer.havocData.map((window, index) => {
     const sequenceEntry = havocSequenceEvents[index];
-    const spenders = window.chaosBolts + window.shadowburns;
+    const shardsSpent = window.chaosBolts * 2 + window.shadowburns;
+    const actualWindowDurationMs =
+      (window.end ?? window.start + havocAnalyzer.havocDuration) - window.start;
+    const windowFraction = actualWindowDurationMs / havocAnalyzer.havocDuration;
+    const isExecuteBurnWindow = window.chaosBolts === 0 && window.shadowburnsInExecute > 0;
+    const fullPerfectBar = havocAnalyzer.havocDuration === 20000 ? 14 : 10;
+    const maxExpectedSpenders = window.targetDied
+      ? Math.max(1, Math.round(fullPerfectBar * windowFraction))
+      : fullPerfectBar;
+
+    const executeBurnFullBar = havocAnalyzer.havocDuration === 20000 ? 12 : 9;
+    const executeBurnBars = isExecuteBurnWindow
+      ? (() => {
+          const perfect = window.targetDied
+            ? Math.max(1, Math.round(executeBurnFullBar * windowFraction))
+            : executeBurnFullBar;
+          return {
+            perfect,
+            good: Math.round(perfect * (10 / 12)),
+            ok: Math.round(perfect * (8 / 12)),
+          };
+        })()
+      : null;
+
+    let performance: QualitativePerformance;
+    if (executeBurnBars) {
+      if (window.shadowburns >= executeBurnBars.perfect)
+        performance = QualitativePerformance.Perfect;
+      else if (window.shadowburns >= executeBurnBars.good)
+        performance = QualitativePerformance.Good;
+      else if (window.shadowburns >= executeBurnBars.ok) performance = QualitativePerformance.Ok;
+      else performance = QualitativePerformance.Fail;
+    } else {
+      performance = rateHavocWindow(shardsSpent, maxExpectedSpenders);
+    }
 
     return {
       timestamp: formatTimestamp(window.start),
-      performance: rateHavocWindow(spenders, havocAnalyzer.havocDuration),
+      performance,
       stats: [
         {
           label: 'Chaos Bolts',
@@ -154,8 +238,12 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
         },
       ],
       details: getHavocFeedback(
-        spenders,
+        shardsSpent,
         window.shadowburns,
+        window.shadowburnsInExecute,
+        hasFiendishCruelty,
+        maxExpectedSpenders,
+        executeBurnBars,
         window.casts,
         havocAnalyzer.havocDuration,
         window.targetDied,

--- a/src/analysis/retail/warlock/destruction/modules/guide/HavocGuide.tsx
+++ b/src/analysis/retail/warlock/destruction/modules/guide/HavocGuide.tsx
@@ -89,9 +89,11 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
     shardsSpent: number,
     shadowburns: number,
     shadowburnsInExecute: number,
+    shardsOnCast: number,
     hasFiendishCruelty: boolean,
     maxExpectedSpenders: number,
     executeBurnBars: { perfect: number; good: number; ok: number } | null,
+    startWasFabricated: boolean,
     casts: CastEvent[],
     duration: number,
     targetDied?: boolean,
@@ -146,6 +148,26 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
         );
     }
 
+    if (!startWasFabricated) {
+      if (shardsOnCast >= 4) {
+        feedback.push(
+          `You entered Havoc with ${shardsOnCast.toFixed(1)} Soul Shard${shardsOnCast !== 1 ? 's' : ''} banked -- great job.`,
+        );
+      } else if (shardsOnCast >= 3) {
+        feedback.push(
+          'You entered Havoc with 3 Soul Shards banked -- a decent pool, but getting closer to max lets you spend faster during the window.',
+        );
+      } else if (shardsOnCast >= 2) {
+        feedback.push(
+          'You entered Havoc with only 2 Soul Shards banked. Try pooling more shards to get closer to max before casting Havoc.',
+        );
+      } else {
+        feedback.push(
+          `You cast Havoc with ${shardsOnCast.toFixed(1)} Soul Shard${shardsOnCast !== 1 ? 's' : ''} banked, which delays your first spenders. Pooling more before casting Havoc lets you start spending immediately.`,
+        );
+      }
+    }
+
     if (shadowburnsInExecute > 0) {
       feedback.push(
         `${shadowburnsInExecute} Shadowburn${shadowburnsInExecute !== 1 ? 's' : ''} landed while the target was in execute range -- good use of Havoc during execute.`,
@@ -155,7 +177,7 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
     const nonExecuteShadowburns = shadowburns - shadowburnsInExecute;
     if (nonExecuteShadowburns > 0 && hasFiendishCruelty) {
       feedback.push(
-        `${nonExecuteShadowburns} Shadowburn${nonExecuteShadowburns !== 1 ? 's' : ''} cast via a Fiendish Cruelty proc (free, no shard cost) outside of execute range - good use of the free cast.`,
+        `${nonExecuteShadowburns} Shadowburn${nonExecuteShadowburns !== 1 ? 's' : ''} cast via a Fiendish Cruelty proc (free, no shard cost) - good use of the free cast.`,
       );
     }
 
@@ -171,11 +193,11 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
       );
 
     return (
-      <>
+      <ul style={{ paddingLeft: 20, margin: 0 }}>
         {feedback.map((line, i) => (
-          <div key={i}>{line}</div>
+          <li key={i}>{line}</li>
         ))}
-      </>
+      </ul>
     );
   }
 
@@ -236,14 +258,21 @@ export function HavocGuide({ havocAnalyzer, formatTimestamp }: HavocGuideProps):
           value: window.casts.length,
           tooltip: 'Total Havocable spells cast during this Havoc window',
         },
+        {
+          label: 'Soul Shards at Cast',
+          value: window.shardsOnCast.toFixed(1),
+          tooltip: 'Soul Shards you had banked when Havoc was applied',
+        },
       ],
       details: getHavocFeedback(
         shardsSpent,
         window.shadowburns,
         window.shadowburnsInExecute,
+        window.shardsOnCast,
         hasFiendishCruelty,
         maxExpectedSpenders,
         executeBurnBars,
+        window.startWasFabricated ?? false,
         window.casts,
         havocAnalyzer.havocDuration,
         window.targetDied,

--- a/src/analysis/retail/warlock/destruction/modules/normalizers/HavocPrepullNormalizer.ts
+++ b/src/analysis/retail/warlock/destruction/modules/normalizers/HavocPrepullNormalizer.ts
@@ -1,0 +1,50 @@
+import SPELLS from 'common/SPELLS';
+import { AnyEvent, EventType, ApplyDebuffEvent, CastEvent } from 'parser/core/Events';
+import EventsNormalizer from 'parser/core/EventsNormalizer';
+
+class HavocPrepullNormalizer extends EventsNormalizer {
+  normalize(events: AnyEvent[]): AnyEvent[] {
+    const fightStartTimestamp = this.owner.fight.start_time;
+    let sawApplyDebuff = false;
+    const fabricatedEvents: (ApplyDebuffEvent | CastEvent)[] = [];
+
+    for (const event of events) {
+      if (!this.owner.byPlayer(event)) continue;
+
+      if (event.type === EventType.ApplyDebuff) {
+        if (event.ability?.guid !== SPELLS.HAVOC.id) continue;
+        sawApplyDebuff = true;
+      } else if (event.type === EventType.RemoveDebuff && !sawApplyDebuff) {
+        if (event.ability?.guid !== SPELLS.HAVOC.id) continue;
+        if (!sawApplyDebuff) {
+          fabricatedEvents.push({
+            type: EventType.ApplyDebuff,
+            ability: event.ability,
+            sourceID: event.sourceID,
+            sourceIsFriendly: event.sourceIsFriendly,
+            targetID: event.targetID,
+            targetInstance: event.targetInstance,
+            targetIsFriendly: event.targetIsFriendly,
+            timestamp: fightStartTimestamp,
+            __fabricated: true,
+          });
+          fabricatedEvents.push({
+            type: EventType.Cast,
+            ability: event.ability,
+            sourceID: event.sourceID ?? this.owner.playerId,
+            sourceIsFriendly: event.sourceIsFriendly,
+            targetID: event.targetID,
+            targetInstance: event.targetInstance,
+            targetIsFriendly: event.targetIsFriendly,
+            timestamp: fightStartTimestamp,
+            __fabricated: true,
+          });
+          sawApplyDebuff = true; // only fabricate once
+        }
+      }
+    }
+    return [...fabricatedEvents, ...events];
+  }
+}
+
+export default HavocPrepullNormalizer;


### PR DESCRIPTION
### Description

This updates/overhauls the Havoc Analyzer and Guide to account for execute range and the free shadowburn procs from the Fiendish Cruelty talent, instead of just counting Chaos Bolts and Shadowburns as if they are interchangeable.
Specifically:
- The guide now knows when a Shadowburn landed in execute range vs. when it was just a free cast off a Fiendish Cruelty proc, and calls out both instead of lumping them together
- Windows are rated by actual shard cost (Chaos bolts cost 2 shards vs Shadowburn costing only 1), rather than a flat cast count, so a Shadowburn-heavy execute window and a Chaos Bolt-heavy window get judged fairly against each other. Windows that end early because of the target dying get pro-rated instead of being unfairly marked down.
- Added a stat/feedback line showing how many Soul shards the player had banked going into the havoc window. I kept this as information only, it doesn't affect the Perfect/Good/Ok/Fail rating because sometimes casting Havoc under-pooled on cooldown is the better call than holding, and didn't want to punish that
- Added a normalizer that reconstructs the missing events for Havoc casts before the pull, so those windows show up in the guide correctly. 
   - This also applies to the Cooldown Usage graph, as previously it would show as a missed cast when it was in fact cast before the pull started 
- Small unrelated change: updated the about section to include my contact info, and also update the example report

### Testing

- Test report URL: 
     - `/report/yCzXLNfpcQTBJD6V/27-Heroic+Entombed+Sentinels+-+Kill+(5:15)/1-Katorrí/standard/overview`
     - `/report/7qCMJYNmQcBX9T13/8-Heroic+Entombed+Sentinels+-+Kill+(3:48)/11-Frendz/standard/overview`
- Screenshot(s):

# Cooldown Usage Before & After
<img width="1277" height="356" alt="image" src="https://github.com/user-attachments/assets/6f2e7a91-2ee5-4f29-822f-66db0d98cba4" />

<img width="1220" height="344" alt="image" src="https://github.com/user-attachments/assets/6d24a52a-b1ce-4f46-92d6-250f27c239e6" />

# Havoc Windows before and After
### Before
<img width="1245" height="571" alt="image" src="https://github.com/user-attachments/assets/de51b232-6310-4778-82fa-7968184443cc" />
<img width="739" height="466" alt="image" src="https://github.com/user-attachments/assets/145d3d91-940f-43ad-9984-2ee33ac975ec" />
<img width="740" height="470" alt="image" src="https://github.com/user-attachments/assets/5f21af22-8484-46b0-90b9-de11555ef8e2" />

### After
<img width="1245" height="658" alt="image" src="https://github.com/user-attachments/assets/18b2ec35-a7fc-431a-bc10-c35ea31fa0d0" />
<img width="706" height="594" alt="image" src="https://github.com/user-attachments/assets/46fa4047-54e9-442e-9608-0e7ed998a056" />
<img width="699" height="618" alt="image" src="https://github.com/user-attachments/assets/7114be6c-1fca-4d3e-97b1-712e93c94f22" />

