### PR TITLE
[Hunter] Beast Mastery - Re-add Bloodshed damage statistic

### DIFF
--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -3113,3 +3113,9 @@ export const Fyperia: Contributor = {
   github: 'fyperia',
   discord: 'Fyperia',
 };
+
+export const LittleBoyBlu: Contributor = {
+  nickname: 'LittleBoyBlu',
+  github: 'RyanMBlue',
+  discord: 'lbb',
+};

--- a/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
+++ b/src/analysis/retail/hunter/beastmastery/CHANGELOG.tsx
@@ -1,8 +1,17 @@
 import { change, date } from 'common/changelog';
 import { TALENTS_HUNTER } from 'common/TALENTS/hunter';
-import { Azortharion, Putro, SheenMachine} from 'CONTRIBUTORS';
+import { Azortharion, LittleBoyBlu, Putro, SheenMachine} from 'CONTRIBUTORS';
 import { SpellLink } from 'interface/index';
 export default [
+  change(
+    date(2026, 9, 12),
+    <>
+      Re-added a statistic for <SpellLink spell={TALENTS_HUNTER.BLOODSHED_TALENT} />, showing the
+      total damage of its bleed and its damage per{' '}
+      <SpellLink spell={TALENTS_HUNTER.BESTIAL_WRATH_TALENT} /> cast
+    </>,
+    LittleBoyBlu,
+  ),
   change(
     date(2026, 7, 9),
     <>

--- a/src/analysis/retail/hunter/beastmastery/CombatLogParser.ts
+++ b/src/analysis/retail/hunter/beastmastery/CombatLogParser.ts
@@ -20,6 +20,7 @@ import BeastMasteryFocusUsage from './modules/resources/BeastMasteryFocusUsage';
 import Focus from './modules/resources/Focus';
 import BeastCleave from './modules/talents/BeastCleave';
 import BestialWrath from './modules/talents/BestialWrath';
+import Bloodshed from './modules/talents/Bloodshed';
 import CobraShot from './modules/talents/CobraShot';
 import AnimalCompanion from './modules/talents/AnimalCompanion';
 import AspectOfTheBeast from './modules/talents/AspectOfTheBeast';
@@ -83,6 +84,7 @@ class CombatLogParser extends CoreCombatLogParser {
     aspectOfTheBeast: AspectOfTheBeast,
     barbedScales: BarbedScales,
     bindingShot: BindingShot,
+    bloodshed: Bloodshed,
     darkHound: DarkHound,
     deathblow: Deathblow,
     direBeast: DireBeast,

--- a/src/analysis/retail/hunter/beastmastery/constants.ts
+++ b/src/analysis/retail/hunter/beastmastery/constants.ts
@@ -16,9 +16,6 @@ export const COBRA_SHOT_FOCUS_THRESHOLD_TO_WAIT = 50;
 export const PACK_TACTICS_FOCUS_REGEN_INCREASE = 0.75;
 // Pack Tactics causes Barbed Shot to instantly generate 25 focus.
 export const PACK_TACTICS_BARBED_SHOT_FOCUS_REGEN = 25;
-/** Bloodshed */
-//Bloodshed increases the damage done by pets by 15%
-export const BLOODSHED_DAMAGE_AMP = 0.15;
 /** Dire Beast */
 //Dire Beast lasts for 8 seconds baseline
 export const DIRE_BEAST_BASE_DURATION = 8000;

--- a/src/analysis/retail/hunter/beastmastery/modules/talents/Bloodshed.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/talents/Bloodshed.tsx
@@ -67,11 +67,10 @@ class Bloodshed extends Analyzer {
         }
       >
         <BoringSpellValueText spell={TALENTS.BLOODSHED_TALENT}>
-          <>
-            <ItemDamageDone amount={this.damage} />
-            <p />
+          <ItemDamageDone amount={this.damage} />
+          <p>
             {formatNumber(this.damagePerBestialWrath)} <small>damage per Bestial Wrath</small>
-          </>
+          </p>
         </BoringSpellValueText>
       </Statistic>
     );

--- a/src/analysis/retail/hunter/beastmastery/modules/talents/Bloodshed.tsx
+++ b/src/analysis/retail/hunter/beastmastery/modules/talents/Bloodshed.tsx
@@ -1,0 +1,81 @@
+import { formatNumber } from 'common/format';
+import SPELLS from 'common/SPELLS';
+import TALENTS from 'common/TALENTS/hunter';
+import { SpellLink } from 'interface';
+import Analyzer, { Options, SELECTED_PLAYER, SELECTED_PLAYER_PET } from 'parser/core/Analyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+import BoringSpellValueText from 'parser/ui/BoringSpellValueText';
+import ItemDamageDone from 'parser/ui/ItemDamageDone';
+import Statistic from 'parser/ui/Statistic';
+import STATISTIC_CATEGORY from 'parser/ui/STATISTIC_CATEGORY';
+import STATISTIC_ORDER from 'parser/ui/STATISTIC_ORDER';
+
+/**
+ * Bestial Wrath provokes your pets to tear into your target, causing your target to bleed for
+ * damage over 12 sec.
+ *
+ * Every active pet (including the second pet from Animal Companion) applies the bleed, so debuff
+ * applications aren't meaningful on their own - damage per Bestial Wrath cast is.
+ *
+ * Example log:
+ * https://www.warcraftlogs.com/reports/fFABwW13pL4xqtrd#fight=7&type=damage-done&ability=321538
+ */
+class Bloodshed extends Analyzer {
+  damage = 0;
+  bestialWrathCasts = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.active = this.selectedCombatant.hasTalent(TALENTS.BLOODSHED_TALENT);
+    if (!this.active) {
+      return;
+    }
+    this.addEventListener(
+      Events.damage.by(SELECTED_PLAYER_PET).spell(SPELLS.BLOODSHED_DEBUFF),
+      this.onBleedDamage,
+    );
+    this.addEventListener(
+      Events.cast.by(SELECTED_PLAYER).spell(TALENTS.BESTIAL_WRATH_TALENT),
+      this.onBestialWrathCast,
+    );
+  }
+
+  onBleedDamage(event: DamageEvent) {
+    this.damage += event.amount + (event.absorbed || 0);
+  }
+
+  onBestialWrathCast() {
+    this.bestialWrathCasts += 1;
+  }
+
+  get damagePerBestialWrath() {
+    return this.bestialWrathCasts > 0 ? this.damage / this.bestialWrathCasts : 0;
+  }
+
+  statistic() {
+    return (
+      <Statistic
+        position={STATISTIC_ORDER.OPTIONAL(13)}
+        size="flexible"
+        category={STATISTIC_CATEGORY.TALENTS}
+        tooltip={
+          <>
+            Your pets' <SpellLink spell={TALENTS.BLOODSHED_TALENT} /> bleed dealt{' '}
+            {formatNumber(this.damage)} damage over {this.bestialWrathCasts}{' '}
+            <SpellLink spell={TALENTS.BESTIAL_WRATH_TALENT} /> casts.
+          </>
+        }
+      >
+        <BoringSpellValueText spell={TALENTS.BLOODSHED_TALENT}>
+          <>
+            <ItemDamageDone amount={this.damage} />
+            <p />
+            {formatNumber(this.damagePerBestialWrath)} <small>damage per Bestial Wrath</small>
+          </>
+        </BoringSpellValueText>
+      </Statistic>
+    );
+  }
+}
+
+export default Bloodshed;


### PR DESCRIPTION
Bloodshed is passive in Midnight and triggered by Bestial Wrath; its bleed (321538) is applied by every active pet. Track the bleed damage and show damage per Bestial Wrath cast. Remove the unused BLOODSHED_DAMAGE_AMP constant left over from the old active version.

_AI Usage Disclosure: Ran project through Claude Code and asked it to identify any items that would prevent the spec from being listed as supported in the current patch, since Beast Mastery Hunter still is flagged with the "This spec has not been updated for patch 12.1.0" note. After that, asked it to identify 1 update for a first prospective Pull Request to submit. Code was initially written by me, then reviewed by Claude Code, both locally._

### Description

<!-- A brief description of the changes made with this pull request.-->
Changes (5 files):
  - modules/talents/Bloodshed.tsx (new): turns on only when Bloodshed is talented. It adds up the bleed damage from all your pets and counts your Bestial Wrath casts. The talent card shows the bleed's DPS and % of total damage, plus damage per Bestial Wrath. The code follows the style of the other BM talent modules.
  - CombatLogParser.ts: registers the module.
  - constants.ts: removes the unused BLOODSHED_DAMAGE_AMP, left over from the old version.
  - CHANGELOG.tsx
  - CONTRIBUTORS.ts

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/fFABwW13pL4xqtrd/7-LFR+The+Twin+Fangs+-+Kill+(7:03)/30-Longwoodrblu/standard/statistics`
- Screenshot(s):
<img width="285" height="154" alt="image" src="https://github.com/user-attachments/assets/4bcffd64-f9d8-48b2-b748-feca31d16475" />
<img width="523" height="151" alt="image" src="https://github.com/user-attachments/assets/fa551363-6af2-438b-bdb9-ee25d5ccfefb" />

