### PR TITLE
Restore has arcane soul flag in onBoltApply

### DIFF
--- a/src/analysis/retail/mage/arcane/analyzers/PrismaticBolt.tsx
+++ b/src/analysis/retail/mage/arcane/analyzers/PrismaticBolt.tsx
@@ -41,6 +41,7 @@ export default class PrismaticBolt extends Analyzer {
     const remove: RemoveBuffEvent | undefined = GetRelatedEvent(event, EventType.RemoveBuff);
     const munched = !cast && !!refresh;
     const expired = !cast && !!remove;
+    
 
     this.prismaticBolts.push({
       timestamp: event.timestamp,
@@ -51,6 +52,7 @@ export default class PrismaticBolt extends Analyzer {
       cumulativePowerStacks: 0,
       salvoStacks: 0,
       has4pc: this.selectedCombatant.has4PieceByTier(TIERS.MID2),
+      hasArcaneSoul: this.selectedCombatant.hasBuff(SPELLS.ARCANE_SOUL_BUFF),
       targetsHit: damage?.length || 0,
       delay: cast ? cast.timestamp - event.timestamp : undefined,
     });


### PR DESCRIPTION
### Description

Munched procs during soul are no longer being tracked after the latest changes tracking pbolt casts. This is simply restoring the has arcane soul flag in the on apply buff section.

### Testing



- Test report URL: `https://www.warcraftlogs.com/reports/yaqcXnkPfAb2967Q/?fight=26&source=1&type=auras&view=events&ability=451038`

- Screenshot(s):
- 
<img width="1000" height="1618" alt="Screenshot_20260910_211534_Brave" src="https://github.com/user-attachments/assets/db2a0de1-d915-467b-b080-f3609383aba3" />
<img width="564" height="433" alt="Screenshot_20260910_211414_Brave" src="https://github.com/user-attachments/assets/353dfafd-1d13-47d3-92c0-3748e2b4b06c" />

