### PR TITLE
[Arcane Mage] Fix Clearcasting Detection for Arcane Barrage

### DIFF
--- a/src/analysis/retail/mage/arcane/CHANGELOG.tsx
+++ b/src/analysis/retail/mage/arcane/CHANGELOG.tsx
@@ -17,6 +17,7 @@ const prismaticBolt = <SpellLink spell={SPELLS.PRISMATIC_BOLT} />
 const cumulativePower = <SpellLink spell={SPELLS.CUMULATIVE_POWER_BUFF} />;
 
 export default [
+  change(date(2026, 9, 11), <>Fixed {clearcasting} buff tracking for {arcaneBarrage}.</>, Sharrq),
   change(date(2026, 9, 10), <>Fixed the {cumulativePower} and {arcaneSalvo} buff stack counts for {prismaticBolt}.</>, Sharrq),
   change(date(2026, 9, 10), <>Added Tip Boxes to explain the "Perfect" conditions for the spells that have them.</>, Sharrq),
   change(date(2026, 9, 10), <>Fixed {arcaneSurge} Active Time calculations.</>, Sharrq),

--- a/src/analysis/retail/mage/arcane/CONFIG.tsx
+++ b/src/analysis/retail/mage/arcane/CONFIG.tsx
@@ -59,7 +59,7 @@ const config: Config = {
     overview: {
       notes: (
         <AlertWarning>
-          This spec has been fully updated for Midnight Season 2 (As of Sept 10). If anything is
+          This spec has been fully updated for Midnight Season 2 (As of Sept 11). If anything is
           missing or incorrect, please ping <code>@Sharrq</code> in the Altered Time Discord.
         </AlertWarning>
       ),

--- a/src/analysis/retail/mage/arcane/CombatLogParser.ts
+++ b/src/analysis/retail/mage/arcane/CombatLogParser.ts
@@ -47,6 +47,7 @@ import PresenceOfMind from './analyzers/PresenceOfMind';
 //Normalizers
 import ArcaneChargesNormalizer from './normalizers/ArcaneCharges';
 import ArcaneSurgeNormalizer from './normalizers/ArcaneSurge';
+import ClearcastingNormalizer from './normalizers/Clearcasting';
 import CastLinkNormalizer from './normalizers/CastLinkNormalizer';
 
 class CombatLogParser extends CoreCombatLogParser {
@@ -54,6 +55,7 @@ class CombatLogParser extends CoreCombatLogParser {
     //Normalizers
     arcaneChargesNormalizer: ArcaneChargesNormalizer,
     arcaneSurgeNormalizer: ArcaneSurgeNormalizer,
+    clercastingNormalizer: ClearcastingNormalizer,
     castLinkNormalizer: CastLinkNormalizer,
 
     //Analyzers

--- a/src/analysis/retail/mage/arcane/analyzers/ArcaneBarrage.tsx
+++ b/src/analysis/retail/mage/arcane/analyzers/ArcaneBarrage.tsx
@@ -38,12 +38,12 @@ export default class ArcaneBarrage extends Analyzer {
     const activeBuffs: number[] = [];
 
     // Clearcasting
-    if (this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE, event.timestamp - 10)) {
+    if (this.selectedCombatant.hasBuff(SPELLS.CLEARCASTING_ARCANE, event.timestamp)) {
       activeBuffs.push(SPELLS.CLEARCASTING_ARCANE.id);
     }
 
     // Arcane Soul
-    if (this.selectedCombatant.hasBuff(SPELLS.ARCANE_SOUL_BUFF, event.timestamp - 10)) {
+    if (this.selectedCombatant.hasBuff(SPELLS.ARCANE_SOUL_BUFF, event.timestamp)) {
       activeBuffs.push(SPELLS.ARCANE_SOUL_BUFF.id);
     }
 

--- a/src/analysis/retail/mage/arcane/analyzers/ArcaneMissiles.tsx
+++ b/src/analysis/retail/mage/arcane/analyzers/ArcaneMissiles.tsx
@@ -47,16 +47,13 @@ export default class ArcaneMissiles extends Analyzer {
       EventType.Damage,
     );
     const salvoStacks =
-      this.selectedCombatant.getBuff(SPELLS.ARCANE_SALVO_BUFF, event.timestamp - 10)?.stacks || 0;
+      this.selectedCombatant.getBuff(SPELLS.ARCANE_SALVO_BUFF, event.timestamp)?.stacks || 0;
 
     this.missileData.push({
       cast: event,
       ticks: damageTicks.length,
       clipped: damageTicks && damageTicks.length < maxTicks,
-      opMissiles: this.selectedCombatant.hasBuff(
-        SPELLS.OVERPOWERED_MISSILES_BUFF,
-        event.timestamp - 10,
-      ),
+      opMissiles: this.selectedCombatant.hasBuff(SPELLS.OVERPOWERED_MISSILES_BUFF, event.timestamp),
       clearcastingCapped:
         (this.selectedCombatant.getBuff(SPELLS.CLEARCASTING_ARCANE.id)?.stacks ?? 0) >= maxCCStacks,
       clearcastingProcs: this.selectedCombatant.getBuff(SPELLS.CLEARCASTING_ARCANE.id)?.stacks ?? 0,

--- a/src/analysis/retail/mage/arcane/normalizers/Clearcasting.ts
+++ b/src/analysis/retail/mage/arcane/normalizers/Clearcasting.ts
@@ -1,0 +1,34 @@
+import SPELLS from 'common/SPELLS';
+import EventOrderNormalizer, { EventOrder } from 'parser/core/EventOrderNormalizer';
+import { EventType } from 'parser/core/Events';
+import { Options } from 'parser/core/Module';
+
+const EVENT_ORDERS: EventOrder[] = [
+  {
+    beforeEventId: SPELLS.CLEARCASTING_ARCANE.id,
+    beforeEventType: EventType.ApplyBuff,
+    afterEventId: SPELLS.ARCANE_BARRAGE.id,
+    afterEventType: EventType.Cast,
+    bufferMs: 25,
+    anyTarget: true,
+  },
+  {
+    beforeEventId: SPELLS.CLEARCASTING_ARCANE.id,
+    beforeEventType: EventType.ApplyBuff,
+    afterEventId: SPELLS.PRISMATIC_BOLT.id,
+    afterEventType: EventType.Cast,
+    bufferMs: 25,
+    anyTarget: true,
+  },
+];
+
+/**
+ * Ensures that the Clearcasting Apply happens before the barrage or prismatic bolt cast if they both happened at the same time.
+ */
+class ClearcastingNormalizer extends EventOrderNormalizer {
+  constructor(options: Options) {
+    super(options, EVENT_ORDERS);
+  }
+}
+
+export default ClearcastingNormalizer;


### PR DESCRIPTION
- Fixed an issue that was causing Clearcasting to not be detected by the Arcane Barrage module if they gained the buff at the same timestamp as the Barrage cast (via Prismatic Bolt or Touch of the Magi)