### PR TITLE
[rShaman] Support for mana cost reduce of Current Control

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -3059,7 +3059,7 @@ export const Xinito: Contributor = {
 
 export const Naltarunir: Contributor = {
   nickname: 'Naltarunir',
-  discord: 'ghosti#1783',
+  discord: 'ghosti1783',
   github: 'Naltarunir',
   about: 'Healer and Nobundo fanboy',
   avatar: avatar('naltarunir-avatar.png'),

--- a/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
+++ b/src/analysis/retail/shaman/restoration/CHANGELOG.tsx
@@ -6,6 +6,7 @@ import { SpellLink } from 'interface';
 
 // prettier-ignore
 export default [
+  change(date(2026, 9, 11), <>Corrected the SpellManaCost from <SpellLink spell={TALENTS.CURRENT_CONTROL_TALENT} /> to show the correct mana cost in the Cooldown tab as well as the Mana Efficiency panel. </>, Naltarunir),
   change(date(2026, 9, 4), <>Corrected the heal increase modifier for <SpellLink spell={TALENTS.OVERSURGE_TALENT} />. </>, Naltarunir),
   change(date(2026, 8, 28), <>Updated the mastery effectiveness module <SpellLink spell={SPELLS.DEEP_HEALING} />. It now respects the baseline and talent increases in all combinations. The tooltip now calulates how much of the total mastery healing originates from stats gained from gear and consumeables. </>, Naltarunir),
   change(date(2026, 8, 23), <>Fixed an error that broke the cast efficiency for <SpellLink spell={SPELLS.SURGING_TOTEM} />. Fixed an issue that prevented the correct calculation of <SpellLink spell={TALENTS.STORMSTREAM_TOTEM_1_RESTORATION_TALENT} /> in the Mana Efficiency section. </>, Naltarunir),

--- a/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
+++ b/src/analysis/retail/shaman/restoration/CombatLogParser.tsx
@@ -7,7 +7,7 @@ import ManaUsageChart from 'parser/shared/modules/resources/mana/ManaUsageChart'
 import EarthElemental from 'src/analysis/retail/shaman/shared/talents/EarthElemental';
 //Core
 import StatTracker from './modules/core/StatTracker';
-
+import SpellManaCost from 'src/analysis/retail/shaman/restoration/modules/core/SpellManaCost';
 import Abilities from './modules/Abilities';
 import HealingDone from './modules/core/HealingDone';
 import HealingEfficiencyDetails from './modules/core/HealingEfficiencyDetails';
@@ -100,6 +100,7 @@ class CombatLogParser extends CoreCombatLogParser {
 
     //Core
     statTracker: StatTracker,
+    spellManaCost: SpellManaCost,
 
     // Features
     alwaysBeCasting: AlwaysBeCasting,

--- a/src/analysis/retail/shaman/restoration/constants.ts
+++ b/src/analysis/retail/shaman/restoration/constants.ts
@@ -129,6 +129,11 @@ export const SPELL_DURATIONS = {
 } as const;
 
 // mana saves
+export const CURRENT_CONTROL_MANA_REDUCTION = 0.15;
+export const CURRENT_CONTROL_AFFECTED_SPELLS: number[] = [
+  SPELLS.HEALING_WAVE.id,
+  TALENTS.CHAIN_HEAL_TALENT.id,
+];
 export const MANA_REGENERATION_PER_SECOND = 2000;
 export const WATER_SHIELD_MANA_REGENERATION_PER_SECOND = 142.8;
 export const RESURGENCE_SPELLS = {

--- a/src/analysis/retail/shaman/restoration/modules/core/HealingEfficiencyDetails.tsx
+++ b/src/analysis/retail/shaman/restoration/modules/core/HealingEfficiencyDetails.tsx
@@ -12,21 +12,36 @@ class HealingEfficiencyDetails extends CoreHealingEfficiencyDetails {
       <Panel
         title={<Trans id="shared.healingEfficiency.title">Mana Efficiency</Trans>}
         explanation={
-          <>
-            <Trans id="shaman.restoration.healingEfficiencyDetails">
-              <SpellLink spell={SPELLS.RESURGENCE} /> mana gained is removed from the spell, meaning
-              the mana spent of that spell will be lower.
-              {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-              <br />
-              Healing that is caused by the <SpellLink spell={TALENTS.UNLEASH_LIFE_TALENT} /> buff,
-              is added to <SpellLink spell={TALENTS.UNLEASH_LIFE_TALENT} /> instead of the spell
-              that was buffed.
-              {/* oxlint-disable-next-line wowanalyzer/no-br -- Baseline suppression */}
-              <br />
-              <SpellLink spell={TALENTS.EARTH_SHIELD_TALENT} /> is given the healing from its
-              healing buff and is removed from the spells that were buffed.
-            </Trans>
-          </>
+          <ul>
+            <li>
+              <Trans id="shaman.restoration.healingEfficiencyDetails.resurgence">
+                <SpellLink spell={SPELLS.RESURGENCE} /> mana gained is removed from the spell,
+                meaning the mana spent of that spell will be lower.
+              </Trans>
+            </li>
+            {this.selectedCombatant.hasTalent(TALENTS.CURRENT_CONTROL_TALENT) && (
+              <li>
+                <Trans id="shaman.restoration.healingEfficiencyDetails.currentControl">
+                  <SpellLink spell={TALENTS.CURRENT_CONTROL_TALENT} /> reduces the mana cost of{' '}
+                  <SpellLink spell={SPELLS.HEALING_WAVE} /> and{' '}
+                  <SpellLink spell={TALENTS.CHAIN_HEAL_TALENT} />.
+                </Trans>
+              </li>
+            )}
+            <li>
+              <Trans id="shaman.restoration.healingEfficiencyDetails.unleashLife">
+                Healing that is caused by the <SpellLink spell={TALENTS.UNLEASH_LIFE_TALENT} /> buff
+                is added to <SpellLink spell={TALENTS.UNLEASH_LIFE_TALENT} /> instead of the spell
+                that was buffed.
+              </Trans>
+            </li>
+            <li>
+              <Trans id="shaman.restoration.healingEfficiencyDetails.earthShield">
+                <SpellLink spell={TALENTS.EARTH_SHIELD_TALENT} /> is given the healing from its
+                healing buff and is removed from the spells that were buffed.
+              </Trans>
+            </li>
+          </ul>
         }
         pad={false}
         position={120}

--- a/src/analysis/retail/shaman/restoration/modules/core/SpellManaCost.ts
+++ b/src/analysis/retail/shaman/restoration/modules/core/SpellManaCost.ts
@@ -1,0 +1,41 @@
+import TALENTS from 'common/TALENTS/shaman';
+import { CastEvent } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+import CoreSpellManaCost from 'parser/shared/modules/SpellManaCost';
+import {
+  CURRENT_CONTROL_MANA_REDUCTION,
+  CURRENT_CONTROL_AFFECTED_SPELLS,
+} from 'src/analysis/retail/shaman/restoration/constants';
+
+/**
+ * Current Control: reduces the mana cost of Healing Wave by 15% and the mana cost of
+ * Chain Heal by 15%.
+ *
+ * The combat log reports the true (reduced) cost, but SpellManaCost prefers the hardcoded
+ * tooltip cost from SPELLS/TALENTS, so the reduction has to be applied here.
+ */
+
+class SpellManaCost extends CoreSpellManaCost {
+  protected hasCurrentControl = false;
+
+  constructor(options: Options) {
+    super(options);
+    this.hasCurrentControl = this.selectedCombatant.hasTalent(TALENTS.CURRENT_CONTROL_TALENT);
+  }
+
+  getResourceCost(event: CastEvent) {
+    const cost = super.getResourceCost(event);
+    if (!cost) {
+      return cost;
+    }
+
+    if (this.hasCurrentControl && CURRENT_CONTROL_AFFECTED_SPELLS.includes(event.ability.guid)) {
+      // mana costs are rounded down
+      return Math.floor(cost * (1 - CURRENT_CONTROL_MANA_REDUCTION));
+    }
+
+    return cost;
+  }
+}
+
+export default SpellManaCost;


### PR DESCRIPTION
### Description

- Support for mana cost reduce of [Current Control](https://www.wowhead.com/spell=1253093/current-control)
- Updated the Mana Efficiency panel to no longer use the old `<br>`
- Fixed my discord handle.

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/aXtqH3M8zrZdnQYF/13-Heroic+Ula'tek+-+Kill+(9:39)/5-Naltarunir/standard/statistics`

**Before:** 
<img width="1155" height="680" alt="Before" src="https://github.com/user-attachments/assets/8f3be095-c2d9-4f8b-a285-272590941031" />
<img width="1202" height="436" alt="BeforeCD" src="https://github.com/user-attachments/assets/47937c1c-67a1-4360-ba05-29005049ac9f" />

---

**After:**
<img width="1147" height="697" alt="after" src="https://github.com/user-attachments/assets/b1e504ea-15e9-4bd8-ac43-66037cab6472" />
<img width="1202" height="436" alt="afterCD" src="https://github.com/user-attachments/assets/11648ad8-037c-4d6a-a50d-2fe9e13d43b2" />


---
### Comment
No clue if the `<li>` and `<ul>` were the right choice here. The frontend/ui stuff is still super confusing to me.